### PR TITLE
fix: correct defaulting logic for failsafe policies

### DIFF
--- a/architecture/evm/trace_filter_test.go
+++ b/architecture/evm/trace_filter_test.go
@@ -236,4 +236,3 @@ func TestUpstreamPreForward_arbtrace_filter(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
-

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1733,7 +1733,9 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 				// Apply defaults to each failsafe config
 				for i, fs := range n.Failsafe {
 					// Find matching default by method/finality
-					var defaultFs *FailsafeConfig
+					defaultFs := &FailsafeConfig{
+						MatchMethod: "*",
+					}
 					for _, dfs := range defaults.Failsafe {
 						// Match method using wildcard (if both are specified)
 						methodMatch := true
@@ -1751,10 +1753,6 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 							defaultFs = dfs
 							break
 						}
-					}
-					// If no specific match found, use first default as general default
-					if defaultFs == nil && len(defaults.Failsafe) > 0 {
-						defaultFs = defaults.Failsafe[0]
 					}
 					if defaultFs != nil {
 						if err := fs.SetDefaults(defaultFs); err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens failsafe defaulting and logging.
> 
> - Preserves user-defined `Failsafe.matchMethod` in `NetworkConfig.SetDefaults` by using a base default (`MatchMethod="*"`) when no default matches, instead of falling back to the first default
> - Keeps merge behavior only when method/finality match (including wildcard and pipe patterns), otherwise applies system defaults; mirrors behavior with upstreams
> - Adds extensive tests covering upstream and network failsafe matching/merging scenarios, wildcard/pipe behavior, and system/defaults application
> - Refactors Conduit vendor to accept an injected `logger` (`zerolog.Logger`) and pass it through `ensureRemoteData`/`fetchConduitNetworks`, replacing global logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bb28334ce6c29ad565369b6203e191465ce9012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->