### PR TITLE
fix: invalid normalization for eth_getStorageAt

### DIFF
--- a/common/evm_json_rpc.go
+++ b/common/evm_json_rpc.go
@@ -48,7 +48,6 @@ func NormalizeEvmHttpJsonRpc(nrq *NormalizedRequest, r *JsonRpcRequest) error {
 
 		}
 	case "eth_getBalance",
-		"eth_getStorageAt",
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call",
@@ -59,6 +58,14 @@ func NormalizeEvmHttpJsonRpc(nrq *NormalizedRequest, r *JsonRpcRequest) error {
 				return err
 			}
 			r.Params[1] = b
+		}
+	case "eth_getStorageAt":
+		if len(r.Params) > 2 {
+			b, err := NormalizeHex(r.Params[2])
+			if err != nil {
+				return err
+			}
+			r.Params[2] = b
 		}
 	case "eth_getLogs":
 		if len(r.Params) > 0 {


### PR DESCRIPTION
The normalization code tries to normalize the block number for `eth_getStorageAt` but incorrectly thinks that the block number is the second parameter. It's actually the third. This causes any storage request to fail.