### PR TITLE
fix: consistent error message text for any sort of eth_getLogs max allowed threshold

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -90,7 +90,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),
 					common.JsonRpcErrorEvmLargeRange,
-					err.Message,
+					fmt.Sprintf("getLogs request exceeded max allowed range: %s", err.Message),
 					nil,
 					details,
 				),
@@ -101,7 +101,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),
 					common.JsonRpcErrorEvmLargeRange,
-					err.Message,
+					fmt.Sprintf("getLogs request exceeded max allowed addresses: %s", err.Message),
 					nil,
 					details,
 				),

--- a/common/errors.go
+++ b/common/errors.go
@@ -1328,72 +1328,6 @@ var NewErrUpstreamShadowing = func(upstreamId string) error {
 	}
 }
 
-type ErrUpstreamGetLogsExceededMaxAllowedRange struct{ BaseError }
-
-const ErrCodeUpstreamGetLogsExceededMaxAllowedRange ErrorCode = "ErrUpstreamGetLogsExceededMaxAllowedRange"
-
-var NewErrUpstreamGetLogsExceededMaxAllowedRange = func(upstreamId string, requestRange int64, maxAllowedRange int64) error {
-	return &ErrUpstreamGetLogsExceededMaxAllowedRange{
-		BaseError{
-			Code:    ErrCodeUpstreamGetLogsExceededMaxAllowedRange,
-			Message: "upstream request range exceeded max allowed range",
-			Details: map[string]interface{}{
-				"upstreamId":      upstreamId,
-				"requestRange":    requestRange,
-				"maxAllowedRange": maxAllowedRange,
-			},
-		},
-	}
-}
-
-func (e *ErrUpstreamGetLogsExceededMaxAllowedRange) ErrorStatusCode() int {
-	return http.StatusRequestEntityTooLarge
-}
-
-type ErrUpstreamGetLogsExceededMaxAllowedAddresses struct{ BaseError }
-
-const ErrCodeUpstreamGetLogsExceededMaxAllowedAddresses ErrorCode = "ErrUpstreamGetLogsExceededMaxAllowedAddresses"
-
-var NewErrUpstreamGetLogsExceededMaxAllowedAddresses = func(upstreamId string, requestAddresses int64, maxAllowedAddresses int64) error {
-	return &ErrUpstreamGetLogsExceededMaxAllowedAddresses{
-		BaseError{
-			Code:    ErrCodeUpstreamGetLogsExceededMaxAllowedAddresses,
-			Message: "upstream request addresses exceeded max allowed addresses",
-			Details: map[string]interface{}{
-				"upstreamId":          upstreamId,
-				"requestAddresses":    requestAddresses,
-				"maxAllowedAddresses": maxAllowedAddresses,
-			},
-		},
-	}
-}
-
-func (e *ErrUpstreamGetLogsExceededMaxAllowedAddresses) ErrorStatusCode() int {
-	return http.StatusRequestEntityTooLarge
-}
-
-type ErrUpstreamGetLogsExceededMaxAllowedTopics struct{ BaseError }
-
-const ErrCodeUpstreamGetLogsExceededMaxAllowedTopics ErrorCode = "ErrUpstreamGetLogsExceededMaxAllowedTopics"
-
-var NewErrUpstreamGetLogsExceededMaxAllowedTopics = func(upstreamId string, requestTopics int64, maxAllowedTopics int64) error {
-	return &ErrUpstreamGetLogsExceededMaxAllowedTopics{
-		BaseError{
-			Code:    ErrCodeUpstreamGetLogsExceededMaxAllowedTopics,
-			Message: "upstream request topics exceeded max allowed topics",
-			Details: map[string]interface{}{
-				"upstreamId":       upstreamId,
-				"requestTopics":    requestTopics,
-				"maxAllowedTopics": maxAllowedTopics,
-			},
-		},
-	}
-}
-
-func (e *ErrUpstreamGetLogsExceededMaxAllowedTopics) ErrorStatusCode() int {
-	return http.StatusRequestEntityTooLarge
-}
-
 type ErrUpstreamNotAllowed struct{ BaseError }
 
 var NewErrUpstreamNotAllowed = func(required, upstreamId string) error {
@@ -2575,7 +2509,7 @@ var NewErrGetLogsExceededMaxAllowedRange = func(requestRange int64, maxAllowedRa
 	return &ErrGetLogsExceededMaxAllowedRange{
 		BaseError{
 			Code:    ErrCodeGetLogsExceededMaxAllowedRange,
-			Message: "getLogs request range exceeded max allowed range",
+			Message: "getLogs request exceeded max allowed range",
 			Details: map[string]interface{}{
 				"requestRange":    requestRange,
 				"maxAllowedRange": maxAllowedRange,
@@ -2596,7 +2530,7 @@ var NewErrGetLogsExceededMaxAllowedAddresses = func(requestAddresses int64, maxA
 	return &ErrGetLogsExceededMaxAllowedAddresses{
 		BaseError{
 			Code:    ErrCodeGetLogsExceededMaxAllowedAddresses,
-			Message: "getLogs request addresses exceeded max allowed addresses",
+			Message: "getLogs request exceeded max allowed addresses",
 			Details: map[string]interface{}{
 				"requestAddresses":    requestAddresses,
 				"maxAllowedAddresses": maxAllowedAddresses,
@@ -2617,7 +2551,7 @@ var NewErrGetLogsExceededMaxAllowedTopics = func(requestTopics int64, maxAllowed
 	return &ErrGetLogsExceededMaxAllowedTopics{
 		BaseError{
 			Code:    ErrCodeGetLogsExceededMaxAllowedTopics,
-			Message: "getLogs request topics exceeded max allowed topics",
+			Message: "getLogs request exceeded max allowed topics",
 			Details: map[string]interface{}{
 				"requestTopics":    requestTopics,
 				"maxAllowedTopics": maxAllowedTopics,

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1500,7 +1500,7 @@ func TranslateToJsonRpcException(err error) error {
 		return NewErrJsonRpcExceptionInternal(
 			0,
 			JsonRpcErrorEvmLargeRange,
-			"allowed block range threshold exceeded for eth_getLogs",
+			"getLogs request exceeded max allowed range",
 			err,
 			nil,
 		)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes eth_getLogs “max allowed” error messages across normalization and JSON-RPC, and removes upstream-specific getLogs limit error types.
> 
> - **Errors**:
>   - Standardize messages for `ErrGetLogsExceededMaxAllowedRange|Addresses|Topics` to "getLogs request exceeded max allowed ...".
>   - Remove upstream-specific `ErrUpstreamGetLogsExceededMaxAllowed{Range,Addresses,Topics}` error types.
> - **EVM Error Normalizer (`architecture/evm/error_normalizer.go`)**:
>   - Prefix provider messages with standardized text for oversized `eth_getLogs` requests (range, addresses).
> - **JSON-RPC (`common/json_rpc.go`)**:
>   - Update translation message for large-range getLogs to "getLogs request exceeded max allowed range".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccab5bb691030014f49cbb52f66d8581c102a84c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->