### PR TITLE
feat: support auth tokens in request URIs

### DIFF
--- a/auth/http.go
+++ b/auth/http.go
@@ -99,3 +99,13 @@ func normalizeSiweMessage(msg string) string {
 	}
 	return string(decoded)
 }
+
+func NewPayloadFromToken(method string, token string) (*AuthPayload, error) {
+	return &AuthPayload{
+		Method: method,
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{
+			Value: token,
+		},
+	}, nil
+}


### PR DESCRIPTION
eRPC primarily supports raw secret values through headers currently. This is a great strategy for clients that have that option (most Eth SDKs and packages do), but prevents easy compatibility with clients that don't. For example, eRPC is a great candidate to use as an L1 RPC source for `op-node` and `erigon` clients, but neither of those components support configuration beyond an RPC URI, which means passing through a static header is not doable without code changes to them.

This PR adds support for adding a raw auth token to the end of eRPC URIs - most RPC providers use this pattern specifically for widespread compatibility. I know that support for the token being passed through query parameters exists today, but it is marked as deprecated in the code, so future support isn't certain.