### PR TITLE
fix: correctly generate Pimlico URL when creating its provider

### DIFF
--- a/thirdparty/pimlico.go
+++ b/thirdparty/pimlico.go
@@ -116,7 +116,12 @@ func (v *PimlicoVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Log
 		return true, nil
 	}
 
-	client, err := v.getOrCreateClient(ctx, logger, chainId, nil)
+	parsedURL, err := v.generateUrl(chainId)
+	if err != nil {
+		return false, err
+	}
+
+	client, err := v.getOrCreateClient(ctx, logger, chainId, parsedURL)
 	if err != nil {
 		return false, err
 	}
@@ -210,6 +215,15 @@ func (v *PimlicoVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
 	return strings.HasPrefix(ups.Endpoint, "pimlico") ||
 		strings.HasPrefix(ups.Endpoint, "evm+pimlico") ||
 		strings.Contains(ups.Endpoint, "pimlico.io")
+}
+
+func (v *PimlicoVendor) generateUrl(chainId int64) (*url.URL, error) {
+	pimlicoUrl := fmt.Sprintf("https://api.pimlico.io/v2/%d", chainId)
+	parsedURL, err := url.Parse(pimlicoUrl)
+	if err != nil {
+		return nil, err
+	}
+	return parsedURL, nil
 }
 
 func (v *PimlicoVendor) getOrCreateClient(ctx context.Context, logger *zerolog.Logger, chainId int64, parsedURL *url.URL) (clients.HttpJsonRpcClient, error) {


### PR DESCRIPTION
While testing eRPC's Pimlico provider we faced a nil pointer issue caused by the Pimlico `GenericHttpJsonRpcClient` receiving a nil URL, copied at the end of this description. The line numbers are not accurate because I added a few debugging statements. We've added a `generateUrl` to Pimlico method based on the one from Thirdweb, and passed it to the client builder.

Our configuration was:

```yaml
#...
    networks:
      - architecture: evm
        alias: ethereum
        evm:
          chainId: 1
#...
    providers:
      - vendor: pimlico
        settings:
          apiKey: <our api key>
        upstreamIdTemplate: "<NETWORK>-<PROVIDER>"
#...
    upstreams:
      - endpoint: pimlico://<our api key>
```

And the output:

```shell
mikel@laptop - github.com/erpc/erpc ‹main*› $ make run
{"level":"info","action":"erpc","version":"dev","commit":"none","time":1748271708240,"message":"executing command"}
{"level":"info","time":1748271708240,"message":"looking for config file: /Users/mikelsr/Code/github.com/erpc/erpc/erpc.yaml"}
{"level":"info","time":1748271708240,"message":"resolved configuration file to: ./erpc.yaml"}

goroutine 123 [running]:
github.com/erpc/erpc/thirdparty.(*PimlicoVendor).getOrCreateClient(0x101c4aaa0?, {0x101e65718, 0x14000575c20}, 0x140000c82a0, 0x15eb, 0x0)
        /Users/mikelsr/Code/github.com/erpc/erpc/thirdparty/pimlico.go:223 +0x144
github.com/erpc/erpc/thirdparty.(*PimlicoVendor).SupportsNetwork(0x1400047be00, {0x101e65718, 0x14000575c20}, 0x140000c82a0, 0x14000115b90?, {0x14000155fd0?, 0x1?})
        /Users/mikelsr/Code/github.com/erpc/erpc/thirdparty/pimlico.go:120 +0xc8
github.com/erpc/erpc/thirdparty.(*Provider).SupportsNetwork(0x14000a54d18?, {0x101e65718?, 0x14000575c20?}, {0x14000155fd0?, 0x2?})
        /Users/mikelsr/Code/github.com/erpc/erpc/thirdparty/provider.go:43 +0x6c
github.com/erpc/erpc/upstream.(*UpstreamsRegistry).buildProviderBootstrapTask.func1({0x101e65718, 0x14000575c20})
        /Users/mikelsr/Code/github.com/erpc/erpc/upstream/registry.go:465 +0x368
github.com/erpc/erpc/util.(*Initializer).attemptRemainingTasks.func1.1(0x140000fae00, 0x0?)
        /Users/mikelsr/Code/github.com/erpc/erpc/util/initializer.go:284 +0x1c4
created by github.com/erpc/erpc/util.(*Initializer).attemptRemainingTasks.func1 in goroutine 167
        /Users/mikelsr/Code/github.com/erpc/erpc/util/initializer.go:267 +0x2a0
exit status 2
make: *** [run] Error 1
```