### PR TITLE
feat: extending rpc json methods for caching

### DIFF
--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -273,7 +273,8 @@ func extractBlockReferenceFromResponse(rpcReq *common.JsonRpcRequest, rpcResp *c
 		//
 		// TODO is there a way to find block number without a new request? (e.g. adding a flag to such requests that exposes block number)
 		return "nil", 1, nil
-	case "eth_chainId":
+	case "eth_chainId",
+		"web3_sha3":
 		// This request is supposed to always return the same response.
 		// "all" means this applies to all blocks
 		// "1" is a placeholder to pass the block number check (is there a cleaner nicer way?)

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -274,7 +274,8 @@ func extractBlockReferenceFromResponse(rpcReq *common.JsonRpcRequest, rpcResp *c
 		// TODO is there a way to find block number without a new request? (e.g. adding a flag to such requests that exposes block number)
 		return "nil", 1, nil
 	case "eth_chainId",
-		"web3_sha3":
+		"web3_sha3",
+		"net_version":
 		// This request is supposed to always return the same response.
 		// "all" means this applies to all blocks
 		// "1" is a placeholder to pass the block number check (is there a cleaner nicer way?)

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -248,10 +248,14 @@ func extractBlockReferenceFromResponse(rpcReq *common.JsonRpcRequest, rpcResp *c
 	}
 
 	switch rpcReq.Method {
-	case "eth_getTransactionReceipt":
+	case "eth_getTransactionReceipt",
+		"eth_getTransactionByHash":
 		if rpcResp.Result != nil {
-			if receipt, ok := rpcResp.Result.(map[string]interface{}); ok {
-				if blockNumber, ok := receipt["blockNumber"].(string); ok {
+			if tx, ok := rpcResp.Result.(map[string]interface{}); ok {
+				if blockHash, ok := tx["blockHash"].(string); ok && blockHash != "" {
+					return blockHash, 0, nil
+				}
+				if blockNumber, ok := tx["blockNumber"].(string); ok && blockNumber != "" {
 					bn, err := hexutil.DecodeUint64(blockNumber)
 					if err != nil {
 						return "", bn, err

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -277,9 +277,7 @@ func extractBlockReferenceFromResponse(rpcReq *common.JsonRpcRequest, rpcResp *c
 		//
 		// TODO is there a way to find block number without a new request? (e.g. adding a flag to such requests that exposes block number)
 		return "nil", 1, nil
-	case "eth_chainId",
-		"web3_sha3",
-		"net_version":
+	case "eth_chainId":
 		// This request is supposed to always return the same response.
 		// "all" means this applies to all blocks
 		// "1" is a placeholder to pass the block number check (is there a cleaner nicer way?)

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -124,30 +124,6 @@ func TestExtractBlockReferenceFromResponse(t *testing.T) {
 			expErr:   false,
 		},
 		{
-			name: "web3_sha",
-			rpcReq: &common.JsonRpcRequest{
-				Method: "web3_sha3",
-			},
-			rpcResp: &common.JsonRpcResponse{
-				Result: nil,
-			},
-			expected: "all",
-			expUint:  1,
-			expErr:   false,
-		},
-		{
-			name: "net_version",
-			rpcReq: &common.JsonRpcRequest{
-				Method: "net_version",
-			},
-			rpcResp: &common.JsonRpcResponse{
-				Result: "1",
-			},
-			expected: "all",
-			expUint:  1,
-			expErr:   false,
-		},
-		{
 			name: "invalid method",
 			rpcReq: &common.JsonRpcRequest{
 				Method: "invalid_method",

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -3,7 +3,7 @@ package erpc
 import (
 	"testing"
 
-	"github.com/flair-sdk/erpc/common"
+	"github.com/erpc/erpc/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -57,6 +57,49 @@ func TestExtractBlockReferenceFromResponse(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "eth_getTransactionByHash with blockHash",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionByHash",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{
+					"blockHash": "0xabc123",
+				},
+			},
+			expected: "0xabc123",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionByHash with blockNumber",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionByHash",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{
+					"blockNumber": "0x1b4",
+				},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionByHash with pending transaction",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionByHash",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{
+					"blockHash":   nil,
+					"blockNumber": nil,
+				},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
 			name: "arbtrace_replayTransaction",
 			rpcReq: &common.JsonRpcRequest{
 				Method: "arbtrace_replayTransaction",

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -136,6 +136,18 @@ func TestExtractBlockReferenceFromResponse(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "net_version",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "net_version",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: "1",
+			},
+			expected: "all",
+			expUint:  1,
+			expErr:   false,
+		},
+		{
 			name: "invalid method",
 			rpcReq: &common.JsonRpcRequest{
 				Method: "invalid_method",

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -1,0 +1,141 @@
+package erpc
+
+import (
+	"testing"
+
+	"github.com/flair-sdk/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBlockReferenceFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		rpcReq   *common.JsonRpcRequest
+		rpcResp  *common.JsonRpcResponse
+		expected string
+		expUint  uint64
+		expErr   bool
+	}{
+		{
+			name: "eth_getTransactionReceipt with valid block number",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionReceipt",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{
+					"blockNumber": "0x1b4",
+				},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionReceipt with invalid block number",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionReceipt",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{
+					"blockNumber": "invalid",
+				},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
+		{
+			name: "eth_getTransactionReceipt with missing block number",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_getTransactionReceipt",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: map[string]interface{}{},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "arbtrace_replayTransaction",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "arbtrace_replayTransaction",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: nil,
+			},
+			expected: "nil",
+			expUint:  1,
+			expErr:   false,
+		},
+		{
+			name: "eth_chainId",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_chainId",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: nil,
+			},
+			expected: "all",
+			expUint:  1,
+			expErr:   false,
+		},
+		{
+			name: "web3_sha",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "web3_sha3",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: nil,
+			},
+			expected: "all",
+			expUint:  1,
+			expErr:   false,
+		},
+		{
+			name: "invalid method",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "invalid_method",
+			},
+			rpcResp: &common.JsonRpcResponse{
+				Result: nil,
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name:   "nil request",
+			rpcReq: nil,
+			rpcResp: &common.JsonRpcResponse{
+				Result: nil,
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
+		{
+			name: "nil response",
+			rpcReq: &common.JsonRpcRequest{
+				Method: "eth_chainId",
+			},
+			rpcResp:  nil,
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, resultUint, err := extractBlockReferenceFromResponse(tt.rpcReq, tt.rpcResp)
+			if tt.expErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expUint, resultUint)
+		})
+	}
+}

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -57,7 +57,6 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		return "", 0, nil
 
 	case "eth_getBalance",
-		"eth_getStorageAt",
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call",
@@ -86,7 +85,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 			return "", 0, fmt.Errorf("first parameter is not a string for method %s it is %+v", r.Method, r.Params)
 		}
 
-	case "eth_getProof":
+	case "eth_getProof",
+		"eth_getStorageAt":
 		if len(r.Params) > 2 {
 			if bns, ok := r.Params[2].(string); ok {
 				if strings.HasPrefix(bns, "0x") {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -38,8 +38,7 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 			return "", 0, fmt.Errorf("unexpected no parameters for method %s", r.Method)
 		}
 
-	case "eth_getLogs",
-		"eth_newFilter":
+	case "eth_getLogs":
 		if len(r.Params) > 0 {
 			if logsFilter, ok := r.Params[0].(map[string]interface{}); ok {
 				if from, ok := logsFilter["fromBlock"].(string); ok {
@@ -62,7 +61,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call",
-		"eth_feeHistory":
+		"eth_feeHistory",
+		"eth_getAccount":
 		if len(r.Params) > 1 {
 			if bns, ok := r.Params[1].(string); ok {
 				if strings.HasPrefix(bns, "0x") {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -20,7 +20,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		"eth_getUncleByBlockNumberAndIndex",
 		"eth_getTransactionByBlockNumberAndIndex",
 		"eth_getUncleCountByBlockNumber",
-		"eth_getBlockTransactionCountByNumber":
+		"eth_getBlockTransactionCountByNumber",
+		"eth_getBlockReceipts":
 		if len(r.Params) > 0 {
 			if bns, ok := r.Params[0].(string); ok {
 				if strings.HasPrefix(bns, "0x") {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -80,7 +80,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		}
 
 	case "eth_getBlockByHash",
-		"eth_getTransactionByBlockHashAndIndex":
+		"eth_getTransactionByBlockHashAndIndex",
+		"eth_getBlockTransactionCountByHash":
 		if len(r.Params) > 0 {
 			if blockHash, ok := r.Params[0].(string); ok {
 				return blockHash, 0, nil

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -38,7 +38,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 			return "", 0, fmt.Errorf("unexpected no parameters for method %s", r.Method)
 		}
 
-	case "eth_getLogs":
+	case "eth_getLogs",
+		"eth_newFilter":
 		if len(r.Params) > 0 {
 			if logsFilter, ok := r.Params[0].(map[string]interface{}); ok {
 				if from, ok := logsFilter["fromBlock"].(string); ok {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -61,7 +61,6 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call",
-		"eth_estimateGas",
 		"eth_feeHistory":
 		if len(r.Params) > 1 {
 			if bns, ok := r.Params[1].(string); ok {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -86,6 +86,23 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 			return "", 0, fmt.Errorf("first parameter is not a string for method %s it is %+v", r.Method, r.Params)
 		}
 
+	case "eth_getProof":
+		if len(r.Params) > 2 {
+			if bns, ok := r.Params[2].(string); ok {
+				if strings.HasPrefix(bns, "0x") {
+					bni, err := hexutil.DecodeUint64(bns)
+					if err != nil {
+						return bns, 0, err
+					}
+					return strconv.FormatUint(bni, 10), bni, nil
+				} else {
+					return "", 0, nil
+				}
+			}
+		} else {
+			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)
+		}
+
 	default:
 		return "", 0, nil
 	}

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -60,7 +60,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call",
-		"eth_estimateGas":
+		"eth_estimateGas",
+		"eth_feeHistory":
 		if len(r.Params) > 1 {
 			if bns, ok := r.Params[1].(string); ok {
 				if strings.HasPrefix(bns, "0x") {

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -79,7 +79,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 			return "", 0, fmt.Errorf("unexpected missing 2nd parameter for method %s: %+v", r.Method, r.Params)
 		}
 
-	case "eth_getBlockByHash":
+	case "eth_getBlockByHash",
+		"eth_getTransactionByBlockHashAndIndex":
 		if len(r.Params) > 0 {
 			if blockHash, ok := r.Params[0].(string); ok {
 				return blockHash, 0, nil

--- a/evm/block_ref.go
+++ b/evm/block_ref.go
@@ -81,7 +81,8 @@ func ExtractBlockReference(r *common.JsonRpcRequest) (string, uint64, error) {
 
 	case "eth_getBlockByHash",
 		"eth_getTransactionByBlockHashAndIndex",
-		"eth_getBlockTransactionCountByHash":
+		"eth_getBlockTransactionCountByHash",
+		"eth_getUncleCountByBlockHash":
 		if len(r.Params) > 0 {
 			if blockHash, ok := r.Params[0].(string); ok {
 				return blockHash, 0, nil

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -102,6 +102,58 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "eth_getCode",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getCode",
+				Params: []interface{}{"0xAddress", "0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionCount",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getTransactionCount",
+				Params: []interface{}{"0xAddress", "0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_call",
+			request: &common.JsonRpcRequest{
+				Method: "eth_call",
+				Params: []interface{}{
+					map[string]interface{}{
+						"from": nil,
+						"to":   "0x6b175474e89094c44da98b954eedeac495271d0f",
+						"data": "0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE",
+					},
+					"0x1b4",
+					map[string]interface{}{
+						"0x1111111111111111111111111111111111111111": map[string]interface{}{
+							"balance": "0xFFFFFFFFFFFFFFFFFFFF",
+						},
+					},
+				},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_feeHistory",
+			request: &common.JsonRpcRequest{
+				Method: "eth_feeHistory",
+				Params: []interface{}{4, "0x1b4", []interface{}{25, 75}},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
 			name: "eth_getBlockByHash",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getBlockByHash",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -157,9 +157,19 @@ func TestExtractBlockReference(t *testing.T) {
 			name: "eth_getBlockByHash",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getBlockByHash",
-				Params: []interface{}{"0xBlockHash"},
+				Params: []interface{}{"0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3", false},
 			},
-			expected: "0xBlockHash",
+			expected: "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionByBlockHashAndIndex",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getTransactionByBlockHashAndIndex",
+				Params: []interface{}{"0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b", "0x0"},
+			},
+			expected: "0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b",
 			expUint:  0,
 			expErr:   false,
 		},

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -15,14 +15,15 @@ func TestExtractBlockReference(t *testing.T) {
 		expUint  uint64
 		expErr   bool
 	}{
+		// METHODS
 		{
 			name: "eth_getBlockByNumber",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getBlockByNumber",
-				Params: []interface{}{"0x1b4"},
+				Params: []interface{}{"0xc5043f", false},
 			},
-			expected: "436",
-			expUint:  436,
+			expected: "12911679",
+			expUint:  12911679,
 			expErr:   false,
 		},
 		{
@@ -33,6 +34,46 @@ func TestExtractBlockReference(t *testing.T) {
 			},
 			expected: "436",
 			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getTransactionByBlockNumberAndIndex",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getTransactionByBlockNumberAndIndex",
+				Params: []interface{}{"0xc5043f", "0x0"},
+			},
+			expected: "12911679",
+			expUint:  12911679,
+			expErr:   false,
+		},
+		{
+			name: "eth_getUncleCountByBlockNumber",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getUncleCountByBlockNumber",
+				Params: []interface{}{"0xc5043f"},
+			},
+			expected: "12911679",
+			expUint:  12911679,
+			expErr:   false,
+		},
+		{
+			name: "eth_getBlockTransactionCountByNumber",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getUncleCountByBlockNumber",
+				Params: []interface{}{"0xc5043f"},
+			},
+			expected: "12911679",
+			expUint:  12911679,
+			expErr:   false,
+		},
+		{
+			name: "eth_getBlockReceipts",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockReceipts",
+				Params: []interface{}{"0xc5043f"},
+			},
+			expected: "12911679",
+			expUint:  12911679,
 			expErr:   false,
 		},
 		{

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -230,6 +230,16 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "eth_getUncleCountByBlockHash",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getUncleCountByBlockHash",
+				Params: []interface{}{"0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b"},
+			},
+			expected: "0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
 			name: "eth_getProof",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getProof",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -3,7 +3,7 @@ package evm
 import (
 	"testing"
 
-	"github.com/flair-sdk/erpc/common"
+	"github.com/erpc/erpc/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -1,0 +1,134 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/flair-sdk/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBlockReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  *common.JsonRpcRequest
+		expected string
+		expUint  uint64
+		expErr   bool
+	}{
+		{
+			name: "eth_getBlockByNumber",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{"0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getUncleByBlockNumberAndIndex",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getUncleByBlockNumberAndIndex",
+				Params: []interface{}{"0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getLogs",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getLogs",
+				Params: []interface{}{
+					map[string]interface{}{
+						"fromBlock": "0x1b4",
+						"toBlock":   "0x1b5",
+					},
+				},
+			},
+			expected: "0x1b4-0x1b5",
+			expUint:  437,
+			expErr:   false,
+		},
+		{
+			name: "eth_getBalance",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBalance",
+				Params: []interface{}{"0xAddress", "0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getBlockByHash",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockByHash",
+				Params: []interface{}{"0xBlockHash"},
+			},
+			expected: "0xBlockHash",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "eth_getProof",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getProof",
+				Params: []interface{}{"0xAddress", "keys", "0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name:     "nil request",
+			request:  nil,
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
+		{
+			name: "invalid hex in eth_getBlockByNumber",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{"invalidHex"},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "missing parameters in eth_getLogs",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getLogs",
+				Params: []interface{}{},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
+			name: "missing parameters in eth_getBalance",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBalance",
+				Params: []interface{}{"0xAddress"},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, resultUint, err := ExtractBlockReference(tt.request)
+			if tt.expErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expUint, resultUint)
+		})
+	}
+}

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -108,6 +108,23 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "eth_newFilter",
+			request: &common.JsonRpcRequest{
+				Method: "eth_newFilter",
+				Params: []interface{}{
+					map[string]interface{}{
+						"fromBlock": "0x1b4",
+						"toBlock":   "0x1b5",
+						"address":   "0x6b175474e89094c44da98b954eedeac495271d0f",
+						"topics":    []interface{}{},
+					},
+				},
+			},
+			expected: "0x1b4-0x1b5",
+			expUint:  437,
+			expErr:   false,
+		},
+		{
 			name: "missing parameters in eth_getLogs",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getLogs",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -108,23 +108,6 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
-			name: "eth_newFilter",
-			request: &common.JsonRpcRequest{
-				Method: "eth_newFilter",
-				Params: []interface{}{
-					map[string]interface{}{
-						"fromBlock": "0x1b4",
-						"toBlock":   "0x1b5",
-						"address":   "0x6b175474e89094c44da98b954eedeac495271d0f",
-						"topics":    []interface{}{},
-					},
-				},
-			},
-			expected: "0x1b4-0x1b5",
-			expUint:  437,
-			expErr:   false,
-		},
-		{
 			name: "missing parameters in eth_getLogs",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getLogs",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -75,7 +75,7 @@ func TestExtractBlockReference(t *testing.T) {
 		{
 			name: "eth_getBlockTransactionCountByNumber",
 			request: &common.JsonRpcRequest{
-				Method: "eth_getUncleCountByBlockNumber",
+				Method: "eth_getBlockTransactionCountByNumber",
 				Params: []interface{}{"0xc5043f"},
 			},
 			expected: "12911679",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -220,6 +220,16 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "eth_getBlockTransactionCountByHash",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockTransactionCountByHash",
+				Params: []interface{}{"0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b"},
+			},
+			expected: "0x829df9bb801fc0494abf2f443423a49ffa32964554db71b098d332d87b70a48b",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
 			name: "eth_getProof",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getProof",

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -15,7 +15,13 @@ func TestExtractBlockReference(t *testing.T) {
 		expUint  uint64
 		expErr   bool
 	}{
-		// METHODS
+		{
+			name:     "nil request",
+			request:  nil,
+			expected: "",
+			expUint:  0,
+			expErr:   true,
+		},
 		{
 			name: "eth_getBlockByNumber",
 			request: &common.JsonRpcRequest{
@@ -24,6 +30,16 @@ func TestExtractBlockReference(t *testing.T) {
 			},
 			expected: "12911679",
 			expUint:  12911679,
+			expErr:   false,
+		},
+		{
+			name: "invalid hex in eth_getBlockByNumber",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{"invalidHex"},
+			},
+			expected: "",
+			expUint:  0,
 			expErr:   false,
 		},
 		{
@@ -92,6 +108,16 @@ func TestExtractBlockReference(t *testing.T) {
 			expErr:   false,
 		},
 		{
+			name: "missing parameters in eth_getLogs",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getLogs",
+				Params: []interface{}{},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   false,
+		},
+		{
 			name: "eth_getBalance",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getBalance",
@@ -100,6 +126,16 @@ func TestExtractBlockReference(t *testing.T) {
 			expected: "436",
 			expUint:  436,
 			expErr:   false,
+		},
+		{
+			name: "missing parameters in eth_getBalance",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getBalance",
+				Params: []interface{}{"0xAddress"},
+			},
+			expected: "",
+			expUint:  0,
+			expErr:   true,
 		},
 		{
 			name: "eth_getCode",
@@ -177,48 +213,29 @@ func TestExtractBlockReference(t *testing.T) {
 			name: "eth_getProof",
 			request: &common.JsonRpcRequest{
 				Method: "eth_getProof",
-				Params: []interface{}{"0xAddress", "keys", "0x1b4"},
+				Params: []interface{}{
+					"0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
+					[]interface{}{"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"},
+					"0x1b4",
+				},
 			},
 			expected: "436",
 			expUint:  436,
 			expErr:   false,
 		},
 		{
-			name:     "nil request",
-			request:  nil,
-			expected: "",
-			expUint:  0,
-			expErr:   true,
-		},
-		{
-			name: "invalid hex in eth_getBlockByNumber",
+			name: "eth_getStorageAt",
 			request: &common.JsonRpcRequest{
-				Method: "eth_getBlockByNumber",
-				Params: []interface{}{"invalidHex"},
+				Method: "eth_getStorageAt",
+				Params: []interface{}{
+					"0xE592427A0AEce92De3Edee1F18E0157C05861564",
+					"0x0",
+					"0x1b4",
+				},
 			},
-			expected: "",
-			expUint:  0,
+			expected: "436",
+			expUint:  436,
 			expErr:   false,
-		},
-		{
-			name: "missing parameters in eth_getLogs",
-			request: &common.JsonRpcRequest{
-				Method: "eth_getLogs",
-				Params: []interface{}{},
-			},
-			expected: "",
-			expUint:  0,
-			expErr:   false,
-		},
-		{
-			name: "missing parameters in eth_getBalance",
-			request: &common.JsonRpcRequest{
-				Method: "eth_getBalance",
-				Params: []interface{}{"0xAddress"},
-			},
-			expected: "",
-			expUint:  0,
-			expErr:   true,
 		},
 	}
 

--- a/evm/block_ref_test.go
+++ b/evm/block_ref_test.go
@@ -183,6 +183,16 @@ func TestExtractBlockReference(t *testing.T) {
 			name: "eth_feeHistory",
 			request: &common.JsonRpcRequest{
 				Method: "eth_feeHistory",
+				Params: []interface{}{"0x8D97689C9818892B700e27F316cc3E41e17fBeb9", "0x1b4"},
+			},
+			expected: "436",
+			expUint:  436,
+			expErr:   false,
+		},
+		{
+			name: "eth_getAccount",
+			request: &common.JsonRpcRequest{
+				Method: "eth_getAccount",
 				Params: []interface{}{4, "0x1b4", []interface{}{25, 75}},
 			},
 			expected: "436",


### PR DESCRIPTION
`blockNumber` or `blockHash` in request:
- [x] `eth_getProof`
- [x] `eth_getStorageAt`
- [x]  `eth_feeHistory`
- [x]  `eth_getBlockReceipts`
- [x]  `eth_getTransactionByBlockHashAndIndex `
- [x]  `eth_getAccount `

`blockNumber` or `blockHash` in response:
- [ ]  `eth_getFilterChanges `
- [ ]  `eth_getFilterLogs `
- [ ]  `eth_newFilter`
- [x]  `eth_getTransactionByHash`