### PR TITLE
fix: allow configuring get timeout for grpc driver

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -233,9 +233,10 @@ type ConnectorConfig struct {
 }
 
 type GrpcConnectorConfig struct {
-	Bootstrap string            `yaml:"bootstrap,omitempty" json:"bootstrap"`
-	Servers   []string          `yaml:"servers,omitempty" json:"servers"`
-	Headers   map[string]string `yaml:"headers,omitempty" json:"headers"`
+	Bootstrap  string            `yaml:"bootstrap,omitempty" json:"bootstrap"`
+	Servers    []string          `yaml:"servers,omitempty" json:"servers"`
+	Headers    map[string]string `yaml:"headers,omitempty" json:"headers"`
+	GetTimeout Duration          `yaml:"getTimeout,omitempty" json:"getTimeout" tstype:"Duration"`
 }
 
 type MemoryConnectorConfig struct {

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -810,6 +810,17 @@ func (c *ConnectorConfig) SetDefaults(scope connectorScope) error {
 			return fmt.Errorf("failed to set defaults for dynamo db connector: %w", err)
 		}
 	}
+	if c.Grpc != nil {
+		c.Driver = DriverGrpc
+	}
+	if c.Driver == DriverGrpc {
+		if c.Grpc == nil {
+			c.Grpc = &GrpcConnectorConfig{}
+		}
+		if c.Grpc.GetTimeout == 0 {
+			c.Grpc.GetTimeout = Duration(200 * time.Millisecond)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `grpc.getTimeout` config (default 200ms) and enforces it per request in the gRPC connector.
> 
> - **Config**:
>   - Add `GrpcConnectorConfig.GetTimeout` (`common/config.go`) with TS type metadata.
>   - Set driver and default `getTimeout` to `200ms` when using gRPC (`common/defaults.go`).
> - **gRPC Connector**:
>   - Store configured timeout and apply a per-request deadline in `Get` (`data/grpc.go`).
>   - Use the timeout-aware context for both `SendRequest` and `JsonRpcResponse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3524db264fb19c14351b6af69efe44a081bee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->