### PR TITLE
fix(doc): fix yaml syntax error in rate limiter budget

### DIFF
--- a/docs/pages/config/auth.mdx
+++ b/docs/pages/config/auth.mdx
@@ -278,8 +278,8 @@ rateLimiters:
   - id: premium
     rules:
     - method: '*'
-        maxCount: 1000
-        period: 1s
+      maxCount: 1000
+      period: 1s
 ```
 </Tabs.Tab>
   <Tabs.Tab>


### PR DESCRIPTION
Fix a small syntax error in the yaml for rate limit budgets in `auth`