### PR TITLE
feat: allow stateful rpc methods with single-target UseUpstream directive

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -344,7 +344,6 @@ type ProjectConfig struct {
 	RateLimitBudget        string                              `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget"`
 	ScoreMetricsWindowSize Duration                            `yaml:"scoreMetricsWindowSize,omitempty" json:"scoreMetricsWindowSize" tstype:"Duration"`
 	DeprecatedHealthCheck  *DeprecatedProjectHealthCheckConfig `yaml:"healthCheck,omitempty" json:"healthCheck"`
-	StatefulMethods        []string                            `yaml:"statefulMethods,omitempty" json:"statefulMethods"`
 }
 
 type NetworkDefaults struct {

--- a/common/config.go
+++ b/common/config.go
@@ -344,6 +344,7 @@ type ProjectConfig struct {
 	RateLimitBudget        string                              `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget"`
 	ScoreMetricsWindowSize Duration                            `yaml:"scoreMetricsWindowSize,omitempty" json:"scoreMetricsWindowSize" tstype:"Duration"`
 	DeprecatedHealthCheck  *DeprecatedProjectHealthCheckConfig `yaml:"healthCheck,omitempty" json:"healthCheck"`
+	StatefulMethods        []string                            `yaml:"statefulMethods,omitempty" json:"statefulMethods"`
 }
 
 type NetworkDefaults struct {
@@ -940,6 +941,7 @@ type NetworkConfig struct {
 	DirectiveDefaults *DirectiveDefaultsConfig `yaml:"directiveDefaults,omitempty" json:"directiveDefaults"`
 	Alias             string                   `yaml:"alias,omitempty" json:"alias"`
 	Methods           *MethodsConfig           `yaml:"methods,omitempty" json:"methods"`
+	StatefulMethods   []string                 `yaml:"statefulMethods,omitempty" json:"statefulMethods"`
 }
 
 // UnmarshalYAML provides backward compatibility for old single failsafe object format

--- a/common/config.go
+++ b/common/config.go
@@ -191,6 +191,7 @@ type CacheMethodConfig struct {
 	RespRefs  [][]interface{} `yaml:"respRefs" json:"respRefs"`
 	Finalized bool            `yaml:"finalized" json:"finalized"`
 	Realtime  bool            `yaml:"realtime" json:"realtime"`
+	Stateful  bool            `yaml:"stateful,omitempty" json:"stateful"`
 }
 
 type CachePolicyConfig struct {
@@ -940,7 +941,6 @@ type NetworkConfig struct {
 	DirectiveDefaults *DirectiveDefaultsConfig `yaml:"directiveDefaults,omitempty" json:"directiveDefaults"`
 	Alias             string                   `yaml:"alias,omitempty" json:"alias"`
 	Methods           *MethodsConfig           `yaml:"methods,omitempty" json:"methods"`
-	StatefulMethods   []string                 `yaml:"statefulMethods,omitempty" json:"statefulMethods"`
 }
 
 // UnmarshalYAML provides backward compatibility for old single failsafe object format

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -518,8 +518,19 @@ func (m *MethodsConfig) SetDefaults() error {
 		}
 
 		m.Definitions = mergedMethods
+	} else {
+		// User provided definitions and doesn't want defaults
+		// Still need to ensure stateful methods are marked correctly
+		for _, mn := range DefaultStatefulMethodNames {
+			if cm, ok := m.Definitions[mn]; ok {
+				// Method exists in user definitions, ensure it's marked as stateful
+				cm.Stateful = true
+			} else {
+				// Method not in user definitions, add it as stateful
+				m.Definitions[mn] = &CacheMethodConfig{Stateful: true}
+			}
+		}
 	}
-	// else: User provided definitions and doesn't want defaults, keep as is
 
 	return nil
 }

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -999,16 +999,10 @@ func (p *ProjectConfig) SetDefaults(opts *DefaultOptions) error {
 			}
 		}
 	}
-	if p.StatefulMethods == nil || len(p.StatefulMethods) == 0 {
-		p.StatefulMethods = DefaultStatefulMethods
-	}
 	if p.Networks != nil {
 		for _, network := range p.Networks {
 			if err := network.SetDefaults(p.Upstreams, p.NetworkDefaults); err != nil {
 				return fmt.Errorf("failed to set defaults for network: %w", err)
-			}
-			if network.StatefulMethods == nil || len(network.StatefulMethods) == 0 {
-				network.StatefulMethods = p.StatefulMethods
 			}
 		}
 	}
@@ -1684,6 +1678,10 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 		if err := n.DirectiveDefaults.SetDefaults(); err != nil {
 			return err
 		}
+	}
+
+	if n.StatefulMethods == nil || len(n.StatefulMethods) == 0 {
+		n.StatefulMethods = DefaultStatefulMethods
 	}
 
 	return nil

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -172,7 +172,8 @@ func (c *Config) SetDefaults(opts *DefaultOptions) error {
 	return nil
 }
 
-var DefaultStatefulMethods = []string{
+
+var DefaultStatefulMethodNames = []string{
 	"eth_newFilter",
 	"eth_newBlockFilter",
 	"eth_newPendingTransactionFilter",
@@ -468,6 +469,15 @@ func (m *MethodsConfig) SetDefaults() error {
 			mergedMethods[name] = method
 		}
 
+		// Mark default stateful methods
+		for _, mn := range DefaultStatefulMethodNames {
+			if cm, ok := mergedMethods[mn]; ok {
+				cm.Stateful = true
+			} else {
+				mergedMethods[mn] = &CacheMethodConfig{Stateful: true}
+			}
+		}
+
 		if m.PreserveDefaultMethods && m.Definitions != nil {
 			// Merge user definitions on top of defaults
 			for name, method := range m.Definitions {
@@ -491,6 +501,15 @@ func (m *MethodsConfig) SetDefaults() error {
 		}
 		for name, method := range DefaultSpecialCacheMethods {
 			mergedMethods[name] = method
+		}
+
+		// Mark default stateful methods
+		for _, mn := range DefaultStatefulMethodNames {
+			if cm, ok := mergedMethods[mn]; ok {
+				cm.Stateful = true
+			} else {
+				mergedMethods[mn] = &CacheMethodConfig{Stateful: true}
+			}
 		}
 
 		// Then override with user definitions
@@ -1680,9 +1699,6 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 		}
 	}
 
-	if n.StatefulMethods == nil || len(n.StatefulMethods) == 0 {
-		n.StatefulMethods = DefaultStatefulMethods
-	}
 
 	return nil
 }

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -172,6 +172,15 @@ func (c *Config) SetDefaults(opts *DefaultOptions) error {
 	return nil
 }
 
+var DefaultStatefulMethods = []string{
+	"eth_newFilter",
+	"eth_newBlockFilter",
+	"eth_newPendingTransactionFilter",
+	"eth_getFilterChanges",
+	"eth_getFilterLogs",
+	"eth_uninstallFilter",
+}
+
 // These methods return a fixed value that does not change over time
 var DefaultStaticCacheMethods = map[string]*CacheMethodConfig{
 	"eth_chainId": {
@@ -990,10 +999,16 @@ func (p *ProjectConfig) SetDefaults(opts *DefaultOptions) error {
 			}
 		}
 	}
+	if p.StatefulMethods == nil || len(p.StatefulMethods) == 0 {
+		p.StatefulMethods = DefaultStatefulMethods
+	}
 	if p.Networks != nil {
 		for _, network := range p.Networks {
 			if err := network.SetDefaults(p.Upstreams, p.NetworkDefaults); err != nil {
 				return fmt.Errorf("failed to set defaults for network: %w", err)
+			}
+			if network.StatefulMethods == nil || len(network.StatefulMethods) == 0 {
+				network.StatefulMethods = p.StatefulMethods
 			}
 		}
 	}

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -951,12 +951,7 @@ func (n *Network) cleanupMultiplexer(mlx *Multiplexer) {
 
 func (n *Network) shouldHandleMethod(req *common.NormalizedRequest, method string, upsList []common.Upstream) error {
 	// Check stateful methods policy
-	var stateful []string
-	if n.cfg != nil && len(n.cfg.StatefulMethods) > 0 {
-		stateful = n.cfg.StatefulMethods
-	} else {
-		stateful = common.DefaultStatefulMethods
-	}
+	stateful := n.cfg.StatefulMethods
 	isStateful := false
 	for _, m := range stateful {
 		if m == method {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -951,31 +951,11 @@ func (n *Network) cleanupMultiplexer(mlx *Multiplexer) {
 
 func (n *Network) shouldHandleMethod(req *common.NormalizedRequest, method string, upsList []common.Upstream) error {
 	// Check stateful methods policy
+	// Methods.Definitions is guaranteed to be populated by SetDefaults() with all necessary stateful methods
 	isStateful := false
 	if n.cfg != nil && n.cfg.Methods != nil && n.cfg.Methods.Definitions != nil {
 		if mc, ok := n.cfg.Methods.Definitions[method]; ok && mc != nil {
 			isStateful = mc.Stateful
-		}
-	}
-	if !isStateful {
-		// fallback to defaults if method not defined in config
-		if mc := common.DefaultWithBlockCacheMethods[method]; mc != nil {
-			isStateful = mc.Stateful
-		}
-		if !isStateful {
-			if mc := common.DefaultSpecialCacheMethods[method]; mc != nil {
-				isStateful = mc.Stateful
-			}
-		}
-		if !isStateful {
-			if mc := common.DefaultRealtimeCacheMethods[method]; mc != nil {
-				isStateful = mc.Stateful
-			}
-		}
-		if !isStateful {
-			if mc := common.DefaultStaticCacheMethods[method]; mc != nil {
-				isStateful = mc.Stateful
-			}
 		}
 	}
 	if isStateful {


### PR DESCRIPTION

- Add project/network-level statefulMethods config with sensible EVM defaults
- Permit filter-related stateful methods when exactly one upstream is targeted (or only one exists)
- Return descriptive error when multiple upstreams are targeted for stateful methods
- Keep eth_accounts/eth_sign unsupported