### PR TITLE
fix: json-rpc params request should never be omitted

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -610,7 +610,7 @@ type JsonRpcRequest struct {
 	JSONRPC string        `json:"jsonrpc,omitempty"`
 	ID      interface{}   `json:"id,omitempty"`
 	Method  string        `json:"method"`
-	Params  []interface{} `json:"params,omitempty"`
+	Params  []interface{} `json:"params"`
 }
 
 func NewJsonRpcRequest(method string, params []interface{}) *JsonRpcRequest {

--- a/common/json_rpc_test.go
+++ b/common/json_rpc_test.go
@@ -202,3 +202,44 @@ func sortJSONReverse(v interface{}) ([]byte, error) {
 		return json.Marshal(v)
 	}
 }
+
+func TestJsonRpcRequest_MarshalParams(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		rawReq, err := SonicCfg.Marshal(JsonRpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "eth_blockNumber",
+		})
+		assert.NoError(t, err)
+
+		expectedRawReq := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}`
+		assert.Equal(t, expectedRawReq, string(rawReq))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		rawReq, err := SonicCfg.Marshal(JsonRpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "eth_blockNumber",
+			Params:  []interface{}{},
+		})
+		assert.NoError(t, err)
+
+		expectedRawReq := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`
+		assert.Equal(t, expectedRawReq, string(rawReq))
+	})
+
+	t.Run("Value", func(t *testing.T) {
+		rawReq, err := SonicCfg.Marshal(JsonRpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "eth_blockNumber",
+			Params:  []interface{}{"0xcafecafecafecafecafecafecafecafecafecafe"},
+		})
+		assert.NoError(t, err)
+
+		expectedRawReq := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":["0xcafecafecafecafecafecafecafecafecafecafe"]}`
+		assert.Equal(t, expectedRawReq, string(rawReq))
+	})
+
+}

--- a/common/json_rpc_test.go
+++ b/common/json_rpc_test.go
@@ -204,18 +204,6 @@ func sortJSONReverse(v interface{}) ([]byte, error) {
 }
 
 func TestJsonRpcRequest_MarshalParams(t *testing.T) {
-	t.Run("Nil", func(t *testing.T) {
-		rawReq, err := SonicCfg.Marshal(JsonRpcRequest{
-			JSONRPC: "2.0",
-			ID:      1,
-			Method:  "eth_blockNumber",
-		})
-		assert.NoError(t, err)
-
-		expectedRawReq := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}`
-		assert.Equal(t, expectedRawReq, string(rawReq))
-	})
-
 	t.Run("Empty", func(t *testing.T) {
 		rawReq, err := SonicCfg.Marshal(JsonRpcRequest{
 			JSONRPC: "2.0",
@@ -241,5 +229,4 @@ func TestJsonRpcRequest_MarshalParams(t *testing.T) {
 		expectedRawReq := `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":["0xcafecafecafecafecafecafecafecafecafecafe"]}`
 		assert.Equal(t, expectedRawReq, string(rawReq))
 	})
-
 }


### PR DESCRIPTION
Solves #329 and includes #328 