### PR TITLE
feat: add a hook for eth_chainId to respond without actual calls

### DIFF
--- a/architecture/evm/eth_chainId.go
+++ b/architecture/evm/eth_chainId.go
@@ -1,8 +1,13 @@
 package evm
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/util"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func BuildEthChainIdRequest() (*common.JsonRpcRequest, error) {
@@ -13,4 +18,48 @@ func BuildEthChainIdRequest() (*common.JsonRpcRequest, error) {
 	}
 
 	return jrq, nil
+}
+
+func networkPreForward_eth_chainId(ctx context.Context, n common.Network, r *common.NormalizedRequest) (handled bool, resp *common.NormalizedResponse, err error) {
+	if r.Directives().SkipCacheRead {
+		return false, nil, nil // Proceed to actual upstream call
+	}
+
+	ctx, span := common.StartDetailSpan(ctx, "Network.PreForwardHook.eth_chainId", trace.WithAttributes(
+		attribute.String("request.id", fmt.Sprintf("%v", r.ID())),
+		attribute.String("network.id", n.Id()),
+	))
+	defer span.End()
+
+	netCfg := n.Config()
+	if netCfg == nil || netCfg.Evm == nil || netCfg.Evm.ChainId == 0 {
+		span.SetAttributes(attribute.Bool("skipped.no_chain_id_config", true))
+		return false, nil, nil
+	}
+
+	chainId := netCfg.Evm.ChainId
+	hexChainId, err := common.NormalizeHex(chainId)
+	if err != nil {
+		span.SetAttributes(attribute.String("error.normalize_hex", err.Error()))
+		return true, nil, fmt.Errorf("failed to normalize chainId %d to hex: %w", chainId, err)
+	}
+
+	jrqID := r.ID()
+	// If original request ID is nil (e.g. for some internal requests), generate one.
+	if jrqID == nil {
+		jrqID = util.RandomID()
+	}
+
+	jrr, err := common.NewJsonRpcResponse(jrqID, hexChainId, nil)
+	if err != nil {
+		span.SetAttributes(attribute.String("error.new_jsonrpc_response", err.Error()))
+		return true, nil, fmt.Errorf("failed to create JsonRpcResponse: %w", err)
+	}
+
+	nr := common.NewNormalizedResponse().
+		WithRequest(r).
+		WithJsonRpcResponse(jrr)
+
+	span.SetAttributes(attribute.Bool("handled_by_hook", true), attribute.String("chain_id_from_config", hexChainId))
+	return true, nr, nil
 }

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"strings"
 
 	"github.com/erpc/erpc/common"
 )
@@ -19,11 +20,13 @@ func HandleNetworkPreForward(ctx context.Context, network common.Network, nq *co
 		return false, nil, err
 	}
 
-	switch method {
-	case "eth_blockNumber":
+	switch strings.ToLower(method) {
+	case "eth_blocknumber":
 		return networkPreForward_eth_blockNumber(ctx, network, nq)
 	case "eth_call":
 		return networkPreForward_eth_call(ctx, network, nq)
+	case "eth_chainid":
+		return networkPreForward_eth_chainId(ctx, network, nq)
 	default:
 		return false, nil, nil
 	}
@@ -40,8 +43,8 @@ func HandleNetworkPostForward(ctx context.Context, network common.Network, nq *c
 		return nr, err
 	}
 
-	switch method {
-	case "eth_getBlockByNumber":
+	switch strings.ToLower(method) {
+	case "eth_getblockbynumber":
 		return networkPostForward_eth_getBlockByNumber(ctx, network, nq, nr, re)
 	default:
 		return nr, re
@@ -57,8 +60,8 @@ func HandleUpstreamPreForward(ctx context.Context, n common.Network, u common.Up
 		return false, nil, err
 	}
 
-	switch method {
-	case "eth_getLogs":
+	switch strings.ToLower(method) {
+	case "eth_getlogs":
 		return upstreamPreForward_eth_getLogs(ctx, n, u, r)
 	default:
 		return false, nil, nil
@@ -74,8 +77,8 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 		return rs, err
 	}
 
-	switch method {
-	case "eth_getLogs":
+	switch strings.ToLower(method) {
+	case "eth_getlogs":
 		return upstreamPostForward_eth_getLogs(ctx, n, u, rq, rs, re, skipCacheRead)
 	}
 


### PR DESCRIPTION
Let's save thousands of $$$

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling the eth_chainId method directly within the EVM network context, providing immediate responses without upstream calls when possible.

- **Improvements**
  - Enhanced method name handling to be case-insensitive across hook functions, ensuring more robust and flexible request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->