### PR TITLE
feat: simplify various default configs to be more explicit

### DIFF
--- a/cmd/erpc/main_test.go
+++ b/cmd/erpc/main_test.go
@@ -192,8 +192,7 @@ projects:
       evm:
         chainId: 1
     networks:
-    - id: mainnet
-      architecture: evm
+    - architecture: evm
       evm:
         chainId: 1
 `)

--- a/common/config.go
+++ b/common/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/erpc/erpc/util"
 	"github.com/grafana/sobek"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 )
@@ -89,38 +88,6 @@ type CacheMethodConfig struct {
 	RespRefs  [][]interface{} `yaml:"respRefs" json:"respRefs"`
 	Finalized bool            `yaml:"finalized" json:"finalized"`
 	Realtime  bool            `yaml:"realtime" json:"realtime"`
-}
-
-func (c *CacheConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type rawCacheConfig CacheConfig
-	raw := rawCacheConfig{}
-
-	if err := unmarshal(&raw); err != nil || (raw.Connectors == nil && raw.Policies == nil) || (len(raw.Connectors) == 0 && len(raw.Policies) == 0) {
-		// Backward compatibility for old config format
-		var rawBackward ConnectorConfig
-		if err := unmarshal(&rawBackward); err != nil {
-			return err
-		}
-		rawBackward.Id = "default"
-		c.Connectors = []*ConnectorConfig{&rawBackward}
-		c.Policies = []*CachePolicyConfig{
-			{
-				Network:   "*",
-				Method:    "*",
-				Finality:  DataFinalityStateFinalized,
-				Empty:     CacheEmptyBehaviorAllow,
-				TTL:       0,
-				Connector: "default",
-			},
-		}
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to unmarshal old cache config, please update to new structure based on cache docs")
-		}
-	} else {
-		*c = CacheConfig(raw)
-	}
-
-	return nil
 }
 
 type CachePolicyConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"time"
@@ -578,7 +579,9 @@ func LoadConfig(fs afero.Fs, filename string) (*Config, error) {
 		cfg = *cfgPtr
 	} else {
 		expandedData := []byte(os.ExpandEnv(string(data)))
-		err = yaml.Unmarshal(expandedData, &cfg)
+		decoder := yaml.NewDecoder(bytes.NewReader(expandedData))
+		decoder.KnownFields(true)
+		err = decoder.Decode(&cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -113,6 +113,7 @@ var DefaultWithBlockCacheMethods = map[string]*CacheMethodConfig{
 		ReqRefs: [][]interface{}{
 			{0, "fromBlock"},
 			{0, "toBlock"},
+			{0, "blockHash"},
 		},
 	},
 	"eth_getBlockByHash": {

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -708,14 +708,14 @@ func (r *RetryPolicyConfig) SetDefaults(defaults *RetryPolicyConfig) {
 		if defaults != nil && defaults.BackoffFactor != 0 {
 			r.BackoffFactor = defaults.BackoffFactor
 		} else {
-			r.BackoffFactor = 1.3
+			r.BackoffFactor = 1.2
 		}
 	}
 	if r.BackoffMaxDelay == "" {
 		if defaults != nil && defaults.BackoffMaxDelay != "" {
 			r.BackoffMaxDelay = defaults.BackoffMaxDelay
 		} else {
-			r.BackoffMaxDelay = "5s"
+			r.BackoffMaxDelay = "3s"
 		}
 	}
 	if r.Delay == "" {

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -18,53 +18,9 @@ func (c *Config) SetDefaults() {
 	}
 	c.Server.SetDefaults()
 
-	if c.Database == nil {
-		c.Database = &DatabaseConfig{
-			EvmJsonRpcCache: &CacheConfig{
-				Connectors: []*ConnectorConfig{
-					{
-						Id:     "memory-cache",
-						Driver: DriverMemory,
-					},
-				},
-				Policies: []*CachePolicyConfig{
-					{
-						Network:     "*",
-						Method:      "*",
-						Finality:    DataFinalityStateFinalized,
-						MaxItemSize: util.StringPtr("1mb"),
-						TTL:         0, // Forever
-						Connector:   "memory-cache",
-					},
-					{
-						Network:     "*",
-						Method:      "*",
-						Finality:    DataFinalityStateUnknown,
-						MaxItemSize: util.StringPtr("1mb"),
-						TTL:         30 * time.Second,
-						Connector:   "memory-cache",
-					},
-					{
-						Network:     "*",
-						Method:      "*",
-						Finality:    DataFinalityStateUnfinalized,
-						MaxItemSize: util.StringPtr("1mb"),
-						TTL:         5 * time.Second,
-						Connector:   "memory-cache",
-					},
-					{
-						Network:     "*",
-						Method:      "*",
-						Finality:    DataFinalityStateRealtime,
-						MaxItemSize: util.StringPtr("1mb"),
-						TTL:         2 * time.Second,
-						Connector:   "memory-cache",
-					},
-				},
-			},
-		}
+	if c.Database != nil {
+		c.Database.SetDefaults()
 	}
-	c.Database.SetDefaults()
 
 	if c.Metrics == nil {
 		c.Metrics = &MetricsConfig{}

--- a/common/defaults_test.go
+++ b/common/defaults_test.go
@@ -13,7 +13,7 @@ func TestSetDefaults_NetworkConfig(t *testing.T) {
 		network := &NetworkConfig{}
 		network.SetDefaults(nil, nil)
 
-		assert.NotNil(t, network.Failsafe, "Failsafe should be defined")
+		assert.Nil(t, network.Failsafe, "Failsafe should be nil")
 		assert.EqualValues(t, sysDefCfg.Failsafe, network.Failsafe)
 	})
 
@@ -88,10 +88,10 @@ func TestSetDefaults_NetworkConfig(t *testing.T) {
 		assert.EqualValues(t, &FailsafeConfig{
 			Retry: &RetryPolicyConfig{
 				MaxAttempts:     12345,
-				Delay:           sysDefCfg.Failsafe.Retry.Delay,
-				BackoffMaxDelay: sysDefCfg.Failsafe.Retry.BackoffMaxDelay,
-				BackoffFactor:   sysDefCfg.Failsafe.Retry.BackoffFactor,
-				Jitter:          sysDefCfg.Failsafe.Retry.Jitter,
+				Delay:           "100ms",
+				BackoffMaxDelay: "3s",
+				BackoffFactor:   1.2,
+				Jitter:          "0ms",
 			},
 		}, network.Failsafe)
 		assert.Nil(t, network.Failsafe.Timeout)

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -62,8 +62,6 @@ func ExtractEvmBlockReferenceFromRequest(cacheDal CacheDAL, r *JsonRpcRequest) (
 					if bn > blockNumber {
 						blockNumber = bn
 					}
-				} else {
-					return "", 0, err
 				}
 			}
 		}

--- a/common/evm_block_ref_test.go
+++ b/common/evm_block_ref_test.go
@@ -93,7 +93,7 @@ func TestExtractBlockReference(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name: "eth_getLogs",
+			name: "eth_getLogs with from/to numbers",
 			request: &JsonRpcRequest{
 				Method: "eth_getLogs",
 				Params: []interface{}{
@@ -108,7 +108,21 @@ func TestExtractBlockReference(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name: "eth_getLogs",
+			name: "eth_getLogs with blockHash",
+			request: &JsonRpcRequest{
+				Method: "eth_getLogs",
+				Params: []interface{}{
+					map[string]interface{}{
+						"blockHash": "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+					},
+				},
+			},
+			expectedRef: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			expectedNum: 0,
+			expectedErr: false,
+		},
+		{
+			name: "eth_getLogs with missing fromBlock",
 			request: &JsonRpcRequest{
 				Method: "eth_getLogs",
 				Params: []interface{}{
@@ -117,9 +131,9 @@ func TestExtractBlockReference(t *testing.T) {
 					},
 				},
 			},
-			expectedRef: "",
-			expectedNum: 0,
-			expectedErr: true,
+			expectedRef: "436",
+			expectedNum: 436,
+			expectedErr: false,
 		},
 		{
 			name: "missing parameters in eth_getLogs",
@@ -129,7 +143,7 @@ func TestExtractBlockReference(t *testing.T) {
 			},
 			expectedRef: "",
 			expectedNum: 0,
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			name: "eth_getBalance",
@@ -149,7 +163,7 @@ func TestExtractBlockReference(t *testing.T) {
 			},
 			expectedRef: "",
 			expectedNum: 0,
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			name: "eth_getCode",

--- a/docs/pages/config/database/evm-json-rpc-cache.mdx
+++ b/docs/pages/config/database/evm-json-rpc-cache.mdx
@@ -543,6 +543,7 @@ database:
         reqRefs: 
           - [0, fromBlock]
           - [0, toBlock]
+          - [0, blockHash]
       eth_getBlockByHash:
         reqRefs: [[0]]
         respRefs: [[number], [hash]]
@@ -699,7 +700,8 @@ export default createConfig({
         eth_getLogs: {
           reqRefs: [
             [0, "fromBlock"],
-            [0, "toBlock"]
+            [0, "toBlock"],
+            [0, "blockHash"]
           ]
         },
         eth_getBlockByHash: {

--- a/docs/pages/config/example.mdx
+++ b/docs/pages/config/example.mdx
@@ -279,9 +279,10 @@ projects:
         type: evm
         endpoint: https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/
         rateLimitBudget: global-quicknode
-        # You can disable auto-ignoring unsupported methods, and instead define them explicitly.
-        # This is useful if provider (e.g. dRPC) is not consistent with "unsupported method" responses.
-        autoIgnoreUnsupportedMethods: false
+        # You can enable auto-ignoring unsupported methods, instead of defining them explicitly.
+        # NOTE: some providers (e.g. dRPC) are not consistent with "unsupported method" responses,
+        # so this feature might mark methods as unsupported that are actually supported!
+        autoIgnoreUnsupportedMethods: true
         # To allow auto-batching requests towards the upstream, use these settings.
         # Remember if "supportsBatch" is false, you still can send batch requests to eRPC
         # but they will be sent to upstream as individual requests.

--- a/docs/pages/config/example.mdx
+++ b/docs/pages/config/example.mdx
@@ -125,6 +125,15 @@ server:
     caFile: "/path/to/ca.pem"  # Optional, for client cert verification
     insecureSkipVerify: false  # Optional, defaults to false
 
+# Optional Prometheus metrics server
+metrics:
+  enabled: true
+  listenV4: true
+  hostV4: "0.0.0.0"
+  listenV6: false
+  hostV6: "[::]"
+  port: 4001
+
 # There are various use-cases of database in erpc, such as caching, dynamic configs, rate limit persistence, etc.
 database:
   # `evmJsonRpcCache` defines the destination for caching JSON-RPC cals towards any EVM architecture upstream.
@@ -154,6 +163,7 @@ database:
         method: "*"
         finality: unfinalized
         connector: memory-cache
+        maxItemSize: 1MB # optional max size of item to store via this policy
         ttl: 5s
       - network: "*"
         method: "*"
@@ -170,15 +180,6 @@ database:
         finality: finalized
         connector: postgres-cache
         ttl: 1d
-
-# Optional Prometheus metrics server.
-metrics:
-  enabled: true
-  listenV4: true
-  hostV4: "0.0.0.0"
-  listenV6: false
-  hostV6: "[::]"
-  port: 4001
 
 # Each project is a collection of networks and upstreams.
 # For example "backend", "indexer", "frontend", and you want to use only 1 project you can name it "main"
@@ -204,21 +205,21 @@ projects:
             duration: 30s
           retry:
             maxCount: 3
-            delay: 500ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 500ms
+            delay: 0ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
           # Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
           # a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
           hedge:
-            delay: 3000ms
-            maxCount: 2
+            delay: 500ms
+            maxCount: 1
           circuitBreaker:
-            failureThresholdCount: 30
-            failureThresholdCapacity: 100
-            halfOpenAfter: 60s
-            successThresholdCount: 8
-            successThresholdCapacity: 10
+            failureThresholdCount: 160 # 80% error rate
+            failureThresholdCapacity: 200
+            halfOpenAfter: 5m
+            successThresholdCount: 3
+            successThresholdCapacity: 3
       - architecture: evm
         evm:
           chainId: 42161
@@ -226,14 +227,14 @@ projects:
           timeout:
             duration: 30s
           retry:
-            maxCount: 5
-            delay: 500ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 200ms
+            maxCount: 3
+            delay: 0ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
           hedge:
-            delay: 1000ms
-            maxCount: 2
+            delay: 500ms
+            maxCount: 1
 
     # Each upstream supports 1 or more networks (chains)
     upstreams:
@@ -255,10 +256,10 @@ projects:
             duration: 15s
           retry:
             maxCount: 2
-            delay: 1000ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 500ms
+            delay: 500ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
       - id: blastapi-chain-1
         type: evm
         endpoint: https://eth-mainnet.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
@@ -270,10 +271,10 @@ projects:
             duration: 15s
           retry:
             maxCount: 2
-            delay: 1000ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 500ms
+            delay: 500ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
       - id: quiknode-chain-42161
         type: evm
         endpoint: https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/
@@ -295,10 +296,10 @@ projects:
             duration: 15s
           retry:
             maxCount: 2
-            delay: 1000ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 500ms
+            delay: 500ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
 
         # "id" is a unique identifier to distinguish in logs and metrics.
       - id: alchemy-multi-chain-example
@@ -312,10 +313,10 @@ projects:
             duration: 15s
           retry:
             maxCount: 2
-            delay: 1000ms
-            backoffMaxDelay: 10s
-            backoffFactor: 0.3
-            jitter: 500ms
+            delay: 500ms
+            backoffMaxDelay: 3s
+            backoffFactor: 1.2
+            jitter: 0ms
 
 # Rate limiter allows you to create "shared" budgets for upstreams.
 # For example upstream A and B can use the same budget, which means both of them together must not exceed the defined limits.
@@ -441,7 +442,7 @@ export default createConfig({
     },
   },
 
-  // Optional Prometheus metrics server.
+  // Optional Prometheus metrics server
   metrics: {
     enabled: true,
     listenV4: true,
@@ -472,30 +473,30 @@ export default createConfig({
             chainId: 1,
           },
           // Refer to "Failsafe" section for more details.
-          // On network-level "timeout" is applied for the whole lifecycle of the request (including however many retries)
+          // On network-level "timeout" is applied for the whole lifecycle of the request (including however many retries on upstreams)
           failsafe: {
             timeout: {
               duration: "30s",
             },
             retry: {
               maxCount: 3,
-              delay: "500ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "500ms",
+              delay: "0ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
             // Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
             // a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
             hedge: {
-              delay: "3000ms",
-              maxCount: 2,
+              delay: "500ms",
+              maxCount: 1,
             },
             circuitBreaker: {
-              failureThresholdCount: 30,
-              failureThresholdCapacity: 100,
-              halfOpenAfter: "60s",
-              successThresholdCount: 8,
-              successThresholdCapacity: 10,
+              failureThresholdCount: 160, // 80% error rate
+              failureThresholdCapacity: 200,
+              halfOpenAfter: "5m",
+              successThresholdCount: 3,
+              successThresholdCapacity: 3,
             },
           },
         },
@@ -511,13 +512,13 @@ export default createConfig({
             retry: {
               maxCount: 5,
               delay: "500ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "200ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
             hedge: {
-              delay: "1000ms",
-              maxCount: 2,
+              delay: "500ms",
+              maxCount: 1,
             },
           },
         },
@@ -544,10 +545,10 @@ export default createConfig({
             },
             retry: {
               maxCount: 2,
-              delay: "1000ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "500ms",
+              delay: "500ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
           },
         },
@@ -565,10 +566,10 @@ export default createConfig({
             },
             retry: {
               maxCount: 2,
-              delay: "1000ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "500ms",
+              delay: "500ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
           },
         },
@@ -578,9 +579,10 @@ export default createConfig({
           endpoint:
             "https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/",
           rateLimitBudget: "global-quicknode",
-          // You can disable auto-ignoring unsupported methods, and instead define them explicitly.
-          // This is useful if provider (e.g. dRPC) is not consistent with "unsupported method" responses.
-          autoIgnoreUnsupportedMethods: false,
+          // You can enable auto-ignoring unsupported methods, instead of defining them explicitly.
+          // NOTE: some providers (e.g. dRPC) are not consistent with "unsupported method" responses,
+          // so this feature might mark methods as unsupported that are actually supported!
+          autoIgnoreUnsupportedMethods: true,
           // To allow auto-batching requests towards the upstream, use these settings.
           // Remember if "supportsBatch" is false, you still can send batch requests to eRPC
           // but they will be sent to upstream as individual requests.
@@ -598,10 +600,10 @@ export default createConfig({
             },
             retry: {
               maxCount: 2,
-              delay: "1000ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "500ms",
+              delay: "500ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
           },
         },
@@ -619,10 +621,10 @@ export default createConfig({
             },
             retry: {
               maxCount: 2,
-              delay: "1000ms",
-              backoffMaxDelay: "10s",
-              backoffFactor: 0.3,
-              jitter: "500ms",
+              delay: "500ms",
+              backoffMaxDelay: "3s",
+              backoffFactor: 1.2,
+              jitter: "0ms",
             },
           },
         },

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -1530,7 +1530,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 					Networks: []*common.NetworkConfig{
 						{
 							Architecture: common.ArchitectureEvm,
-							Evm: &common.EvmNetworkConfig{ChainId: 1},
+							Evm:          &common.EvmNetworkConfig{ChainId: 1},
 							Failsafe: &common.FailsafeConfig{
 								// We allow a 2-attempt hedge: the “original” plus 1 “hedge”.
 								Hedge: &common.HedgePolicyConfig{
@@ -1623,7 +1623,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 					Networks: []*common.NetworkConfig{
 						{
 							Architecture: common.ArchitectureEvm,
-							Evm: &common.EvmNetworkConfig{ChainId: 1},
+							Evm:          &common.EvmNetworkConfig{ChainId: 1},
 							Failsafe: &common.FailsafeConfig{
 								// We allow a 2-attempt hedge: the “original” plus 1 “hedge”.
 								Hedge: &common.HedgePolicyConfig{

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -241,7 +241,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				var cancelFn context.CancelFunc
 				ictx, cancelFn = context.WithTimeout(
 					ectx,
-					// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode). 
+					// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
 					//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
 					//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
 					//      but allow the failsafe execution to fail with timeout first for proper error handling.

--- a/erpc/projects_test.go
+++ b/erpc/projects_test.go
@@ -337,15 +337,15 @@ func TestProject_LazyLoadNetworkDefaults(t *testing.T) {
 			ctx,
 			&log.Logger,
 			[]*common.ProjectConfig{prjConfig},
-			nil,                     // EvmJsonRpcCache
-			rateLimiters,           // RateLimitersRegistry
+			nil,          // EvmJsonRpcCache
+			rateLimiters, // RateLimitersRegistry
 			vendors.NewVendorsRegistry(),
 		)
 		if err != nil {
 			t.Fatalf("failed to create ProjectsRegistry: %v", err)
 		}
 
-		// Begin mocking an upstream response for a brand new chain "evm:9999" 
+		// Begin mocking an upstream response for a brand new chain "evm:9999"
 		// that isn't explicitly defined in prjConfig.Networks:
 		gock.New("http://mock.localhost").
 			Post("/").

--- a/upstream/http_json_rpc_client.go
+++ b/upstream/http_json_rpc_client.go
@@ -903,6 +903,21 @@ func extractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					}
 				}
 			}
+			if strings.Contains(err.Message, "tx of type") {
+				// TODO For now we're returning a server-side exception for this error
+				// so that the request is retried on a different upstream which supports the requested TX type.
+				// This must be properly handled when "Upstream Features" is implemented which allows for feature-based routing.
+				return common.NewErrEndpointServerSideException(
+					common.NewErrJsonRpcExceptionInternal(
+						int(code),
+						common.JsonRpcErrorCallException,
+						err.Message,
+						nil,
+						details,
+					),
+					nil,
+				)
+			}
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -407,7 +407,7 @@ func (u *Upstream) Forward(ctx context.Context, req *common.NormalizedRequest, b
 					var cancelFn context.CancelFunc
 					ectx, cancelFn = context.WithTimeout(
 						ectx,
-						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode). 
+						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
 						//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
 						//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
 						//      but allow the failsafe execution to fail with timeout first for proper error handling.


### PR DESCRIPTION
Based on various users' experiences certain defaults are a bit 'too much magic' and they surprise or confuse users:
- [X] By default remove any caching config to allow users to explicitly define what they want
- [x] No defaults for failsafe policies as we have a basic failure rotation and these defaults add some 'unexpected latency'  that confuses users (e.g. default retries or hedges) but if they define them explicitly they know why such overhead is added (cost vs performance)