### PR TITLE
fix: retryable client side errors mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __debug*
 node_modules
 .next
 .env
+bin/**

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -159,7 +159,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				true, // retryable
+				true, // retryable towards network
 			)
 		}
 
@@ -235,7 +235,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				false, // not retryable
+				false, // not retryable towards network
 			)
 		}
 
@@ -301,7 +301,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						nil,
 						details,
 					),
-					true, // retryable
+					true, // retryable towards network
 				)
 			}
 		}
@@ -348,7 +348,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				true, // retryable
+				true, // retryable towards network
 			)
 		} else if code == -32600 {
 			if dt, ok := err.Data.(map[string]interface{}); ok {
@@ -363,7 +363,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 								nil,
 								details,
 							),
-							true, // retryable
+							true, // retryable towards network
 						)
 					}
 				}
@@ -386,7 +386,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				false, // not retryable
+				false, // not retryable towards network
 			)
 		}
 

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -169,9 +169,6 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.HasPrefix(msg, "Safe block not found") ||
 			strings.HasPrefix(msg, "finalized block not found") ||
 			strings.HasPrefix(msg, "Finalized block not found") {
-
-			details["blockTag"] = strings.ToLower(strings.SplitN(err.Message, " ", 2)[0])
-
 			// by default, we retry this type of clien-side exception as other upstreams might
 			// have/support this specific block tag data.
 			return common.NewErrEndpointClientSideException(

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -278,6 +278,20 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 				)
 			}
+			// Special case for envio's handling of "eth_getBlockReceipts" where they don't support object of
+			// type "BlockNumber" in the "blockHash" field.
+			if strings.Contains(msg, "invalid type: map, expected BlockNumber, 'latest', or 'earliest'") {
+				return common.NewErrEndpointClientSideException(
+					common.NewErrJsonRpcExceptionInternal(
+						int(code),
+						common.JsonRpcErrorInvalidArgument,
+						err.Message,
+						nil,
+						details,
+					),
+					true,
+				)
+			}
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -169,6 +169,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.HasPrefix(msg, "Safe block not found") ||
 			strings.HasPrefix(msg, "finalized block not found") ||
 			strings.HasPrefix(msg, "Finalized block not found") {
+
 			// by default, we retry this type of clien-side exception as other upstreams might
 			// have/support this specific block tag data.
 			return common.NewErrEndpointClientSideException(
@@ -350,7 +351,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			if dt, ok := err.Data.(map[string]interface{}); ok {
 				if innerMsg, ok := dt["message"]; ok {
 					if strings.Contains(innerMsg.(string), "validation errors in batch") {
-						// Return a server-side error so the caller might retry or split the batch.
+						// Return a retryable client-side error so the caller might retry or split the batch.
 						return common.NewErrEndpointClientSideException(
 							common.NewErrJsonRpcExceptionInternal(
 								int(code),

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -159,8 +159,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				common.WithRetryableTowardNetwork(true),
-			)
+			).WithRetryableTowardNetwork(true)
 		}
 
 		//----------------------------------------------------------------
@@ -235,8 +234,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				common.WithRetryableTowardNetwork(false),
-			)
+			).WithRetryableTowardNetwork(false)
 		}
 
 		//----------------------------------------------------------------
@@ -301,8 +299,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						nil,
 						details,
 					),
-					common.WithRetryableTowardNetwork(true),
-				)
+				).WithRetryableTowardNetwork(true)
 			}
 		}
 
@@ -348,8 +345,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				common.WithRetryableTowardNetwork(true),
-			)
+			).WithRetryableTowardNetwork(true)
 		} else if code == -32600 {
 			if dt, ok := err.Data.(map[string]interface{}); ok {
 				if innerMsg, ok := dt["message"]; ok {
@@ -363,8 +359,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 								nil,
 								details,
 							),
-							common.WithRetryableTowardNetwork(true),
-						)
+						).WithRetryableTowardNetwork(true)
 					}
 				}
 			}
@@ -386,8 +381,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				common.WithRetryableTowardNetwork(false),
-			)
+			).WithRetryableTowardNetwork(false)
 		}
 
 		//----------------------------------------------------------------

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -354,7 +354,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						return common.NewErrEndpointClientSideException(
 							common.NewErrJsonRpcExceptionInternal(
 								int(code),
-								common.JsonRpcErrorInvalidArgument,
+								common.JsonRpcErrorUnsupportedException,
 								err.Message,
 								nil,
 								details,

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -149,7 +149,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.HasPrefix(msg, "finalized block not found") ||
 			strings.HasPrefix(msg, "Finalized block not found") {
 
-			// by default, we retry this type of clien-side exception as other upstreams might
+			// by default, we retry this type of client-side exception as other upstreams might
 			// have/support this specific block tag data.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
@@ -368,8 +368,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.Contains(msg, "Invalid Request") ||
 			strings.Contains(msg, "validation errors") ||
 			strings.Contains(msg, "invalid argument") ||
-			strings.Contains(msg, "invalid params") ||
-			strings.Contains(msg, "tx of type") {
+			strings.Contains(msg, "invalid params") {
 
 			// For invalid args/params errors, there is a high chance that the error is due to a mistake that the user
 			// has done, and retrying another upstream would not help.

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -159,7 +159,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				true, // retryable towards network
+				common.WithRetryableTowardNetwork(true),
 			)
 		}
 
@@ -235,7 +235,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				false, // not retryable towards network
+				common.WithRetryableTowardNetwork(false),
 			)
 		}
 
@@ -301,7 +301,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						nil,
 						details,
 					),
-					true, // retryable towards network
+					common.WithRetryableTowardNetwork(true),
 				)
 			}
 		}
@@ -348,7 +348,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				true, // retryable towards network
+				common.WithRetryableTowardNetwork(true),
 			)
 		} else if code == -32600 {
 			if dt, ok := err.Data.(map[string]interface{}); ok {
@@ -363,7 +363,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 								nil,
 								details,
 							),
-							true, // retryable towards network
+							common.WithRetryableTowardNetwork(true),
 						)
 					}
 				}
@@ -386,7 +386,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-				false, // not retryable towards network
+				common.WithRetryableTowardNetwork(false),
 			)
 		}
 

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -159,7 +159,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-			).WithRetryableTowardNetwork(true)
+			)
 		}
 
 		//----------------------------------------------------------------
@@ -299,7 +299,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						nil,
 						details,
 					),
-				).WithRetryableTowardNetwork(true)
+				)
 			}
 		}
 
@@ -345,7 +345,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					nil,
 					details,
 				),
-			).WithRetryableTowardNetwork(true)
+			)
 		} else if code == -32600 {
 			if dt, ok := err.Data.(map[string]interface{}); ok {
 				if innerMsg, ok := dt["message"]; ok {
@@ -359,7 +359,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 								nil,
 								details,
 							),
-						).WithRetryableTowardNetwork(true)
+						)
 					}
 				}
 			}

--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -340,7 +340,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),
-					common.JsonRpcErrorInvalidArgument,
+					common.JsonRpcErrorUnsupportedException,
 					err.Message,
 					nil,
 					details,
@@ -354,7 +354,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 						return common.NewErrEndpointClientSideException(
 							common.NewErrJsonRpcExceptionInternal(
 								int(code),
-								common.JsonRpcErrorUnsupportedException,
+								common.JsonRpcErrorInvalidArgument,
 								err.Message,
 								nil,
 								details,

--- a/common/config.go
+++ b/common/config.go
@@ -393,12 +393,11 @@ type FailsafeConfig struct {
 }
 
 type RetryPolicyConfig struct {
-	MaxAttempts        int      `yaml:"maxAttempts" json:"maxAttempts"`
-	Delay              Duration `yaml:"delay,omitempty" json:"delay" tstype:"Duration"`
-	BackoffMaxDelay    Duration `yaml:"backoffMaxDelay,omitempty" json:"backoffMaxDelay" tstype:"Duration"`
-	BackoffFactor      float32  `yaml:"backoffFactor,omitempty" json:"backoffFactor"`
-	Jitter             Duration `yaml:"jitter,omitempty" json:"jitter" tstype:"Duration"`
-	IgnoreClientErrors bool     `yaml:"ignoreClientErrors,omitempty" json:"ignoreClientErrors"`
+	MaxAttempts     int      `yaml:"maxAttempts" json:"maxAttempts"`
+	Delay           Duration `yaml:"delay,omitempty" json:"delay" tstype:"Duration"`
+	BackoffMaxDelay Duration `yaml:"backoffMaxDelay,omitempty" json:"backoffMaxDelay" tstype:"Duration"`
+	BackoffFactor   float32  `yaml:"backoffFactor,omitempty" json:"backoffFactor"`
+	Jitter          Duration `yaml:"jitter,omitempty" json:"jitter" tstype:"Duration"`
 }
 
 type CircuitBreakerPolicyConfig struct {

--- a/common/errors.go
+++ b/common/errors.go
@@ -1524,12 +1524,12 @@ type ErrEndpointClientSideException struct{ BaseError }
 
 const ErrCodeEndpointClientSideException = "ErrEndpointClientSideException"
 
-func NewErrEndpointClientSideException(cause error, retriable ...bool) error {
-	// Default retriable to false
-	isRetriable := false
+func NewErrEndpointClientSideException(cause error, retryable ...bool) error {
+	// Default retryable to false
+	isRetryable := false
 
-	if len(retriable) > 0 {
-		isRetriable = retriable[0]
+	if len(retryable) > 0 {
+		isRetryable = retryable[0]
 	}
 
 	return &ErrEndpointClientSideException{
@@ -1538,7 +1538,7 @@ func NewErrEndpointClientSideException(cause error, retriable ...bool) error {
 			Message: "client-side error when sending request to remote endpoint",
 			Cause:   cause,
 			Details: map[string]interface{}{
-				"retriable": isRetriable,
+				"retryable": isRetryable,
 			},
 		},
 	}

--- a/common/errors.go
+++ b/common/errors.go
@@ -1984,6 +1984,7 @@ func IsRetryableTowardNetwork(err error) bool {
 		}
 	}
 
+	// If the error is retryable towards upstream, then it is also retryable towards network
 	return IsRetryableTowardsUpstream(err)
 }
 

--- a/common/errors.go
+++ b/common/errors.go
@@ -1543,7 +1543,7 @@ const ErrCodeEndpointClientSideException = "ErrEndpointClientSideException"
 
 var NewErrEndpointClientSideException = func(cause error) RetryableError {
 	return &ErrEndpointClientSideException{
-		BaseError: BaseError{
+		BaseError{
 			Code:    ErrCodeEndpointClientSideException,
 			Message: "client-side error when sending request to remote endpoint",
 			Cause:   cause,

--- a/common/errors.go
+++ b/common/errors.go
@@ -1720,9 +1720,6 @@ var NewErrEndpointMissingData = func(cause error) error {
 			Code:    ErrCodeEndpointMissingData,
 			Message: "remote endpoint does not have this data/block or not synced yet",
 			Cause:   cause,
-			Details: map[string]interface{}{
-				"retryableTowardNetwork": true,
-			},
 		},
 	}
 }

--- a/common/errors.go
+++ b/common/errors.go
@@ -936,7 +936,9 @@ func (e *ErrUpstreamsExhausted) DeepestMessage() string {
 
 func (e *ErrUpstreamsExhausted) UpstreamId() string {
 	if val := e.DeepSearch("upstreamId"); val != nil {
-		return val.(string)
+		if s, ok := val.(string); ok {
+			return s
+		}
 	}
 	return ""
 }

--- a/common/errors.go
+++ b/common/errors.go
@@ -1545,7 +1545,7 @@ func NewErrEndpointClientSideException(cause error) RetryableError {
 	return &ErrEndpointClientSideException{
 		BaseError: BaseError{
 			Code:    ErrCodeEndpointClientSideException,
-			Message: "client-side error, etc.",
+			Message: "client-side error when sending request to remote endpoint",
 			Cause:   cause,
 			Details: map[string]interface{}{
 				"retryableTowardNetwork": true,

--- a/common/errors.go
+++ b/common/errors.go
@@ -90,7 +90,7 @@ type StandardError interface {
 	HasCode(...ErrorCode) bool
 	CodeChain() string
 	DeepestMessage() string
-	DeepSearch(key string) string
+	DeepSearch(key string) interface{}
 	GetCause() error
 	ErrorStatusCode() int
 	Base() *BaseError
@@ -152,13 +152,10 @@ func (e *BaseError) DeepestMessage() string {
 
 	return e.Message
 }
-
-func (e *BaseError) DeepSearch(key string) string {
+func (e *BaseError) DeepSearch(key string) interface{} {
 	if e.Details != nil {
 		if v, ok := e.Details[key]; ok {
-			if s, ok := v.(string); ok {
-				return s
-			}
+			return v
 		}
 	}
 	if e.Cause != nil {
@@ -169,14 +166,14 @@ func (e *BaseError) DeepSearch(key string) string {
 			for _, err := range cs.Unwrap() {
 				if be, ok := err.(StandardError); ok {
 					ds := be.DeepSearch(key)
-					if ds != "" {
+					if ds != nil {
 						return ds
 					}
 				}
 			}
 		}
 	}
-	return ""
+	return nil
 }
 
 func (e *BaseError) GetCause() error {
@@ -938,7 +935,10 @@ func (e *ErrUpstreamsExhausted) DeepestMessage() string {
 }
 
 func (e *ErrUpstreamsExhausted) UpstreamId() string {
-	return e.DeepSearch("upstreamId")
+	if val := e.DeepSearch("upstreamId"); val != nil {
+		return val.(string)
+	}
+	return ""
 }
 
 func (e *ErrUpstreamsExhausted) FromCache() bool {

--- a/common/errors.go
+++ b/common/errors.go
@@ -1956,7 +1956,7 @@ func HasErrorCode(err error, codes ...ErrorCode) bool {
 }
 
 func IsRetryableTowardsUpstream(err error) bool {
-	if !HasErrorCode(
+	if HasErrorCode(
 		err,
 
 		// Circuit breaker is open -> No Retry

--- a/common/errors.go
+++ b/common/errors.go
@@ -2062,7 +2062,7 @@ func ClassifySeverity(err error) Severity {
 	if IsClientError(err) || HasErrorCode(err, ErrCodeEndpointExecutionException) {
 		return SeverityInfo
 	}
-	if IsCapacityIssue(err) || !IsRetryableTowardsUpstream(err) {
+	if !IsRetryableTowardsUpstream(err) {
 		return SeverityWarning
 	}
 	// Usually context cancellation is due to discarded hedged requests.

--- a/common/errors.go
+++ b/common/errors.go
@@ -2033,9 +2033,6 @@ func IsRetryableTowardsUpstream(err error) bool {
 	if HasErrorCode(
 		err,
 
-		// Missing data errors -> No Retry
-		ErrCodeEndpointMissingData,
-
 		// Circuit breaker is open -> No Retry
 		ErrCodeFailsafeCircuitBreakerOpen,
 

--- a/common/errors.go
+++ b/common/errors.go
@@ -1541,7 +1541,7 @@ type ErrEndpointClientSideException struct{ BaseError }
 
 const ErrCodeEndpointClientSideException = "ErrEndpointClientSideException"
 
-func NewErrEndpointClientSideException(cause error) RetryableError {
+var NewErrEndpointClientSideException = func(cause error) RetryableError {
 	return &ErrEndpointClientSideException{
 		BaseError: BaseError{
 			Code:    ErrCodeEndpointClientSideException,

--- a/common/errors.go
+++ b/common/errors.go
@@ -1525,8 +1525,8 @@ type ErrEndpointClientSideException struct{ BaseError }
 const ErrCodeEndpointClientSideException = "ErrEndpointClientSideException"
 
 func NewErrEndpointClientSideException(cause error, retryable ...bool) error {
-	// Default retryable to false
-	isRetryable := false
+	// Default retryable to true
+	isRetryable := true
 
 	if len(retryable) > 0 {
 		isRetryable = retryable[0]

--- a/docs/pages/config/failsafe.mdx
+++ b/docs/pages/config/failsafe.mdx
@@ -95,7 +95,7 @@ export default createConfig({
 
 ## `retry` policy
 
-This policies will retry certain retriable failures, either on network-level and/or upstream-level.
+This policies will retry certain retryable failures, either on network-level and/or upstream-level.
 
 <Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
   <Tabs.Tab>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -3792,7 +3792,7 @@ projects:
 
 ## `retry` policy [Permalink for this section](https://docs.erpc.cloud/config/failsafe\#retry-policy)
 
-This policies will retry certain retriable failures, either on network-level and/or upstream-level.
+This policies will retry certain retryable failures, either on network-level and/or upstream-level.
 
 yamltypescript
 

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -4650,7 +4650,7 @@ func TestHttpServer_EvmGetLogs(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
-		defer util.AssertNoPendingMocks(t, 0)
+		defer util.AssertNoPendingMocks(t, 1)
 
 		cfg := &common.Config{
 			Server: &common.ServerConfig{

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -5318,7 +5318,7 @@ func TestHttpServer_EvmGetBlockByNumber(t *testing.T) {
 
 		statusCode, body := sendRequest(requestBody, nil, nil)
 
-		assert.Equal(t, http.StatusBadRequest, statusCode)
+		assert.Equal(t, http.StatusServiceUnavailable, statusCode)
 
 		var respObject map[string]interface{}
 		err := sonic.UnmarshalString(body, &respObject)

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -276,7 +276,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				}
 				if prevErr, exists := errorsByUpstream.Load(u); exists {
 					pe := prevErr.(error)
-					if !common.IsRetryableTowardsUpstream(pe) || common.IsCapacityIssue(pe) {
+					if !common.IsRetryableTowardsUpstream(pe) {
 						// Do not even try this upstream if we already know
 						// the previous error was not retryable. e.g. Billing issues
 						// Or there was a rate-limit error.

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -1243,7 +1243,7 @@ func TestNetwork_Forward(t *testing.T) {
 		gock.New("http://rpc1.localhost").
 			Post("").
 			Reply(400).
-			JSON([]byte(`{"error":{"message":"invalid argument 0: json: cannot unmarshal string into Go value of type map[string]interface {}"}}}`))
+			JSON([]byte(`{"error":{"code":-32602,"message":"invalid argument 0: json: cannot unmarshal string into Go value of type map[string]interface {}"}}}`))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -179,6 +179,9 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr int
 				nil,
 			)
 		} else if code >= -32099 && code <= -32599 || code >= -32603 && code <= -32699 || code >= -32701 && code <= -32768 {
+			// For invalid request errors (codes above), there is a high chance that the error is due to a mistake that the user
+			// has done, and retrying another upstream would not help.
+			// Ref: https://docs.alchemy.com/reference/error-reference#json-rpc-error-codes
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
 					code,
@@ -187,6 +190,7 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr int
 					nil,
 					details,
 				),
+				false, // not retryable
 			)
 		} else if code == 3 {
 			return common.NewErrEndpointExecutionException(

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -190,8 +190,7 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr int
 					nil,
 					details,
 				),
-				common.WithRetryableTowardNetwork(false),
-			)
+			).WithRetryableTowardNetwork(false)
 		} else if code == 3 {
 			return common.NewErrEndpointExecutionException(
 				common.NewErrJsonRpcExceptionInternal(

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -190,7 +190,7 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr int
 					nil,
 					details,
 				),
-				false, // not retryable towards network
+				common.WithRetryableTowardNetwork(false),
 			)
 		} else if code == 3 {
 			return common.NewErrEndpointExecutionException(

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -190,7 +190,7 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr int
 					nil,
 					details,
 				),
-				false, // not retryable
+				false, // not retryable towards network
 			)
 		} else if code == 3 {
 			return common.NewErrEndpointExecutionException(

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -64,20 +64,20 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 			// We do not retry on parse errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorParseException, msg, nil, details),
-				false, // not retryable
+				false, // not retryable towards network
 			)
 		} else if code == -32010 { // Transaction cost exceeds current gas limit
 			// retrying on gas limit exceeded errors toward other upstreams would be helpful, as max gas limit
 			// can be defined per client (reth, geth, parity, etc.) (still needs to be lower than overall block gas limit)
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorClientSideException, msg, nil, details),
-				true, // retryable
+				true, // retryable towards network
 			)
 		} else if code == -32602 && strings.Contains(msg, "cannot unmarshal hex string") {
 			// we do not retry on invalid argument errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorInvalidArgument, msg, nil, details),
-				false, // not retryable
+				false, // not retryable towards network
 			)
 		} else if strings.Contains(msg, "UNAUTHORIZED") {
 			return common.NewErrEndpointUnauthorized(

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -64,21 +64,18 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 			// We do not retry on parse errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorParseException, msg, nil, details),
-				common.WithRetryableTowardNetwork(false),
-			)
+			).WithRetryableTowardNetwork(false)
 		} else if code == -32010 { // Transaction cost exceeds current gas limit
 			// retrying on gas limit exceeded errors toward other upstreams would be helpful, as max gas limit
 			// can be defined per client (reth, geth, parity, etc.) (still needs to be lower than overall block gas limit)
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorClientSideException, msg, nil, details),
-				common.WithRetryableTowardNetwork(true),
-			)
+			).WithRetryableTowardNetwork(true)
 		} else if code == -32602 && strings.Contains(msg, "cannot unmarshal hex string") {
 			// we do not retry on invalid argument errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorInvalidArgument, msg, nil, details),
-				common.WithRetryableTowardNetwork(false),
-			)
+			).WithRetryableTowardNetwork(false)
 		} else if strings.Contains(msg, "UNAUTHORIZED") {
 			return common.NewErrEndpointUnauthorized(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorUnauthorized, msg, nil, details),

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -46,7 +46,8 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 			details["data"] = err.Data
 		}
 
-		if code == -32614 && strings.Contains(msg, "eth_getLogs") && strings.Contains(msg, "limited") {
+		if (code == -32614 && strings.Contains(msg, "eth_getLogs") && strings.Contains(msg, "limited")) ||
+			strings.Contains(msg, "eth_getLogs and eth_newFilter are limited") {
 			return common.NewErrEndpointRequestTooLarge(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorEvmLargeRange, msg, nil, details),
 				common.EvmBlockRangeTooLarge,

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -60,8 +60,9 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorCapacityExceeded, msg, nil, details),
 			)
 		} else if strings.Contains(msg, "failed to parse") {
+			// We do not retry on parse errors, as they are not retryable.
 			return common.NewErrEndpointClientSideException(
-				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorParseException, msg, nil, details),
+				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorParseException, msg, nil, details), false, // not retryable
 			)
 		} else if code == -32010 {
 			return common.NewErrEndpointClientSideException(

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -64,20 +64,20 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 			// We do not retry on parse errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorParseException, msg, nil, details),
-				false, // not retryable towards network
+				common.WithRetryableTowardNetwork(false),
 			)
 		} else if code == -32010 { // Transaction cost exceeds current gas limit
 			// retrying on gas limit exceeded errors toward other upstreams would be helpful, as max gas limit
 			// can be defined per client (reth, geth, parity, etc.) (still needs to be lower than overall block gas limit)
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorClientSideException, msg, nil, details),
-				true, // retryable towards network
+				common.WithRetryableTowardNetwork(true),
 			)
 		} else if code == -32602 && strings.Contains(msg, "cannot unmarshal hex string") {
 			// we do not retry on invalid argument errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorInvalidArgument, msg, nil, details),
-				false, // not retryable towards network
+				common.WithRetryableTowardNetwork(false),
 			)
 		} else if strings.Contains(msg, "UNAUTHORIZED") {
 			return common.NewErrEndpointUnauthorized(

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -70,7 +70,7 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 			// can be defined per client (reth, geth, parity, etc.) (still needs to be lower than overall block gas limit)
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorClientSideException, msg, nil, details),
-			).WithRetryableTowardNetwork(true)
+			)
 		} else if code == -32602 && strings.Contains(msg, "cannot unmarshal hex string") {
 			// we do not retry on invalid argument errors, as retrying another upstream would not help.
 			return common.NewErrEndpointClientSideException(

--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -66,14 +66,15 @@ func (v *QuicknodeVendor) GetVendorSpecificErrorIfAny(resp *http.Response, jrr i
 				false, // not retryable
 			)
 		} else if code == -32010 { // Transaction cost exceeds current gas limit
-			// We do not retry low gas limit errors, as retrying another upstream would not help.
+			// retrying on gas limit exceeded errors toward other upstreams would be helpful, as max gas limit
+			// can be defined per client (reth, geth, parity, etc.) (still needs to be lower than overall block gas limit)
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorClientSideException, msg, nil, details),
-				false, // not retryable
+				true, // retryable
 			)
 		} else if code == -32602 {
 			if strings.Contains(msg, "cannot unmarshal hex string") {
-				// We do not retry on invalid argument errors, as retrying another upstream would not help.
+				// we do not retry on invalid argument errors, as retrying another upstream would not help.
 				return common.NewErrEndpointClientSideException(
 					common.NewErrJsonRpcExceptionInternal(code, common.JsonRpcErrorInvalidArgument, msg, nil, details),
 					false, // not retryable

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -298,11 +298,14 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig) (fails
 			return false
 		}
 
+		// We are only short-circuiting retry if the error is not retryable towards the upstream or network
 		if scope == common.ScopeUpstream && err != nil {
-			return common.IsRetryableTowardsUpstream(err)
+			if !common.IsRetryableTowardsUpstream(err) {
+				return false
+			}
 		} else if scope == common.ScopeNetwork && err != nil {
-			if rt := common.IsRetryableTowardNetwork(err); rt != nil {
-				return *rt
+			if !common.IsRetryableTowardNetwork(err) {
+				return false
 			}
 		}
 

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -301,7 +301,9 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig) (fails
 		if scope == common.ScopeUpstream && err != nil {
 			return common.IsRetryableTowardsUpstream(err)
 		} else if scope == common.ScopeNetwork && err != nil {
-			return common.IsRetryableTowardNetwork(err)
+			if rt := common.IsRetryableTowardNetwork(err); rt != nil {
+				return *rt
+			}
 		}
 
 		if scope == common.ScopeNetwork && result != nil && !result.IsObjectNull() {

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -298,9 +298,9 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig) (fails
 			return false
 		}
 
-		if scope == common.ScopeUpstream {
+		if scope == common.ScopeUpstream && err != nil {
 			return common.IsRetryableTowardsUpstream(err)
-		} else if scope == common.ScopeNetwork {
+		} else if scope == common.ScopeNetwork && err != nil {
 			return common.IsRetryableTowardNetwork(err)
 		}
 


### PR DESCRIPTION
Since when we have client error it'll not be retried properly towards other upstreams, it would be useful to have a mechanism for such retryable client-side errors.