### PR TITLE
fix: skip and failover on "method ignored" errors

### DIFF
--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -604,7 +604,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 					r.SetUpstream(u)
 				}
 
-				if !common.HasErrorCode(err, common.ErrCodeUpstreamRequestSkipped) {
+				if !common.HasErrorCode(err, common.ErrCodeUpstreamRequestSkipped, common.ErrCodeUpstreamMethodIgnored) {
 					if err == nil {
 						loopSpan.SetStatus(codes.Ok, "")
 					} else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats `ErrCodeUpstreamMethodIgnored` as skippable, enabling failover to the next upstream instead of returning immediately.
> 
> - **Networking (forwarding loop)**:
>   - Extend skippable error check in `erpc/networks.go` to include `common.ErrCodeUpstreamMethodIgnored` alongside `common.ErrCodeUpstreamRequestSkipped`, allowing iteration to the next upstream without marking the attempt as final.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c3fadc41adf57129f3395c8833b37f11b2135ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->