### PR TITLE
fix: add blockHash support for certain eth_methods (eip-1898)

### DIFF
--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -104,13 +104,16 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 		if len(r.Params) > 1 {
 			switch secondParam := r.Params[1].(type) {
 			case string:
-				// Handle the second parameter as a HEX String
-				if strings.HasPrefix(secondParam, "0x") {
+				// Handle the 2nd parameter as a blockNumber HEX String
+				if len(secondParam) < 66 && strings.HasPrefix(secondParam, "0x") {
 					bni, err := HexToInt64(secondParam)
 					if err != nil {
 						return secondParam, 0, err
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
+					// Handle the 2nd parameter as a blockHash HEX String
+				} else if len(secondParam) == 66 && strings.HasPrefix(secondParam, "0x") { // 32 bytes * 2 + "0x"
+					return secondParam, 0, nil
 				}
 				return "", 0, nil
 
@@ -176,13 +179,16 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 		if len(r.Params) > 2 {
 			switch thirdParam := r.Params[2].(type) {
 			case string:
-				// Handle the third parameter as a HEX String
+				// Handle the 3rd parameter as a HEX String
 				if strings.HasPrefix(thirdParam, "0x") {
 					bni, err := HexToInt64(thirdParam)
 					if err != nil {
 						return thirdParam, 0, err
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
+					// Handle the 3rd parameter as a blockHash HEX String
+				} else if len(thirdParam) == 66 && strings.HasPrefix(thirdParam, "0x") { // 32 bytes * 2 + "0x"
+					return thirdParam, 0, nil
 				}
 				return "", 0, nil
 

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -79,11 +79,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 
 		return "", 0, nil
 
-	case "eth_getBalance",
-		"eth_getCode",
-		"eth_getTransactionCount",
-		"eth_call",
-		"eth_feeHistory",
+	case "eth_feeHistory",
 		"eth_getAccount":
 		if len(r.Params) > 1 {
 			if bns, ok := r.Params[1].(string); ok {
@@ -99,6 +95,54 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 			}
 		} else {
 			return "", 0, fmt.Errorf("unexpected missing 2nd parameter for method %s: %+v", r.Method, r.Params)
+		}
+
+	case "eth_getBalance",
+		"eth_getTransactionCount",
+		"eth_getCode",
+		"eth_call":
+		if len(r.Params) > 1 {
+			switch secondParam := r.Params[1].(type) {
+			case string:
+				// Handle the second parameter as a HEX String
+				if strings.HasPrefix(secondParam, "0x") {
+					bni, err := HexToInt64(secondParam)
+					if err != nil {
+						return secondParam, 0, err
+					}
+					return strconv.FormatInt(bni, 10), bni, nil
+				}
+				return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+
+			case map[string]interface{}:
+				// Handle the third parameter as an object
+				if blockNumber, exists := secondParam["blockNumber"]; exists {
+					if bns, ok := blockNumber.(string); ok && strings.HasPrefix(bns, "0x") {
+						bni, err := HexToInt64(bns)
+						if err != nil {
+							return bns, 0, err
+						}
+						return strconv.FormatInt(bni, 10), bni, nil
+					}
+					return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				}
+
+				if blockHash, exists := secondParam["blockHash"]; exists {
+					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
+						return bh, 0, nil
+					}
+					return "", 0, fmt.Errorf("invalid blockHash format for method %s: %+v", r.Method, r.Params)
+				}
+
+				// If neither blockNumber nor blockHash is provided
+				return "", 0, fmt.Errorf("missing blockNumber or blockHash in second parameter object for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+
+			default:
+				// If the second parameter is neither string nor map
+				return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+			}
+		} else {
+			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)
 		}
 
 	case "eth_chainId",
@@ -130,16 +174,44 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 	case "eth_getProof",
 		"eth_getStorageAt":
 		if len(r.Params) > 2 {
-			if bns, ok := r.Params[2].(string); ok {
-				if strings.HasPrefix(bns, "0x") {
-					bni, err := HexToInt64(bns)
+			switch thirdParam := r.Params[2].(type) {
+			case string:
+				// Handle the third parameter as a HEX String
+				if strings.HasPrefix(thirdParam, "0x") {
+					bni, err := HexToInt64(thirdParam)
 					if err != nil {
-						return bns, 0, err
+						return thirdParam, 0, err
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
-				} else {
-					return "", 0, nil
 				}
+				return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+
+			case map[string]interface{}:
+				// Handle the third parameter as an object
+				if blockNumber, exists := thirdParam["blockNumber"]; exists {
+					if bns, ok := blockNumber.(string); ok && strings.HasPrefix(bns, "0x") {
+						bni, err := HexToInt64(bns)
+						if err != nil {
+							return bns, 0, err
+						}
+						return strconv.FormatInt(bni, 10), bni, nil
+					}
+					return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				}
+
+				if blockHash, exists := thirdParam["blockHash"]; exists {
+					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
+						return bh, 0, nil
+					}
+					return "", 0, fmt.Errorf("invalid blockHash format for method %s: %+v", r.Method, r.Params)
+				}
+
+				// If neither blockNumber nor blockHash is provided
+				return "", 0, fmt.Errorf("missing blockNumber or blockHash in third parameter object for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+
+			default:
+				// If the third parameter is neither string nor map
+				return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
 			}
 		} else {
 			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -112,7 +112,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
 				}
-				return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
 
 			case map[string]interface{}:
 				// Handle the third parameter as an object
@@ -124,14 +124,14 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 						}
 						return strconv.FormatInt(bni, 10), bni, nil
 					}
-					return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+					return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
 				}
 
 				if blockHash, exists := secondParam["blockHash"]; exists {
 					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
 						return bh, 0, nil
 					}
-					return "", 0, fmt.Errorf("invalid blockHash format for method %s: %+v", r.Method, r.Params)
+					return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
 				}
 
 				// If neither blockNumber nor blockHash is provided
@@ -139,10 +139,10 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 
 			default:
 				// If the second parameter is neither string nor map
-				return "", 0, fmt.Errorf("unsupported second parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
 			}
 		} else {
-			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)
+			return "", 0, fmt.Errorf("unexpected missing 2nd parameter for method %s: %+v", r.Method, r.Params)
 		}
 
 	case "eth_chainId",

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -112,7 +112,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
 				}
-				return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
+				return "", 0, nil
 
 			case map[string]interface{}:
 				// Handle the third parameter as an object
@@ -124,22 +124,22 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 						}
 						return strconv.FormatInt(bni, 10), bni, nil
 					}
-					return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
+					return "", 0, nil
 				}
 
 				if blockHash, exists := secondParam["blockHash"]; exists {
 					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") {
 						return bh, 0, nil
 					}
-					return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
+					return "", 0, nil
 				}
 
 				// If neither blockNumber nor blockHash is provided
-				return "", 0, fmt.Errorf("missing blockNumber or blockHash in 2nd parameter (as an object) for method %s: %+v", r.Method, r.Params)
+				return "", 0, nil
 
 			default:
 				// If the second parameter is neither string nor map
-				return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
+				return "", 0, nil
 			}
 		} else {
 			return "", 0, fmt.Errorf("unexpected missing 2nd parameter for method %s: %+v", r.Method, r.Params)
@@ -184,7 +184,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
 				}
-				return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
+				return "", 0, nil
 
 			case map[string]interface{}:
 				// Handle the third parameter as an object
@@ -196,22 +196,22 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 						}
 						return strconv.FormatInt(bni, 10), bni, nil
 					}
-					return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
+					return "", 0, nil
 				}
 
 				if blockHash, exists := thirdParam["blockHash"]; exists {
 					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") {
 						return bh, 0, nil
 					}
-					return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
+					return "", 0, nil
 				}
 
 				// If neither blockNumber nor blockHash is provided
-				return "", 0, fmt.Errorf("missing blockNumber or blockHash in 3rd parameter (as an object) for method %s: %+v", r.Method, r.Params)
+				return "", 0, nil
 
 			default:
 				// If the third parameter is neither string nor map
-				return "", 0, fmt.Errorf("unsupported 3rd parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, nil
 			}
 		} else {
 			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -135,7 +135,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				}
 
 				// If neither blockNumber nor blockHash is provided
-				return "", 0, fmt.Errorf("missing blockNumber or blockHash in second parameter object for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("missing blockNumber or blockHash in 2nd parameter (as an object) for method %s: %+v", r.Method, r.Params)
 
 			default:
 				// If the second parameter is neither string nor map
@@ -184,7 +184,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 					}
 					return strconv.FormatInt(bni, 10), bni, nil
 				}
-				return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
 
 			case map[string]interface{}:
 				// Handle the third parameter as an object
@@ -196,22 +196,22 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 						}
 						return strconv.FormatInt(bni, 10), bni, nil
 					}
-					return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+					return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
 				}
 
 				if blockHash, exists := thirdParam["blockHash"]; exists {
 					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
 						return bh, 0, nil
 					}
-					return "", 0, fmt.Errorf("invalid blockHash format for method %s: %+v", r.Method, r.Params)
+					return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)
 				}
 
 				// If neither blockNumber nor blockHash is provided
-				return "", 0, fmt.Errorf("missing blockNumber or blockHash in third parameter object for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("missing blockNumber or blockHash in 3rd parameter (as an object) for method %s: %+v", r.Method, r.Params)
 
 			default:
 				// If the third parameter is neither string nor map
-				return "", 0, fmt.Errorf("unsupported third parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
+				return "", 0, fmt.Errorf("unsupported 3rd parameter type for ExtractEvmBlockReferenceFromRequest: %+v", r.Params)
 			}
 		} else {
 			return "", 0, fmt.Errorf("unexpected missing 3rd parameter for method %s: %+v", r.Method, r.Params)

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -118,7 +118,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				return "", 0, nil
 
 			case map[string]interface{}:
-				// Handle the third parameter as an object
+				// Handle the 2nd parameter as an object
 				if blockNumber, exists := secondParam["blockNumber"]; exists {
 					if bns, ok := blockNumber.(string); ok && strings.HasPrefix(bns, "0x") {
 						bni, err := HexToInt64(bns)
@@ -141,7 +141,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				return "", 0, nil
 
 			default:
-				// If the second parameter is neither string nor map
+				// If the 2nd parameter is neither string nor map
 				return "", 0, nil
 			}
 		} else {
@@ -193,7 +193,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				return "", 0, nil
 
 			case map[string]interface{}:
-				// Handle the third parameter as an object
+				// Handle the 3rd parameter as an object
 				if blockNumber, exists := thirdParam["blockNumber"]; exists {
 					if bns, ok := blockNumber.(string); ok && strings.HasPrefix(bns, "0x") {
 						bni, err := HexToInt64(bns)
@@ -216,7 +216,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				return "", 0, nil
 
 			default:
-				// If the third parameter is neither string nor map
+				// If the 3rd parameter is neither string nor map
 				return "", 0, nil
 			}
 		} else {

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -128,7 +128,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				}
 
 				if blockHash, exists := secondParam["blockHash"]; exists {
-					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
+					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") {
 						return bh, 0, nil
 					}
 					return "", 0, fmt.Errorf("unsupported 2nd parameter for method %s: %+v", r.Method, r.Params)
@@ -200,7 +200,7 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 				}
 
 				if blockHash, exists := thirdParam["blockHash"]; exists {
-					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") && len(bh) == 66 { // 32 bytes * 2 + "0x"
+					if bh, ok := blockHash.(string); ok && strings.HasPrefix(bh, "0x") {
 						return bh, 0, nil
 					}
 					return "", 0, fmt.Errorf("unsupported 3rd parameter for method %s: %+v", r.Method, r.Params)

--- a/common/evm_block_ref_test.go
+++ b/common/evm_block_ref_test.go
@@ -180,6 +180,44 @@ func TestExtractBlockReference(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name: "eth_call with blockHash object",
+			request: &JsonRpcRequest{
+				Method: "eth_call",
+				Params: []interface{}{
+					map[string]interface{}{
+						"from": nil,
+						"to":   "0x6b175474e89094c44da98b954eedeac495271d0f",
+						"data": "0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE",
+					},
+					map[string]interface{}{
+						"blockHash": "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3",
+					},
+				},
+			},
+			expectedRef: "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3",
+			expectedNum: 0,
+			expectedErr: false,
+		},
+		{
+			name: "eth_call with blockNumber object",
+			request: &JsonRpcRequest{
+				Method: "eth_call",
+				Params: []interface{}{
+					map[string]interface{}{
+						"from": nil,
+						"to":   "0x6b175474e89094c44da98b954eedeac495271d0f",
+						"data": "0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE",
+					},
+					map[string]interface{}{
+						"blockNumber": "0x1b4",
+					},
+				},
+			},
+			expectedRef: "436",
+			expectedNum: 436,
+			expectedErr: false,
+		},
+		{
 			name: "eth_feeHistory",
 			request: &JsonRpcRequest{
 				Method: "eth_feeHistory",
@@ -247,6 +285,38 @@ func TestExtractBlockReference(t *testing.T) {
 					"0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
 					[]interface{}{"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"},
 					"0x1b4",
+				},
+			},
+			expectedRef: "436",
+			expectedNum: 436,
+			expectedErr: false,
+		},
+		{
+			name: "eth_getProof with blockHash object",
+			request: &JsonRpcRequest{
+				Method: "eth_getProof",
+				Params: []interface{}{
+					"0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
+					[]interface{}{"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"},
+					map[string]interface{}{
+						"blockHash": "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3",
+					},
+				},
+			},
+			expectedRef: "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3",
+			expectedNum: 0,
+			expectedErr: false,
+		},
+		{
+			name: "eth_getProof with blockNumber object",
+			request: &JsonRpcRequest{
+				Method: "eth_getProof",
+				Params: []interface{}{
+					"0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
+					[]interface{}{"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"},
+					map[string]interface{}{
+						"blockNumber": "0x1b4",
+					},
 				},
 			},
 			expectedRef: "436",

--- a/common/evm_json_rpc.go
+++ b/common/evm_json_rpc.go
@@ -60,9 +60,20 @@ func NormalizeEvmHttpJsonRpc(nrq *NormalizedRequest, jrq *JsonRpcRequest) {
 		}
 	case "eth_getStorageAt":
 		if len(jrq.Params) > 2 {
-			b, err := NormalizeHex(jrq.Params[2])
-			if err == nil {
-				jrq.Params[2] = b
+			if strValue, ok := jrq.Params[2].(string); ok {
+				if strings.HasPrefix(strValue, "0x") {
+					b, err := NormalizeHex(strValue)
+					if err == nil {
+						jrq.Params[2] = b
+					}
+				}
+			} else if mapValue, ok := jrq.Params[2].(map[string]interface{}); ok {
+				if blockNumber, ok := mapValue["blockNumber"]; ok {
+					b, err := NormalizeHex(blockNumber)
+					if err == nil {
+						mapValue["blockNumber"] = b
+					}
+				}
 			}
 		}
 	case "eth_getLogs":


### PR DESCRIPTION
This PR updates the `ExtractEvmBlockReferenceFromRequest` for methods (referenced [here](https://eips.ethereum.org/EIPS/eip-1898)) that currently accept a default block parameter (`blockNumber` HEX string or tag such as `latest`) to additionally support block hashes (as an object).

* `"earliest"`
* `"0x0"`
* `{ "blockNumber": "0x0" }`
* `{ "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" }`