### PR TITLE
fix: enhance eth_getBlockReceipts request reference handling

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -294,7 +294,11 @@ var DefaultWithBlockCacheMethods = map[string]*CacheMethodConfig{
 		ReqRefs: SecondParam,
 	},
 	"eth_getBlockReceipts": {
-		ReqRefs:  FirstParam,
+		ReqRefs: [][]interface{}{
+			{0},
+			{0, "blockHash"},
+			{0, "blockNumber"},
+		},
 		RespRefs: BlockNumberOrBlockHashParam,
 	},
 	"trace_block": {

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -147,7 +147,7 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 
 	if err == nil || common.IsClientError(err) || common.HasErrorCode(err, common.ErrCodeEndpointExecutionException) {
 		if err != nil {
-			lg.Error().Err(err).Msgf("finished forwarding request for network with some client-side exception")
+			lg.Info().Err(err).Msgf("finished forwarding request for network with some client-side exception")
 		} else {
 			if lg.GetLevel() == zerolog.TraceLevel {
 				lg.Info().Object("response", resp).Msgf("successfully forwarded request for network")

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -147,7 +147,7 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 
 	if err == nil || common.IsClientError(err) || common.HasErrorCode(err, common.ErrCodeEndpointExecutionException) {
 		if err != nil {
-			lg.Info().Err(err).Msgf("finished forwarding request for network with some client-side exception")
+			lg.Error().Err(err).Msgf("finished forwarding request for network with some client-side exception")
 		} else {
 			if lg.GetLevel() == zerolog.TraceLevel {
 				lg.Info().Object("response", resp).Msgf("successfully forwarded request for network")


### PR DESCRIPTION
`eth_getBlockReceipts` supports passing an object containing `blockNumber` or `blockHash` as param as well. 

We were only supporting a basic blockNumber or blockTag as string, but with this change, we also support this as well.

```
{
  "jsonrpc": "2.0",
  "method": "eth_getBlockReceipts",
  "params": [
    {
      "blockHash": "0xe869f24fc3596bfaf3d046e5db65c0fc879f6e634fa702bc16f88b37032b19a8"
    }
  ],
  "id": 703
}
```

```
{
    "jsonrpc": "2.0",
    "id": 703,
    "result": [
        {
            "blockHash": "0xe869f24fc3596bfaf3d046e5db65c0fc879f6e634fa702bc16f88b37032b19a8",
            "blockNumber": "0x14f87d8",
            "contractAddress": null,
            ...
}
```