### PR TITLE
Feat: Redis modifications

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -66,17 +66,19 @@ type TLSConfig struct {
 }
 
 type RedisConnectorConfig struct {
-	Addr     string     `yaml:"addr" json:"addr"`
-	Password string     `yaml:"password" json:"password"`
-	DB       int        `yaml:"db" json:"db"`
-	TLS      *TLSConfig `yaml:"tls" json:"tls"`
+	Addr         string     `yaml:"addr" json:"addr"`
+	Password     string     `yaml:"password" json:"password"`
+	DB           int        `yaml:"db" json:"db"`
+	TLS          *TLSConfig `yaml:"tls" json:"tls"`
+	ConnPoolSize int        `yaml:"connPoolSize" json:"connPoolSize"`
 }
 
 func (r *RedisConnectorConfig) MarshalJSON() ([]byte, error) {
 	return sonic.Marshal(map[string]interface{}{
-		"addr":     r.Addr,
-		"password": "REDACTED",
-		"db":       r.DB,
+		"addr":         r.Addr,
+		"password":     "REDACTED",
+		"db":           r.DB,
+		"connPoolSize": r.ConnPoolSize,
 	})
 }
 

--- a/common/config.go
+++ b/common/config.go
@@ -51,6 +51,7 @@ type ConnectorConfig struct {
 	Redis      *RedisConnectorConfig      `yaml:"redis" json:"redis"`
 	DynamoDB   *DynamoDBConnectorConfig   `yaml:"dynamodb" json:"dynamodb"`
 	PostgreSQL *PostgreSQLConnectorConfig `yaml:"postgresql" json:"postgresql"`
+	Methods    []*MethodCacheConfig       `yaml:"methods" json:"methods"`
 }
 
 type MemoryConnectorConfig struct {
@@ -80,6 +81,11 @@ func (r *RedisConnectorConfig) MarshalJSON() ([]byte, error) {
 		"db":           r.DB,
 		"connPoolSize": r.ConnPoolSize,
 	})
+}
+
+type MethodCacheConfig struct {
+	Method string `yaml:"method" json:"method"`
+	TTL    string `yamle:"ttl" json:"ttl"`
 }
 
 type DynamoDBConnectorConfig struct {

--- a/data/connector.go
+++ b/data/connector.go
@@ -15,6 +15,8 @@ const (
 type Connector interface {
 	Get(ctx context.Context, index, partitionKey, rangeKey string) (string, error)
 	Set(ctx context.Context, partitionKey, rangeKey, value string) error
+	SetTTL(method string, ttlStr string) error
+	HasTTL(method string) bool
 	Delete(ctx context.Context, index, partitionKey, rangeKey string) error
 }
 

--- a/data/dynamodb.go
+++ b/data/dynamodb.go
@@ -261,6 +261,15 @@ func ensureGlobalSecondaryIndexes(
 	return err
 }
 
+func (d *DynamoDBConnector) SetTTL(_ string, _ string) error {
+	d.logger.Debug().Msgf("Method TTLs not implemented for DynamoDBConnector")
+	return nil
+}
+
+func (d *DynamoDBConnector) HasTTL(_ string) bool {
+	return false
+}
+
 func (d *DynamoDBConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	if d.client == nil {
 		return fmt.Errorf("DynamoDB client not initialized yet")

--- a/data/memory.go
+++ b/data/memory.go
@@ -42,6 +42,15 @@ func NewMemoryConnector(ctx context.Context, logger *zerolog.Logger, cfg *common
 	}, nil
 }
 
+func (m *MemoryConnector) SetTTL(_ string, _ string) error {
+	m.logger.Debug().Msgf("Method TTLs not implemented for MemoryConnector")
+	return nil
+}
+
+func (d *MemoryConnector) HasTTL(_ string) bool {
+	return false
+}
+
 func (m *MemoryConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	m.cache.Add(key, value)

--- a/data/mock_connector.go
+++ b/data/mock_connector.go
@@ -32,6 +32,18 @@ func (m *MockConnector) Delete(ctx context.Context, index, partitionKey, rangeKe
 	return args.Error(0)
 }
 
+// SetTTL mocks the SetTTL method of the Connector interface
+func (m *MockConnector) SetTTL(method string, ttlStr string) error {
+	args := m.Called(method, ttlStr)
+	return args.Error(0)
+}
+
+// HasTTL mocks the HasTTL method of the Connector interface
+func (m *MockConnector) HasTTL(method string) bool {
+	args := m.Called(method)
+	return args.Bool(0)
+}
+
 // NewMockConnector creates a new instance of MockConnector
 func NewMockConnector() *MockConnector {
 	return &MockConnector{}

--- a/data/postgresql.go
+++ b/data/postgresql.go
@@ -89,6 +89,15 @@ func (p *PostgreSQLConnector) connect(ctx context.Context) error {
 	return nil
 }
 
+func (p *PostgreSQLConnector) SetTTL(_ string, _ string) error {
+	p.logger.Debug().Msgf("Method TTLs not implemented for PostgresSQLConnector")
+	return nil
+}
+
+func (p *PostgreSQLConnector) HasTTL(_ string) bool {
+	return false
+}
+
 func (p *PostgreSQLConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	if p.conn == nil {
 		return fmt.Errorf("PostgreSQLConnector not connected yet")

--- a/data/redis.go
+++ b/data/redis.go
@@ -36,6 +36,7 @@ func NewRedisConnector(
 
 	connector := &RedisConnector{
 		logger: logger,
+		ttls:   make(map[string]time.Duration),
 	}
 
 	// Attempt the actual connecting in background to avoid blocking the main thread.

--- a/data/redis.go
+++ b/data/redis.go
@@ -24,6 +24,7 @@ var _ Connector = (*RedisConnector)(nil)
 type RedisConnector struct {
 	logger *zerolog.Logger
 	client *redis.Client
+	ttls   map[string]time.Duration
 }
 
 func NewRedisConnector(
@@ -113,14 +114,33 @@ func createTLSConfig(tlsCfg *common.TLSConfig) (*tls.Config, error) {
 	return config, nil
 }
 
+func (r *RedisConnector) SetTTL(method string, ttlStr string) error {
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		return err
+	}
+	r.ttls[strings.ToLower(method)] = ttl
+	return nil
+}
+
+func (r *RedisConnector) HasTTL(method string) bool {
+	_, found := r.ttls[strings.ToLower(method)]
+	return found
+}
+
 func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	if r.client == nil {
 		return fmt.Errorf("redis client not initialized yet")
 	}
 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
+	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
+	ttl, found := r.ttls[method]
+	if !found {
+		ttl = time.Duration(0)
+	}
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
-	rs := r.client.Set(ctx, key, value, 0)
+	rs := r.client.Set(ctx, key, value, ttl)
 	return rs.Err()
 }
 

--- a/data/redis.go
+++ b/data/redis.go
@@ -65,6 +65,7 @@ func (r *RedisConnector) connect(ctx context.Context, cfg *common.RedisConnector
 		Addr:     cfg.Addr,
 		Password: cfg.Password,
 		DB:       cfg.DB,
+		PoolSize: cfg.ConnPoolSize,
 	}
 
 	if cfg.TLS != nil && cfg.TLS.Enabled {

--- a/data/redis.go
+++ b/data/redis.go
@@ -134,10 +134,11 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 	}
 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
-	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
-	ttl, found := r.ttls[method]
-	if !found {
-		ttl = time.Duration(0)
+
+	ttl := time.Duration(0)
+	if strings.HasSuffix(partitionKey, ":nil") {
+		method := strings.ToLower(strings.Split(rangeKey, ":")[0])
+		ttl = r.ttls[method]
 	}
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	rs := r.client.Set(ctx, key, value, ttl)

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -81,6 +81,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":{"hash":"0xabc","blockNumber":"0x2"}}`))
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -96,6 +97,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":{"hash":"0xabc","number":"0x2"}}`))
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -148,6 +150,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 				resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(tc.result))
 
 				mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+				mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 				err := cache.Set(context.Background(), req, resp)
 
@@ -167,6 +170,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":{"number":"0x1","hash":"0xabc"}}`))
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -180,6 +184,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x399",false],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":{"number":"0x399","hash":"0xdef"}}`))
 
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -193,6 +198,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		req.SetNetwork(mockNetwork)
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":"0x0"}`))
 
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -206,6 +212,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		req.SetNetwork(mockNetwork)
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":"0x0"}`))
 
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -219,6 +226,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		req.SetNetwork(mockNetwork)
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":"0x0"}`))
 
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -232,6 +240,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		req.SetNetwork(mockNetwork)
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":"0x0"}`))
 
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -246,6 +255,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody(util.StringToReaderCloser(`{"result":"0x0"}`))
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -263,6 +273,7 @@ func TestEvmJsonRpcCache_Get(t *testing.T) {
 
 		cachedResponse := `{"number":"0x1","hash":"0xabc"}`
 		mockConnector.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything).Return(cachedResponse, nil)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 
 		resp, err := cache.Get(context.Background(), req)
 
@@ -279,6 +290,7 @@ func TestEvmJsonRpcCache_Get(t *testing.T) {
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x32345",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
+		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
 		resp, err := cache.Get(context.Background(), req)
 
 		assert.NoError(t, err)


### PR DESCRIPTION
## What?
This PR adds TTL to specific methods and adds connection pool size configuration.
## Why?
TTL has been useful for our specific use case here and we added the connection pool size configuration to help debug a latency issue we are experiencing with batched requests.
## How?
This accomplished by adding SetTTL() and HasTTL() methods to the connector interface.
## Testing?
We've been running this in our environments for a few weeks with no issues.

Most of the contributions were completed by @dshiell and I helped with some debugging and testing.