### PR TITLE
fix: docker build arguments for version and commit sha injection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,7 @@ node_modules/
 *.log
 tmp/
 scylla/data/
+Makefile
 
 # Documentation
 docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG COMMIT_SHA
 # Set environment variables for Go build
 ENV CGO_ENABLED=0 \
     GOOS=linux \
-    LDFLAGS="-w -s -X common.ErpcVersion=${VERSION} -X common.ErpcCommitSha=${COMMIT_SHA}"
+    LDFLAGS="-w -s -X github.com/erpc/erpc/common.ErpcVersion=${VERSION} -X github.com/erpc/erpc/common.ErpcCommitSha=${COMMIT_SHA}"
 
 # Build the Go binary
 RUN go build -v -ldflags="$LDFLAGS" -a -installsuffix cgo -o erpc-server ./cmd/erpc/main.go && \
@@ -48,7 +48,7 @@ COPY pnpm* /temp/dev/
 COPY package.json /temp/dev/package.json
 
 # Install everything and build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store cd /temp/dev &&  pnpm install --frozen-lockfile 
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store cd /temp/dev &&  pnpm install --frozen-lockfile
 RUN cd /temp/dev && pnpm build
 
 # Stage where we will install prod dependencies only

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo " up                            Up docker services"
 	@echo " down                          Down docker services"
 	@echo " fmt                           Format source code"
+	@echo " docker-build                  Build docker image. Arg: platform=linux/amd64 (default) or platform=linux/arm64"
 
 .PHONY: setup
 setup:
@@ -64,7 +65,7 @@ test-race:
 
 .PHONY: bench
 bench:
-	@go test -run=^$$ -bench=. -benchmem -count=8 -v ./... 
+	@go test -run=^$$ -bench=. -benchmem -count=8 -v ./...
 
 .PHONY: coverage
 coverage:
@@ -83,5 +84,15 @@ down:
 .PHONY: fmt
 fmt:
 	@go fmt ./...
+
+.PHONY: docker-build
+docker-build:
+	$(eval platform ?= linux/amd64)
+	@docker build -t local/erpc-server --platform $(platform) --build-arg VERSION=local --build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) .
+
+.PHONY: docker-run
+docker-run:
+	$(eval platform ?= linux/amd64)
+	@docker run --rm -it --platform $(platform) -p 4000:4000 -p 4001:4001 -v $(PWD)/erpc.yaml:/erpc.yaml local/erpc-server /erpc-server --config /erpc.yaml
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo " down                          Down docker services"
 	@echo " fmt                           Format source code"
 	@echo " docker-build                  Build docker image. Arg: platform=linux/amd64 (default) or platform=linux/arm64"
+	@echo " docker-run                    Run docker image. Arg: platform=linux/amd64 (default) or platform=linux/arm64"
 
 .PHONY: setup
 setup:

--- a/common/config.go
+++ b/common/config.go
@@ -18,10 +18,18 @@ import (
 )
 
 var (
-	ErpcVersion   = "dev"
+	// ErpcVersion is the version of eRPC, overridden at build time via ldflags.
+	// Default: "dev" for development builds.
+	// Build example: -ldflags="-X github.com/erpc/erpc/common.ErpcVersion=v1.0.0"
+	ErpcVersion = "dev"
+
+	// ErpcCommitSha is the git commit SHA, overridden at build time via ldflags.
+	// Default: "none" for development builds.
+	// Build example: -ldflags="-X github.com/erpc/erpc/common.ErpcCommitSha=abc123def"
 	ErpcCommitSha = "none"
-	TRUE          = true
-	FALSE         = false
+
+	TRUE  = true
+	FALSE = false
 )
 
 // Config represents the configuration of the application.


### PR DESCRIPTION
# Problem

The application was not properly displaying version and commit SHA information in response headers. The build arguments `VERSION` and `COMMIT_SHA` defined in the Dockerfile were not being correctly injected into the Go variables `ErpcVersion` and `ErpcCommitSha`.

Current behavior:
- `X-ERPC-Version` header always shows "dev"
- `X-ERPC-Commit` header always shows "none"

Root cause:
The `-X` flags in `LDFLAGS` were using incorrect package paths (`common.ErpcVersion`) instead of the full module path required by Go's linker.

# Solution

Updated the `LDFLAGS` in the Dockerfile to use the correct full module paths:

```diff
- LDFLAGS="-w -s -X common.ErpcVersion=${VERSION} -X common.ErpcCommitSha=${COMMIT_SHA}"
+ LDFLAGS="-w -s -X github.com/erpc/erpc/common.ErpcVersion=${VERSION} -X github.com/erpc/erpc/common.ErpcCommitSha=${COMMIT_SHA}"
```

# Testing

Build Docker image:
```sh
make docker-build platform=linux/amd64
```

Create configuration file for test:
```sh
cat <<EOF > erpc.yaml
logLevel: debug

projects:
  - id: ethereum
    networks:
      - architecture: evm
        evm:
          chainId: 1
    upstreams:
      - endpoint: https://ethereum-rpc.publicnode.com
        evm:
          chainId: 1
EOF
```

Run Docker:
```sh
make docker-run platform=linux/amd64
```

Open a new terminal window and run:
```sh
curl -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false],"id":1}' -i http://localhost:4000/ethereum/evm/1
```

Notice that `X-Erpc-Version` is `local` and `X-Erpc-Commit` is the same value as output of `git rev-parse --short HEAD`.

# Details

### Main changes

**Dockerfile**
- Changed `LDFLAGS` references to include the full package path `github.com/erpc/erpc/common` for `ErpcVersion` and `ErpcCommitSha`.
- Removed unnecessary trailing whitespace after `pnpm install --frozen-lockfile` command.

**common/config.go**
- Updated comments for `ErpcVersion` and `ErpcCommitSha` variables, explicitly stating they can be overridden via `ldflags` during build time.
- Defaults for `ErpcVersion` and `ErpcCommitSha` are now documented as `"dev"` and `"none"`, respectively, for development builds.

### Minor improvements

**.dockerignore**- Added `Makefile` to `.dockerignore` for exclusion.
- Minor formatting adjustment (added a newline at the file's end).

**Makefile**
- Added a new target: `docker-build` to build Docker images with an optional `platform` argument (`linux/amd64` as the default).
- Added a new target: `docker-run` to run Docker containers with configurable platform and port settings, and mapping the `erpc.yaml` configuration file.
- Fixed a minor typo with trailing whitespace in the `bench` target.

