### PR TITLE
fix: patch typescript types

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -332,7 +332,7 @@ type ProjectConfig struct {
 	NetworkDefaults        *NetworkDefaults                    `yaml:"networkDefaults,omitempty" json:"networkDefaults"`
 	Networks               []*NetworkConfig                    `yaml:"networks,omitempty" json:"networks"`
 	RateLimitBudget        string                              `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget"`
-	ScoreMetricsWindowSize Duration                            `yaml:"scoreMetricsWindowSize" json:"scoreMetricsWindowSize" tstype:"Duration"`
+	ScoreMetricsWindowSize Duration                            `yaml:"scoreMetricsWindowSize,omitempty" json:"scoreMetricsWindowSize" tstype:"Duration"`
 	DeprecatedHealthCheck  *DeprecatedProjectHealthCheckConfig `yaml:"healthCheck,omitempty" json:"healthCheck"`
 }
 
@@ -341,7 +341,7 @@ type NetworkDefaults struct {
 	Failsafe          *FailsafeConfig          `yaml:"failsafe,omitempty" json:"failsafe"`
 	SelectionPolicy   *SelectionPolicyConfig   `yaml:"selectionPolicy,omitempty" json:"selectionPolicy"`
 	DirectiveDefaults *DirectiveDefaultsConfig `yaml:"directiveDefaults,omitempty" json:"directiveDefaults"`
-	Evm               *EvmNetworkConfig        `yaml:"evm,omitempty" json:"evm"`
+	Evm               *EvmNetworkConfig        `yaml:"evm,omitempty" json:"evm" tstype:"TsEvmNetworkConfigForDefaults"`
 }
 
 type CORSConfig struct {
@@ -926,8 +926,8 @@ type MetricsConfig struct {
 	ListenV6         *bool     `yaml:"listenV6" json:"listenV6"`
 	HostV6           *string   `yaml:"hostV6" json:"hostV6"`
 	Port             *int      `yaml:"port" json:"port"`
-	ErrorLabelMode   LabelMode `yaml:"errorLabelMode" json:"errorLabelMode"`
-	HistogramBuckets string    `yaml:"histogramBuckets" json:"histogramBuckets"`
+	ErrorLabelMode   LabelMode `yaml:"errorLabelMode,omitempty" json:"errorLabelMode"`
+	HistogramBuckets string    `yaml:"histogramBuckets,omitempty" json:"histogramBuckets"`
 }
 
 // GetProjectConfig returns the project configuration by the specified project ID.

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -23,6 +23,7 @@ packages:
         NetworkArchitecture as TsNetworkArchitecture,
         AuthType as TsAuthType,
         AuthStrategyConfig as TsAuthStrategyConfig,
+        NetworkDefaults as TsEvmNetworkConfigForDefaults,
         SelectionPolicyEvalFunction
       } from "./types"
     exclude_files:

--- a/typescript/config/package.json
+++ b/typescript/config/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "lib",
-    "src/*.ts"
+    "src/*.ts",
+    "src/types/*.ts"
   ],
   "exports": {
     ".": {

--- a/typescript/config/src/index.ts
+++ b/typescript/config/src/index.ts
@@ -11,6 +11,7 @@ export type {
   PolicyEvalUpstreamMetrics,
   PolicyEvalUpstream,
   SelectionPolicyEvalFunction,
+  EvmNetworkConfigForDefaults,
 } from "./types";
 export {
   // Data finality const exports
@@ -114,7 +115,6 @@ export type {
   TLSConfig,
   // Proxy pools related
   ProxyPoolConfig,
-
 } from "./generated";
 
 import type { Config } from './generated'

--- a/typescript/config/src/types/generic.ts
+++ b/typescript/config/src/types/generic.ts
@@ -1,5 +1,6 @@
 import type {
     DynamoDBConnectorConfig,
+    EvmNetworkConfig,
     AuthStrategyConfig as GenAuthStrategyConfig,
     JwtStrategyConfig,
     MemoryConnectorConfig,
@@ -137,3 +138,7 @@ import type {
         }
     );
   
+  /**
+    * Network defaults override (chainId isn't needed for defaults config)
+    */
+  export type EvmNetworkConfigForDefaults = Omit<EvmNetworkConfig, "chainId">;

--- a/typescript/config/src/types/index.ts
+++ b/typescript/config/src/types/index.ts
@@ -8,6 +8,7 @@ export type {
     NetworkArchitecture,
     AuthType,
     AuthStrategyConfig,
+    EvmNetworkConfigForDefaults,
   } from "./generic";
   export type {
     PolicyEvalUpstreamMetrics,


### PR DESCRIPTION
 - Remove `chainId` prop in `project.networkDefaults.evm` field
 - Mark `scoreMetricsWindowSize` and `histogramBuckets` as optional
 - Include `types/*.ts` folder when publishing packages