### PR TITLE
fix: correct json-rpc and status code for eth_getLogs invalid argument

### DIFF
--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -174,7 +174,9 @@ func networkPreForward_eth_getLogs(ctx context.Context, n common.Network, ups []
 	jrq.RUnlock()
 
 	if fromBlock > toBlock {
-		return true, nil, errors.New("fromBlock (" + strconv.FormatInt(fromBlock, 10) + ") must be less than or equal to toBlock (" + strconv.FormatInt(toBlock, 10) + ")")
+		return true, nil, common.NewErrInvalidRequest(
+			errors.New("fromBlock (" + strconv.FormatInt(fromBlock, 10) + ") must be less than or equal to toBlock (" + strconv.FormatInt(toBlock, 10) + ")"),
+		)
 	}
 
 	ncfg := n.Config()
@@ -314,7 +316,9 @@ func upstreamPreForward_eth_getLogs(ctx context.Context, n common.Network, u com
 	jrq.RUnlock()
 
 	if fromBlock > toBlock {
-		return true, nil, errors.New("fromBlock (" + strconv.FormatInt(fromBlock, 10) + ") must be less than or equal to toBlock (" + strconv.FormatInt(toBlock, 10) + ")")
+		return true, nil, common.NewErrInvalidRequest(
+			errors.New("fromBlock (" + strconv.FormatInt(fromBlock, 10) + ") must be less than or equal to toBlock (" + strconv.FormatInt(toBlock, 10) + ")"),
+		)
 	}
 
 	statePoller := up.EvmStatePoller()

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1490,8 +1490,8 @@ func TranslateToJsonRpcException(err error) error {
 	if HasErrorCode(err, ErrCodeInvalidRequest, ErrCodeInvalidUrlPath) {
 		return NewErrJsonRpcExceptionInternal(
 			0,
-			JsonRpcErrorClientSideException,
-			"bad request url and/or body",
+			JsonRpcErrorInvalidArgument,
+			"invalid request url and/or body",
 			err,
 			nil,
 		)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wrap eth_getLogs invalid block range as InvalidRequest and translate invalid request/url errors to JSON-RPC InvalidArgument with updated message.
> 
> - **EVM `eth_getLogs`**:
>   - Wrap invalid block-range (`fromBlock > toBlock`) as `common.NewErrInvalidRequest(...)` in `networkPreForward_eth_getLogs` and `upstreamPreForward_eth_getLogs`.
> - **JSON-RPC error translation**:
>   - Map `ErrCodeInvalidRequest`/`ErrCodeInvalidUrlPath` to `JsonRpcErrorInvalidArgument` with message "invalid request url and/or body" (was `ClientSideException`/"bad request url and/or body").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9aee3155ab9e86a764e7898a6dc3a8bd31675c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->