### PR TITLE
fix: check eth_syncing result to return syncing true state properly

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -553,8 +553,7 @@ func (e *EvmStatePoller) fetchSyncingState(ctx context.Context) (bool, error) {
 	// And any value for "msgCount" means the node is syncing.
 	// Ref. https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/rpc-methods#eth_syncing
 	//
-	// For other EVM chains, returning an object containing "currentBlock", "highestBlock"
-	// means the node is syncing.
+	// For other EVM chains, returning an object containing "currentBlock" means the node is syncing.
 	// Ref. https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_syncing
 	if objectSync, ok := syncing.(map[string]interface{}); ok &&
 		(objectSync["currentBlock"] != nil || objectSync["msgCount"] != nil) {

--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -550,7 +550,9 @@ func (e *EvmStatePoller) fetchSyncingState(ctx context.Context) (bool, error) {
 	}
 
 	if s, ok := syncing.(map[string]interface{}); ok {
-		// Check Arbitrum’s "msgCount" field
+		// For chains such as Arbitrum L2, the syncing state is returned as an object with a "msgCount" field
+		// And any value for "msgCount" means the node is syncing.
+		// Ref. https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/rpc-methods#eth_syncing
 		if _, okMsg := s["msgCount"]; okMsg {
 			return true, nil
 		}

--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -553,7 +553,7 @@ func (e *EvmStatePoller) fetchSyncingState(ctx context.Context) (bool, error) {
 		// For chains such as Arbitrum L2, the syncing state is returned as an object with a "msgCount" field
 		// And any value for "msgCount" means the node is syncing.
 		// Ref. https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/rpc-methods#eth_syncing
-		if _, okMsg := s["msgCount"]; okMsg {
+		if _, ok := s["msgCount"]; ok {
 			return true, nil
 		}
 


### PR DESCRIPTION
Fixing the `eth_syncing` parsing logic so that any object containing the keys startingBlock, currentBlock, or highestBlock is recognized as syncing: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_syncing