### PR TITLE
fix: avoid panicing and fail-open when rate limiter redis is not available

### DIFF
--- a/erpc/config_analyzer.go
+++ b/erpc/config_analyzer.go
@@ -325,7 +325,7 @@ func GenerateValidationReport(ctx context.Context, cfg *common.Config) *Validati
 		}
 		clReg := clients.NewClientRegistry(&silent, project.Id, prxPool, evm.NewJsonRpcErrorExtractor())
 		vndReg := thirdparty.NewVendorsRegistry()
-		rlr, err := upstream.NewRateLimitersRegistry(cfg.RateLimiters, &silent)
+		rlr, err := upstream.NewRateLimitersRegistry(ctx, cfg.RateLimiters, &silent)
 		if err != nil {
 			appendErr(fmt.Sprintf("project=%s failed to create rate limiters registry: %v", project.Id, err))
 			continue
@@ -806,6 +806,7 @@ func validateUpstreamEndpoints(ctx context.Context, cfg *common.Config, logger z
 		)
 		vndReg := thirdparty.NewVendorsRegistry()
 		rlr, err := upstream.NewRateLimitersRegistry(
+			ctx,
 			cfg.RateLimiters,
 			&logger,
 		)

--- a/erpc/erpc.go
+++ b/erpc/erpc.go
@@ -33,6 +33,7 @@ func NewERPC(
 	}
 
 	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		appCtx,
 		cfg.RateLimiters,
 		logger,
 	)

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -99,7 +99,7 @@ func createCacheTestFixtures(ctx context.Context, upstreamConfigs []upsTestCfg) 
 
 	for _, cfg := range upstreamConfigs {
 		mt := health.NewTracker(&logger, "prjA", 100*time.Second)
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &logger)
 		if err != nil {
 			panic(err)
 		}
@@ -2622,7 +2622,7 @@ func createMockUpstream(t *testing.T, ctx context.Context, chainId int64, upstre
 	require.NoError(t, err)
 
 	mt := health.NewTracker(&logger, "prjA", 100*time.Second)
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &logger)
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &logger)
 	require.NoError(t, err)
 
 	mockUpstream, err := upstream.NewUpstream(ctx, "test", &common.UpstreamConfig{
@@ -3244,7 +3244,7 @@ func createCacheTestFixturesWithCompression(ctx context.Context, upstreamConfigs
 
 	for _, cfg := range upstreamConfigs {
 		mt := health.NewTracker(&logger, "prjA", 100*time.Second)
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &logger)
 		if err != nil {
 			panic(err)
 		}

--- a/erpc/networks_availability_test.go
+++ b/erpc/networks_availability_test.go
@@ -49,7 +49,7 @@ func TestNetworkAvailability_LowerExactBlock_Skip(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -114,7 +114,7 @@ func TestNetworkAvailability_LowerLatestMinus_Skip(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -187,7 +187,7 @@ func TestNetworkAvailability_LowerEarliestPlus_InitAndSkip(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -297,7 +297,7 @@ func TestNetworkAvailability_InvalidRange_FailOpen_AllowsRequest(t *testing.T) {
 		Reply(200).
 		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x1"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -374,7 +374,7 @@ func TestNetworkAvailability_Window_ExactLowerUpper(t *testing.T) {
 		Reply(200).
 		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x64"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -475,7 +475,7 @@ func TestNetworkAvailability_EarliestPlus_Freeze_NoAdvance(t *testing.T) {
 		return strings.Contains(b, "\"eth_getBlockByNumber\"") && strings.Contains(b, "\"0x3\"")
 	}).Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x3"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -564,7 +564,7 @@ func TestNetworkAvailability_EarliestPlus_UpdateRate_Advance(t *testing.T) {
 		return strings.Contains(b, "\"eth_getBlockByNumber\"") && strings.Contains(b, "\"0x1\"")
 	}).Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x1"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -637,7 +637,7 @@ func TestNetworkAvailability_UnsupportedProbe_FailOpen(t *testing.T) {
 		return strings.Contains(b, "\"eth_getBlockByNumber\"") && strings.Contains(b, "\"0x0\"")
 	}).Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x0"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -718,7 +718,7 @@ func TestNetworkAvailability_UpperEarliestPlus_Enforced(t *testing.T) {
 		return strings.Contains(b, "\"eth_getBlockByNumber\"") && !strings.Contains(b, "\"0x0\"") && !strings.Contains(b, "\"0x1\"")
 	}).Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x1"}}`))
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -803,7 +803,7 @@ func TestNetworkAvailability_Enforce_Precedence_DefaultDoesNotOverrideMethod(t *
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -882,7 +882,7 @@ func TestNetworkAvailability_Enforce_Precedence_DefaultDoesNotOverrideNetwork(t 
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -953,7 +953,7 @@ func TestNetworkAvailability_Enforce_DefaultFalse_Disables_WhenNoExplicitConfig(
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1019,7 +1019,7 @@ func TestNetworkAvailability_Enforce_NetworkFalse_Disables(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1073,7 +1073,7 @@ func TestCheckUpstreamBlockAvailability_BlockBeyondLatest_ReturnsRetryableError(
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1140,7 +1140,7 @@ func TestCheckUpstreamBlockAvailability_SmallDistance_IsRetryable(t *testing.T) 
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1231,7 +1231,7 @@ func TestCheckUpstreamBlockAvailability_ErrorHasCorrectDetails(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1312,7 +1312,7 @@ func TestRetryableBlockUnavailability_NoInfiniteLoop(t *testing.T) {
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)

--- a/erpc/networks_bench_test.go
+++ b/erpc/networks_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkNetworkForward_SimpleSuccess(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 		Budgets: []*common.RateLimitBudgetConfig{},
 	}, &log.Logger)
 	if err != nil {
@@ -141,7 +141,7 @@ func BenchmarkNetworkForward_MethodIgnoreCase(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 		Budgets: []*common.RateLimitBudgetConfig{},
 	}, &log.Logger)
 	if err != nil {
@@ -252,7 +252,7 @@ func BenchmarkNetworkForward_RetryFailures(b *testing.B) {
 			MaxAttempts: 3,
 		},
 	}
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 		Budgets: []*common.RateLimitBudgetConfig{},
 	}, &log.Logger)
 	if err != nil {
@@ -368,7 +368,7 @@ func BenchmarkNetworkForward_ConcurrentEthGetLogsIntegrityEnabled(b *testing.B) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 		Budgets: []*common.RateLimitBudgetConfig{},
 	}, &log.Logger)
 	if err != nil {

--- a/erpc/networks_bootstrap_test.go
+++ b/erpc/networks_bootstrap_test.go
@@ -52,7 +52,7 @@ func TestNetworksBootstrap_SlowProviderUpstreams_InitializeThenServe(t *testing.
 	})
 	require.NoError(t, err)
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	upr := upstream.NewUpstreamsRegistry(
@@ -100,7 +100,7 @@ func TestNetworksBootstrap_UnsupportedNetwork_FatalFast(t *testing.T) {
 	ssr, err := data.NewSharedStateRegistry(ctx, &log.Logger, &common.SharedStateConfig{Connector: &common.ConnectorConfig{Driver: "memory", Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"}}})
 	require.NoError(t, err)
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "prjA", []*common.UpstreamConfig{}, ssr, rlr, vr, pr, nil, mt, 1*time.Second, nil)
@@ -141,7 +141,7 @@ func TestNetworksBootstrap_ProviderInitializing_503Retry(t *testing.T) {
 	ssr, err := data.NewSharedStateRegistry(ctx, &log.Logger, &common.SharedStateConfig{Connector: &common.ConnectorConfig{Driver: "memory", Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"}}})
 	require.NoError(t, err)
 
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "prjA", []*common.UpstreamConfig{}, ssr, rlr, vr, pr, nil, mt, 1*time.Second, nil)

--- a/erpc/networks_earliest_detection_test.go
+++ b/erpc/networks_earliest_detection_test.go
@@ -61,7 +61,7 @@ func TestEarliestDetection_FailOpenWhenNoEarliestConfigured(t *testing.T) {
 			"result":  map[string]interface{}{"number": "0x5"},
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -174,7 +174,7 @@ func TestEarliestDetection_BlocksRequestAfterSuccessfulDetection(t *testing.T) {
 			"result":  nil, // Pruned
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -259,7 +259,7 @@ func TestEarliestDetection_InitialDetectionAlwaysRunsOnBootstrap(t *testing.T) {
 			},
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -351,7 +351,7 @@ func TestEarliestDetection_SchedulerHandlesPeriodicUpdates(t *testing.T) {
 			},
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -450,7 +450,7 @@ func TestEarliestDetection_InvalidRangeTriggersFailOpen(t *testing.T) {
 			"result":  nil,
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -589,7 +589,7 @@ func TestEarliestDetection_StaleHighValueInSharedState(t *testing.T) {
 			},
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)

--- a/erpc/networks_failsafe_test.go
+++ b/erpc/networks_failsafe_test.go
@@ -725,7 +725,7 @@ func setupTestNetworkWithRetryConfig(t *testing.T, ctx context.Context, directiv
 		}},
 	}
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
@@ -801,7 +801,7 @@ func setupTestNetworkWithMultipleFailsafePolicies(t *testing.T, ctx context.Cont
 		Failsafe: failsafeConfigs,
 	}
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)

--- a/erpc/networks_forward_test.go
+++ b/erpc/networks_forward_test.go
@@ -44,7 +44,7 @@ func TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping(t *testing.T) {
 				},
 			},
 		})
-		rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, logger)
 		mt := health.NewTracker(logger, "testProject", 2*time.Second)
@@ -132,7 +132,7 @@ func TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, logger)
 		require.NoError(t, err)
 
 		mt := health.NewTracker(logger, "testProject", 2*time.Second)
@@ -212,7 +212,7 @@ func TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping(t *testing.T) {
 		require.NoError(t, err)
 
 		// Setup rate limiters registry
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, logger)
 		require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, logger)
 		require.NoError(t, err)

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -968,7 +968,7 @@ func setupTestNetworkWithMultipleUpstreams(t *testing.T, ctx context.Context, nu
 func setupTestNetwork(t *testing.T, ctx context.Context, upstreamConfigs []*common.UpstreamConfig, networkConfig *common.NetworkConfig) *Network {
 	t.Helper()
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)

--- a/erpc/networks_integrity_test.go
+++ b/erpc/networks_integrity_test.go
@@ -50,7 +50,7 @@ func mustHexToBytes(hex string) []byte {
 
 // Helper to setup test network for integrity tests
 func setupIntegrityTestNetwork(t *testing.T, ctx context.Context, upstreams []*common.UpstreamConfig, ntwCfg *common.NetworkConfig) (*Network, *upstream.UpstreamsRegistry) {
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)

--- a/erpc/networks_interpolation_test.go
+++ b/erpc/networks_interpolation_test.go
@@ -39,7 +39,7 @@ func setupTestNetworkForInterpolation(t *testing.T, ctx context.Context, network
 		},
 	}
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -1936,7 +1936,7 @@ func TestInterpolation_UpstreamSkipping_OnInterpolatedLatest(t *testing.T) {
 			"result":  "0x1234",
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
@@ -2054,7 +2054,7 @@ func TestInterpolation_UpstreamSkipping_DisabledByMethodConfig(t *testing.T) {
 			"result":  "0x99",
 		})
 
-	rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)

--- a/erpc/networks_multiplexer_test.go
+++ b/erpc/networks_multiplexer_test.go
@@ -387,7 +387,7 @@ func setupTestNetworkForMultiplexer(t *testing.T, ctx context.Context) *Network 
 		// No caching to test pure multiplexing
 	}
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)

--- a/erpc/networks_sendrawtx_test.go
+++ b/erpc/networks_sendrawtx_test.go
@@ -1671,7 +1671,7 @@ func setupSendRawTxTestNetworkWithRetryAndHedge(t *testing.T, ctx context.Contex
 func setupSendRawTxNetwork(t *testing.T, ctx context.Context, upstreamConfigs []*common.UpstreamConfig, networkConfig *common.NetworkConfig) *Network {
 	t.Helper()
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -45,7 +45,7 @@ func TestNetwork_Forward(t *testing.T) {
 		util.SetupMocksForEvmStatePoller()
 		defer util.AssertNoPendingMocks(t, 0)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{
 				Store: &common.RateLimitStoreConfig{
 					Driver: "memory",
@@ -212,7 +212,7 @@ func TestNetwork_Forward(t *testing.T) {
 				EmptyResultMaxAttempts: 2, // cap empties at 2 total attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -331,7 +331,7 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{MaxAttempts: 3}, // no EmptyResultMaxAttempts set
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -447,7 +447,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{Retry: &common.RetryPolicyConfig{MaxAttempts: 3, EmptyResultMaxAttempts: 2}}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -541,7 +541,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{Retry: &common.RetryPolicyConfig{MaxAttempts: 5, EmptyResultMaxAttempts: 2}}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -627,7 +627,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{Retry: &common.RetryPolicyConfig{MaxAttempts: 5, EmptyResultMaxAttempts: 4, EmptyResultIgnore: []string{"eth_getBalance"}}}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -693,7 +693,7 @@ func TestNetwork_Forward(t *testing.T) {
 		util.SetupMocksForEvmStatePoller()
 		defer util.AssertNoPendingMocks(t, 0)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{
 				Budgets: []*common.RateLimitBudgetConfig{
 					{
@@ -829,7 +829,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -954,7 +954,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -1095,7 +1095,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -1261,7 +1261,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -1418,7 +1418,7 @@ func TestNetwork_Forward(t *testing.T) {
 
 		// Initialize various components for the test environment
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -1615,7 +1615,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -1825,7 +1825,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -2017,7 +2017,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -2242,7 +2242,7 @@ func TestNetwork_Forward(t *testing.T) {
 
 		// Set up the test environment
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
-		rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		vr := thirdparty.NewVendorsRegistry()
 		pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, []*common.ProviderConfig{}, nil)
 		mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
@@ -2380,7 +2380,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -2588,7 +2588,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -2778,7 +2778,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -2961,7 +2961,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -3163,7 +3163,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 4, // Allow up to 4 attempts (1 initial + 3 retries)
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -3392,7 +3392,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -3583,7 +3583,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3, // Allow up to 3 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -3771,7 +3771,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2, // Allow up to 2 retry attempts
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -3952,7 +3952,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4081,7 +4081,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4219,7 +4219,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4391,7 +4391,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4521,7 +4521,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4623,7 +4623,7 @@ func TestNetwork_Forward(t *testing.T) {
 		util.SetupMocksForEvmStatePoller()
 		defer util.AssertNoPendingMocks(t, 0)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{
 				Budgets: []*common.RateLimitBudgetConfig{
 					{
@@ -4769,7 +4769,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 3,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -4899,7 +4899,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 4,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5027,7 +5027,7 @@ func TestNetwork_Forward(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5160,7 +5160,7 @@ func TestNetwork_Forward(t *testing.T) {
 				Duration: common.Duration(1 * time.Second),
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5293,7 +5293,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxCount: 1,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5446,7 +5446,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxCount: 5,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5597,7 +5597,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxCount: 5,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5755,7 +5755,7 @@ func TestNetwork_Forward(t *testing.T) {
 			},
 		}
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -5889,7 +5889,7 @@ func TestNetwork_Forward(t *testing.T) {
 			},
 		}
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6022,7 +6022,7 @@ func TestNetwork_Forward(t *testing.T) {
 			t.Fatal(err)
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6175,7 +6175,7 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6313,7 +6313,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6458,7 +6458,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6586,7 +6586,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6738,7 +6738,7 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts: 2,
 			},
 		}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -6883,7 +6883,7 @@ func TestNetwork_Forward(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -7019,7 +7019,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -7142,7 +7142,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -7264,7 +7264,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -7380,7 +7380,7 @@ func TestNetwork_Forward(t *testing.T) {
 
 		metricsTracker.Bootstrap(ctx)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &logger)
 		assert.NoError(t, err)
@@ -7566,7 +7566,7 @@ func TestNetwork_Forward(t *testing.T) {
 		defer cancel()
 
 		fsCfg := &common.FailsafeConfig{}
-		rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 			Budgets: []*common.RateLimitBudgetConfig{},
 		}, &log.Logger)
 		if err != nil {
@@ -9236,7 +9236,7 @@ func TestNetwork_EvmGetLogs(t *testing.T) {
 			defer cancel()
 
 			// Build network with tight best-effort budgets to force fallback
-			rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+			rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 			metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 			vr := thirdparty.NewVendorsRegistry()
 			pr, err := thirdparty.NewProvidersRegistry(&log.Logger, vr, []*common.ProviderConfig{}, nil)
@@ -10170,7 +10170,7 @@ func TestNetwork_ThunderingHerdProtection(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		mt := health.NewTracker(&log.Logger, "prjA", 5*time.Second)
 
 		pollerInterval := 2000 * time.Millisecond
@@ -10372,7 +10372,7 @@ func TestNetwork_ThunderingHerdProtection(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 
 		upCfg := &common.UpstreamConfig{
@@ -10557,7 +10557,7 @@ func TestNetwork_ThunderingHerdProtection(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		rlr, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
 
 		upCfg := &common.UpstreamConfig{
@@ -10655,7 +10655,7 @@ func TestNetwork_ThunderingHerdProtection(t *testing.T) {
 func setupTestNetworkSimple(t *testing.T, ctx context.Context, upstreamConfig *common.UpstreamConfig, networkConfig *common.NetworkConfig) *Network {
 	t.Helper()
 
-	rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 	if upstreamConfig == nil {
@@ -10764,7 +10764,7 @@ func setupTestNetworkWithFullAndArchiveNodeUpstreams(
 ) *Network {
 	t.Helper()
 
-	rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 	up1 := &common.UpstreamConfig{
@@ -10929,7 +10929,7 @@ func TestNetwork_HighestLatestBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11082,7 +11082,7 @@ func TestNetwork_HighestLatestBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11240,7 +11240,7 @@ func TestNetwork_HighestLatestBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11367,7 +11367,7 @@ func TestNetwork_HighestLatestBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11501,7 +11501,7 @@ func TestNetwork_HighestFinalizedBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11632,7 +11632,7 @@ func TestNetwork_HighestFinalizedBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()
@@ -11761,7 +11761,7 @@ func TestNetwork_HighestFinalizedBlockNumber(t *testing.T) {
 			Reply(200).
 			JSON([]byte(`{"result":"0x7b"}`))
 
-		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimitersRegistry, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
 
 		vr := thirdparty.NewVendorsRegistry()

--- a/erpc/policy_evaluator_test.go
+++ b/erpc/policy_evaluator_test.go
@@ -1724,7 +1724,7 @@ func TestPolicyEvaluator(t *testing.T) {
 }
 
 func createTestNetwork(t *testing.T, ctx context.Context) (*Network, *upstream.Upstream, *upstream.Upstream, *upstream.Upstream) {
-	rlr, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{
+	rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
 		Budgets: []*common.RateLimitBudgetConfig{},
 	}, &log.Logger)
 	if err != nil {

--- a/erpc/projects_test.go
+++ b/erpc/projects_test.go
@@ -25,7 +25,7 @@ func TestProject_Forward(t *testing.T) {
 		util.SetupMocksForEvmStatePoller()
 		defer util.AssertNoPendingMocks(t, 0)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{
 				Store: &common.RateLimitStoreConfig{
 					Driver: "memory",
@@ -136,7 +136,7 @@ func TestProject_TimeoutScenarios(t *testing.T) {
 
 		// Create a rate limiters registry (not specifically needed for this test,
 		// but it's part of the usual setup.)
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{},
 			&log.Logger,
 		)
@@ -248,7 +248,7 @@ func TestProject_TimeoutScenarios(t *testing.T) {
 		util.SetupMocksForEvmStatePoller()
 		defer util.AssertNoPendingMocks(t, 0)
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{},
 			&log.Logger,
 		)
@@ -416,7 +416,7 @@ func TestProject_LazyLoadNetworkDefaults(t *testing.T) {
 		}
 
 		// Build ProjectsRegistry with no existing EvmJsonRpcCache or RateLimiter
-		rateLimiters, _ := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+		rateLimiters, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 		ssr, err := data.NewSharedStateRegistry(ctx, &log.Logger, &common.SharedStateConfig{
 			Connector: &common.ConnectorConfig{
 				Driver: "memory",
@@ -512,7 +512,7 @@ func TestProject_NetworkAlias(t *testing.T) {
 			panic(err)
 		}
 
-		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(
+		rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(),
 			&common.RateLimiterConfig{},
 			&log.Logger,
 		)

--- a/erpc/upstream_selection_test.go
+++ b/erpc/upstream_selection_test.go
@@ -809,7 +809,7 @@ func setupTestNetworkWithFourUpstreams(t *testing.T, ctx context.Context, failsa
 func setupTestNetworkWithConfig(t *testing.T, ctx context.Context, upstreamConfigs []*common.UpstreamConfig, failsafeConfig *common.FailsafeConfig) *Network {
 	t.Helper()
 
-	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(&common.RateLimiterConfig{}, &log.Logger)
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
 	require.NoError(t, err)
 
 	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)

--- a/upstream/ratelimiter_registry.go
+++ b/upstream/ratelimiter_registry.go
@@ -1,7 +1,10 @@
 package upstream
 
 import (
+	"context"
+	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -17,18 +20,23 @@ import (
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/telemetry"
+	"github.com/erpc/erpc/util"
 )
 
 type RateLimitersRegistry struct {
+	appCtx          context.Context
 	logger          *zerolog.Logger
 	cfg             *common.RateLimiterConfig
 	budgetsLimiters sync.Map
 	envoyCache      limiter.RateLimitCache
 	statsManager    stats.Manager
+	cacheMu         sync.RWMutex
+	initializer     *util.Initializer
 }
 
-func NewRateLimitersRegistry(cfg *common.RateLimiterConfig, logger *zerolog.Logger) (*RateLimitersRegistry, error) {
+func NewRateLimitersRegistry(appCtx context.Context, cfg *common.RateLimiterConfig, logger *zerolog.Logger) (*RateLimitersRegistry, error) {
 	r := &RateLimitersRegistry{
+		appCtx: appCtx,
 		cfg:    cfg,
 		logger: logger,
 	}
@@ -42,57 +50,109 @@ func (r *RateLimitersRegistry) bootstrap() error {
 		return nil
 	}
 
+	// Create a default stats manager (needed even if cache is nil)
+	store := gostats.NewStore(gostats.NewNullSink(), false)
+	r.statsManager = stats.NewStatManager(store, settings.NewSettings())
+
 	// Initialize shared cache if configured
 	if r.cfg.Store != nil && r.cfg.Store.Driver == "redis" && r.cfg.Store.Redis != nil {
-		store := gostats.NewStore(gostats.NewNullSink(), false)
-		mgr := stats.NewStatManager(store, settings.NewSettings())
-		useTLS := r.cfg.Store.Redis.TLS != nil && r.cfg.Store.Redis.TLS.Enabled
-		url := r.cfg.Store.Redis.URI
-		if url == "" {
-			url = r.cfg.Store.Redis.Addr
+		// Create initializer for background retry
+		r.initializer = util.NewInitializer(r.appCtx, r.logger, nil)
+
+		// Attempt Redis connection with panic recovery - don't block startup
+		connectTask := util.NewBootstrapTask("redis-ratelimiter-connect", r.connectRedisTask)
+		if err := r.initializer.ExecuteTasks(r.appCtx, connectTask); err != nil {
+			// Cache stays nil - rate limiting will fail-open until Redis connects
+			r.logger.Warn().Err(err).Msg("failed to initialize Redis rate limiter on first attempt (rate limiting will fail-open until connected, retrying in background)")
 		}
-		poolSize := r.cfg.Store.Redis.ConnPoolSize
-		client := redis.NewClientImpl(
-			store.Scope("erpc_rl"),
-			useTLS,
-			r.cfg.Store.Redis.Username,
-			"tcp",
-			"single",
-			url,
-			poolSize,
-			5*time.Millisecond,
-			32,
-			nil,
-			false,
-			nil,
-		)
-		r.envoyCache = redis.NewFixedRateLimitCacheImpl(
-			client,
-			nil,
-			utils.NewTimeSourceImpl(),
-			rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
-			5,
-			nil,
-			defaultNearLimitRatio(r.cfg.Store.NearLimitRatio),
-			defaultCacheKeyPrefix(r.cfg.Store.CacheKeyPrefix),
-			mgr,
-			false,
-		)
-		r.statsManager = mgr
 	} else if r.cfg.Store != nil && r.cfg.Store.Driver == "memory" {
-		store := gostats.NewStore(gostats.NewNullSink(), false)
-		mgr := stats.NewStatManager(store, settings.NewSettings())
+		// Explicitly configured for memory
 		r.envoyCache = NewMemoryRateLimitCache(
 			utils.NewTimeSourceImpl(),
 			rand.New(rand.NewSource(time.Now().Unix())), // #nosec G404
 			0,
 			defaultNearLimitRatio(r.cfg.Store.NearLimitRatio),
 			defaultCacheKeyPrefix(r.cfg.Store.CacheKeyPrefix),
-			mgr,
+			r.statsManager,
 		)
-		r.statsManager = mgr
 	}
 
+	// Initialize budgets (cache may be nil for Redis until it connects)
+	r.initializeBudgets()
+
+	return nil
+}
+
+// connectRedisTask attempts to connect to Redis with panic recovery
+func (r *RateLimitersRegistry) connectRedisTask(ctx context.Context) (err error) {
+	// Recover from panics in the envoyproxy/ratelimit library
+	defer func() {
+		if rec := recover(); rec != nil {
+			telemetry.MetricUnexpectedPanicTotal.WithLabelValues(
+				"ratelimiter-redis-connect",
+				fmt.Sprintf("store:%s", r.cfg.Store.Redis.URI),
+				common.ErrorFingerprint(rec),
+			).Inc()
+			r.logger.Error().
+				Interface("panic", rec).
+				Str("stack", string(debug.Stack())).
+				Msg("panic recovered during Redis rate limiter connection (rate limiting will fail-open)")
+			err = fmt.Errorf("panic during Redis connection: %v", rec)
+		}
+	}()
+
+	store := gostats.NewStore(gostats.NewNullSink(), false)
+	mgr := stats.NewStatManager(store, settings.NewSettings())
+	useTLS := r.cfg.Store.Redis.TLS != nil && r.cfg.Store.Redis.TLS.Enabled
+	url := r.cfg.Store.Redis.URI
+	if url == "" {
+		url = r.cfg.Store.Redis.Addr
+	}
+	poolSize := r.cfg.Store.Redis.ConnPoolSize
+
+	r.logger.Debug().Str("url", util.RedactEndpoint(url)).Bool("tls", useTLS).Int("poolSize", poolSize).Msg("attempting to connect to Redis for rate limiting")
+
+	client := redis.NewClientImpl(
+		store.Scope("erpc_rl"),
+		useTLS,
+		r.cfg.Store.Redis.Username,
+		"tcp",
+		"single",
+		url,
+		poolSize,
+		5*time.Millisecond,
+		32,
+		nil,
+		false,
+		nil,
+	)
+
+	cache := redis.NewFixedRateLimitCacheImpl(
+		client,
+		nil,
+		utils.NewTimeSourceImpl(),
+		rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
+		5,
+		nil,
+		defaultNearLimitRatio(r.cfg.Store.NearLimitRatio),
+		defaultCacheKeyPrefix(r.cfg.Store.CacheKeyPrefix),
+		mgr,
+		false,
+	)
+
+	// Successfully connected - update the cache
+	// Note: statsManager is NOT updated here to avoid data races.
+	// The statsManager created in bootstrap() is sufficient and identical.
+	r.cacheMu.Lock()
+	r.envoyCache = cache
+	r.cacheMu.Unlock()
+
+	r.logger.Info().Str("url", util.RedactEndpoint(url)).Msg("successfully connected to Redis for rate limiting")
+	return nil
+}
+
+// initializeBudgets creates the rate limiter budgets
+func (r *RateLimitersRegistry) initializeBudgets() {
 	for _, budgetCfg := range r.cfg.Budgets {
 		lg := r.logger.With().Str("budget", budgetCfg.Id).Logger()
 		lg.Debug().Msgf("initializing rate limiter budget")
@@ -105,7 +165,6 @@ func (r *RateLimitersRegistry) bootstrap() error {
 			Rules:      make([]*RateLimitRule, 0),
 			registry:   r,
 			logger:     &lg,
-			cache:      r.envoyCache,
 			maxTimeout: maxTimeout,
 		}
 
@@ -131,8 +190,13 @@ func (r *RateLimitersRegistry) bootstrap() error {
 
 		r.budgetsLimiters.Store(budgetCfg.Id, budget)
 	}
+}
 
-	return nil
+// GetCache returns the current rate limit cache (thread-safe)
+func (r *RateLimitersRegistry) GetCache() limiter.RateLimitCache {
+	r.cacheMu.RLock()
+	defer r.cacheMu.RUnlock()
+	return r.envoyCache
 }
 
 func (r *RateLimitersRegistry) GetBudget(budgetId string) (*RateLimiterBudget, error) {

--- a/upstream/ratelimiter_test.go
+++ b/upstream/ratelimiter_test.go
@@ -16,7 +16,7 @@ func TestRateLimitersRegistry_New(t *testing.T) {
 	logger := zerolog.Nop()
 
 	t.Run("nil config", func(t *testing.T) {
-		registry, err := NewRateLimitersRegistry(nil, &logger)
+		registry, err := NewRateLimitersRegistry(context.Background(), nil, &logger)
 		require.NoError(t, err)
 		assert.NotNil(t, registry)
 	})
@@ -37,7 +37,7 @@ func TestRateLimitersRegistry_New(t *testing.T) {
 				},
 			},
 		}
-		registry, err := NewRateLimitersRegistry(cfg, &logger)
+		registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
 		require.NoError(t, err)
 		assert.NotNil(t, registry)
 	})
@@ -60,7 +60,7 @@ func TestRateLimitersRegistry_GetBudget(t *testing.T) {
 			},
 		},
 	}
-	registry, err := NewRateLimitersRegistry(cfg, &logger)
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
 	require.NoError(t, err)
 
 	t.Run("existing budget", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestRateLimiterBudget_GetRulesByMethod(t *testing.T) {
 			},
 		},
 	}
-	registry, err := NewRateLimitersRegistry(cfg, &logger)
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
 	require.NoError(t, err)
 
 	budget, err := registry.GetBudget("test-budget")
@@ -152,7 +152,7 @@ func TestRateLimiter_ConcurrentPermits(t *testing.T) {
 			},
 		},
 	}
-	registry, err := NewRateLimitersRegistry(cfg, &logger)
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
 	require.NoError(t, err)
 
 	budget, err := registry.GetBudget("test-budget")
@@ -203,7 +203,7 @@ func TestRateLimiter_ExceedCapacity(t *testing.T) {
 		},
 	}
 
-	registry, err := NewRateLimitersRegistry(cfg, &logger)
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
 	require.NoError(t, err)
 
 	budget, err := registry.GetBudget("test-budget")

--- a/upstream/registry_contention_bench_test.go
+++ b/upstream/registry_contention_bench_test.go
@@ -25,7 +25,7 @@ func buildRegistryForBench(b *testing.B, numNetworks, upstreamsPerNetwork int, m
 
 	vr := thirdparty.NewVendorsRegistry()
 	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
-	rlr, _ := NewRateLimitersRegistry(nil, &log.Logger)
+	rlr, _ := NewRateLimitersRegistry(context.Background(), nil, &log.Logger)
 	mt := health.NewTracker(&log.Logger, "bench-prj", time.Minute)
 
 	reg := NewUpstreamsRegistry(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures resilient rate limiting and propagates context through registry creation.
> 
> - Change `upstream.NewRateLimitersRegistry` to `NewRateLimitersRegistry(ctx, cfg, logger)` and update all call sites (prod and tests)
> - Implement async Redis connection with panic recovery in `upstream/ratelimiter_registry.go`; rate limiting now fail-opens until Redis connects
> - Remove direct cache field from `RateLimiterBudget`; access cache via thread-safe `registry.GetCache()` and handle `nil` cache to fail-open
> - Add timeout-aware `doLimitWithTimeout` path using provided cache; protect cache with RW lock
> - Initialize budgets independently of cache; keep in-memory store path; add benches/tests adjusted for new API
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55107bf13c66584a7e7010467b023c31da941442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->