### PR TITLE
refactor: make Alchemy network configuration fully dynamic

### DIFF
--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -16,49 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var defaultAlchemyNetworkSubdomains = map[int64]string{
-	1:         "eth-mainnet",
-	10:        "opt-mainnet",
-	100:       "gnosis-mainnet",
-	10200:     "gnosis-chiado",
-	1088:      "metis-mainnet",
-	1101:      "polygonzkevm-mainnet",
-	11011:     "shape-sepolia",
-	11155111:  "eth-sepolia",
-	11155420:  "opt-sepolia",
-	137:       "polygon-mainnet",
-	168587773: "blast-sepolia",
-	17000:     "eth-holesky",
-	204:       "opbnb-mainnet",
-	2442:      "polygonzkevm-cardona",
-	250:       "fantom-mainnet",
-	300:       "zksync-sepolia",
-	324:       "zksync-mainnet",
-	4002:      "fantom-testnet",
-	42161:     "arb-mainnet",
-	421614:    "arb-sepolia",
-	42170:     "arbnova-mainnet",
-	42220:     "celo-mainnet",
-	43113:     "avax-fuji",
-	43114:     "avax-mainnet",
-	5000:      "mantle-mainnet",
-	56:        "bnb-mainnet",
-	5611:      "opbnb-testnet",
-	59141:     "linea-sepolia",
-	59144:     "linea-mainnet",
-	592:       "astar-mainnet",
-	7000:      "zetachain-mainnet",
-	7001:      "zetachain-testnet",
-	7777777:   "zora-mainnet",
-	80002:     "polygon-amoy",
-	81457:     "blast-mainnet",
-	8453:      "base-mainnet",
-	84532:     "base-sepolia",
-	97:        "bnb-testnet",
-	999999999: "zora-sepolia",
-	534351:    "scroll-sepolia",
-	534352:    "scroll-mainnet",
-}
+var defaultAlchemyNetworkSubdomains = map[int64]string{}
 
 const DefaultAlchemyRecheckInterval = 24 * time.Hour
 const alchemyApiUrl = "https://app-api.alchemy.com/trpc/config.getNetworkConfig"
@@ -302,13 +260,6 @@ func (v *AlchemyVendor) fetchAlchemyNetworks(ctx context.Context) (map[int64]str
 	for _, network := range apiResp.Result.Data {
 		if network.KebabCaseID != "" && network.NetworkChainID != 0 {
 			newData[network.NetworkChainID] = network.KebabCaseID
-		}
-	}
-
-	// Merge with defaults, API data takes precedence
-	for chainID, subdomain := range defaultAlchemyNetworkSubdomains {
-		if _, exists := newData[chainID]; !exists {
-			newData[chainID] = subdomain
 		}
 	}
 


### PR DESCRIPTION
## Summary
Makes Alchemy network configuration fully dynamic by fetching all supported chains from their official API.

## Changes
- Removed static `defaultAlchemyNetworkSubdomains` list (now empty map)
- Fetch all EVM chains dynamically from `https://app-api.alchemy.com/trpc/config.getNetworkConfig`
- Automatically filters to chains with valid `networkChainId` (EVM-compatible only)
- Removed merge logic - rely entirely on API data

## Benefits
- No code maintenance when Alchemy adds new chains
- Always up-to-date with Alchemy's supported networks  
- Automatic support for 100+ EVM chains
- Non-EVM chains (Solana, Starknet, Bitcoin, Tron, Aptos) automatically excluded

## Currently Supported (automatically from API)
All EVM chains with `networkChainId` including: Ethereum, Optimism, Arbitrum, Polygon, Base, ZKsync, Zora, Blast, Scroll, Linea, Gnosis, Mantle, Celo, BNB, Avalanche, Flow, World Chain, Frax, Boba, Sei, Berachain, Shape, Polynomial, BOB, Mode, Anime, ApeChain, Lens, Soneium, Rootstock, Lumia, Unichain, Sonic, Abstract, Monad, Superseed, Ink, Ronin, Humanity, Story, Hyperliquid, Plasma, and more as Alchemy adds them.