### PR TITLE
feat: allow js/ts Map objects in config

### DIFF
--- a/erpc/erpc.go
+++ b/erpc/erpc.go
@@ -122,6 +122,22 @@ func (e *ERPC) AdminHandleRequest(ctx context.Context, nq *common.NormalizedRequ
 		}
 		return common.NewNormalizedResponse().WithJsonRpcResponse(jrrs), nil
 
+	case "erpc_config":
+		jrr, err := nq.JsonRpcRequest()
+		if err != nil {
+			return nil, err
+		}
+
+		jrrs, err := common.NewJsonRpcResponse(
+			jrr.ID,
+			e.cfg,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return common.NewNormalizedResponse().WithJsonRpcResponse(jrrs), nil
+
 	case "erpc_project":
 		jrr, err := nq.JsonRpcRequest()
 		if err != nil {


### PR DESCRIPTION
Allow to pass js/ts records for map object (useful for the `methods` config properties in the `evmJsonRpcCache`)

Add a new admin endpoint `erpc_config` to get the current config. Useful to check and debug that the current erpc config matches the one provided (especially for dynamic js/ts stuff)