### PR TITLE
feat: add support for custom response headers and resource attributes in trace

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -88,24 +88,25 @@ func LoadConfig(fs afero.Fs, filename string, opts *DefaultOptions) (*Config, er
 }
 
 type ServerConfig struct {
-	ListenV4            *bool           `yaml:"listenV4,omitempty" json:"listenV4"`
-	HttpHostV4          *string         `yaml:"httpHostV4,omitempty" json:"httpHostV4"`
-	ListenV6            *bool           `yaml:"listenV6,omitempty" json:"listenV6"`
-	HttpHostV6          *string         `yaml:"httpHostV6,omitempty" json:"httpHostV6"`
-	HttpPort            *int            `yaml:"httpPort,omitempty" json:"httpPort"` // Deprecated: use HttpPortV4
-	HttpPortV4          *int            `yaml:"httpPortV4,omitempty" json:"httpPortV4"`
-	HttpPortV6          *int            `yaml:"httpPortV6,omitempty" json:"httpPortV6"`
-	MaxTimeout          *Duration       `yaml:"maxTimeout,omitempty" json:"maxTimeout" tstype:"Duration"`
-	ReadTimeout         *Duration       `yaml:"readTimeout,omitempty" json:"readTimeout" tstype:"Duration"`
-	WriteTimeout        *Duration       `yaml:"writeTimeout,omitempty" json:"writeTimeout" tstype:"Duration"`
-	EnableGzip          *bool           `yaml:"enableGzip,omitempty" json:"enableGzip"`
-	TLS                 *TLSConfig      `yaml:"tls,omitempty" json:"tls"`
-	Aliasing            *AliasingConfig `yaml:"aliasing" json:"aliasing"`
-	WaitBeforeShutdown  *Duration       `yaml:"waitBeforeShutdown,omitempty" json:"waitBeforeShutdown" tstype:"Duration"`
-	WaitAfterShutdown   *Duration       `yaml:"waitAfterShutdown,omitempty" json:"waitAfterShutdown" tstype:"Duration"`
-	IncludeErrorDetails *bool           `yaml:"includeErrorDetails,omitempty" json:"includeErrorDetails"`
-	TrustedIPForwarders []string        `yaml:"trustedIPForwarders,omitempty" json:"trustedIPForwarders"`
-	TrustedIPHeaders    []string        `yaml:"trustedIPHeaders,omitempty" json:"trustedIPHeaders"`
+	ListenV4            *bool             `yaml:"listenV4,omitempty" json:"listenV4"`
+	HttpHostV4          *string           `yaml:"httpHostV4,omitempty" json:"httpHostV4"`
+	ListenV6            *bool             `yaml:"listenV6,omitempty" json:"listenV6"`
+	HttpHostV6          *string           `yaml:"httpHostV6,omitempty" json:"httpHostV6"`
+	HttpPort            *int              `yaml:"httpPort,omitempty" json:"httpPort"` // Deprecated: use HttpPortV4
+	HttpPortV4          *int              `yaml:"httpPortV4,omitempty" json:"httpPortV4"`
+	HttpPortV6          *int              `yaml:"httpPortV6,omitempty" json:"httpPortV6"`
+	MaxTimeout          *Duration         `yaml:"maxTimeout,omitempty" json:"maxTimeout" tstype:"Duration"`
+	ReadTimeout         *Duration         `yaml:"readTimeout,omitempty" json:"readTimeout" tstype:"Duration"`
+	WriteTimeout        *Duration         `yaml:"writeTimeout,omitempty" json:"writeTimeout" tstype:"Duration"`
+	EnableGzip          *bool             `yaml:"enableGzip,omitempty" json:"enableGzip"`
+	TLS                 *TLSConfig        `yaml:"tls,omitempty" json:"tls"`
+	Aliasing            *AliasingConfig   `yaml:"aliasing" json:"aliasing"`
+	WaitBeforeShutdown  *Duration         `yaml:"waitBeforeShutdown,omitempty" json:"waitBeforeShutdown" tstype:"Duration"`
+	WaitAfterShutdown   *Duration         `yaml:"waitAfterShutdown,omitempty" json:"waitAfterShutdown" tstype:"Duration"`
+	IncludeErrorDetails *bool             `yaml:"includeErrorDetails,omitempty" json:"includeErrorDetails"`
+	TrustedIPForwarders []string          `yaml:"trustedIPForwarders,omitempty" json:"trustedIPForwarders"`
+	TrustedIPHeaders    []string          `yaml:"trustedIPHeaders,omitempty" json:"trustedIPHeaders"`
+	ResponseHeaders     map[string]string `yaml:"responseHeaders,omitempty" json:"responseHeaders"`
 }
 
 type HealthCheckConfig struct {
@@ -141,14 +142,15 @@ const (
 )
 
 type TracingConfig struct {
-	Enabled     bool              `yaml:"enabled,omitempty" json:"enabled"`
-	Endpoint    string            `yaml:"endpoint,omitempty" json:"endpoint"`
-	Protocol    TracingProtocol   `yaml:"protocol,omitempty" json:"protocol"`
-	SampleRate  float64           `yaml:"sampleRate,omitempty" json:"sampleRate"`
-	Detailed    bool              `yaml:"detailed,omitempty" json:"detailed"`
-	ServiceName string            `yaml:"serviceName,omitempty" json:"serviceName"`
-	Headers     map[string]string `yaml:"headers,omitempty" json:"headers"`
-	TLS         *TLSConfig        `yaml:"tls,omitempty" json:"tls"`
+	Enabled            bool              `yaml:"enabled,omitempty" json:"enabled"`
+	Endpoint           string            `yaml:"endpoint,omitempty" json:"endpoint"`
+	Protocol           TracingProtocol   `yaml:"protocol,omitempty" json:"protocol"`
+	SampleRate         float64           `yaml:"sampleRate,omitempty" json:"sampleRate"`
+	Detailed           bool              `yaml:"detailed,omitempty" json:"detailed"`
+	ServiceName        string            `yaml:"serviceName,omitempty" json:"serviceName"`
+	Headers            map[string]string `yaml:"headers,omitempty" json:"headers"`
+	TLS                *TLSConfig        `yaml:"tls,omitempty" json:"tls"`
+	ResourceAttributes map[string]string `yaml:"resourceAttributes,omitempty" json:"resourceAttributes"`
 
 	// ForceTraceMatchers defines conditions for force-tracing requests.
 	// Each matcher can specify network and/or method patterns.

--- a/docs/pages/operation/production.mdx
+++ b/docs/pages/operation/production.mdx
@@ -86,3 +86,31 @@ server:
 Shorter values let Envoy reuse a connection after the listener is gone or try to reach
 a pod that has already exited. Use these numbers as a safe starting point and adjust
 to match your own probe intervals.
+
+## Custom response headers
+
+You can add custom headers to all HTTP responses using `server.responseHeaders`. This is useful for exposing instance metadata (region, machine ID, pod name) directly in responses for debugging.
+
+Values support environment variable expansion using `${VAR}` syntax. Headers with empty values (after expansion) are automatically omitted.
+
+```yaml
+server:
+  responseHeaders:
+    X-ERPC-Region: ${FLY_REGION}         # Fly.io region
+    X-ERPC-Machine: ${FLY_MACHINE_ID}    # Fly.io machine ID
+    # Or for Kubernetes:
+    # X-ERPC-Pod: ${HOSTNAME}
+```
+
+This allows quick identification of which instance handled a request without checking traces:
+
+```
+HTTP/1.1 200 OK
+X-ERPC-Version: main
+X-ERPC-Region: sin
+X-ERPC-Machine: 4d891234ab
+```
+
+<Callout type="info">
+  For deeper debugging, combine this with [custom trace attributes](/operation/tracing#custom-resource-attributes) to get full observability in your tracing backend.
+</Callout>

--- a/docs/pages/operation/tracing.mdx
+++ b/docs/pages/operation/tracing.mdx
@@ -32,6 +32,29 @@ When `tracing.detailed` is set to true, eRPC will include detailed tracing infor
 
 Remember that detailed tracing can significantly increase the volume of traces, so use it judiciously.
 
+### Custom resource attributes
+
+You can add custom attributes to all traces from an eRPC instance using `resourceAttributes`. This is useful for adding deployment-specific metadata like region, machine ID, or pod name.
+
+Values support environment variable expansion using `${VAR}` syntax. Attributes with empty values (after expansion) are automatically omitted.
+
+```yaml
+tracing:
+  enabled: true
+  endpoint: "localhost:4317"
+  protocol: "grpc"
+  sampleRate: 0.1
+  # Custom attributes added to all traces from this instance
+  resourceAttributes:
+    fly.region: ${FLY_REGION}           # Fly.io region
+    fly.machine_id: ${FLY_MACHINE_ID}   # Fly.io machine ID
+    # Or for Kubernetes:
+    # k8s.pod_name: ${HOSTNAME}
+    # k8s.node_name: ${NODE_NAME}
+```
+
+This allows you to filter and group traces by region/machine in your tracing backend (Jaeger, Tempo, etc.) to debug region-specific issues.
+
 ## Using with Jaeger
 
 The included [`docker-compose.yml`](https://github.com/erpc/erpc/blob/main/docker-compose.yml) file contains a Jaeger service for visualizing traces. To use it:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable `server.responseHeaders` and `tracing.resourceAttributes`, applying env-expanded headers to all responses and custom attributes to OpenTelemetry resources, with docs.
> 
> - **Backend**
>   - **Server**: Add `server.responseHeaders` to `ServerConfig`; expand env vars at startup and append headers to every HTTP response in `erpc/http_server.go`.
>   - **Tracing**: Add `tracing.resourceAttributes` to `TracingConfig`; include attributes when constructing OTEL resource in `common/tracing_core.go`.
> - **Docs**
>   - Production: New section on configuring `server.responseHeaders`.
>   - Tracing: New section on custom `resourceAttributes` for traces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bbb6f55f39932f3df08d684b61e086419898209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->