### PR TITLE
fix: scorecard action must run on github managed runners

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -3,19 +3,16 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
-# Workflow temporarily disabled
-# on:
-#   # For Branch-Protection check. Only the default branch is supported. See
-#   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-#   branch_protection_rule:
-#   # To guarantee Maintained check is occasionally updated. See
-#   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
-#   schedule:
-#     - cron: '20 7 * * 2'
-#   push:
-#     branches: ["main"]
 on:
-  workflow_dispatch: # Only allow manual runs when needed
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -23,7 +20,10 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # this must run on github managed runners for the report publication to succeed without 500 error
+    # due to limited trusted runners per https://github.com/ossf/scorecard-webapp/blob/main/app/server/verify_workflow.go#L51-L57
+    # avoid configuring this to run on blacksmith runners.
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Since it was introduced in https://github.com/erpc/erpc/pull/474, we haven't had a successful run to completion of the scorecard action over two runs.
<img width="1146" height="248" alt="image" src="https://github.com/user-attachments/assets/4e1bff24-a968-4f0e-85d1-3fe7a1eb486d" />

The runs seems to be largely fine, executing most of the job to completion and uploading to GHAS - however it seems that it's unable to successfully post the report to the scorecard-webapp. Which fails with error:
```
2025/10/30 14:43:55 error sending scorecard results to webapp: http response 500, status: 500 Internal Server Error, error: {"code":500,"message":"something went wrong and we are looking into it."}
```

Based on a cursory search, this issue sounded related https://github.com/ossf/scorecard-action/issues/1381 - where it seems that the scorecard-webapp _only_ supports a trusted set of runners which it accepts reports from, alongside a number of other validation criteria.

This can be found here: https://github.com/ossf/scorecard-webapp/blob/main/app/server/verify_workflow.go#L51-L57

It seems that running the action on self-hosted or third party runners is generally not accepted, perhaps raising an issue in scorecard-webapp for to trust the likes of blacksmith, but this should be resolvable through switching the runner back to a github managed runner.
