### PR TITLE
fix: disable interpolation for eth_getBlockByNumber as the source of truth for tags

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -275,6 +275,12 @@ var DefaultWithBlockCacheMethods = map[string]*CacheMethodConfig{
 		RespRefs: NumberOrHashParam,
 		// evm/eth_getBlockByNumber.go hook already enforces lower/upper-bound against per-upstream latest/finality, so we don't need to enforce it here.
 		EnforceBlockAvailability: util.BoolPtr(false),
+		// Don't interpolate "latest"/"finalized" tags for this method - it should fetch actual
+		// current state from upstream. This method is the source of truth for block tags,
+		// not a consumer of interpolated values. Other methods (eth_getLogs, eth_call, etc.)
+		// will still interpolate tags using the state poller's highest known block.
+		TranslateLatestTag:    util.BoolPtr(false),
+		TranslateFinalizedTag: util.BoolPtr(false),
 	},
 	"eth_getTransactionByBlockHashAndIndex": {
 		ReqRefs:  FirstParam,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `eth_getBlockByNumber` no longer translates "latest"/"finalized"; requests forward tags to upstream, with integrity logic re-fetching as needed; tests updated and added to verify behavior.
> 
> - **Config/Defaults**:
>   - In `common/defaults.go`, set `TranslateLatestTag=false` and `TranslateFinalizedTag=false` for `eth_getBlockByNumber` (keep `EnforceBlockAvailability=false`).
> - **Tests**:
>   - Update `erpc/http_server_test.go` mocks/filters to expect raw tags ("latest"/"finalized") instead of interpolated hex; clarify enforcement/re-fetch behavior in comments.
>   - Add `erpc/networks_interpolation_test.go` cases asserting no interpolation for `eth_getBlockByNumber` and confirming other methods (e.g., `eth_getBalance`) still interpolate to hex.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a90c3575f06fc097f80ce5a5db7d3c2423b47dd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->