### PR TITLE
fix: handle quoted syncing state responses in EVM state poller

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -548,6 +548,15 @@ func (e *EvmStatePoller) fetchSyncingState(ctx context.Context) (bool, error) {
 		}
 	}
 
+	// Some upstreams incorrectly wrap the syncing object in quotes, i.e. a JSON string
+	// containing another JSON object. In that case, we handle it below with a second unmarshal.
+	if s, ok := syncing.(string); ok {
+		var nested map[string]interface{}
+		if err := common.SonicCfg.Unmarshal([]byte(s), &nested); err == nil {
+			return true, nil
+		}
+	}
+
 	return false, &common.BaseError{
 		Code:    "ErrEvmStatePoller",
 		Message: "cannot parse syncing state result (must be boolean or object)",


### PR DESCRIPTION
Add a fallback in the `EvmStatePoller` to handle cases where `eth_syncing` is returned as a double-encoded JSON string. This prevents parsing errors when certain upstream providers incorrectly wrap the syncing object in quotes.

```
{
  "level": "error",
  "projectId": "main",
  "upstreamId": "https://rpc.graffiti.farm#redacted=fb0b0",
  "component": "evmStatePoller",
  "error": "ErrEvmStatePoller: cannot parse syncing state result (must be boolean or object) -> ({\"result\":\"{\\\"startingBlock\\\":\\\"0x146e799\\\",\\\"currentBlock\\\":\\\"0x146e79b\\\",\\\"highestBlock\\\":\\\"0x146e79b\\\",\\\"warpChunksAmount\\\":null,\\\"warpChunksProcessed\\\":null}\"})",
  "time": 1741278283561,
  "message": "failed to poll evm state for upstream https://rpc.graffiti.farm#redacted=fb0b0"
}
```