### PR TITLE
Encode empty slices as empty slices instead of null values

### DIFF
--- a/common/sonic.go
+++ b/common/sonic.go
@@ -47,6 +47,7 @@ func init() {
 	}
 	SonicCfg = sonic.Config{
 		CopyString:              false,
+		NoNullSliceOrMap:        true,
 		NoQuoteTextMarshaler:    true,
 		NoValidateJSONMarshaler: true,
 		NoValidateJSONSkip:      true,


### PR DESCRIPTION
ERPC is encoding empty JSONRPC map or slice fields as null. Some bundlers, namely the [alto bundlers](https://github.com/pimlicolabs/alto) we are using, expect the fields to be present and have a non-null value even for requests that take no params.

In our specific case, we're sending this request to eRPC:

```json
{
    "jsonrpc": "2.0",
    "method": "pimlico_getUserOperationGasPrice",
    "params": [],
    "id": 1
}
```

Which rather than forward the JSON directly is sending this to the bundler:

```
{
    "jsonrpc": "2.0",
    "method": "pimlico_getUserOperationGasPrice",
    "id": 1
}
```

Empty and null values are different, so we propose changing one Sonic configuration field to keep them that way.