### PR TITLE
fix: correct column order in PostgreSQL `idx_reverse` index

### DIFF
--- a/data/postgresql.go
+++ b/data/postgresql.go
@@ -186,9 +186,9 @@ func (p *PostgreSQLConnector) connectTask(ctx context.Context, cfg *common.Postg
 		return fmt.Errorf("failed to add expires_at column: %w", err)
 	}
 
-	// Create index for reverse lookups
+	// Create index for reverse lookups (range_key first to support queries that filter by range_key)
 	_, err = conn.Exec(ctx, fmt.Sprintf(`
-		CREATE INDEX IF NOT EXISTS idx_reverse ON %s (partition_key, range_key)
+		CREATE INDEX IF NOT EXISTS idx_reverse ON %s (range_key, partition_key)
 	`, cfg.Table))
 	if err != nil {
 		return fmt.Errorf("failed to create reverse index: %w", err)


### PR DESCRIPTION
## Summary

- Fix incorrect column order in `idx_reverse` index that was causing full table scans for reverse lookups
- The index was `(partition_key, range_key)` but the reverse lookup query filters by `range_key` first

## Problem

The `idx_reverse` index was accidentally created with the wrong column order in PR #105 (commit 567769b). The current index `(partition_key, range_key)` duplicates the primary key column order and cannot efficiently serve reverse lookup queries that filter by `range_key = $1` first.

This affects high-volume RPC methods including:
- `eth_getTransactionReceipt`
- `eth_getTransactionByHash`
- `debug_traceTransaction`
- `trace_transaction`
- `eth_getLogs` (when fromBlock != toBlock)

## Solution

Swap the column order to `(range_key, partition_key)` so the index can efficiently serve the reverse lookup query:

```sql
SELECT value FROM erpc_cache
WHERE range_key = $1 AND partition_key LIKE $2
  AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'UTC')
ORDER BY partition_key DESC
LIMIT 1;
```

## Benchmark Results

**Before fix** (wrong column order `partition_key, range_key`):
```
Execution Time: 110.659 ms
Buffers: shared hit=3 read=27009 written=5853
```

**After fix** (correct column order `range_key, partition_key`):
```
Execution Time: 0.040 ms
Buffers: shared hit=3 read=3
```

<details>
<summary>EXPLAIN ANALYZE output</summary>

### Before (with buggy index)
```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT value FROM erpc_cache
WHERE range_key = 'net_version:5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456'
  AND partition_key LIKE 'evm:480:%'
  AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'UTC')
ORDER BY partition_key DESC
LIMIT 1;
```
```
 Limit  (cost=0.69..1936.75 rows=1 width=443) (actual time=110.640..110.642 rows=1.00 loops=1)
   Buffers: shared hit=3 read=27009 written=5853
   ->  Index Scan Backward using idx_reverse on erpc_cache  (cost=0.69..1936.75 rows=1 width=443) (actual time=110.638..110.639 rows=1.00 loops=1)
         Index Cond: ((partition_key >= 'evm:480:'::text) AND (partition_key < 'evm:480;'::text) AND (range_key = 'net_version:5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456'::text))
         Filter: ((partition_key ~~ 'evm:480:%'::text) AND ((expires_at IS NULL) OR (expires_at > (now() AT TIME ZONE 'UTC'::text))))
         Index Searches: 1
         Buffers: shared hit=3 read=27009 written=5853
 Planning Time: 0.242 ms
 Execution Time: 110.659 ms
```

### After (with correct index)
```sql
CREATE INDEX CONCURRENTLY idx_reverse_proper ON erpc_cache (range_key, partition_key);

EXPLAIN (ANALYZE, BUFFERS)
SELECT value FROM erpc_cache
WHERE range_key = 'net_version:5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456'
  AND partition_key LIKE 'evm:480:%'
  AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'UTC')
ORDER BY partition_key DESC
LIMIT 1;
```
```
 Limit  (cost=0.69..8.72 rows=1 width=443) (actual time=0.027..0.027 rows=1.00 loops=1)
   Buffers: shared hit=3 read=3
   ->  Index Scan Backward using idx_reverse_proper on erpc_cache  (cost=0.69..8.72 rows=1 width=443) (actual time=0.026..0.026 rows=1.00 loops=1)
         Index Cond: ((range_key = 'net_version:5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456'::text) AND (partition_key >= 'evm:480:'::text) AND (partition_key < 'evm:480;'::text))
         Filter: ((partition_key ~~ 'evm:480:%'::text) AND ((expires_at IS NULL) OR (expires_at > (now() AT TIME ZONE 'UTC'::text))))
         Index Searches: 1
         Buffers: shared hit=3 read=3
 Planning Time: 0.405 ms
 Execution Time: 0.040 ms
```

</details>

## Migration for Existing Deployments

```sql
CREATE INDEX CONCURRENTLY idx_reverse_new ON erpc_cache (range_key, partition_key);
DROP INDEX idx_reverse;
ALTER INDEX idx_reverse_new RENAME TO idx_reverse;
```
