### PR TITLE
fix: correct error code for grpc timeouts

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -740,7 +740,7 @@ func (e *EvmStatePoller) pollEarliest(ctx context.Context) {
 					Int64("earliestBlock", earliest).
 					Str("probe", string(probe)).
 					Str("upstreamId", e.upstream.Config().Id).
-					Msg("initialized earliest block availability bound")
+					Msg("fetched earliest block availability bound")
 			}
 		}
 		// Start scheduler per probe if updateRate>0 and not started yet

--- a/test/k6/evm-tip-of-chain.js
+++ b/test/k6/evm-tip-of-chain.js
@@ -40,14 +40,22 @@ const CHAINS = {
   //     transactions: []
   //   }
   // },
-  POLYGON: {
-    id: '137',
+  MONAD: {
+    id: '143',
     cached: {
       latestBlock: null,
       latestBlockTimestamp: 0,
       transactions: []
     }
   },
+  // POLYGON: {
+  //   id: '137',
+  //   cached: {
+  //     latestBlock: null,
+  //     latestBlockTimestamp: 0,
+  //     transactions: []
+  //   }
+  // },
   // ARBITRUM: {
   //   id: '42161',
   //   cached: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remaps gRPC/BDS timeouts to request-timeout and adds canceled handling; minor EVM poller log tweak; k6 test now targets MONAD chain.
> 
> - **Errors/Mapping (`common/grpc_errors.go`)**:
>   - Map `bdscommon.TIMEOUT_ERROR` and gRPC `codes.DeadlineExceeded` to `NewErrEndpointRequestTimeout` (was server-side error).
>   - Add handling for `codes.Canceled` -> `NewErrEndpointRequestCanceled` with preserved details.
> - **EVM State Poller (`architecture/evm/evm_state_poller.go`)**:
>   - Update info log message text when earliest block bound is obtained ("fetched" wording).
> - **Tests (`test/k6/evm-tip-of-chain.js`)**:
>   - Switch default chain from Polygon (`137`) to Monad (`143`) in `CHAINS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d188af5ed6d13073dcd832b4f04e87cae68bea1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->