### PR TITLE
Add Ankr provider support

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1064,6 +1064,10 @@ func buildProviderSettings(vendorName string, endpoint *url.URL) (VendorSettings
 		return VendorSettings{
 			"apiKey": endpoint.Host,
 		}, nil
+	case "ankr", "evm+ankr":
+		return VendorSettings{
+			"apiKey": endpoint.Host,
+		}, nil
 	case "erpc", "evm+erpc":
 		settings := VendorSettings{
 			"endpoint": "https://" + endpoint.Host + "/" + strings.TrimPrefix(endpoint.Path, "/"),

--- a/docs/pages/config/projects/providers.mdx
+++ b/docs/pages/config/projects/providers.mdx
@@ -25,6 +25,7 @@ Providers make it easy to add well-known third-parties RPC endpoints quickly. He
 - [`onfinality`](#onfinality) Accepts onfinality.io api key and automatically adds all their EVM chains.
 - [`tenderly`](#tenderly) Accepts tenderly.co api key and automatically adds all their EVM chains.
 - [`blockpi`](#blockpi) Accepts blockpi.io api key and automatically adds all their EVM chains.
+- [`ankr`](#ankr) Accepts ankr.com api key and automatically adds all their EVM chains.
 
 <Callout type='info'>
   eRPC supports **any EVM-compatible** JSON-RPC endpoint when using [`evm` type](/config/projects/upstreams). 
@@ -745,6 +746,44 @@ export default createConfig({
 </Tabs.Tab>
 </Tabs>
 
+#### `ankr`
+
+Built for [Ankr](https://www.ankr.com/) 3rd-party provider to make it easier to import "all supported evm chains" with just an API key.
+
+<Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
+  <Tabs.Tab>
+```yaml filename="erpc.yaml"
+# ...
+projects:
+  - id: main
+    # ...
+    upstreams:
+      - endpoint: ankr://YOUR_ANKR_API_KEY
+        # ...
+```
+</Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="erpc.ts"
+import { createConfig } from "@erpc-cloud/config";
+
+export default createConfig({
+  projects: [
+    {
+      id: "main",
+      // ...
+      upstreams: [
+        {
+          endpoint: "ankr://YOUR_ANKR_API_KEY",
+          // ...
+        },
+      ],
+    },
+  ],
+});
+```
+</Tabs.Tab>
+</Tabs>
+
 ## Advanced config
 
 You can use dedicated `providers:` config to customize per-network configurations (e.g. different config for Alchemy eth-mainnet vs Alchemy polygon) as follows:
@@ -913,4 +952,7 @@ providers:
   - vendor: blockpi
     settings:
       apiKey: xxxxx # Your BlockPi API key
+  - vendor: ankr
+    settings:
+      apiKey: xxxxx # Your Ankr API key
 ```

--- a/thirdparty/vendors_registry.go
+++ b/thirdparty/vendors_registry.go
@@ -28,6 +28,7 @@ func NewVendorsRegistry() *VendorsRegistry {
 	r.Register(CreateOnFinalityVendor())
 	r.Register(CreateErpcVendor())
 	r.Register(CreateBlockPiVendor())
+	r.Register(CreateAnkrVendor())
 	return r
 }
 

--- a/typescript/config/lib/types/generic.d.ts
+++ b/typescript/config/lib/types/generic.d.ts
@@ -43,7 +43,7 @@ export type ConnectorConfig = {
 /**
  * Supported upstream type
  */
-export type UpstreamType = "evm" | "evm+alchemy" | "evm+blastapi" | "evm+conduit" | "evm+drpc" | "evm+dwellir" | "evm+envio" | "evm+etherspot" | "evm+infura" | "evm+pimlico" | "evm+quicknode" | "evm+llama" | "evm+thirdweb" | "evm+repository" | "evm+superchain" | "evm+chainstack" | "evm+tenderly" | "evm+onfinality" | "evm+erpc" | "evm+blockpi";
+export type UpstreamType = "evm" | "evm+alchemy" | "evm+blastapi" | "evm+conduit" | "evm+drpc" | "evm+dwellir" | "evm+envio" | "evm+etherspot" | "evm+infura" | "evm+pimlico" | "evm+quicknode" | "evm+llama" | "evm+thirdweb" | "evm+repository" | "evm+superchain" | "evm+chainstack" | "evm+tenderly" | "evm+onfinality" | "evm+erpc" | "evm+blockpi" | "evm+ankr";
 /**
  * Supported auth type
  */

--- a/typescript/config/src/types/generic.ts
+++ b/typescript/config/src/types/generic.ts
@@ -105,7 +105,8 @@ import type {
     | "evm+tenderly"
     | "evm+onfinality"
     | "evm+erpc"
-    | "evm+blockpi";
+    | "evm+blockpi"
+    | "evm+ankr";
   
   /**
    * Supported auth type


### PR DESCRIPTION
## Summary
- include Ankr in vendors registry
- parse `ankr://` endpoints in defaults
- document Ankr provider usage
- support `evm+ankr` in config types

## Testing
- `make fmt`
- `pnpm -r run format` *(fails: Request was cancelled)*
- `make test` *(fails: Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842f10dff40832caf3e496df5d1bcc0