### PR TITLE
feat: allow full user-agent preservation per project

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -359,7 +359,21 @@ type ProjectConfig struct {
 	ScoreMetricsWindowSize Duration                            `yaml:"scoreMetricsWindowSize,omitempty" json:"scoreMetricsWindowSize" tstype:"Duration"`
 	ScoreRefreshInterval   Duration                            `yaml:"scoreRefreshInterval,omitempty" json:"scoreRefreshInterval" tstype:"Duration"`
 	DeprecatedHealthCheck  *DeprecatedProjectHealthCheckConfig `yaml:"healthCheck,omitempty" json:"healthCheck"`
+	// Configure user agent tracking at the project level
+	UserAgentMode UserAgentTrackingMode `yaml:"userAgentMode,omitempty" json:"userAgentMode"`
 }
+
+// UserAgentTrackingMode controls how user agents are recorded for metrics/labels
+type UserAgentTrackingMode string
+
+const (
+	// UserAgentTrackingModeSimplified lowers cardinality by bucketing common user agents
+	UserAgentTrackingModeSimplified UserAgentTrackingMode = "simplified"
+	// UserAgentTrackingModeRaw records the user agent string as-is (high cardinality)
+	UserAgentTrackingModeRaw UserAgentTrackingMode = "raw"
+)
+
+// Removed legacy nested UserAgentConfig; use ProjectConfig.UserAgentMode
 
 type NetworkDefaults struct {
 	RateLimitBudget   string                   `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget"`

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -517,7 +517,12 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 				nq.SetNetwork(nw)
 
 				nq.ApplyDirectiveDefaults(nw.Config().DirectiveDefaults)
-				nq.EnrichFromHttp(headers, queryArgs)
+				// Configure how to store User-Agent (raw vs simplified) based on project config
+				uaMode := common.UserAgentTrackingModeSimplified
+				if project != nil && project.Config.UserAgentMode != "" {
+					uaMode = project.Config.UserAgentMode
+				}
+				nq.EnrichFromHttp(headers, queryArgs, uaMode)
 				rlg.Trace().Interface("directives", nq.Directives()).Msgf("applied request directives")
 
 				resp, err := project.Forward(requestCtx, networkId, nq)

--- a/erpc/networks_failsafe_test.go
+++ b/erpc/networks_failsafe_test.go
@@ -468,7 +468,7 @@ func TestNetworkFailsafe_RetryEmpty(t *testing.T) {
 		headers := http.Header{
 			"X-ERPC-Retry-Empty": []string{"false"},
 		}
-		req.EnrichFromHttp(headers, nil)
+		req.EnrichFromHttp(headers, nil, common.UserAgentTrackingModeSimplified)
 
 		resp, err := network.Forward(ctx, req)
 

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -3004,7 +3004,7 @@ func TestNetwork_Forward(t *testing.T) {
 			}`))
 		fakeReq.EnrichFromHttp(http.Header{
 			"X-Erpc-Retry-Pending": []string{"true"},
-		}, url.Values{})
+		}, url.Values{}, common.UserAgentTrackingModeSimplified)
 		resp, err := ntw.Forward(ctx, fakeReq)
 
 		if err != nil {
@@ -3625,7 +3625,7 @@ func TestNetwork_Forward(t *testing.T) {
 			"X-Erpc-Retry-Pending": []string{"true"},
 		}
 		queryArgs := url.Values{}
-		fakeReq.EnrichFromHttp(headers, queryArgs)
+		fakeReq.EnrichFromHttp(headers, queryArgs, common.UserAgentTrackingModeSimplified)
 		resp, err := ntw.Forward(ctx, fakeReq)
 
 		if err != nil {
@@ -3812,7 +3812,7 @@ func TestNetwork_Forward(t *testing.T) {
 		headers := http.Header{}
 		headers.Set("x-erpc-retry-pending", "false")
 		queryArgs := url.Values{}
-		fakeReq.EnrichFromHttp(headers, queryArgs)
+		fakeReq.EnrichFromHttp(headers, queryArgs, common.UserAgentTrackingModeSimplified)
 		resp, err := ntw.Forward(ctx, fakeReq)
 
 		if err != nil {
@@ -3964,7 +3964,7 @@ func TestNetwork_Forward(t *testing.T) {
 		fakeReq2 := common.NewNormalizedRequest(requestBytes)
 		headers := http.Header{}
 		headers.Set("x-erpc-skip-cache-read", "true")
-		fakeReq2.EnrichFromHttp(headers, url.Values{})
+		fakeReq2.EnrichFromHttp(headers, url.Values{}, common.UserAgentTrackingModeSimplified)
 		resp2, err := ntw.Forward(ctx, fakeReq2)
 		if err != nil {
 			t.Fatalf("Expected nil error, got %v", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce ProjectConfig.userAgentMode to control raw vs simplified User-Agent labeling, wire it through HTTP request enrichment, and remove agent version tracking.
> 
> - **Config**:
>   - Add `ProjectConfig.userAgentMode` with `"raw" | "simplified"` (`UserAgentTrackingMode`).
> - **Request handling**:
>   - `NormalizedRequest.EnrichFromHttp(..)` accepts `mode` and stores `agentName` as raw or simplified accordingly.
>   - Remove `agentVersion` caching and `simplifyAgentVersion`; update `CopyHttpContextFrom` to stop copying version.
> - **HTTP server**:
>   - Read `project.Config.UserAgentMode` (default `simplified`) and pass to `EnrichFromHttp`.
> - **Tests**:
>   - Update all callers to pass `UserAgentTrackingMode` to `EnrichFromHttp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70658d816d3e10501e78fee02493cfe2a7ab986b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->