### PR TITLE
fix: add trace_filter to DefaultMarkEmptyAsErrorMethods

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1911,6 +1911,7 @@ var DefaultMarkEmptyAsErrorMethods = []string{
 	"debug_traceTransaction",
 	"trace_transaction",
 	"trace_block",
+	"trace_filter",
 	"trace_get",
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns empty-result handling for traces with other trace methods.
> 
> - Adds `trace_filter` to `DefaultMarkEmptyAsErrorMethods` in `common/defaults.go` to mark empty/null results as errors and enable retry behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f710a4bc64ab36e1a3bea9468259f413b132b150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->