### PR TITLE
feat: allow appending misbehaviors to a file

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -917,9 +917,7 @@ const (
 )
 
 type ConsensusPolicyConfig struct {
-	MaxParticipants int `yaml:"maxParticipants" json:"maxParticipants"`
-	// @deprecated: use MaxParticipants instead
-	RequiredParticipants    int                              `yaml:"requiredParticipants" json:"-"`
+	MaxParticipants         int                              `yaml:"maxParticipants" json:"maxParticipants"`
 	AgreementThreshold      int                              `yaml:"agreementThreshold,omitempty" json:"agreementThreshold"`
 	DisputeBehavior         ConsensusDisputeBehavior         `yaml:"disputeBehavior,omitempty" json:"disputeBehavior"`
 	LowParticipantsBehavior ConsensusLowParticipantsBehavior `yaml:"lowParticipantsBehavior,omitempty" json:"lowParticipantsBehavior"`
@@ -928,7 +926,7 @@ type ConsensusPolicyConfig struct {
 	IgnoreFields            map[string][]string              `yaml:"ignoreFields,omitempty" json:"ignoreFields"`
 	PreferNonEmpty          *bool                            `yaml:"preferNonEmpty,omitempty" json:"preferNonEmpty"`
 	PreferLargerResponses   *bool                            `yaml:"preferLargerResponses,omitempty" json:"preferLargerResponses"`
-	AppendMisbehaviorsTo    string                           `yaml:"appendMisbehaviorsTo,omitempty" json:"appendMisbehaviorsTo"`
+	MisbehaviorsDestination *MisbehaviorsDestinationConfig   `yaml:"misbehaviorsDestination,omitempty" json:"misbehaviorsDestination"`
 }
 
 func (c *ConsensusPolicyConfig) Copy() *ConsensusPolicyConfig {
@@ -942,6 +940,10 @@ func (c *ConsensusPolicyConfig) Copy() *ConsensusPolicyConfig {
 		copied.PunishMisbehavior = c.PunishMisbehavior.Copy()
 	}
 
+	if c.MisbehaviorsDestination != nil {
+		copied.MisbehaviorsDestination = c.MisbehaviorsDestination.Copy()
+	}
+
 	if c.IgnoreFields != nil {
 		copied.IgnoreFields = make(map[string][]string, len(c.IgnoreFields))
 		for method, fields := range c.IgnoreFields {
@@ -950,6 +952,82 @@ func (c *ConsensusPolicyConfig) Copy() *ConsensusPolicyConfig {
 		}
 	}
 
+	return copied
+}
+
+type MisbehaviorsDestinationType string
+
+const (
+	MisbehaviorsDestinationTypeFile MisbehaviorsDestinationType = "file"
+	MisbehaviorsDestinationTypeS3   MisbehaviorsDestinationType = "s3"
+)
+
+type MisbehaviorsDestinationConfig struct {
+	// Type of destination: "file" or "s3"
+	Type MisbehaviorsDestinationType `yaml:"type" json:"type" tstype:"'file' | 's3'"`
+
+	// Path for file destination, or S3 URI (s3://bucket/prefix/) for S3 destination
+	Path string `yaml:"path" json:"path"`
+
+	// Pattern for generating file names. Supports placeholders:
+	// {dateByHour} - formatted as 2006-01-02-15
+	// {dateByDay} - formatted as 2006-01-02
+	// {method} - the RPC method name
+	// {networkId} - the network ID with : replaced by _
+	// {instanceId} - unique instance identifier
+	FilePattern string `yaml:"filePattern,omitempty" json:"filePattern"`
+
+	// S3-specific settings for bulk flushing
+	S3 *S3FlushConfig `yaml:"s3,omitempty" json:"s3,omitempty"`
+}
+
+type S3FlushConfig struct {
+	// Maximum number of records to buffer before flushing (default: 100)
+	MaxRecords int `yaml:"maxRecords,omitempty" json:"maxRecords"`
+
+	// Maximum size in bytes to buffer before flushing (default: 1MB)
+	MaxSize int64 `yaml:"maxSize,omitempty" json:"maxSize"`
+
+	// Maximum time to wait before flushing buffered records (default: 60s)
+	FlushInterval Duration `yaml:"flushInterval,omitempty" json:"flushInterval" tstype:"Duration"`
+
+	// AWS region for S3 bucket (defaults to AWS_REGION env var)
+	Region string `yaml:"region,omitempty" json:"region"`
+
+	// AWS credentials config (optional). If not specified, uses standard AWS credential chain:
+	// 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+	// 2. IAM role (for EC2/ECS/EKS)
+	// 3. Shared credentials file (~/.aws/credentials)
+	// Supported modes: "env", "file", "secret"
+	Credentials *AwsAuthConfig `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+
+	// Content type for uploaded files (default: "application/jsonl")
+	ContentType string `yaml:"contentType,omitempty" json:"contentType"`
+}
+
+func (c *MisbehaviorsDestinationConfig) Copy() *MisbehaviorsDestinationConfig {
+	if c == nil {
+		return nil
+	}
+	copied := &MisbehaviorsDestinationConfig{
+		Type:        c.Type,
+		Path:        c.Path,
+		FilePattern: c.FilePattern,
+	}
+	if c.S3 != nil {
+		copied.S3 = &S3FlushConfig{
+			MaxRecords:    c.S3.MaxRecords,
+			MaxSize:       c.S3.MaxSize,
+			FlushInterval: c.S3.FlushInterval,
+			Region:        c.S3.Region,
+			ContentType:   c.S3.ContentType,
+		}
+		if c.S3.Credentials != nil {
+			// AwsAuthConfig already exists in the codebase
+			creds := *c.S3.Credentials
+			copied.S3.Credentials = &creds
+		}
+	}
 	return copied
 }
 

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -633,7 +633,7 @@ func (e *executor) trackAndPunishMisbehavingUpstreams(lg *zerolog.Logger, req *c
 		// Export full event if configured
 		if e.exporter != nil {
 			if recBytes, err := e.buildMisbehaviorRecord(labels, req, winner, analysis, consensusGroup, allParticipants); err == nil {
-				if err2 := e.exporter.Append(recBytes); err2 != nil {
+				if err2 := e.exporter.AppendWithMetadata(recBytes, labels.method, labels.networkId); err2 != nil {
 					lg.Warn().Err(err2).Msg("failed to append misbehavior record")
 				}
 			} else {

--- a/consensus/export_s3.go
+++ b/consensus/export_s3.go
@@ -1,0 +1,251 @@
+package consensus
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+)
+
+// s3MisbehaviorExporter implements buffered S3 uploads
+type s3MisbehaviorExporter struct {
+	mu        sync.Mutex
+	cfg       *common.MisbehaviorsDestinationConfig
+	log       *zerolog.Logger
+	s3Client  *s3.S3
+	bucket    string
+	keyPrefix string
+
+	// Per-key buffers and counters (key := resolved file name)
+	buffers           map[string]*bytes.Buffer
+	counts            map[string]int
+	lastPeriodicFlush time.Time
+
+	// Channel for async flush
+	flushCh chan struct{}
+	closeCh chan struct{}
+	closeWg sync.WaitGroup
+}
+
+func newS3MisbehaviorExporter(cfg *common.MisbehaviorsDestinationConfig, log *zerolog.Logger) (*s3MisbehaviorExporter, error) {
+	if cfg == nil || cfg.Path == "" {
+		return nil, fmt.Errorf("empty S3 path configuration")
+	}
+
+	// Parse S3 path
+	bucket, keyPrefix, err := parseS3Path(cfg.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create AWS session with tuned HTTP transport for better connection reuse
+	awsConfig := &aws.Config{
+		Region: aws.String(cfg.S3.Region),
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 60 * time.Second,
+				}).DialContext,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          256,
+				MaxIdleConnsPerHost:   256,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+			Timeout: 0,
+		},
+		MaxRetries: aws.Int(5),
+	}
+
+	// Configure credentials if provided
+	if cfg.S3.Credentials != nil {
+		switch cfg.S3.Credentials.Mode {
+		case "secret":
+			awsConfig.Credentials = credentials.NewStaticCredentials(
+				cfg.S3.Credentials.AccessKeyID,
+				cfg.S3.Credentials.SecretAccessKey,
+				"",
+			)
+		case "file":
+			awsConfig.Credentials = credentials.NewSharedCredentials(
+				cfg.S3.Credentials.CredentialsFile,
+				cfg.S3.Credentials.Profile,
+			)
+		case "env":
+			// Use environment variables (default behavior)
+			awsConfig.Credentials = credentials.NewEnvCredentials()
+		default:
+			// Use default credential chain (env, IAM role, etc.)
+		}
+	}
+	// If no credentials specified, AWS SDK will use default chain:
+	// 1. Environment variables
+	// 2. Shared credentials file
+	// 3. IAM role (for EC2/ECS/EKS)
+
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
+	}
+
+	s3Client := s3.New(sess)
+
+	// Verify bucket access
+	_, err = s3Client.HeadBucket(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to access S3 bucket %s: %w", bucket, err)
+	}
+
+	exp := &s3MisbehaviorExporter{
+		cfg:               cfg,
+		log:               log,
+		s3Client:          s3Client,
+		bucket:            bucket,
+		keyPrefix:         keyPrefix,
+		buffers:           make(map[string]*bytes.Buffer),
+		counts:            make(map[string]int),
+		lastPeriodicFlush: time.Now(),
+		flushCh:           make(chan struct{}, 1),
+		closeCh:           make(chan struct{}),
+	}
+
+	// Start background flush worker
+	exp.closeWg.Add(1)
+	go exp.flushWorker()
+
+	return exp, nil
+}
+
+// flushWorker handles periodic flushing in the background
+func (e *s3MisbehaviorExporter) flushWorker() {
+	defer e.closeWg.Done()
+
+	ticker := time.NewTicker(e.cfg.S3.FlushInterval.Duration())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.closeCh:
+			// Final flush before closing
+			e.mu.Lock()
+			_ = e.flush()
+			e.mu.Unlock()
+			return
+
+		case <-ticker.C:
+			// Periodic flush
+			e.mu.Lock()
+			if e.shouldFlush() {
+				_ = e.flush()
+			}
+			e.mu.Unlock()
+
+		case <-e.flushCh:
+			// Triggered flush
+			e.mu.Lock()
+			_ = e.flush()
+			e.mu.Unlock()
+		}
+	}
+}
+
+// shouldFlush determines if buffer should be flushed (called with lock held)
+func (e *s3MisbehaviorExporter) shouldFlush() bool {
+	// Time-based periodic flush when anything exists
+	if len(e.buffers) == 0 {
+		return false
+	}
+	if time.Since(e.lastPeriodicFlush) >= e.cfg.S3.FlushInterval.Duration() {
+		return true
+	}
+	// Size or record thresholds on any buffer
+	for key := range e.buffers {
+		if int64(e.buffers[key].Len()) >= e.cfg.S3.MaxSize {
+			return true
+		}
+		if e.counts[key] >= e.cfg.S3.MaxRecords {
+			return true
+		}
+	}
+	return false
+}
+
+// flush uploads the current buffer to S3 (called with lock held)
+func (e *s3MisbehaviorExporter) flush() error {
+	if len(e.buffers) == 0 {
+		return nil
+	}
+	now := time.Now()
+	for fileName, buf := range e.buffers {
+		if buf == nil || buf.Len() == 0 {
+			continue
+		}
+		key := e.keyPrefix + fileName
+		input := &s3.PutObjectInput{
+			Bucket:      aws.String(e.bucket),
+			Key:         aws.String(key),
+			Body:        bytes.NewReader(buf.Bytes()),
+			ContentType: aws.String(e.cfg.S3.ContentType),
+		}
+		if _, err := e.s3Client.PutObject(input); err != nil {
+			e.log.Error().Err(err).Str("bucket", e.bucket).Str("key", key).Int("bytes", buf.Len()).Int("records", e.counts[fileName]).Msg("failed to upload misbehavior records to S3")
+			continue
+		}
+		e.log.Info().Str("bucket", e.bucket).Str("key", key).Int("bytes", buf.Len()).Int("records", e.counts[fileName]).Msg("uploaded misbehavior records to S3")
+		buf.Reset()
+		e.counts[fileName] = 0
+	}
+	e.lastPeriodicFlush = now
+	return nil
+}
+
+// AppendWithMetadata adds a record to the appropriate buffer and flushes if necessary
+func (e *s3MisbehaviorExporter) AppendWithMetadata(line []byte, method string, networkId string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Derive fileName directly from provided metadata to respect user pattern
+	fileName := resolveFilePatternWithDefaults(e.cfg, method, networkId, time.Now())
+
+	// Get/Create buffer for this key
+	buf := e.buffers[fileName]
+	if buf == nil {
+		buf = new(bytes.Buffer)
+		e.buffers[fileName] = buf
+	}
+
+	// Add to buffer
+	if _, err := buf.Write(line); err != nil {
+		return err
+	}
+	if _, err := buf.Write([]byte("\n")); err != nil {
+		return err
+	}
+	e.counts[fileName]++
+
+	// Check if we should flush
+	if e.shouldFlush() {
+		// Trigger async flush
+		select {
+		case e.flushCh <- struct{}{}:
+		default:
+			// Channel is full, flush already pending
+		}
+	}
+
+	return nil
+}

--- a/consensus/export_utils.go
+++ b/consensus/export_utils.go
@@ -1,0 +1,135 @@
+package consensus
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/erpc/erpc/common"
+)
+
+var (
+	instanceID     string
+	instanceIDOnce sync.Once
+)
+
+// getInstanceID returns a unique identifier for this instance.
+// Priority order:
+// 1. INSTANCE_ID environment variable
+// 2. POD_NAME environment variable (Kubernetes)
+// 3. HOSTNAME environment variable
+// 4. Generated hash based on startup time and process ID
+func getInstanceID() string {
+	instanceIDOnce.Do(func() {
+		// Try environment variables first
+		if id := os.Getenv("INSTANCE_ID"); id != "" {
+			instanceID = sanitizeForFilename(id)
+			return
+		}
+		if id := os.Getenv("POD_NAME"); id != "" {
+			instanceID = sanitizeForFilename(id)
+			return
+		}
+		if id := os.Getenv("HOSTNAME"); id != "" {
+			instanceID = sanitizeForFilename(id)
+			return
+		}
+
+		// Generate a deterministic ID based on startup time and process
+		h := sha256.New()
+		h.Write([]byte(fmt.Sprintf("%d-%d", time.Now().UnixNano(), os.Getpid())))
+		hash := hex.EncodeToString(h.Sum(nil))
+		instanceID = hash[:8] // Use first 8 chars of hash
+	})
+	return instanceID
+}
+
+// sanitizeForFilename replaces characters that are problematic in filenames
+func sanitizeForFilename(s string) string {
+	replacer := strings.NewReplacer(
+		":", "_",
+		"/", "_",
+		"\\", "_",
+		" ", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+		"\n", "_",
+		"\r", "_",
+		"\t", "_",
+	)
+	return replacer.Replace(s)
+}
+
+// resolveFilePattern resolves placeholders in the file pattern.
+// Supported placeholders:
+// - {dateByHour}: formatted as 2006-01-02-15
+// - {dateByDay}: formatted as 2006-01-02
+// - {method}: the RPC method name
+// - {networkId}: the network ID with : replaced by _
+// - {instanceId}: unique instance identifier
+func resolveFilePattern(pattern string, method string, networkId string, timestamp time.Time) string {
+	// No defaulting here; defaults are applied during config SetDefaults
+
+	replacements := map[string]string{
+		"{dateByHour}":  timestamp.UTC().Format("2006-01-02-15"),
+		"{dateByDay}":   timestamp.UTC().Format("2006-01-02"),
+		"{method}":      sanitizeForFilename(method),
+		"{networkId}":   sanitizeForFilename(networkId),
+		"{instanceId}":  getInstanceID(),
+		"{timestampMs}": fmt.Sprintf("%d", timestamp.UTC().UnixMilli()),
+	}
+
+	result := pattern
+	for placeholder, value := range replacements {
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+
+	if !strings.HasSuffix(result, ".ndjson") && !strings.HasSuffix(result, ".jsonl") {
+		result += ".jsonl"
+	}
+
+	return result
+}
+
+// resolveFilePatternWithDefaults uses different defaults based on destination type
+func resolveFilePatternWithDefaults(cfg *common.MisbehaviorsDestinationConfig, method string, networkId string, timestamp time.Time) string {
+	pattern := cfg.FilePattern
+	return resolveFilePattern(pattern, method, networkId, timestamp)
+}
+
+// parseS3Path parses an S3 URI into bucket and key prefix
+// Format: s3://bucket-name/optional/prefix/path/
+func parseS3Path(s3Path string) (bucket string, keyPrefix string, err error) {
+	if !strings.HasPrefix(s3Path, "s3://") {
+		return "", "", fmt.Errorf("invalid S3 path: must start with s3://")
+	}
+
+	path := strings.TrimPrefix(s3Path, "s3://")
+	parts := strings.SplitN(path, "/", 2)
+
+	if len(parts) == 0 || parts[0] == "" {
+		return "", "", fmt.Errorf("invalid S3 path: no bucket specified")
+	}
+
+	bucket = parts[0]
+	if len(parts) > 1 {
+		keyPrefix = parts[1]
+		// Ensure prefix ends with / if not empty
+		if keyPrefix != "" && !strings.HasSuffix(keyPrefix, "/") {
+			keyPrefix += "/"
+		}
+	}
+
+	return bucket, keyPrefix, nil
+}
+
+// setDefaultS3Config sets default values for S3 configuration
+// Removed defaulting helpers; defaults are handled in common/defaults.go

--- a/docs/pages/config/failsafe/consensus.mdx
+++ b/docs/pages/config/failsafe/consensus.mdx
@@ -34,7 +34,24 @@ projects:
               preferLargerResponses: true
               ignoreFields:
                 eth_getBlockByNumber: ["timestamp"]
-              appendMisbehaviorsTo: /var/log/erpc/misbehaviors.jsonl
+              misbehaviorsDestination:
+                type: file        # 'file' | 's3'
+                path: /var/log/erpc/misbehaviors   # absolute directory for file, or s3://bucket/prefix for S3
+                filePattern: "{timestampMs}-{method}-{networkId}"  # default for file; S3 default adds -{instanceId}
+                # s3:
+                #   region: us-west-2
+                #   maxRecords: 100
+                #   maxSize: 1048576        # 1MB
+                #   flushInterval: 60s
+                #   contentType: application/jsonl
+                #   credentials:
+                #     mode: env            # 'env' | 'file' | 'secret'
+                #     # for mode 'file':
+                #     # credentialsFile: ~/.aws/credentials
+                #     # profile: default
+                #     # for mode 'secret':
+                #     # accessKeyID: AKIA...
+                #     # secretAccessKey: ...
               punishMisbehavior: # (optional) To exclude bad upstreams from consensus for a while
                 disputeThreshold: 10 
                 disputeWindow: 10m
@@ -63,7 +80,20 @@ export default createConfig({
               preferNonEmpty: true,
               preferLargerResponses: true,
               ignoreFields: { eth_getBlockByNumber: ["timestamp"] },
-              appendMisbehaviorsTo: "/var/log/erpc/misbehaviors.jsonl",
+              misbehaviorsDestination: {
+                type: "file",
+                path: "/var/log/erpc/misbehaviors",
+                filePattern: "{timestampMs}-{method}-{networkId}.jsonl",
+                // s3: {
+                //   region: "us-west-2",
+                //   maxRecords: 100,
+                //   maxSize: 1048576,
+                //   flushInterval: "60s",
+                //   contentType: "application/jsonl",
+                //   credentials: { mode: "env" }
+                //   credentials: { mode: "secret", accessKeyID: "...", secretAccessKey: "..." }
+                // }
+              },
               punishMisbehavior: {
                 disputeThreshold: 3,
                 disputeWindow: "10s",
@@ -187,8 +217,28 @@ Temporarily removes upstreams that consistently disagree with the consensus:
 - **`disputeWindow`**: Time window for counting disputes (e.g., 10m)
 - **`sitOutPenalty`**: How long the upstream is cordoned (e.g., 30m)
 
-### `appendMisbehaviorsTo`
-Append full misbehavior events as JSONL to a file. Each line contains the full JSON-RPC request, all participant responses or errors, the analysis summary, the winner, and the policy snapshot. No truncation is applied. Ensure you use external log rotation for large files.
+### `misbehaviorsDestination`
+Append full misbehavior events (JSONL) to a destination. Each line contains the full JSON-RPC request, all participant responses or errors, the analysis summary, the winner, and the policy snapshot. No truncation is applied.
+
+- **type**: `file` | `s3`
+- **path**:
+  - For `file`: absolute directory path; files are created using `filePattern`.
+  - For `s3`: `s3://bucket/prefix` where files are uploaded using `filePattern`.
+- **filePattern** placeholders:
+  - `{dateByHour}`: UTC hour (`YYYY-MM-DD-HH`)
+  - `{dateByDay}`: UTC day (`YYYY-MM-DD`)
+  - `{method}`: JSON-RPC method
+  - `{networkId}`: network id with `:` replaced by `_`
+  - `{instanceId}`: unique instance ID (auto from env/pod/hostname or generated)
+  - `{timestampMs}`: UTC timestamp in milliseconds (useful to avoid key collisions on S3)
+  - Defaults: `{timestampMs}-{method}-{networkId}.jsonl`
+- **s3** (when type=`s3`):
+  - `region`, `maxRecords`, `maxSize` (bytes), `flushInterval`, `contentType`
+  - `credentials.mode`: `env` | `file` | `secret` (+ required fields per mode)
+
+Notes:
+- File writes use atomic append; use external rotation for large files.
+- S3 uploads are buffered and flushed by size, count, or time.
 
 ## Performance
 Consensus increases costs and latency since it waits for multiple responses. Use it selectively for critical workloads and specific methods rather than all requests.

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -654,8 +654,8 @@ func createConsensusPolicy(logger *zerolog.Logger, cfg *common.ConsensusPolicyCo
 	builder = builder.WithLogger(logger)
 
 	// Configure misbehavior export if requested
-	if cfg.AppendMisbehaviorsTo != "" {
-		builder = builder.WithMisbehaviorExportFile(cfg.AppendMisbehaviorsTo)
+	if cfg.MisbehaviorsDestination != nil {
+		builder = builder.WithMisbehaviorsDestination(cfg.MisbehaviorsDestination)
 	}
 
 	// Set ignore fields if configured


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable export of consensus misbehavior events to file or S3 and wires it through config→policy→executor; also removes the deprecated `requiredParticipants` field.
> 
> - **Consensus misbehavior export (file/S3)**:
>   - Add `consensus.misbehaviorsDestination` to `ConsensusPolicyConfig` with types: `MisbehaviorsDestinationConfig` (`type`, `path`, `filePattern`, `s3`), `S3FlushConfig` (buffering/credentials/region/contentType).
>   - Implement exporters:
>     - `fileMisbehaviorExporter` writes JSONL with pattern-based filenames.
>     - `s3MisbehaviorExporter` buffers records and uploads to S3 by count/size/interval; supports creds and region.
>     - Utilities for filename pattern resolution and instance ID.
>   - Executor: collect participant details when exporting/logging; build full misbehavior record (request, winner, analysis, participants, policy) and append via exporter; keep existing dispute logging.
>   - Policy: add builder `WithMisbehaviorsDestination`; initialize appropriate exporter (file/S3) on build.
>   - Upstream wiring: pass `misbehaviorsDestination` from config into consensus builder.
> - **Config**:
>   - Defaults/validation for `misbehaviorsDestination` (file/S3 paths, S3 buffering, credentials); deep-copy support.
>   - Remove deprecated `requiredParticipants` handling and warning.
> - **Docs**:
>   - Extend consensus config docs with `misbehaviorsDestination` usage, options, and examples (YAML/TS).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f519b653793c63a57424054828a35702820ba7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->