### PR TITLE
fix: allow healthcheck endpoint when architecture-only alias is defined

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -834,6 +834,12 @@ func (s *HttpServer) parseUrlPath(
 
 	case projectId == "" && architecture != "" && chainId == "":
 		switch len(segments) {
+		case 0:
+			// Allow global healthcheck when only architecture is aliased
+			// (e.g., host preselects architecture like "evm" and path is just /healthcheck or /)
+			if !isHealthCheck {
+				return "", "", "", false, false, common.NewErrInvalidUrlPath("for architecture-only alias must provide /<project>", ps)
+			}
 		case 1:
 			projectId = segments[0]
 		case 2:

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -3595,6 +3595,18 @@ func TestHttpServer_ParseUrlPath(t *testing.T) {
 			wantChain:          "123",
 			wantErr:            false,
 		},
+		{
+			name:            "Architecture-only preselected, global healthcheck",
+			path:            "/healthcheck",
+			method:          "GET",
+			preSelectedArch: "evm",
+			wantProject:     "",
+			wantArch:        "evm",
+			wantChain:       "",
+			wantAdmin:       false,
+			wantHealthcheck: true,
+			wantErr:         false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Permits global healthcheck requests when only the architecture is aliased and adds a test to cover it.
> 
> - **Routing/URL parsing (`erpc/http_server.go`)**:
>   - Allow healthcheck when only `architecture` is preselected (no `project`/`chain`) by accepting empty path segments for healthcheck.
> - **Tests (`erpc/http_server_test.go`)**:
>   - Add test case validating architecture-only alias supports global healthcheck (`/healthcheck`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5dd9ae2d4882d1b0b9edf1642ba4f10fde8f233. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->