### PR TITLE
fix: add ProxyPool and Headers to upstreamDefaults

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -966,6 +966,8 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 			BatchMaxSize:  defaults.JsonRpc.BatchMaxSize,
 			BatchMaxWait:  defaults.JsonRpc.BatchMaxWait,
 			EnableGzip:    defaults.JsonRpc.EnableGzip,
+			ProxyPool:     defaults.JsonRpc.ProxyPool,
+			Headers:       defaults.JsonRpc.Headers,
 		}
 	}
 	if u.Routing == nil {


### PR DESCRIPTION
We were not applying `ProxyPool` and `Headers` from `upstreamDefaults` to individual ones