### PR TITLE
feat: add interceptors to capture or override request and/or responses

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -19,13 +19,14 @@ var (
 
 // Config represents the configuration of the application.
 type Config struct {
-	LogLevel     string             `yaml:"logLevel" json:"logLevel"`
-	Server       *ServerConfig      `yaml:"server" json:"server"`
-	Database     *DatabaseConfig    `yaml:"database" json:"database"`
-	Projects     []*ProjectConfig   `yaml:"projects" json:"projects"`
-	RateLimiters *RateLimiterConfig `yaml:"rateLimiters" json:"rateLimiters"`
-	Metrics      *MetricsConfig     `yaml:"metrics" json:"metrics"`
-	Admin        *AdminConfig       `yaml:"admin" json:"admin"`
+	LogLevel     string               `yaml:"logLevel" json:"logLevel"`
+	Server       *ServerConfig        `yaml:"server" json:"server"`
+	Database     *DatabaseConfig      `yaml:"database" json:"database"`
+	Projects     []*ProjectConfig     `yaml:"projects" json:"projects"`
+	RateLimiters *RateLimiterConfig   `yaml:"rateLimiters" json:"rateLimiters"`
+	Metrics      *MetricsConfig       `yaml:"metrics" json:"metrics"`
+	Admin        *AdminConfig         `yaml:"admin" json:"admin"`
+	Interceptors []*InterceptorConfig `yaml:"interceptors" json:"interceptors"`
 }
 
 type ServerConfig struct {
@@ -322,6 +323,65 @@ type MetricsConfig struct {
 	ListenV6 bool   `yaml:"listenV6" json:"listenV6"`
 	HostV6   string `yaml:"hostV6" json:"hostV6"`
 	Port     int    `yaml:"port" json:"port"`
+}
+
+type InterceptorType string
+
+const (
+	InterceptorTypeIncomingRequest  InterceptorType = "incomingRequest"
+	InterceptorTypeOutgoingResponse InterceptorType = "outgoingResponse"
+)
+
+type InterceptorConfig struct {
+	Id          string            `yaml:"id" json:"id"`
+	Enabled     bool              `yaml:"enabled" json:"enabled"`
+	Type        InterceptorType   `yaml:"type" json:"type"`
+	Destination DestinationConfig `yaml:"destination" json:"destination"`
+	Evaluation  EvaluationConfig  `yaml:"evaluation" json:"evaluation"`
+}
+
+type DestinationDriver string
+
+const (
+	DestinationDriverFile DestinationDriver = "file"
+)
+
+type DestinationConfig struct {
+	Driver DestinationDriver      `yaml:"driver" json:"driver"`
+	File   *FileDestinationConfig `yaml:"file" json:"file"`
+}
+
+type EvaluationConfig struct {
+	FieldMatch   *FieldMatchConfig   `yaml:"fieldMatch" json:"fieldMatch"`
+	Typescript   *TypescriptConfig   `yaml:"typescript" json:"typescript"`
+	EvmAbiParser *EvmAbiParserConfig `yaml:"evmAbiParser" json:"evmAbiParser"`
+}
+
+type FileDestinationConfig struct {
+	Path string `yaml:"path" json:"path"`
+}
+
+type FieldMatchConfig struct {
+	Networks              []string `yaml:"networks" json:"networks"`
+	Upstreams             []string `yaml:"upstreams" json:"upstreams"`
+	Methods               []string `yaml:"methods" json:"methods"`
+	RequestStringIncludes []string `yaml:"requestRawIncludes" json:"requestRawIncludes"`
+	ResultStringIncludes  []string `yaml:"resultRawIncludes" json:"resultRawIncludes"`
+	ErrorCodes            []string `yaml:"errorCodes" json:"errorCodes"`
+	StatusCodes           []int    `yaml:"statusCodes" json:"statusCodes"`
+}
+
+type TypescriptConfig struct {
+	AllowOverriding bool   `yaml:"allowOverriding" json:"allowOverriding"`
+	ScriptPath      string `yaml:"scriptPath" json:"scriptPath"`
+	ScriptContent   string `yaml:"scriptContent" json:"scriptContent"`
+	Handler         string `yaml:"handler" json:"handler"`
+}
+
+type EvmAbiParserConfig struct {
+	Import                        []string `yaml:"import" json:"import"`
+	EnableForEventsTopicsAndData  bool     `yaml:"enableForLogTopicsAndData" json:"enableForLogTopicsAndData"`
+	EnableForTransactionsCallData bool     `yaml:"enableForTransactionsCallData" json:"enableForTransactionsCallData"`
 }
 
 var cfgInstance *Config


### PR DESCRIPTION
### For debugging

Many times as a user I want to capture a specific request and/or response for debugging purpose. Using logs I end up having either too much noise, or not enough for the specific goal I have.

For example I want to capture only certain eth_* methods only if a certain response is being returned. Or I want to capture timeouts only for certain network, etc. With this module we're able to specific rules (field-based or script-based) to write those request/responses to a file.

---

### For overrides

Additionally we can allow script-based interceptors to override a response (or request) body for example when covering an edge-case on a certain chain or upstream. This allows encapsulating all the RPC-related logic in 1 place (i.e. eRPC config) in a web3 project, rather than spreading these logic across multiple places (backend, frontend, erpc, etc)

An example would be to parse EVM event topics/data or transactions call data arguments, adding USD values, etc, as part of the response, to avoid having extra logic on client-side.