### PR TITLE
feat: add tag filtering support for QuickNode endpoints

### DIFF
--- a/common/defaults_test.go
+++ b/common/defaults_test.go
@@ -421,4 +421,23 @@ func TestBuildProviderSettings(t *testing.T) {
 		assert.Nil(t, settings["provider"])
 		assert.Nil(t, settings["type"])
 	})
+
+	// Test case for QuickNode with tag filters
+	t.Run("quicknode with filters", func(t *testing.T) {
+		endpoint, _ := url.Parse("quicknode://test-api-key?tagIds=123,456&tagLabels=production,staging")
+		settings, err := buildProviderSettings("quicknode", endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-api-key", settings["apiKey"])
+		assert.Equal(t, []int{123, 456}, settings["tagIds"])
+		assert.Equal(t, []string{"production", "staging"}, settings["tagLabels"])
+	})
+
+	t.Run("quicknode without filters", func(t *testing.T) {
+		endpoint, _ := url.Parse("quicknode://test-api-key")
+		settings, err := buildProviderSettings("quicknode", endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-api-key", settings["apiKey"])
+		assert.Nil(t, settings["tagIds"])
+		assert.Nil(t, settings["tagLabels"])
+	})
 }

--- a/thirdparty/quicknode_test.go
+++ b/thirdparty/quicknode_test.go
@@ -1,0 +1,30 @@
+package thirdparty
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuicknodeFilterParams(t *testing.T) {
+	vendor := CreateQuicknodeVendor().(*QuicknodeVendor)
+
+	t.Run("extracts both tag IDs and labels", func(t *testing.T) {
+		settings := common.VendorSettings{
+			"apiKey":    "test-key",
+			"tagIds":    []interface{}{123, 456},
+			"tagLabels": []interface{}{"production", "staging"},
+		}
+		result := vendor.extractFilterParams(settings)
+		assert.Equal(t, []int{123, 456}, result.TagIDs)
+		assert.Equal(t, []string{"production", "staging"}, result.TagLabels)
+	})
+
+	t.Run("handles empty settings", func(t *testing.T) {
+		settings := common.VendorSettings{"apiKey": "test-key"}
+		result := vendor.extractFilterParams(settings)
+		assert.Empty(t, result.TagIDs)
+		assert.Empty(t, result.TagLabels)
+	})
+}


### PR DESCRIPTION
## Motivation

QuickNode allows organizing endpoints using tags (e.g., "production", "staging", "us-east"). Previously, eRPC would fetch ALL endpoints for an API key. This adds filtering support to selectively use specific endpoints by tag IDs or labels.

## Usage

```yaml
upstreams:
  - id: quicknode-prod
    endpoint: quicknode://API_KEY?tagLabels=production,us-east
```

## Changes

- Add query parameter parsing for `tagIds` and `tagLabels` in URL format
- Add `QuicknodeFilterParams` struct for type-safe filter handling
- Format filters as comma-separated values per QuickNode Console API spec
- Add tests for URL parsing and filter extraction

## Reference

QuickNode Console API: https://www.quicknode.com/docs/console-api/endpoints/v0-endpoints