### PR TITLE
fix(third-party): add celo-mainnet to alchemy's supported chains

### DIFF
--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -38,6 +38,7 @@ var defaultAlchemyNetworkSubdomains = map[int64]string{
 	42161:     "arb-mainnet",
 	421614:    "arb-sepolia",
 	42170:     "arbnova-mainnet",
+    42220:     "celo-mainnet",
 	43113:     "avax-fuji",
 	43114:     "avax-mainnet",
 	5000:      "mantle-mainnet",


### PR DESCRIPTION
erpc is not querying alchemy about celo mainnet data (chain id 42220). It has been supported since April 2025, so add it to the list of suported chains  https://www.alchemy.com/blog/alchemy-celo-l2-integrate

I'm not sure if this all we need for the erpc to auto-detect alchemy as an RPC provider for celo, feel free to edit and ajust as needed. Thanks ❤️  