### PR TITLE
test: speed up test ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,33 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25.x'
+          cache: true
       - name: Install dependencies
         run: make setup
       - name: Build
         run: make build
       - name: Test with the Go CLI
         run: make test
+
+  gosec:
+    runs-on: "${{ github.repository_owner == 'erpc' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04' }}"
+    timeout-minutes: 20
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: '1.25.x'
+          cache: true
+      - name: Download dependencies
+        run: go mod download
       - name: Run Gosec Security Scanner
         uses: securego/gosec@8a5404eabf56aa8ca2fb9e4e8eb526da0a5a8c48 # master
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ help:
 	@echo " docker-build                  Build docker image. Arg: platform=linux/amd64 (default) or platform=linux/arm64"
 	@echo " docker-run                    Run docker image. Arg: platform=linux/amd64 (default) or platform=linux/arm64"
 
+GO_TEST_PARALLEL ?= $(shell (getconf _NPROCESSORS_ONLN 2>/dev/null || nproc))
+GO_TEST_P ?= $(GO_TEST_PARALLEL)
+
 .PHONY: setup
 setup:
 	@go mod tidy
@@ -49,14 +52,14 @@ build:
 .PHONY: test
 test:
 	@go clean -testcache
-	@go test ./cmd/... -count 1 -parallel 1
-	@go test $$(ls -d */ | grep -v "cmd/" | grep -v "test/" | awk '{print "./" $$1 "..."}') -covermode=atomic -v -race -count 1 -parallel 1 -timeout 15m -failfast=false
+	@go test ./cmd/... -count 1 -parallel $(GO_TEST_PARALLEL) -p $(GO_TEST_P)
+	@go test $$(ls -d */ | grep -v "cmd/" | grep -v "test/" | awk '{print "./" $$1 "..."}') -covermode=atomic -v -race -count 1 -parallel $(GO_TEST_PARALLEL) -p $(GO_TEST_P) -timeout 15m -failfast=false
 
 .PHONY: test-fast
 test-fast:
 	@go clean -testcache
-	@go test ./cmd/... -count 1 -parallel 1 -v
-	@go test $$(ls -d */ | grep -v "cmd/" | grep -v "test/" | awk '{print "./" $$1 "..."}') -count 1 -parallel 1 -v -timeout 10m -failfast=false
+	@go test ./cmd/... -count 1 -parallel $(GO_TEST_PARALLEL) -p $(GO_TEST_P) -v
+	@go test $$(ls -d */ | grep -v "cmd/" | grep -v "test/" | awk '{print "./" $$1 "..."}') -count 1 -parallel $(GO_TEST_PARALLEL) -p $(GO_TEST_P) -v -timeout 10m -failfast=false
 
 .PHONY: test-race
 test-race:


### PR DESCRIPTION
### Motivation
- Reduce CI wall time by increasing Go test parallelism and allowing test runners to use available CPU cores.  
- Run security scanning (`gosec`) in parallel with unit tests to avoid serial bottlenecks.  
- Speed up dependency setup by enabling Go module caching in the workflow.  

### Description
- Add `GO_TEST_PARALLEL` and `GO_TEST_P` to the `Makefile`, defaulting to the number of online CPUs (`getconf _NPROCESSORS_ONLN` / `nproc`).  
- Update `test` and `test-fast` targets to pass `-parallel $(GO_TEST_PARALLEL)` and `-p $(GO_TEST_P)` to `go test`.  
- Enable `cache: true` for `actions/setup-go` in the `units` job to cache module downloads.  
- Split the `gosec` run into its own workflow job (`gosec`) that runs `go mod download` then the scanner so it can execute in parallel with the `units` job.  

### Testing
- No automated tests were executed as part of this patch; CI will run the `units` job (which invokes `make test`) and the new `gosec` job when the workflow triggers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e5668b47883319058dd3305a5abc3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes CI time by parallelizing tests and security scanning, and by caching Go modules.
> 
> - Add `GO_TEST_PARALLEL` and `GO_TEST_P` defaults in `Makefile`; pass `-parallel` and `-p` in `test` and `test-fast`
> - Split `gosec` into its own `gosec` job running `go mod download` then the scanner in parallel with `units` (`.github/workflows/test.yml`)
> - Enable `cache: true` for `actions/setup-go` in both `units` and `gosec` jobs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a358eac13e67c8b51366c888a959e6cd646c175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->