### PR TITLE
fix: copy upstream headers to avoid map concurrent access

### DIFF
--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -816,9 +816,12 @@ func (c *GenericGrpcBdsClient) SetHeaders(h map[string]string) {
 	if c == nil || h == nil {
 		return
 	}
+	// Make a copy of the headers map to avoid sharing the same reference
+	newHeaders := make(map[string]string, len(h))
 	for k, v := range h {
-		c.headers[k] = v
+		newHeaders[k] = v
 	}
+	c.headers = newHeaders
 }
 
 // Helper functions for conversion

--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -123,7 +123,11 @@ func NewGenericHttpJsonRpcClient(
 		}
 
 		if jsonRpcCfg.Headers != nil {
-			client.headers = jsonRpcCfg.Headers
+			// Make a copy of the headers map to avoid sharing the same reference
+			client.headers = make(map[string]string, len(jsonRpcCfg.Headers))
+			for k, v := range jsonRpcCfg.Headers {
+				client.headers[k] = v
+			}
 		}
 
 		client.proxyPool = proxyPool

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1343,13 +1343,22 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 		}
 	}
 	if u.JsonRpc == nil && defaults.JsonRpc != nil {
+		// Make a copy of the headers map to avoid sharing the same reference
+		var headers map[string]string
+		if defaults.JsonRpc.Headers != nil {
+			headers = make(map[string]string, len(defaults.JsonRpc.Headers))
+			for k, v := range defaults.JsonRpc.Headers {
+				headers[k] = v
+			}
+		}
+
 		u.JsonRpc = &JsonRpcUpstreamConfig{
 			SupportsBatch: defaults.JsonRpc.SupportsBatch,
 			BatchMaxSize:  defaults.JsonRpc.BatchMaxSize,
 			BatchMaxWait:  defaults.JsonRpc.BatchMaxWait,
 			EnableGzip:    defaults.JsonRpc.EnableGzip,
 			ProxyPool:     defaults.JsonRpc.ProxyPool,
-			Headers:       defaults.JsonRpc.Headers,
+			Headers:       headers,
 		}
 	}
 	// Integrity moved under Evm.Integrity

--- a/common/upstream.go
+++ b/common/upstream.go
@@ -56,8 +56,13 @@ func UniqueUpstreamKey(up Upstream) string {
 	sha.Write([]byte(cfg.Id))
 	sha.Write([]byte(cfg.Endpoint))
 	sha.Write([]byte(up.NetworkId()))
-	if cfg.JsonRpc != nil {
+	if cfg.JsonRpc != nil && cfg.JsonRpc.Headers != nil {
+		// Create a copy of the headers map to avoid concurrent map iteration
+		headersCopy := make(map[string]string, len(cfg.JsonRpc.Headers))
 		for k, v := range cfg.JsonRpc.Headers {
+			headersCopy[k] = v
+		}
+		for k, v := range headersCopy {
 			sha.Write([]byte(k))
 			sha.Write([]byte(v))
 		}

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -92,6 +92,8 @@ func NewGrpcConnector(
 		initializer:       util.NewInitializer(ctx, &lg, nil),
 	}
 	if cfg.Headers != nil {
+		// Make a copy of the headers map to avoid sharing the same reference
+		gc.headers = make(map[string]string, len(cfg.Headers))
 		for k, v := range cfg.Headers {
 			gc.headers[k] = v
 		}

--- a/thirdparty/repository.go
+++ b/thirdparty/repository.go
@@ -125,8 +125,7 @@ func (v *RepositoryVendor) GenerateConfigs(ctx context.Context, logger *zerolog.
 		}
 		var jsonRpc *common.JsonRpcUpstreamConfig
 		if upstream.JsonRpc != nil {
-			jsonRpc = &common.JsonRpcUpstreamConfig{}
-			*jsonRpc = *upstream.JsonRpc
+			jsonRpc = upstream.JsonRpc.Copy()
 		}
 		var failsafe []*common.FailsafeConfig
 		if upstream.Failsafe != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Copy JSON-RPC headers/maps across clients, defaults, upstream hashing, gRPC connector, and repository vendor to prevent shared references and concurrent map access issues.
> 
> - **Safety: copy headers/config to avoid shared references and concurrent map iteration**
>   - `clients/http_json_rpc_client.go`: copy `jsonRpcCfg.Headers` into a new map.
>   - `clients/grpc_bds_client.go`: `SetHeaders` now copies input headers into a new map.
>   - `data/grpc.go`: copy `cfg.Headers` into `gc.headers`.
>   - `common/defaults.go`: when initializing `u.JsonRpc`, copy `defaults.JsonRpc.Headers` into a new map.
>   - `common/upstream.go`: `UniqueUpstreamKey` copies `cfg.JsonRpc.Headers` before iterating; adds nil checks.
>   - `thirdparty/repository.go`: use `upstream.JsonRpc.Copy()` for deep copy instead of shallow struct copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c3d86c3733a7c5262b7523dbbc0f287f3470cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->