### PR TITLE
fix: pass enriched log for projectNotFound error

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -115,7 +115,7 @@ func (s *HttpServer) createRequestHandler(mainCtx context.Context, reqMaxTimeout
 
 		project, err := s.erpc.GetProject(projectId)
 		if err != nil {
-			handleErrorResponse(s.logger, nil, err, fastCtx, encoder, buf)
+			handleErrorResponse(&lg, nil, err, fastCtx, encoder, buf)
 			return
 		}
 


### PR DESCRIPTION
Passing the enriched logger (`lg`) instead of the base logger (`s.logger`). By doing so, error logs will include additional context fields like projectId, architecture, and chainId.