### PR TITLE
ci: parameterize docker image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up Docker tags
+        id: tag_param
+        run: |
+          REPO="${{ github.repository }}"
+          echo "repo=${REPO@L}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -91,5 +97,5 @@ jobs:
             VERSION=${{ github.event.inputs.version_tag }}
             COMMIT_SHA=${{ github.sha }}
           tags: |
-            ghcr.io/erpc/erpc:latest
-            ghcr.io/erpc/erpc:${{ github.event.inputs.version_tag }}
+            ghcr.io/${{ steps.tag_param.outputs.repo }}:latest
+            ghcr.io/${{ steps.tag_param.outputs.repo }}:${{ github.event.inputs.version_tag }}


### PR DESCRIPTION
Makes the Docker image building part of the release pipeline parameterized, just so that forks can make their own Docker images.

The extra `tag_param` step is necessary as GitHub Actions expressions do not allow string case manipulation, but here we need the lower case ref of the repo.

The change has been tested. A successful run can be found [here](https://github.com/xJonathanLEI/erpc/actions/runs/10647714084/job/29515953574) (apparently ignore the `release` job).