### PR TITLE
 chore: grouping dependabot changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,20 +23,70 @@ updates:
 
   - package-ecosystem: gomod
     directory: /
+    schedule:
+      interval: "weekly"
+    update-types:
+      - major
+
+  - package-ecosystem: gomod
+    directory: /
     multi-ecosystem-group: "service"
+    update-types:
+      - patch
+      - minor
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: "weekly"
+    update-types:
+      - major
     
   - package-ecosystem: npm
     directory: /
     multi-ecosystem-group: "service"
+    update-types:
+      - patch
+      - minor
+
+  - package-ecosystem: npm
+    directory: /test/util
+    schedule:
+      interval: "weekly"
+    update-types:
+      - major
 
   - package-ecosystem: npm
     directory: /test/util
     multi-ecosystem-group: "service"
+    update-types:
+      - patch
+      - minor
+
+  - package-ecosystem: npm
+    directory: /typescript/cli
+    schedule:
+      interval: "weekly"
+    update-types:
+      - major
 
   - package-ecosystem: npm
     directory: /typescript/cli
     multi-ecosystem-group: "service"
+    update-types:
+      - patch
+      - minor
+
+  - package-ecosystem: npm
+    directory: /typescript/cli
+    schedule:
+      interval: "weekly"
+    update-types:
+      - major
 
   - package-ecosystem: npm
     directory: /typescript/config
     multi-ecosystem-group: "service"
+    update-types:
+      - patch
+      - minor


### PR DESCRIPTION
Interest was express in not having dependabot updates for docs, and minimizing the number of pull requests (or grouping them) to avoid flooding the changelog with various dependency updates.
This changes sets up two dependabot groups, one for auxiliary infrastructure changes (ie. docker, github actions) and another for the actual service changes itself.