### PR TITLE
fix: handle cases where all upstream responses are empty

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
 
       # First, for a PR, checkout the base repository's main branch
       - name: Checkout base main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
 
       - name: Generate types
         run: |
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - name: Install dependencies
         run: make setup
       - name: Build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,9 +20,11 @@
             "cwd": "${workspaceFolder}",
             "showLog": true,
             "dlvFlags": [
+                "--check-go-version",
+                "false",
                 "--log",
                 "--log-output",
-                "debugger,debuglineerr,gdbwire,lldbout,rpc"
+                "debugger,debuglineerr,gdbwire,lldbout,rpc",
             ]
         }
     ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #     - final -> Final stage where we copy the Go binary and the TS files
 
 # Build stage for Go
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.23-alpine AS go-builder
 
 WORKDIR /root
 

--- a/Dockerfile.fake
+++ b/Dockerfile.fake
@@ -1,5 +1,5 @@
 # Use a Go base image
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 

--- a/architecture/evm/eth_getLogs_test.go
+++ b/architecture/evm/eth_getLogs_test.go
@@ -352,7 +352,7 @@ func TestUpstreamPreForward_eth_getLogs(t *testing.T) {
 					"fromBlock": "0x1",
 					"toBlock":   "0x14", // 20 blocks
 				})
-
+				n.On("Id").Return("evm:123")
 				n.On("Config").Return(&common.NetworkConfig{
 					Evm: &common.EvmNetworkConfig{
 						Integrity: &common.EvmIntegrityConfig{
@@ -393,7 +393,7 @@ func TestUpstreamPreForward_eth_getLogs(t *testing.T) {
 					"toBlock":   "0x2",
 					"address":   []interface{}{"0xABC", "0xDEF", "0x123"},
 				})
-
+				n.On("Id").Return("evm:123")
 				n.On("Config").Return(&common.NetworkConfig{
 					Evm: &common.EvmNetworkConfig{
 						Integrity: &common.EvmIntegrityConfig{
@@ -425,13 +425,13 @@ func TestUpstreamPreForward_eth_getLogs(t *testing.T) {
 			setup: func() (*mockNetwork, *mockEvmUpstream, *common.NormalizedRequest) {
 				n := new(mockNetwork)
 				u := new(mockEvmUpstream)
-
 				r := createTestRequest(map[string]interface{}{
 					"fromBlock": "0x1",
 					"toBlock":   "0x2",
 					"topics":    []interface{}{"0xAAA", "0xBBB", "0xCCC"},
 				})
 
+				n.On("Id").Return("evm:123")
 				n.On("Config").Return(&common.NetworkConfig{
 					Evm: &common.EvmNetworkConfig{
 						Integrity: &common.EvmIntegrityConfig{

--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -391,7 +391,7 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 			}
 		} else {
 			for _, req := range requests {
-				req.err <- common.NewErrEndpointTransportFailure(err)
+				req.err <- common.NewErrEndpointTransportFailure(c.Url, err)
 			}
 		}
 		return
@@ -630,7 +630,7 @@ func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *c
 		} else if errors.Is(err, context.Canceled) {
 			return nil, common.NewErrEndpointRequestCanceled(err)
 		}
-		return nil, common.NewErrEndpointTransportFailure(err)
+		return nil, common.NewErrEndpointTransportFailure(c.Url, err)
 	}
 	defer resp.Body.Close()
 
@@ -638,7 +638,7 @@ func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *c
 	if resp.Header.Get("Content-Encoding") == "gzip" {
 		gzReader, err := gzip.NewReader(resp.Body)
 		if err != nil {
-			return nil, common.NewErrEndpointTransportFailure(fmt.Errorf("cannot create gzip reader: %w", err))
+			return nil, common.NewErrEndpointTransportFailure(c.Url, fmt.Errorf("cannot create gzip reader: %w", err))
 		}
 		defer gzReader.Close()
 		bodyReader = gzReader

--- a/common/errors.go
+++ b/common/errors.go
@@ -97,6 +97,7 @@ type StandardError interface {
 	ErrorStatusCode() int
 	Base() *BaseError
 	MarshalZerologObject(v *zerolog.Event)
+	Error() string
 }
 
 type RetryableError interface {
@@ -881,6 +882,9 @@ func (e *ErrUpstreamsExhausted) SummarizeCauses() string {
 		}
 		if billing > 0 {
 			reasons = append(reasons, fmt.Sprintf("%d upstream billing issues", billing))
+		}
+		if transport > 0 {
+			reasons = append(reasons, fmt.Sprintf("%d upstream transport errors", transport))
 		}
 		if cancelled > 0 {
 			reasons = append(reasons, fmt.Sprintf("%d hedges cancelled", cancelled))

--- a/data/redis.go
+++ b/data/redis.go
@@ -141,7 +141,7 @@ func (r *RedisConnector) checkReady() error {
 	}
 	state := r.initializer.State()
 	if state != util.StateReady {
-		return fmt.Errorf("redis is not connected (%s)", state.String())
+		return fmt.Errorf("redis is not connected (state: %s), errors: %v", state.String(), r.initializer.Errors())
 	}
 	if r.client == nil {
 		return fmt.Errorf("redis client not initialized yet")

--- a/docs/pages/config/example.mdx
+++ b/docs/pages/config/example.mdx
@@ -206,9 +206,6 @@ projects:
           retry:
             maxAttempts: 3
             delay: 0ms
-            backoffMaxDelay: 3s
-            backoffFactor: 1.2
-            jitter: 0ms
           # Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
           # a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
           hedge:
@@ -229,9 +226,6 @@ projects:
           retry:
             maxAttempts: 3
             delay: 0ms
-            backoffMaxDelay: 3s
-            backoffFactor: 1.2
-            jitter: 0ms
           hedge:
             delay: 500ms
             maxCount: 1
@@ -487,9 +481,6 @@ export default createConfig({
             retry: {
               maxAttempts: 3,
               delay: "0ms",
-              backoffMaxDelay: "3s",
-              backoffFactor: 1.2,
-              jitter: "0ms",
             },
             // Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
             // a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
@@ -517,10 +508,7 @@ export default createConfig({
             },
             retry: {
               maxAttempts: 3,
-              delay: "500ms",
-              backoffMaxDelay: "3s",
-              backoffFactor: 1.2,
-              jitter: "0ms",
+              delay: "0ms",
             },
             hedge: {
               delay: "500ms",

--- a/docs/pages/config/failsafe.mdx
+++ b/docs/pages/config/failsafe.mdx
@@ -110,12 +110,12 @@ projects:
         failsafe:
           # ...
           # On network-level retry policy applies to the incoming request to eRPC,
-          # this is additional to the retry policy set on upstream level.
+          # this will be additional to the retry policy set on upstream level.
           retry:
             # Total retries besides the initial request:
             maxAttempts: 3
-            # Min delay between retries:
-            delay: 500ms
+            # Min delay between retries (most often you don't need to set this for network-level retry):
+            delay: 0ms
             # Maximum delay between retries:
             backoffMaxDelay: 10s
             # Multiplier for each retry for exponential backoff:
@@ -161,8 +161,8 @@ export default createConfig({
             retry: {
               // Total retries besides the initial request:
               maxAttempts: 3,
-              // Min delay between retries:
-              delay: "500ms",
+              // Min delay between retries (most often you don't need to set this for network-level retry):
+              delay: "0ms",
               // Maximum delay between retries:
               backoffMaxDelay: "10s",
               // Multiplier for each retry for exponential backoff:

--- a/docs/pages/config/projects/networks.mdx
+++ b/docs/pages/config/projects/networks.mdx
@@ -114,12 +114,9 @@ projects:
             duration: 30s
           retry:
             # It is recommended to set a retry policy on network-level to make sure if one upstream is rate-limited,
-            # the request will be retried on another upstream.
+            # the request will be retried on another upstream. Most often you don't need to set a delay.
             maxAttempts: 3
-            delay: 100ms
-            jitter: 0ms
-            backoffMaxDelay: 1s
-            backoffFactor: 1.5
+            delay: 0ms
           # Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
           # a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
           hedge:
@@ -249,12 +246,9 @@ export default createConfig({
             },
             retry: {
               // It is recommended to set a retry policy on network-level to make sure if one upstream is rate-limited,
-              // the request will be retried on another upstream.
+              // the request will be retried on another upstream. Most often you don't need to set a delay.
               maxAttempts: 3,
-              delay: "100ms",
-              jitter: "0ms",
-              backoffMaxDelay: "1s",
-              backoffFactor: 1.5,
+              delay: "0ms",
             },
             // Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
             // a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
@@ -296,7 +290,6 @@ projects:
       # https://docs.erpc.cloud/config/failsafe
       # If a network has its own failsafe defined, it will not take any of policies from networkDefaults.
       # i.e. if network has only "timeout" policy, it will NOT get hedge/retry from networkDefaults (those will be disabled).
-      # Here are default values used for networkDefaults if not explicitly defined:
       failsafe:
         timeout:
           duration: "30s"
@@ -305,10 +298,7 @@ projects:
           maxCount: 3
         retry:
           maxAttempts: 3
-          delay: "100ms"
-          jitter: "0ms"
-          backoffMaxDelay: "1s"
-          backoffFactor: 1.5
+          delay: "0ms"
 
       # (OPTIONAL) Refer to "Selection Policy" section for more details about default values.
       # https://docs.erpc.cloud/config/projects/selection-policies#config
@@ -354,7 +344,6 @@ export default createConfig({
 
         // (OPTIONAL) Refer to "Failsafe" section for more details.
         // https://docs.erpc.cloud/config/failsafe
-        // Here are default values used for networks if not explicitly defined:
         failsafe: {
           timeout: {
             duration: "30s",
@@ -365,10 +354,7 @@ export default createConfig({
           },
           retry: {
             maxAttempts: 3,
-            delay: "100ms",
-            jitter: "0ms",
-            backoffMaxDelay: "1s",
-            backoffFactor: 1.5,
+            delay: "0ms",
           },
         },
 

--- a/docs/pages/operation/tracing.mdx
+++ b/docs/pages/operation/tracing.mdx
@@ -12,6 +12,7 @@ tracing:
   endpoint: "localhost:4317"  # OTLP endpoint (Jaeger, Tempo, etc.)
   protocol: "grpc"            # "grpc" or "http"
   samplingRatio: 0.1          # Sample 10% of requests
+  detailed: true              # Include detailed tracing information
   tls:
     enabled: false            # Enable TLS for secure connections
     # certFile: "/path/to/cert.pem"
@@ -22,6 +23,14 @@ server:
 projects:
  # ...
 ```
+
+### Detailed tracing
+
+When `tracing.detailed` is set to true, eRPC will include detailed tracing information in the traces. This includes:
+- Internal operations and mutex locks (useful to debug long requests that are not waiting for any I/O)
+- High-cardinality attributes (e.g. request json-rpc IDs, request params, actual cache keys used, etc.)
+
+Remember that detailed tracing can significantly increase the volume of traces, so use it judiciously.
 
 ## Using with Jaeger
 
@@ -39,11 +48,12 @@ The included [`docker-compose.yml`](https://github.com/erpc/erpc/blob/main/docke
      endpoint: "localhost:4317"
      protocol: "grpc"
      samplingRatio: 1.0 # Sample all requests during development
+     detailed: true
    ```
 
 3. Access the Jaeger UI at http://localhost:16686
 
-## Traced Components
+## Traced components
 
 The following components are instrumented with tracing:
 
@@ -53,3 +63,8 @@ The following components are instrumented with tracing:
 - Cache operations (get/set)
 - Failsafe executor operations (hedges, retries)
 - HTTP client requests to upstreams
+- Rate limiters
+- And more...
+
+If you noticed a missing component from tracing, free free to open an [issue or PR](https://github.com/erpc/erpc/issues/new)!
+

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -840,12 +840,12 @@ func processErrorBody(logger *zerolog.Logger, startedAt *time.Time, nq *common.N
 			reqId = jrr.ID
 		}
 	}
-	jre := &common.ErrJsonRpcExceptionInternal{}
 	// This is a special attempt to extract execution errors first (e.g. execution reverted):
 	exe := &common.ErrEndpointExecutionException{}
 	if errors.As(err, &exe) {
 		err = exe
 	}
+	jre := &common.ErrJsonRpcExceptionInternal{}
 	if errors.As(err, &jre) {
 		message := jre.Message
 		deepestMessage := jre.DeepestMessage()

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -3368,6 +3368,150 @@ func TestHttpServer_MultipleUpstreams(t *testing.T) {
 		assert.Equal(t, http.StatusOK, statusCode1)
 		assert.Contains(t, body1, "0x1111111")
 	})
+
+	t.Run("ShouldReturnEmptyArrayWhenHedgeAndRetryDefinedOnBothNetworkAndUpstream", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		// Configure multiple upstreams to test failover behavior
+		cfg := &common.Config{
+			Server: &common.ServerConfig{
+				MaxTimeout: common.Duration(5 * time.Second).Ptr(),
+			},
+			Projects: []*common.ProjectConfig{
+				{
+					Id: "test_project",
+					NetworkDefaults: &common.NetworkDefaults{
+						DirectiveDefaults: &common.DirectiveDefaultsConfig{
+							RetryEmpty: &common.TRUE,
+						},
+					},
+					Networks: []*common.NetworkConfig{
+						{
+							Architecture: common.ArchitectureEvm,
+							Evm: &common.EvmNetworkConfig{
+								ChainId: 1,
+							},
+							Failsafe: &common.FailsafeConfig{
+								Hedge: &common.HedgePolicyConfig{
+									MaxCount: 2,
+									Quantile: 0.99,
+								},
+								Retry: &common.RetryPolicyConfig{
+									MaxAttempts: 8,
+									Delay:       common.Duration(5 * time.Millisecond),
+								},
+							},
+						},
+					},
+					Upstreams: []*common.UpstreamConfig{
+						{
+							Id:       "rpc1",
+							Type:     common.UpstreamTypeEvm,
+							Endpoint: "http://rpc1.localhost",
+							Evm: &common.EvmUpstreamConfig{
+								ChainId: 1,
+							},
+							JsonRpc: &common.JsonRpcUpstreamConfig{
+								SupportsBatch: &common.FALSE,
+							},
+							Failsafe: &common.FailsafeConfig{
+								Retry: &common.RetryPolicyConfig{
+									MaxAttempts: 3,
+									Delay:       common.Duration(10 * time.Millisecond),
+								},
+							},
+						},
+						{
+							Id:       "rpc2",
+							Type:     common.UpstreamTypeEvm,
+							Endpoint: "http://rpc2.localhost",
+							Evm: &common.EvmUpstreamConfig{
+								ChainId: 1,
+							},
+							JsonRpc: &common.JsonRpcUpstreamConfig{
+								SupportsBatch: &common.FALSE,
+							},
+							Failsafe: &common.FailsafeConfig{
+								Retry: &common.RetryPolicyConfig{
+									MaxAttempts: 3,
+									Delay:       common.Duration(10 * time.Millisecond),
+								},
+							},
+						},
+					},
+				},
+			},
+			RateLimiters: &common.RateLimiterConfig{},
+		}
+
+		// Mock the first upstream to return an empty result array
+		gock.New("http://rpc1.localhost").
+			Post("/").
+			Times(2).
+			Filter(func(request *http.Request) bool {
+				body := util.SafeReadBody(request)
+				return strings.Contains(string(body), "eth_getLogs")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  []interface{}{}, // Empty array result
+			})
+
+		// Mock the second upstream to also return an empty result array
+		gock.New("http://rpc2.localhost").
+			Post("/").
+			Times(1).
+			Filter(func(request *http.Request) bool {
+				body := util.SafeReadBody(request)
+				return strings.Contains(string(body), "eth_getLogs")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  []interface{}{}, // Empty array result
+			})
+
+		// Set up test fixtures
+		sendRequest, _, _, shutdown, _ := createServerTestFixtures(cfg, t)
+		defer shutdown()
+
+		// Prepare a getLogs request with specific parameters
+		requestBody := `{
+			"jsonrpc": "2.0",
+			"method": "eth_getLogs",
+			"params": [{
+				"fromBlock": "0x1ab771",
+				"toBlock": "0x1ab7d5",
+				"topics": ["0xbccc00b713f54173962e7de6098f643d8ebf53d488d71f4b2a5171496d038f9e"]
+			}],
+			"id": 1
+		}`
+
+		// Send the request
+		statusCode, body := sendRequest(requestBody, nil, nil)
+
+		// Verify the response
+		assert.Equal(t, http.StatusOK, statusCode, "Status code should be 200 OK")
+		
+		var response map[string]interface{}
+		err := json.Unmarshal([]byte(body), &response)
+		require.NoError(t, err, "Should be able to decode response")
+		
+		// Verify the result is an empty array, not an error
+		assert.Contains(t, response, "result", "Response should contain 'result' field")
+		assert.NotContains(t, response, "error", "Response should not contain 'error' field")
+		
+		// Verify the result is an empty array
+		result, ok := response["result"].([]interface{})
+		assert.True(t, ok, "Result should be an array")
+		assert.Empty(t, result, "Result should be an empty array")
+	})
 }
 
 func TestHttpServer_IntegrationTests(t *testing.T) {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -432,8 +432,8 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	if execErr != nil {
 		err := upstream.TranslateFailsafeError(common.ScopeNetwork, "", method, execErr, &startTime)
 		// If error is due to empty response be generous and accept it,
-		// because this means after many retries still no data is available.
-		if common.HasErrorCode(err, common.ErrCodeFailsafeRetryExceeded) {
+		// because this means after many retries or exhausting all upstreams still no data is available.
+		if common.HasErrorCode(err, common.ErrCodeFailsafeRetryExceeded) || common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted) {
 			// TODO is there a cleaner way to use last result when retry is exhausted?
 			lvr := req.LastValidResponse()
 			if !lvr.IsObjectNull(ctx) {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -386,6 +386,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				if err != nil {
 					errorsByUpstream.Store(u, err)
 				} else if r.IsResultEmptyish(loopCtx) {
+					errorsByUpstream.Store(u, common.NewErrEndpointMissingData(nil))
 					emptyResponses.Store(u, true)
 				}
 
@@ -430,26 +431,21 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	defer req.RUnlock()
 
 	if execErr != nil {
-		err := upstream.TranslateFailsafeError(common.ScopeNetwork, "", method, execErr, &startTime)
-		// If error is due to empty response be generous and accept it,
-		// because this means after many retries or exhausting all upstreams still no data is available.
-		if common.HasErrorCode(err, common.ErrCodeFailsafeRetryExceeded) || common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted) {
-			// TODO is there a cleaner way to use last result when retry is exhausted?
-			lvr := req.LastValidResponse()
-			if !lvr.IsObjectNull(ctx) {
-				if lvr.IsResultEmptyish(ctx) {
-					// We don't need to worry about replying wrongly empty responses for unfinalized data
-					// because cache layer already is not caching unfinalized data.
-					resp = lvr
-				} else if n.Architecture() == common.ArchitectureEvm {
-					// TODO Move the logic to evm package as a post-forward hook?
-					_, evmBlkNum, err := evm.ExtractBlockReferenceFromRequest(ctx, req)
-					if err == nil && evmBlkNum == 0 {
-						// For pending txs we can accept the response, if after retries it is still pending.
-						// This avoids failing with "retry" error, when we actually do have a response but blockNumber is null since tx is pending.
-						resp = lvr
-					}
-				}
+		lvr := req.LastValidResponse()
+		// TODO is there a cleaner way to use last result when retry is exhausted?
+		if lvr != nil && !lvr.IsObjectNull() {
+			// If error is due to empty response be generous and accept it,
+			// because this means after many retries or exhausting all upstreams still no data is available.
+			//
+			// We don't need to worry about wrongly replying empty responses for unfinalized data
+			// because cache layer has mechanism to deal with empty and/or unfinalized data.
+			//
+			// For pending txs we can accept the response, if after retries it is still pending.
+			// This avoids failing with "retry" error, when we actually do have a response but blockNumber is null since tx is pending.
+			resp = lvr
+		} else {
+			if serr, ok := execErr.(common.StandardError); ok {
+				err = serr
 			} else {
 				err = common.NewErrUpstreamsExhausted(
 					req,
@@ -462,12 +458,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 					execution.Retries(),
 					execution.Hedges(),
 				)
-				if mlx != nil {
-					mlx.Close(ctx, nil, err)
-				}
-				return nil, err
 			}
-		} else {
 			if mlx != nil {
 				mlx.Close(ctx, nil, err)
 			}

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -5794,11 +5794,6 @@ func TestNetwork_Forward(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		fsCfg := &common.FailsafeConfig{
-			Retry: &common.RetryPolicyConfig{
-				MaxAttempts: 2,
-			},
-		}
 		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
@@ -5874,7 +5869,11 @@ func TestNetwork_Forward(t *testing.T) {
 				Evm: &common.EvmNetworkConfig{
 					ChainId: 123,
 				},
-				Failsafe: fsCfg,
+				Failsafe: &common.FailsafeConfig{
+					Retry: &common.RetryPolicyConfig{
+						MaxAttempts: 2,
+					},
+				},
 			},
 			rlr,
 			upr,

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -177,7 +177,7 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 		_, errSpan := common.StartDetailSpan(finishCtx, "Project.ErrorMetrics")
 		defer errSpan.End()
 		lg.Debug().Err(err).Object("request", nq).Msgf("failed to forward request for network")
-		health.MetricNetworkFailedRequests.WithLabelValues(network.projectId, network.networkId, method, strconv.Itoa(resp.Attempts()), common.ErrorSummary(err)).Inc()
+		health.MetricNetworkFailedRequests.WithLabelValues(network.projectId, network.networkId, method, strconv.Itoa(resp.Attempts()), common.ErrorFingerprint(err)).Inc()
 	}
 
 	return nil, err

--- a/util/initializer.go
+++ b/util/initializer.go
@@ -367,8 +367,20 @@ func (i *Initializer) Status() *InitializerStatus {
 	}
 }
 
+func (i *Initializer) Errors() error {
+	var errs []error
+	i.tasks.Range(func(key, value interface{}) bool {
+		t := value.(*BootstrapTask)
+		if t.Error() != nil {
+			errs = append(errs, t.Error().Err)
+		}
+		return true
+	})
+	return errors.Join(errs...)
+}
+
 func (i *Initializer) MarkTaskAsFailed(name string, err error) {
-	i.logger.Warn().Str("task", name).Err(err).Msg("marking task as failed")
+	i.logger.Error().Str("task", name).Err(err).Msg("marking task as failed")
 	i.tasks.Range(func(key, value interface{}) bool {
 		t := value.(*BootstrapTask)
 		if t.Name == name {


### PR DESCRIPTION
Return last empty response instead of `all upstream attempts failed` error when all upstreams return empty results.

fixes #214 