### PR TITLE
fix: extract filters from URL-based QuickNode provider settings

### DIFF
--- a/thirdparty/quicknode.go
+++ b/thirdparty/quicknode.go
@@ -63,6 +63,8 @@ func (v *QuicknodeVendor) extractFilterParams(settings common.VendorSettings) *Q
 		switch val := tagIds.(type) {
 		case int:
 			params.TagIDs = []int{val}
+		case []int:
+			params.TagIDs = val
 		case []interface{}:
 			for _, id := range val {
 				if intVal, ok := id.(int); ok {
@@ -77,6 +79,8 @@ func (v *QuicknodeVendor) extractFilterParams(settings common.VendorSettings) *Q
 		switch val := tagLabels.(type) {
 		case string:
 			params.TagLabels = []string{val}
+		case []string:
+			params.TagLabels = val
 		case []interface{}:
 			for _, label := range val {
 				if strLabel, ok := label.(string); ok {

--- a/thirdparty/quicknode_test.go
+++ b/thirdparty/quicknode_test.go
@@ -10,11 +10,22 @@ import (
 func TestQuicknodeFilterParams(t *testing.T) {
 	vendor := CreateQuicknodeVendor().(*QuicknodeVendor)
 
-	t.Run("extracts both tag IDs and labels", func(t *testing.T) {
+	t.Run("extracts both tag IDs and labels from interface arrays", func(t *testing.T) {
 		settings := common.VendorSettings{
 			"apiKey":    "test-key",
 			"tagIds":    []interface{}{123, 456},
 			"tagLabels": []interface{}{"production", "staging"},
+		}
+		result := vendor.extractFilterParams(settings)
+		assert.Equal(t, []int{123, 456}, result.TagIDs)
+		assert.Equal(t, []string{"production", "staging"}, result.TagLabels)
+	})
+
+	t.Run("extracts both tag IDs and labels from concrete types", func(t *testing.T) {
+		settings := common.VendorSettings{
+			"apiKey":    "test-key",
+			"tagIds":    []int{123, 456},
+			"tagLabels": []string{"production", "staging"},
 		}
 		result := vendor.extractFilterParams(settings)
 		assert.Equal(t, []int{123, 456}, result.TagIDs)


### PR DESCRIPTION
The extractFilterParams function only handled []interface{} types produced by YAML parsing. URL-based configuration uses buildProviderSettings which stores filters as []int and []string. Go cannot type assert between these types, causing URL-based filters to be ignored.

Changes:
- Add []int and []string cases to extractFilterParams for URL parsing path
- Add test case verifying extraction from concrete slice types