### PR TITLE
fix: correct unknown finality detection for certain methods

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1678,6 +1678,13 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 					}
 				}
 			}
+		} else if len(n.Failsafe) > 0 {
+			// Apply system default to each failsafe config
+			for i, fs := range n.Failsafe {
+				if err := fs.SetDefaults(nil); err != nil {
+					return fmt.Errorf("failed to set defaults for failsafe[%d]: %w", i, err)
+				}
+			}
 		}
 		if n.SelectionPolicy == nil && defaults.SelectionPolicy != nil {
 			n.SelectionPolicy = &SelectionPolicyConfig{}

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -624,7 +624,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 				params:         `["0x123"]`,
 				result:         `"result":{"hash":"0x123","blockNumber":null}`,
 				expectedCache:  true, // wildcard '*' → Unfinalized
-				expectedPolicy: unfinalizedPolicy,
+				expectedPolicy: unknownPolicy,
 			},
 			{
 				name:           "UnknownAccount_Cache",
@@ -669,8 +669,8 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 				method:         "eth_getTransactionReceipt",
 				params:         `["0xdead"]`,
 				result:         `"result":{"hash":"0xdead","blockNumber":null}`,
-				expectedCache:  true, // Pending ⇒ wildcard '*' ⇒ Unfinalized
-				expectedPolicy: unfinalizedPolicy,
+				expectedCache:  true, // Pending ⇒ wildcard '*' ⇒ Unknown
+				expectedPolicy: unknownPolicy,
 			},
 			{
 				name:           "HighBlockBalance_Cache",

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -849,7 +849,7 @@ func (n *Network) GetFinality(ctx context.Context, req *common.NormalizedRequest
 	blockRef, blockNumber, _ := evm.ExtractBlockReferenceFromRequest(ctx, req)
 
 	if blockRef == "*" && blockNumber == 0 {
-		finality = common.DataFinalityStateUnfinalized
+		finality = common.DataFinalityStateUnknown
 		return finality
 	} else if blockRef != "" && blockRef != "*" && (blockRef[0] < '0' || blockRef[0] > '9') {
 		finality = common.DataFinalityStateRealtime

--- a/erpc/networks_finality_test.go
+++ b/erpc/networks_finality_test.go
@@ -85,7 +85,7 @@ func TestNetworkGetFinality(t *testing.T) {
 		req.SetEvmBlockRef("*")
 		req.SetEvmBlockNumber(int64(0))
 		finality := network.GetFinality(ctx, req, nil)
-		assert.Equal(t, common.DataFinalityStateUnfinalized, finality)
+		assert.Equal(t, common.DataFinalityStateUnknown, finality)
 	})
 
 	t.Run("FinalityCachingBehavior", func(t *testing.T) {

--- a/thirdparty/routemesh.go
+++ b/thirdparty/routemesh.go
@@ -165,4 +165,3 @@ func (v *RoutemeshVendor) getOrCreateClient(ctx context.Context, logger *zerolog
 	v.headlessClients.Store(clientKey, client)
 	return client, nil
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Classifies '*' block references as unknown finality (adjusting cache policy expectations) and ensures network failsafe entries receive system defaults when no defaults are provided.
> 
> - **EVM finality & caching**:
>   - `Network.GetFinality`: `blockRef == "*" && blockNumber == 0` now yields `DataFinalityStateUnknown` (was Unfinalized).
>   - Tests updated to expect Unknown finality and cache policy (`eth_getTransactionByHash` pending, `eth_getTransactionReceipt` pending).
> - **Defaults handling**:
>   - `NetworkConfig.SetDefaults`: when `defaults.Failsafe` is empty or `defaults` is nil but `n.Failsafe` has items, apply `SetDefaults(nil)` to each failsafe (system defaults).
> - **Misc**:
>   - Minor cleanup in `thirdparty/routemesh.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10574ff8cdb16f77a8b82a4e2cdbe75ae8c3a985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->