### PR TITLE
fix: expose upstream header even for error responses

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -67,8 +67,12 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					details,
 				),
 			)
-		} else if strings.Contains(msg, "block range") ||
+		} else if strings.Contains(msg, "Try with this block range") ||
+			strings.Contains(msg, "block range is too wide") ||
+			strings.Contains(msg, "this block range should work") ||
+			strings.Contains(msg, "range too large") ||
 			strings.Contains(msg, "exceeds the range") ||
+			strings.Contains(msg, "max block range") ||
 			strings.Contains(msg, "Max range") ||
 			strings.Contains(msg, "limited to") ||
 			strings.Contains(msg, "response size should not") ||
@@ -78,7 +82,8 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.Contains(msg, "too large, max is") ||
 			strings.Contains(msg, "response too large") ||
 			strings.Contains(msg, "query exceeds limit") ||
-			strings.Contains(msg, "exceeds the range") ||
+			strings.Contains(msg, "limit the query to") ||
+			strings.Contains(msg, "maximum block range") ||
 			strings.Contains(msg, "range limit exceeded") {
 			return common.NewErrEndpointRequestTooLarge(
 				common.NewErrJsonRpcExceptionInternal(
@@ -97,7 +102,8 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.Contains(msg, "Too many requests") ||
 			strings.Contains(msg, "Too Many Requests") ||
 			strings.Contains(msg, "under too much load") ||
-			strings.Contains(msg, "reached the quota") {
+			strings.Contains(msg, "reached the quota") ||
+			strings.Contains(msg, "rate limited") {
 			return common.NewErrEndpointCapacityExceeded(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -129,6 +129,8 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-ERPC-Version", common.ErpcVersion)
+		w.Header().Set("X-ERPC-Commit", common.ErpcCommitSha)
 
 		projectId, architecture, chainId, isAdmin, isHealthCheck, err = s.parseUrlPath(r, projectId, architecture, chainId)
 		if err != nil {
@@ -685,8 +687,8 @@ func setResponseHeaders(res interface{}, w http.ResponseWriter) {
 		} else {
 			w.Header().Set("X-ERPC-Cache", "MISS")
 		}
-		if rm.UpstreamId() != "" {
-			w.Header().Set("X-ERPC-Upstream", rm.UpstreamId())
+		if ups := rm.UpstreamId(); ups != "" {
+			w.Header().Set("X-ERPC-Upstream", ups)
 		}
 		w.Header().Set("X-ERPC-Attempts", fmt.Sprintf("%d", rm.Attempts()))
 		w.Header().Set("X-ERPC-Retries", fmt.Sprintf("%d", rm.Retries()))


### PR DESCRIPTION
- Expose `X-Erpc-Upstream` header even for error responses
- Add more error cases for getLogs too-large scenarios, and avoid wrongly handling "invalid block range"
- Expose `X-Erpc-Version` and `X-Erpc-Commit` headers for easier debugging