### PR TITLE
feat: cache empty responses for synced and finalized blocks

### DIFF
--- a/common/request.go
+++ b/common/request.go
@@ -149,8 +149,8 @@ func (r *NormalizedRequest) SetNetwork(network Network) {
 
 func (r *NormalizedRequest) ApplyDirectivesFromHttpHeaders(headers *fasthttp.RequestHeader) {
 	drc := &RequestDirectives{
-		RetryEmpty:   string(headers.Peek("X-ERPC-Retry-Empty")) != "false",
-		RetryPending: string(headers.Peek("X-ERPC-Retry-Pending")) != "false",
+		RetryEmpty:    string(headers.Peek("X-ERPC-Retry-Empty")) != "false",
+		RetryPending:  string(headers.Peek("X-ERPC-Retry-Pending")) != "false",
 		SkipCacheRead: string(headers.Peek("X-ERPC-Skip-Cache-Read")) == "true",
 	}
 	r.directives = drc

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func createFixtures(finBlockNumber int64, latestBlockNumber int64) (*data.MockConnector, *Network, *EvmJsonRpcCache) {
+func createFixtures(finBlockNumber int64, latestBlockNumber int64, syncing *bool) (*data.MockConnector, *Network, *EvmJsonRpcCache) {
 	logger := zerolog.New(zerolog.NewConsoleWriter())
 
 	mockConnector := &data.MockConnector{}
@@ -33,6 +33,7 @@ func createFixtures(finBlockNumber int64, latestBlockNumber int64) (*data.MockCo
 		Endpoint: "http://rpc1.localhost",
 		Evm: &common.EvmUpstreamConfig{
 			ChainId: 123,
+			Syncing: syncing,
 		},
 	}, clr, nil, vnr, &logger, nil)
 	if err != nil {
@@ -57,7 +58,7 @@ func createFixtures(finBlockNumber int64, latestBlockNumber int64) (*data.MockCo
 
 func TestEvmJsonRpcCache_Set(t *testing.T) {
 	t.Run("DoNotCacheWhenEthGetTransactionByHashMissingBlockNumber", func(t *testing.T) {
-		mockConnector, _, cache := createFixtures(10, 15)
+		mockConnector, _, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x123"],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"hash":"0x123","blockNumber":null}`))
@@ -69,7 +70,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("CacheIfBlockNumberIsFinalizedWhenBlockIsIrrelevantForPrimaryKey", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xabc",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
@@ -84,7 +85,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("CacheIfBlockNumberIsFinalizedWhenBlockIsUsedForPrimaryKey", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
@@ -99,7 +100,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("SkipWhenNoRefAndNoBlockNumberFound", func(t *testing.T) {
-		mockConnector, _, cache := createFixtures(10, 15)
+		mockConnector, _, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody([]byte(`"0x1234"`))
@@ -111,7 +112,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("CacheIfBlockRefFoundWhetherBlockNumberExistsOrNot", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		testCases := []struct {
 			name        string
@@ -155,7 +156,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("CacheResponseForFinalizedBlock", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
@@ -170,7 +171,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 	})
 
 	t.Run("SkipCachingForUnfinalizedBlock", func(t *testing.T) {
-		mockConnector, _, cache := createFixtures(10, 15)
+		mockConnector, _, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x399",false],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":{"number":"0x399","hash":"0xdef"}}`))
@@ -180,11 +181,78 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		assert.NoError(t, err)
 		mockConnector.AssertNotCalled(t, "Set")
 	})
+
+	t.Run("ShouldNotCacheEmptyResponseIfNodeNotSynced", func(t *testing.T) {
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, &common.TRUE)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`))
+		req.SetNetwork(mockNetwork)
+		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
+
+		err := cache.Set(context.Background(), req, resp)
+
+		assert.NoError(t, err)
+		mockConnector.AssertNotCalled(t, "Set")
+	})
+
+	t.Run("ShouldNotCacheEmptyResponseIfUnknownSyncState", func(t *testing.T) {
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`))
+		req.SetNetwork(mockNetwork)
+		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
+
+		err := cache.Set(context.Background(), req, resp)
+
+		assert.NoError(t, err)
+		mockConnector.AssertNotCalled(t, "Set")
+	})
+
+	t.Run("ShouldNotCacheEmptyResponseIfBlockNotFinalized", func(t *testing.T) {
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, &common.FALSE)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","0x14"],"id":1}`))
+		req.SetNetwork(mockNetwork)
+		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
+
+		err := cache.Set(context.Background(), req, resp)
+
+		assert.NoError(t, err)
+		mockConnector.AssertNotCalled(t, "Set")
+	})
+
+	t.Run("ShouldNotCacheEmptyResponseIfCannotDetermineBlockNumber", func(t *testing.T) {
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, &common.FALSE)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`))
+		req.SetNetwork(mockNetwork)
+		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
+
+		err := cache.Set(context.Background(), req, resp)
+
+		assert.NoError(t, err)
+		mockConnector.AssertNotCalled(t, "Set")
+	})
+
+	t.Run("ShouldCacheEmptyResponseIfNodeSyncedAndBlockFinalized", func(t *testing.T) {
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, &common.FALSE)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","0x5"],"id":1}`))
+		req.SetNetwork(mockNetwork)
+		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
+
+		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		err := cache.Set(context.Background(), req, resp)
+
+		assert.NoError(t, err)
+		mockConnector.AssertCalled(t, "Set", mock.Anything, "evm:123:5", mock.Anything, mock.Anything)
+	})
 }
 
 func TestEvmJsonRpcCache_Get(t *testing.T) {
 	t.Run("ReturnCachedResponseForFinalizedBlock", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
@@ -203,7 +271,7 @@ func TestEvmJsonRpcCache_Get(t *testing.T) {
 	})
 
 	t.Run("SkipCacheForUnfinalizedBlock", func(t *testing.T) {
-		mockConnector, mockNetwork, cache := createFixtures(10, 15)
+		mockConnector, mockNetwork, cache := createFixtures(10, 15, nil)
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x32345",false],"id":1}`))
 		req.SetNetwork(mockNetwork)

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -2152,19 +2152,19 @@ func TestNetwork_Forward(t *testing.T) {
 		defer gock.Off()
 		defer gock.Clean()
 		defer gock.CleanUnmatchedRequest()
-	
+
 		var requestBytes = json.RawMessage(`{"jsonrpc":"2.0","id":9199,"method":"eth_traceTransaction","params":["0x1273c18",false]}`)
-	
+
 		// Mock the upstream response
 		gock.New("http://rpc1.localhost").
 			Post("").
 			Times(2). // Expect two calls
 			Reply(200).
 			JSON(json.RawMessage(`{"result":{"hash":"0x64d340d2470d2ed0ec979b72d79af9cd09fc4eb2b89ae98728d5fb07fd89baf9","fromHost":"rpc1"}}`))
-	
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-	
+
 		clr := upstream.NewClientRegistry(&log.Logger)
 		fsCfg := &common.FailsafeConfig{}
 		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
@@ -2212,7 +2212,7 @@ func TestNetwork_Forward(t *testing.T) {
 			t.Fatal(err)
 		}
 		pup1.Client = cl1
-	
+
 		ntw, err := NewNetwork(
 			&log.Logger,
 			"prjA",
@@ -2230,14 +2230,14 @@ func TestNetwork_Forward(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	
+
 		// First request (should be cached)
 		fakeReq1 := common.NewNormalizedRequest(requestBytes)
 		resp1, err := ntw.Forward(ctx, fakeReq1)
 		if err != nil {
 			t.Fatalf("Expected nil error, got %v", err)
 		}
-	
+
 		// Second request with no-cache directive
 		fakeReq2 := common.NewNormalizedRequest(requestBytes)
 		hdr := &fasthttp.RequestHeader{}
@@ -2247,7 +2247,7 @@ func TestNetwork_Forward(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Expected nil error, got %v", err)
 		}
-	
+
 		// Check that both responses are not nil and different
 		if resp1 == nil || resp2 == nil {
 			t.Fatalf("Expected non-nil responses")
@@ -5246,4 +5246,4 @@ func safeReadBody(request *http.Request) string {
 	}
 	request.Body = io.NopCloser(bytes.NewBuffer(body))
 	return string(body)
-		}
+}


### PR DESCRIPTION
Related to https://github.com/erpc/erpc/issues/55