### PR TITLE
fix: cache never used for `eth_chainId`

### DIFF
--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -105,6 +105,9 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)
 		}
 
+	case "eth_chainId":
+		return "all", 1, nil
+
 	default:
 		return "", 0, nil
 	}


### PR DESCRIPTION
When setting response cache, `eth_chainId` has block ref set to `all`:

https://github.com/erpc/erpc/blob/f214de4266d0d86ac33356668ef0e4f32bf3a1aa/common/evm_block_ref.go#L158-L162

However, when fetching cache entry, `eth_chainId` falls under this branch:

https://github.com/erpc/erpc/blob/f214de4266d0d86ac33356668ef0e4f32bf3a1aa/erpc/evm_json_rpc_cache.go#L74-L76

This results in the chain ID request successfully getting cached but never used. This PR fixes it by setting the same block ref as in the response.