### PR TITLE
fix: skip polling when upstream does not support finalized/latest tags

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -150,7 +150,8 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.HasPrefix(msg, "safe block not found") ||
 			strings.HasPrefix(msg, "Safe block not found") ||
 			strings.HasPrefix(msg, "finalized block not found") ||
-			strings.HasPrefix(msg, "Finalized block not found") {
+			strings.HasPrefix(msg, "Finalized block not found") ||
+			strings.HasPrefix(msg, "malformed blocknumber") {
 
 			// by default, we retry this type of client-side exception as other upstreams might
 			// have/support this specific block tag data.


### PR DESCRIPTION
These behaviors have been seen on Sonic and Oasis chains, and probably others.