### PR TITLE
fix: return 200 OK for all json-rpc requests to comply with most popular vendors

### DIFF
--- a/consensus/export_utils.go
+++ b/consensus/export_utils.go
@@ -130,6 +130,3 @@ func parseS3Path(s3Path string) (bucket string, keyPrefix string, err error) {
 
 	return bucket, keyPrefix, nil
 }
-
-// setDefaultS3Config sets default values for S3 configuration
-// Removed defaulting helpers; defaults are handled in common/defaults.go

--- a/erpc/http_server_hedge_test.go
+++ b/erpc/http_server_hedge_test.go
@@ -235,8 +235,8 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 
 		statusCode, _, body := sendRequest(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`, nil, nil)
 
-		// Should fail immediately with error from rpc1 (no waiting for hedges)
-		assert.Equal(t, http.StatusInternalServerError, statusCode)
+		// Should fail immediately but transport stays 200 per JSON-RPC over HTTP
+		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, "internal server error")
 	})
 
@@ -1102,7 +1102,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 		statusCode, _, body := sendRequest(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`, nil, nil)
 
 		// Should fail immediately with primary error
-		assert.Equal(t, http.StatusInternalServerError, statusCode)
+		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, "internal server error")
 	})
 
@@ -1398,7 +1398,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 		statusCode, _, body := sendRequest(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`, nil, nil)
 
 		// Should fail immediately with primary error (500)
-		assert.Equal(t, http.StatusInternalServerError, statusCode)
+		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, "internal server error")
 	})
 
@@ -1497,7 +1497,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 		statusCode, _, body := sendRequest(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`, nil, nil)
 
 		// Should wait for both to complete and return error
-		assert.Equal(t, http.StatusServiceUnavailable, statusCode)
+		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, "error")
 	})
 
@@ -2519,7 +2519,7 @@ func TestHttpServer_HedgedRequests(t *testing.T) {
 
 		statusCode, _, body := sendRequest(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123"],"id":1}`, nil, nil)
 
-		assert.Equal(t, http.StatusGatewayTimeout, statusCode)
+		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, ErrHandlerTimeout.Error())
 	})
 

--- a/erpc/http_timeout_test.go
+++ b/erpc/http_timeout_test.go
@@ -1,0 +1,213 @@
+package erpc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	util.ConfigureTestLogger()
+}
+
+func TestTimeoutHandler_TimeoutReturnsJsonRpcError(t *testing.T) {
+	// Handler that takes longer than the timeout
+	slowHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+	})
+
+	handler := TimeoutHandler(slowHandler, 10*time.Millisecond)
+
+	t.Run("POST request timeout returns 200 with JSON-RPC error body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}`))
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		body := rec.Body.String()
+		assert.NotEmpty(t, body, "response body should not be empty")
+		assert.Contains(t, body, `"jsonrpc":"2.0"`)
+		assert.Contains(t, body, `"error"`)
+		assert.Contains(t, body, `"code":-32603`)
+		assert.Contains(t, body, "timeout")
+	})
+
+	t.Run("GET request timeout returns 504 Gateway Timeout", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+	})
+}
+
+func TestTimeoutHandler_NonTimeoutContextCancellation(t *testing.T) {
+	// This test verifies the bug fix: non-timeout context cancellation should
+	// still return a proper JSON-RPC error body for POST requests, not an empty body.
+
+	// Create a handler that waits for context cancellation
+	handlerStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		<-r.Context().Done() // Wait for context cancellation
+	})
+
+	// Use a long timeout so we can cancel the context before timeout
+	wrappedHandler := TimeoutHandler(handler, 10*time.Second)
+
+	t.Run("POST request with context.Canceled returns 200 with JSON-RPC error body", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}`))
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		go func() {
+			wrappedHandler.ServeHTTP(rec, req)
+			close(done)
+		}()
+
+		// Wait for handler to start, then cancel
+		<-handlerStarted
+		cancel()
+		<-done
+
+		assert.Equal(t, http.StatusOK, rec.Code, "POST request should return 200 OK for JSON-RPC")
+		body := rec.Body.String()
+		assert.NotEmpty(t, body, "response body should not be empty - this is the bug!")
+		assert.Contains(t, body, `"jsonrpc":"2.0"`, "should return valid JSON-RPC error")
+		assert.Contains(t, body, `"error"`, "should contain error field")
+		assert.Contains(t, body, "cancelled by client", "should indicate client cancellation")
+	})
+
+	t.Run("GET request with context.Canceled returns 503 Service Unavailable", func(t *testing.T) {
+		handlerStarted2 := make(chan struct{})
+		handler2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(handlerStarted2)
+			<-r.Context().Done()
+		})
+		wrappedHandler2 := TimeoutHandler(handler2, 10*time.Second)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		go func() {
+			wrappedHandler2.ServeHTTP(rec, req)
+			close(done)
+		}()
+
+		<-handlerStarted2
+		cancel()
+		<-done
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "GET request should return 503")
+	})
+}
+
+func TestTimeoutHandler_SuccessfulResponse(t *testing.T) {
+	// Handler that responds quickly
+	fastHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+	})
+
+	handler := TimeoutHandler(fastHandler, 1*time.Second)
+
+	t.Run("successful POST request returns response body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}`))
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		body := rec.Body.String()
+		assert.Equal(t, `{"jsonrpc":"2.0","id":1,"result":"0x1"}`, body)
+	})
+}
+
+func TestTimeoutHandler_PanicRecovery(t *testing.T) {
+	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	handler := TimeoutHandler(panicHandler, 1*time.Second)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	assert.Panics(t, func() {
+		handler.ServeHTTP(rec, req)
+	})
+}
+
+func TestTimeoutWriter_Header(t *testing.T) {
+	fastHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom-Header", "test-value")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("response"))
+	})
+
+	handler := TimeoutHandler(fastHandler, 1*time.Second)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, "test-value", rec.Header().Get("X-Custom-Header"))
+	assert.Equal(t, "response", rec.Body.String())
+}
+
+func TestTimeoutWriter_Push(t *testing.T) {
+	// Test that Push returns ErrNotSupported for non-pusher response writers
+	fastHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if pusher, ok := w.(http.Pusher); ok {
+			err := pusher.Push("/resource", nil)
+			assert.Equal(t, http.ErrNotSupported, err)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TimeoutHandler(fastHandler, 1*time.Second)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// BenchmarkTimeoutHandler measures overhead of the timeout wrapper
+func BenchmarkTimeoutHandler(b *testing.B) {
+	fastHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":"0x1"}`)
+	})
+
+	handler := TimeoutHandler(fastHandler, 1*time.Second)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+}

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -210,8 +210,6 @@ func (t *Tracker) getUpstreamRequestDurationObserver(up common.Upstream, method,
 	return actual.(prometheus.Observer)
 }
 
-// Removed upstream self rate-limited counter; consolidated under budget decision metric elsewhere.
-
 // Reuse the same shape previously used for upstream rate limit counters to keep cache keys stable for remote.
 type rrltKey struct {
 	project   string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Returns 200 OK for JSON-RPC POST/batch responses while mapping only transport-level failures (400/401/404/413/429) to HTTP codes; revamps timeout/error handling and updates tests.
> 
> - **HTTP Server / Transport semantics**
>   - Always return `200 OK` for JSON-RPC POST and batch responses; use non-200 only for transport-level issues (auth, bad request, not found, too large, rate-limit).
>   - Replace status resolution with `determineResponseStatusCode` that maps specific `common` error codes to HTTP `400/401/404/413/429`; otherwise `200`.
>   - Final error writer forces `200` for POST; batch writes `200` unconditionally.
> - **Timeout handling**
>   - `TimeoutHandler`: on timeout or client cancel, return JSON-RPC error body; keep transport `200` for POST (adds `id:null`, clearer messages).
> - **Errors / Codes**
>   - Remove `ErrorStatusCode()` usage from base and several error types; introduce `ErrCodeNetworkNotFound` constant and use it.
> - **Tests**
>   - Update server, hedging, timeout, consensus, and integration tests to expect `200` for JSON-RPC failures; add new timeout tests ensuring JSON-RPC error body is returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b419725eec37bf959a699923ae5fe00dec1b1c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->