### PR TITLE
fix: dynamodb shared client and higher idle connections for scale

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -267,6 +267,7 @@ type DynamoDBConnectorConfig struct {
 	InitTimeout       Duration       `yaml:"initTimeout,omitempty" json:"initTimeout" tstype:"Duration"`
 	GetTimeout        Duration       `yaml:"getTimeout,omitempty" json:"getTimeout" tstype:"Duration"`
 	SetTimeout        Duration       `yaml:"setTimeout,omitempty" json:"setTimeout" tstype:"Duration"`
+	MaxRetries        int            `yaml:"maxRetries,omitempty" json:"maxRetries"`
 	StatePollInterval Duration       `yaml:"statePollInterval,omitempty" json:"statePollInterval" tstype:"Duration"`
 	LockRetryInterval Duration       `yaml:"lockRetryInterval,omitempty" json:"lockRetryInterval" tstype:"Duration"`
 }

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -886,7 +886,7 @@ func (p *ProjectConfig) SetDefaults(opts *DefaultOptions) error {
 			log.Warn().Msg("projects.*.healthCheck.scoreMetricsWindowSize is deprecated; use projects.*.scoreMetricsWindowSize instead")
 			p.ScoreMetricsWindowSize = p.DeprecatedHealthCheck.ScoreMetricsWindowSize
 		} else {
-			p.ScoreMetricsWindowSize = Duration(30 * time.Minute)
+			p.ScoreMetricsWindowSize = Duration(10 * time.Minute)
 		}
 	}
 

--- a/data/dynamodb_test.go
+++ b/data/dynamodb_test.go
@@ -323,7 +323,7 @@ func TestDynamoDBDistributedLocking(t *testing.T) {
 		formattedLockKey := fmt.Sprintf("%s:lock", lockKey)
 		lockExpiryTime := time.Now().Add(lockExpiry).Unix()
 
-		_, err := connector.client.PutItem(&dynamodb.PutItemInput{
+		_, err := connector.writeClient.PutItem(&dynamodb.PutItemInput{
 			TableName: aws.String(connector.table),
 			Item: map[string]*dynamodb.AttributeValue{
 				connector.partitionKeyName: {S: aws.String(formattedLockKey)},
@@ -355,7 +355,7 @@ func TestDynamoDBDistributedLocking(t *testing.T) {
 		formattedLockKey := fmt.Sprintf("%s:lock", lockKey)
 		lockExpiryTime := time.Now().Add(100 * time.Second).Unix() // Won't expire during our test
 
-		_, err := connector.client.PutItem(&dynamodb.PutItemInput{
+		_, err := connector.writeClient.PutItem(&dynamodb.PutItemInput{
 			TableName: aws.String(connector.table),
 			Item: map[string]*dynamodb.AttributeValue{
 				connector.partitionKeyName: {S: aws.String(formattedLockKey)},
@@ -387,7 +387,7 @@ func TestDynamoDBDistributedLocking(t *testing.T) {
 		formattedLockKey := fmt.Sprintf("%s:lock", lockKey)
 		lockExpiryTime := time.Now().Add(5 * time.Second).Unix()
 
-		_, err := connector.client.PutItem(&dynamodb.PutItemInput{
+		_, err := connector.writeClient.PutItem(&dynamodb.PutItemInput{
 			TableName: aws.String(connector.table),
 			Item: map[string]*dynamodb.AttributeValue{
 				connector.partitionKeyName: {S: aws.String(formattedLockKey)},
@@ -427,7 +427,7 @@ func TestDynamoDBDistributedLocking(t *testing.T) {
 		formattedLockKey := fmt.Sprintf("%s:lock", lockKey)
 		expiredLockTime := time.Now().Add(-60 * time.Second).Unix() // Expired 1 minute ago
 
-		_, err := connector.client.PutItem(&dynamodb.PutItemInput{
+		_, err := connector.writeClient.PutItem(&dynamodb.PutItemInput{
 			TableName: aws.String(connector.table),
 			Item: map[string]*dynamodb.AttributeValue{
 				connector.partitionKeyName: {S: aws.String(formattedLockKey)},

--- a/erpc/projects_registry.go
+++ b/erpc/projects_registry.go
@@ -101,12 +101,7 @@ func (r *ProjectsRegistry) RegisterProject(prjCfg *common.ProjectConfig) (*Prepa
 
 	lg := r.logger.With().Str("projectId", prjCfg.Id).Logger()
 
-	var wsDuration time.Duration
-	if prjCfg.ScoreMetricsWindowSize > 0 {
-		wsDuration = prjCfg.ScoreMetricsWindowSize.Duration()
-	} else {
-		wsDuration = 30 * time.Minute
-	}
+	wsDuration := prjCfg.ScoreMetricsWindowSize.Duration()
 	metricsTracker := health.NewTracker(&lg, prjCfg.Id, wsDuration)
 	providersRegistry, err := thirdparty.NewProvidersRegistry(
 		&lg,

--- a/test/k6/evm-historical-randomized.js
+++ b/test/k6/evm-historical-randomized.js
@@ -40,26 +40,26 @@ const CHAINS = {
   //     blockHashSamplePool: []
   //   }
   // },
-  // ARBITRUM: {
-  //   id: '42161',
-  //   blockMin: 0x10E1A300,
-  //   blockMax: 0x11E1A300,
-  //   cached: {
-  //     latestBlock: null,
-  //     latestBlockTimestamp: 0,
-  //     blockHashSamplePool: []
-  //   }
-  // },
-  BASE: {
-    id: '8453',
-    blockMin: 0x1312D00,
-    blockMax: 0x1D05E9C,
+  ARBITRUM: {
+    id: '42161',
+    blockMin: 0x9000000,
+    blockMax: 0x11000000,
     cached: {
       latestBlock: null,
       latestBlockTimestamp: 0,
       blockHashSamplePool: []
     }
-  }
+  },
+  // BASE: {
+  //   id: '8453',
+  //   blockMin: 0x1312D00,
+  //   blockMax: 0x1D05E9C,
+  //   cached: {
+  //     latestBlock: null,
+  //     latestBlockTimestamp: 0,
+  //     blockHashSamplePool: []
+  //   }
+  // }
 };
 
 if (__ENV.RANDOM_SEED) {
@@ -68,11 +68,11 @@ if (__ENV.RANDOM_SEED) {
 
 // Traffic pattern weights (in percentage, should sum to 100)
 const TRAFFIC_PATTERNS = {
-  RANDOM_HISTORICAL_BLOCKS: 0,      // Fetch random blocks from history
-  RANDOM_LOG_RANGES: 30,             // Get logs for random block ranges
-  RANDOM_HISTORICAL_RECEIPTS: 0,    // Get random transaction receipts from history
+  RANDOM_HISTORICAL_BLOCKS: 30,      // Fetch random blocks from history
+  RANDOM_LOG_RANGES: 60,             // Get logs for random block ranges
+  RANDOM_HISTORICAL_RECEIPTS: 10,    // Get random transaction receipts from history
   RANDOM_TRACE_TRANSACTIONS: 0,     // Trace random transactions with various methods
-  RANDOM_BLOCK_BY_HASH: 70,         // Get random block by hash
+  RANDOM_BLOCK_BY_HASH: 0,         // Get random block by hash
 };
 
 // Configuration
@@ -87,11 +87,11 @@ export const options = {
   scenarios: {    
     constant_request_rate: {
       executor: 'constant-arrival-rate',
-      rate: 300,
+      rate: 200,
       timeUnit: '1s',
       duration: '30m',
       preAllocatedVUs: 200,
-      maxVUs: 500,
+      maxVUs: 1000,
     },
   },
 };
@@ -336,7 +336,7 @@ export default async function () {
       parsedBody = JSON.parse(res.body);
     } catch (e) {
       parsingErrorsCounter.add(1, tags);
-      console.error(`Failed to parse response body: ${e} body: ${res.body}`);
+      console.error(`Failed to parse response body: ${e} body: ${res.body?.slice(0, 100)}(.........)${res.body?.slice(-100)}`);
     }
 
     if (parsedBody?.error?.code) {


### PR DESCRIPTION
Later we could make these configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a configurable maximum retries setting for DynamoDB connections.

- **Improvements**
	- Enhanced DynamoDB performance and scalability by separating read and write clients, each with optimized connection settings.
	- Updated load testing to use a different blockchain network, adjusted traffic pattern weights, and modified test load profiles for more effective simulation.
	- Improved error logging in load tests by truncating long JSON responses for easier debugging.
	- Streamlined metrics window size assignment by removing fallback defaults for more consistent configuration handling.

- **Bug Fixes**
	- Reduced default metrics window size from 30 minutes to 10 minutes for more responsive monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->