### PR TITLE
fix: retried consensus executions bypassing consensus

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -544,8 +544,6 @@ func (r *JsonRpcResponse) CanonicalHash(ctx ...context.Context) (string, error) 
 		return "", err
 	}
 
-	println(string(canonical))
-
 	b := sha256.Sum256(canonical)
 
 	return fmt.Sprintf("%x", b), nil


### PR DESCRIPTION
We observed a scenario where with upstreams for avalanche fuji configured pointing at quicknode (finalized blocks only) and alchemy (unfinalized blocks) which were frequent reorgs which we weren't expecting to handle due to previously _only_ having processed finalised blocks due to running on nodes with the configuration for [allow-unfinalized-queries](https://build.avax.network/docs/nodes/chain-configs/c-chain#allow-unfinalized-queries) was defaulted to false.

Whilst the introduction of alchemy as a provider which allows for unfinalized blocks explained how we were seeing these blocks in the first place, it didn't explain _how_ they were getting past the consensus functionality recently introduced https://github.com/erpc/erpc/pull/265 which we've been running experimentally.

Digging deeper into traces around errors such as `cannot query unfinalized data`, which is handled in eRPC as an ErrEndpointMissingData error - we found that there were frequent retries of consensus execution which wrapped the consensus errors with failsafe errors such as:
> *errors.errorString: {"code":"ErrFailsafeRetryExceeded","message":"gave up retrying on network-level after 78.98683ms","details":{"durationMs":78},"cause":{"code":"ErrConsensusDispute","message":"not enough agreement among responses"}}

Adding a test case for errors wrapped such as this to indeed confirmed that there was an issue within networks.go where using the error codes of the consensus execution, we short-circuit existing behaviour where the `LastValidResponse` is utilised.