### PR TITLE
fix: rate limiter autotuner budget clamping

### DIFF
--- a/upstream/ratelimiter_autotuner.go
+++ b/upstream/ratelimiter_autotuner.go
@@ -99,9 +99,19 @@ func (arl *RateLimitAutoTuner) adjustBudget(method string) {
 			var newMaxCount uint
 			if errorRate > arl.errorRateThreshold {
 				newMaxCount = uint(math.Ceil(float64(currentMax) * arl.decreaseFactor))
+				if int(newMaxCount) < arl.minBudget {
+					newMaxCount = uint(arl.minBudget)
+				}
 			} else if errorRate == 0 {
 				newMaxCount = uint(math.Ceil(float64(currentMax) * arl.increaseFactor))
+				if int(newMaxCount) > arl.maxBudget {
+					newMaxCount = uint(arl.maxBudget)
+				}
 			} else {
+				continue
+			}
+
+			if newMaxCount == currentMax {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- clamp autodetected rate limiter budgets within configured bounds
- skip budget updates if new value is unchanged
