### PR TITLE
fix: alchemy rpc endpoint

### DIFF
--- a/upstream/alchemy_http_json_rpc_client.go
+++ b/upstream/alchemy_http_json_rpc_client.go
@@ -142,7 +142,7 @@ func (c *AlchemyHttpJsonRpcClient) getOrCreateClient(network common.Network) (Ht
 		return nil, fmt.Errorf("unsupported network chain ID for Alchemy: %d", chainID)
 	}
 
-	alchemyURL := fmt.Sprintf("https://%s.alchemyapi.io/v2/%s", subdomain, c.apiKey)
+	alchemyURL := fmt.Sprintf("https://%s.g.alchemy.com/v2/%s", subdomain, c.apiKey)
 	parsedURL, err := url.Parse(alchemyURL)
 	if err != nil {
 		return nil, err

--- a/vendors/infura.go
+++ b/vendors/infura.go
@@ -64,5 +64,5 @@ func (v *InfuraVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr inte
 }
 
 func (v *InfuraVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
-	return strings.Contains(ups.Endpoint, ".alchemy.com") || strings.Contains(ups.Endpoint, ".alchemyapi.io")
+	return strings.Contains(ups.Endpoint, ".infura.io")
 }


### PR DESCRIPTION
Correct the alchemy rpc endpoint rebuilt url for type `evm-alchemy` or for url starting with `evm+alchemy://xxx` or `alchemy://xxx` endpoints.

The `alchemyapi.io` endpoint don't work on all the chains, for example with `arb-sepolia` or `base-mainnet` it's ko