### PR TITLE
feat: make http client timeouts configurable

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -793,6 +793,29 @@ type JsonRpcUpstreamConfig struct {
 	EnableGzip    *bool             `yaml:"enableGzip,omitempty" json:"enableGzip"`
 	Headers       map[string]string `yaml:"headers,omitempty" json:"headers"`
 	ProxyPool     string            `yaml:"proxyPool,omitempty" json:"proxyPool"`
+
+	// HTTP client timeout settings (optional, with sensible defaults)
+	// Timeout is the total time limit for a request including connection, headers, and body.
+	// Default: 60s
+	Timeout Duration `yaml:"timeout,omitempty" json:"timeout" tstype:"Duration"`
+
+	// ResponseHeaderTimeout specifies the time to wait for a server's response headers
+	// after fully writing the request. This does not include the time to read the response body.
+	// Default: 30s
+	ResponseHeaderTimeout Duration `yaml:"responseHeaderTimeout,omitempty" json:"responseHeaderTimeout" tstype:"Duration"`
+
+	// TLSHandshakeTimeout specifies the maximum time waiting for a TLS handshake.
+	// Default: 10s
+	TLSHandshakeTimeout Duration `yaml:"tlsHandshakeTimeout,omitempty" json:"tlsHandshakeTimeout" tstype:"Duration"`
+
+	// IdleConnTimeout is the maximum time an idle connection will remain idle before closing.
+	// Default: 90s
+	IdleConnTimeout Duration `yaml:"idleConnTimeout,omitempty" json:"idleConnTimeout" tstype:"Duration"`
+
+	// ExpectContinueTimeout specifies the time to wait for a server's first response headers
+	// after fully writing the request headers if the request has an "Expect: 100-continue" header.
+	// Default: 1s
+	ExpectContinueTimeout Duration `yaml:"expectContinueTimeout,omitempty" json:"expectContinueTimeout" tstype:"Duration"`
 }
 
 func (c *JsonRpcUpstreamConfig) Copy() *JsonRpcUpstreamConfig {
@@ -1385,6 +1408,29 @@ func (c *Config) HasRateLimiterBudget(id string) bool {
 type ProxyPoolConfig struct {
 	ID   string   `yaml:"id" json:"id"`
 	Urls []string `yaml:"urls" json:"urls"`
+
+	// HTTP client timeout settings (optional, with sensible defaults)
+	// Timeout is the total time limit for a request including connection, headers, and body.
+	// Default: 60s
+	Timeout Duration `yaml:"timeout,omitempty" json:"timeout" tstype:"Duration"`
+
+	// ResponseHeaderTimeout specifies the time to wait for a server's response headers
+	// after fully writing the request. This does not include the time to read the response body.
+	// Default: 30s
+	ResponseHeaderTimeout Duration `yaml:"responseHeaderTimeout,omitempty" json:"responseHeaderTimeout" tstype:"Duration"`
+
+	// TLSHandshakeTimeout specifies the maximum time waiting for a TLS handshake.
+	// Default: 10s
+	TLSHandshakeTimeout Duration `yaml:"tlsHandshakeTimeout,omitempty" json:"tlsHandshakeTimeout" tstype:"Duration"`
+
+	// IdleConnTimeout is the maximum time an idle connection will remain idle before closing.
+	// Default: 90s
+	IdleConnTimeout Duration `yaml:"idleConnTimeout,omitempty" json:"idleConnTimeout" tstype:"Duration"`
+
+	// ExpectContinueTimeout specifies the time to wait for a server's first response headers
+	// after fully writing the request headers if the request has an "Expect: 100-continue" header.
+	// Default: 1s
+	ExpectContinueTimeout Duration `yaml:"expectContinueTimeout,omitempty" json:"expectContinueTimeout" tstype:"Duration"`
 }
 
 type DeprecatedProjectHealthCheckConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -786,15 +786,9 @@ func (c *RateLimitAutoTuneConfig) Copy() *RateLimitAutoTuneConfig {
 	return copied
 }
 
-type JsonRpcUpstreamConfig struct {
-	SupportsBatch *bool             `yaml:"supportsBatch,omitempty" json:"supportsBatch"`
-	BatchMaxSize  int               `yaml:"batchMaxSize,omitempty" json:"batchMaxSize"`
-	BatchMaxWait  Duration          `yaml:"batchMaxWait,omitempty" json:"batchMaxWait" tstype:"Duration"`
-	EnableGzip    *bool             `yaml:"enableGzip,omitempty" json:"enableGzip"`
-	Headers       map[string]string `yaml:"headers,omitempty" json:"headers"`
-	ProxyPool     string            `yaml:"proxyPool,omitempty" json:"proxyPool"`
-
-	// HTTP client timeout settings (optional, with sensible defaults)
+// HTTPClientTimeouts contains HTTP client timeout configuration fields.
+// These are shared between JsonRpcUpstreamConfig and ProxyPoolConfig.
+type HTTPClientTimeouts struct {
 	// Timeout is the total time limit for a request including connection, headers, and body.
 	// Default: 60s
 	Timeout Duration `yaml:"timeout,omitempty" json:"timeout" tstype:"Duration"`
@@ -816,6 +810,117 @@ type JsonRpcUpstreamConfig struct {
 	// after fully writing the request headers if the request has an "Expect: 100-continue" header.
 	// Default: 1s
 	ExpectContinueTimeout Duration `yaml:"expectContinueTimeout,omitempty" json:"expectContinueTimeout" tstype:"Duration"`
+}
+
+// Default timeout values for HTTP clients
+const (
+	DefaultHTTPClientTimeout     = 60 * time.Second
+	DefaultResponseHeaderTimeout = 30 * time.Second
+	DefaultTLSHandshakeTimeout   = 10 * time.Second
+	DefaultIdleConnTimeout       = 90 * time.Second
+	DefaultExpectContinueTimeout = 1 * time.Second
+)
+
+// ResolvedHTTPClientTimeouts contains the resolved timeout values with defaults applied.
+type ResolvedHTTPClientTimeouts struct {
+	Timeout               time.Duration
+	ResponseHeaderTimeout time.Duration
+	TLSHandshakeTimeout   time.Duration
+	IdleConnTimeout       time.Duration
+	ExpectContinueTimeout time.Duration
+}
+
+// Resolve applies default values to any unset timeout fields and returns resolved timeouts.
+func (t *HTTPClientTimeouts) Resolve() ResolvedHTTPClientTimeouts {
+	if t == nil {
+		return ResolvedHTTPClientTimeouts{
+			Timeout:               DefaultHTTPClientTimeout,
+			ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
+			TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+			IdleConnTimeout:       DefaultIdleConnTimeout,
+			ExpectContinueTimeout: DefaultExpectContinueTimeout,
+		}
+	}
+	return ResolvedHTTPClientTimeouts{
+		Timeout:               t.Timeout.WithDefault(DefaultHTTPClientTimeout),
+		ResponseHeaderTimeout: t.ResponseHeaderTimeout.WithDefault(DefaultResponseHeaderTimeout),
+		TLSHandshakeTimeout:   t.TLSHandshakeTimeout.WithDefault(DefaultTLSHandshakeTimeout),
+		IdleConnTimeout:       t.IdleConnTimeout.WithDefault(DefaultIdleConnTimeout),
+		ExpectContinueTimeout: t.ExpectContinueTimeout.WithDefault(DefaultExpectContinueTimeout),
+	}
+}
+
+// MergeFrom copies timeout values from defaults for any fields that are not set (zero value).
+func (t *HTTPClientTimeouts) MergeFrom(defaults *HTTPClientTimeouts) {
+	if defaults == nil {
+		return
+	}
+	if t.Timeout == 0 && defaults.Timeout != 0 {
+		t.Timeout = defaults.Timeout
+	}
+	if t.ResponseHeaderTimeout == 0 && defaults.ResponseHeaderTimeout != 0 {
+		t.ResponseHeaderTimeout = defaults.ResponseHeaderTimeout
+	}
+	if t.TLSHandshakeTimeout == 0 && defaults.TLSHandshakeTimeout != 0 {
+		t.TLSHandshakeTimeout = defaults.TLSHandshakeTimeout
+	}
+	if t.IdleConnTimeout == 0 && defaults.IdleConnTimeout != 0 {
+		t.IdleConnTimeout = defaults.IdleConnTimeout
+	}
+	if t.ExpectContinueTimeout == 0 && defaults.ExpectContinueTimeout != 0 {
+		t.ExpectContinueTimeout = defaults.ExpectContinueTimeout
+	}
+}
+
+// Validate checks that all configured timeout values are valid (positive durations).
+// Zero values are allowed as they indicate "use default".
+func (t *HTTPClientTimeouts) Validate(prefix string) error {
+	if t == nil {
+		return nil
+	}
+
+	// Validate individual timeout values - they must be positive if set
+	if t.Timeout != 0 && t.Timeout.Duration() <= 0 {
+		return fmt.Errorf("%stimeout must be a positive duration, got: %v", prefix, t.Timeout)
+	}
+	if t.ResponseHeaderTimeout != 0 && t.ResponseHeaderTimeout.Duration() <= 0 {
+		return fmt.Errorf("%sresponseHeaderTimeout must be a positive duration, got: %v", prefix, t.ResponseHeaderTimeout)
+	}
+	if t.TLSHandshakeTimeout != 0 && t.TLSHandshakeTimeout.Duration() <= 0 {
+		return fmt.Errorf("%stlsHandshakeTimeout must be a positive duration, got: %v", prefix, t.TLSHandshakeTimeout)
+	}
+	if t.IdleConnTimeout != 0 && t.IdleConnTimeout.Duration() <= 0 {
+		return fmt.Errorf("%sidleConnTimeout must be a positive duration, got: %v", prefix, t.IdleConnTimeout)
+	}
+	if t.ExpectContinueTimeout != 0 && t.ExpectContinueTimeout.Duration() <= 0 {
+		return fmt.Errorf("%sexpectContinueTimeout must be a positive duration, got: %v", prefix, t.ExpectContinueTimeout)
+	}
+
+	// Validate timeout relationships
+	if t.Timeout != 0 && t.ResponseHeaderTimeout != 0 &&
+		t.ResponseHeaderTimeout.Duration() > t.Timeout.Duration() {
+		return fmt.Errorf("%sresponseHeaderTimeout (%v) cannot exceed timeout (%v)",
+			prefix, t.ResponseHeaderTimeout, t.Timeout)
+	}
+	if t.Timeout != 0 && t.TLSHandshakeTimeout != 0 &&
+		t.TLSHandshakeTimeout.Duration() > t.Timeout.Duration() {
+		return fmt.Errorf("%stlsHandshakeTimeout (%v) cannot exceed timeout (%v)",
+			prefix, t.TLSHandshakeTimeout, t.Timeout)
+	}
+
+	return nil
+}
+
+type JsonRpcUpstreamConfig struct {
+	SupportsBatch *bool             `yaml:"supportsBatch,omitempty" json:"supportsBatch"`
+	BatchMaxSize  int               `yaml:"batchMaxSize,omitempty" json:"batchMaxSize"`
+	BatchMaxWait  Duration          `yaml:"batchMaxWait,omitempty" json:"batchMaxWait" tstype:"Duration"`
+	EnableGzip    *bool             `yaml:"enableGzip,omitempty" json:"enableGzip"`
+	Headers       map[string]string `yaml:"headers,omitempty" json:"headers"`
+	ProxyPool     string            `yaml:"proxyPool,omitempty" json:"proxyPool"`
+
+	// HTTP client timeout settings (optional, with sensible defaults)
+	HTTPClientTimeouts `yaml:",inline" json:",inline"`
 }
 
 func (c *JsonRpcUpstreamConfig) Copy() *JsonRpcUpstreamConfig {
@@ -1410,27 +1515,7 @@ type ProxyPoolConfig struct {
 	Urls []string `yaml:"urls" json:"urls"`
 
 	// HTTP client timeout settings (optional, with sensible defaults)
-	// Timeout is the total time limit for a request including connection, headers, and body.
-	// Default: 60s
-	Timeout Duration `yaml:"timeout,omitempty" json:"timeout" tstype:"Duration"`
-
-	// ResponseHeaderTimeout specifies the time to wait for a server's response headers
-	// after fully writing the request. This does not include the time to read the response body.
-	// Default: 30s
-	ResponseHeaderTimeout Duration `yaml:"responseHeaderTimeout,omitempty" json:"responseHeaderTimeout" tstype:"Duration"`
-
-	// TLSHandshakeTimeout specifies the maximum time waiting for a TLS handshake.
-	// Default: 10s
-	TLSHandshakeTimeout Duration `yaml:"tlsHandshakeTimeout,omitempty" json:"tlsHandshakeTimeout" tstype:"Duration"`
-
-	// IdleConnTimeout is the maximum time an idle connection will remain idle before closing.
-	// Default: 90s
-	IdleConnTimeout Duration `yaml:"idleConnTimeout,omitempty" json:"idleConnTimeout" tstype:"Duration"`
-
-	// ExpectContinueTimeout specifies the time to wait for a server's first response headers
-	// after fully writing the request headers if the request has an "Expect: 100-continue" header.
-	// Default: 1s
-	ExpectContinueTimeout Duration `yaml:"expectContinueTimeout,omitempty" json:"expectContinueTimeout" tstype:"Duration"`
+	HTTPClientTimeouts `yaml:",inline" json:",inline"`
 }
 
 type DeprecatedProjectHealthCheckConfig struct {

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -974,7 +974,240 @@ func TestHTTPClientTimeouts_MergeFrom(t *testing.T) {
 			ResponseHeaderTimeout: Duration(60 * time.Second),
 		}
 		timeouts.MergeFrom(defaults)
-		assert.Equal(t, Duration(30*time.Second), timeouts.Timeout) // Not overwritten
+		assert.Equal(t, Duration(30*time.Second), timeouts.Timeout)               // Not overwritten
 		assert.Equal(t, Duration(60*time.Second), timeouts.ResponseHeaderTimeout) // Merged
+	})
+}
+
+func TestHTTPClientTimeouts_Validate_ExpectContinueTimeout(t *testing.T) {
+	t.Run("expectContinueTimeout exceeding timeout should fail validation", func(t *testing.T) {
+		timeouts := &HTTPClientTimeouts{
+			Timeout:               Duration(5 * time.Second),
+			ExpectContinueTimeout: Duration(10 * time.Second),
+		}
+		err := timeouts.Validate("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expectContinueTimeout")
+		assert.Contains(t, err.Error(), "cannot exceed timeout")
+	})
+
+	t.Run("valid expectContinueTimeout should pass", func(t *testing.T) {
+		timeouts := &HTTPClientTimeouts{
+			Timeout:               Duration(60 * time.Second),
+			ExpectContinueTimeout: Duration(1 * time.Second),
+		}
+		err := timeouts.Validate("")
+		assert.NoError(t, err)
+	})
+}
+
+func TestDuration_WithDefault(t *testing.T) {
+	t.Run("zero duration should return default", func(t *testing.T) {
+		d := Duration(0)
+		result := d.WithDefault(30 * time.Second)
+		assert.Equal(t, 30*time.Second, result)
+	})
+
+	t.Run("positive duration should return itself", func(t *testing.T) {
+		d := Duration(60 * time.Second)
+		result := d.WithDefault(30 * time.Second)
+		assert.Equal(t, 60*time.Second, result)
+	})
+
+	t.Run("negative duration should return default", func(t *testing.T) {
+		d := Duration(-10 * time.Second)
+		result := d.WithDefault(30 * time.Second)
+		assert.Equal(t, 30*time.Second, result)
+	})
+
+	t.Run("small positive duration should return itself", func(t *testing.T) {
+		d := Duration(1 * time.Millisecond)
+		result := d.WithDefault(30 * time.Second)
+		assert.Equal(t, 1*time.Millisecond, result)
+	})
+}
+
+func TestUpstreamConfig_ApplyDefaults_HTTPClientTimeouts(t *testing.T) {
+	t.Run("upstream with nil JsonRpc inherits from defaults", func(t *testing.T) {
+		defaults := &UpstreamConfig{
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout:               Duration(120 * time.Second),
+					ResponseHeaderTimeout: Duration(60 * time.Second),
+				},
+			},
+		}
+
+		upstream := &UpstreamConfig{
+			Endpoint: "http://rpc1.localhost",
+		}
+
+		err := upstream.ApplyDefaults(defaults)
+		assert.NoError(t, err)
+		assert.NotNil(t, upstream.JsonRpc)
+		assert.Equal(t, Duration(120*time.Second), upstream.JsonRpc.Timeout)
+		assert.Equal(t, Duration(60*time.Second), upstream.JsonRpc.ResponseHeaderTimeout)
+	})
+
+	t.Run("upstream with empty JsonRpc HTTPClientTimeouts inherits from defaults", func(t *testing.T) {
+		defaults := &UpstreamConfig{
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout:               Duration(120 * time.Second),
+					ResponseHeaderTimeout: Duration(60 * time.Second),
+					TLSHandshakeTimeout:   Duration(15 * time.Second),
+				},
+			},
+		}
+
+		upstream := &UpstreamConfig{
+			Endpoint: "http://rpc1.localhost",
+			JsonRpc:  &JsonRpcUpstreamConfig{},
+		}
+
+		err := upstream.ApplyDefaults(defaults)
+		assert.NoError(t, err)
+		assert.Equal(t, Duration(120*time.Second), upstream.JsonRpc.Timeout)
+		assert.Equal(t, Duration(60*time.Second), upstream.JsonRpc.ResponseHeaderTimeout)
+		assert.Equal(t, Duration(15*time.Second), upstream.JsonRpc.TLSHandshakeTimeout)
+	})
+
+	t.Run("upstream HTTPClientTimeouts override defaults", func(t *testing.T) {
+		defaults := &UpstreamConfig{
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout:               Duration(120 * time.Second),
+					ResponseHeaderTimeout: Duration(60 * time.Second),
+				},
+			},
+		}
+
+		upstream := &UpstreamConfig{
+			Endpoint: "http://rpc1.localhost",
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout: Duration(30 * time.Second), // Override
+				},
+			},
+		}
+
+		err := upstream.ApplyDefaults(defaults)
+		assert.NoError(t, err)
+		assert.Equal(t, Duration(30*time.Second), upstream.JsonRpc.Timeout)               // Not overwritten
+		assert.Equal(t, Duration(60*time.Second), upstream.JsonRpc.ResponseHeaderTimeout) // Inherited
+	})
+
+	t.Run("partial timeout inheritance", func(t *testing.T) {
+		defaults := &UpstreamConfig{
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout:               Duration(120 * time.Second),
+					ResponseHeaderTimeout: Duration(60 * time.Second),
+					TLSHandshakeTimeout:   Duration(15 * time.Second),
+					IdleConnTimeout:       Duration(180 * time.Second),
+					ExpectContinueTimeout: Duration(2 * time.Second),
+				},
+			},
+		}
+
+		upstream := &UpstreamConfig{
+			Endpoint: "http://rpc1.localhost",
+			JsonRpc: &JsonRpcUpstreamConfig{
+				HTTPClientTimeouts: HTTPClientTimeouts{
+					Timeout:             Duration(30 * time.Second),
+					TLSHandshakeTimeout: Duration(5 * time.Second),
+				},
+			},
+		}
+
+		err := upstream.ApplyDefaults(defaults)
+		assert.NoError(t, err)
+		assert.Equal(t, Duration(30*time.Second), upstream.JsonRpc.Timeout)               // Not overwritten
+		assert.Equal(t, Duration(60*time.Second), upstream.JsonRpc.ResponseHeaderTimeout) // Inherited
+		assert.Equal(t, Duration(5*time.Second), upstream.JsonRpc.TLSHandshakeTimeout)    // Not overwritten
+		assert.Equal(t, Duration(180*time.Second), upstream.JsonRpc.IdleConnTimeout)      // Inherited
+		assert.Equal(t, Duration(2*time.Second), upstream.JsonRpc.ExpectContinueTimeout)  // Inherited
+	})
+}
+
+func TestJsonRpcUpstreamConfig_Validate_HTTPClientTimeouts(t *testing.T) {
+	t.Run("valid HTTPClientTimeouts should pass validation", func(t *testing.T) {
+		cfg := &JsonRpcUpstreamConfig{
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout:               Duration(60 * time.Second),
+				ResponseHeaderTimeout: Duration(30 * time.Second),
+			},
+		}
+		err := cfg.Validate(&Config{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid HTTPClientTimeouts should fail validation", func(t *testing.T) {
+		cfg := &JsonRpcUpstreamConfig{
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout: Duration(-30 * time.Second),
+			},
+		}
+		err := cfg.Validate(&Config{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jsonRpc:")
+		assert.Contains(t, err.Error(), "timeout must be a positive duration")
+	})
+
+	t.Run("HTTPClientTimeouts relationship validation", func(t *testing.T) {
+		cfg := &JsonRpcUpstreamConfig{
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout:               Duration(30 * time.Second),
+				ResponseHeaderTimeout: Duration(60 * time.Second),
+			},
+		}
+		err := cfg.Validate(&Config{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "responseHeaderTimeout")
+		assert.Contains(t, err.Error(), "cannot exceed timeout")
+	})
+}
+
+func TestProxyPoolConfig_Validate_HTTPClientTimeouts(t *testing.T) {
+	t.Run("valid HTTPClientTimeouts should pass validation", func(t *testing.T) {
+		cfg := &ProxyPoolConfig{
+			ID:   "test-pool",
+			Urls: []string{"http://proxy1.example.com:8080"},
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout:               Duration(60 * time.Second),
+				ResponseHeaderTimeout: Duration(30 * time.Second),
+			},
+		}
+		err := cfg.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid HTTPClientTimeouts should fail validation with pool ID", func(t *testing.T) {
+		cfg := &ProxyPoolConfig{
+			ID:   "my-proxy-pool",
+			Urls: []string{"http://proxy1.example.com:8080"},
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout: Duration(-30 * time.Second),
+			},
+		}
+		err := cfg.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "proxyPool 'my-proxy-pool':")
+		assert.Contains(t, err.Error(), "timeout must be a positive duration")
+	})
+
+	t.Run("HTTPClientTimeouts relationship validation", func(t *testing.T) {
+		cfg := &ProxyPoolConfig{
+			ID:   "test-pool",
+			Urls: []string{"http://proxy1.example.com:8080"},
+			HTTPClientTimeouts: HTTPClientTimeouts{
+				Timeout:             Duration(5 * time.Second),
+				TLSHandshakeTimeout: Duration(10 * time.Second),
+			},
+		}
+		err := cfg.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tlsHandshakeTimeout")
+		assert.Contains(t, err.Error(), "cannot exceed timeout")
 	})
 }

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1491,12 +1491,52 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 	}
 	if u.JsonRpc == nil && defaults.JsonRpc != nil {
 		u.JsonRpc = &JsonRpcUpstreamConfig{
-			SupportsBatch: defaults.JsonRpc.SupportsBatch,
-			BatchMaxSize:  defaults.JsonRpc.BatchMaxSize,
-			BatchMaxWait:  defaults.JsonRpc.BatchMaxWait,
-			EnableGzip:    defaults.JsonRpc.EnableGzip,
-			ProxyPool:     defaults.JsonRpc.ProxyPool,
-			Headers:       defaults.JsonRpc.Headers,
+			SupportsBatch:         defaults.JsonRpc.SupportsBatch,
+			BatchMaxSize:          defaults.JsonRpc.BatchMaxSize,
+			BatchMaxWait:          defaults.JsonRpc.BatchMaxWait,
+			EnableGzip:            defaults.JsonRpc.EnableGzip,
+			ProxyPool:             defaults.JsonRpc.ProxyPool,
+			Headers:               defaults.JsonRpc.Headers,
+			Timeout:               defaults.JsonRpc.Timeout,
+			ResponseHeaderTimeout: defaults.JsonRpc.ResponseHeaderTimeout,
+			TLSHandshakeTimeout:   defaults.JsonRpc.TLSHandshakeTimeout,
+			IdleConnTimeout:       defaults.JsonRpc.IdleConnTimeout,
+			ExpectContinueTimeout: defaults.JsonRpc.ExpectContinueTimeout,
+		}
+	} else if u.JsonRpc != nil && defaults.JsonRpc != nil {
+		// Merge individual fields from defaults if not set on upstream
+		if u.JsonRpc.SupportsBatch == nil && defaults.JsonRpc.SupportsBatch != nil {
+			u.JsonRpc.SupportsBatch = defaults.JsonRpc.SupportsBatch
+		}
+		if u.JsonRpc.BatchMaxSize == 0 && defaults.JsonRpc.BatchMaxSize != 0 {
+			u.JsonRpc.BatchMaxSize = defaults.JsonRpc.BatchMaxSize
+		}
+		if u.JsonRpc.BatchMaxWait == 0 && defaults.JsonRpc.BatchMaxWait != 0 {
+			u.JsonRpc.BatchMaxWait = defaults.JsonRpc.BatchMaxWait
+		}
+		if u.JsonRpc.EnableGzip == nil && defaults.JsonRpc.EnableGzip != nil {
+			u.JsonRpc.EnableGzip = defaults.JsonRpc.EnableGzip
+		}
+		if u.JsonRpc.ProxyPool == "" && defaults.JsonRpc.ProxyPool != "" {
+			u.JsonRpc.ProxyPool = defaults.JsonRpc.ProxyPool
+		}
+		if u.JsonRpc.Headers == nil && defaults.JsonRpc.Headers != nil {
+			u.JsonRpc.Headers = defaults.JsonRpc.Headers
+		}
+		if u.JsonRpc.Timeout == 0 && defaults.JsonRpc.Timeout != 0 {
+			u.JsonRpc.Timeout = defaults.JsonRpc.Timeout
+		}
+		if u.JsonRpc.ResponseHeaderTimeout == 0 && defaults.JsonRpc.ResponseHeaderTimeout != 0 {
+			u.JsonRpc.ResponseHeaderTimeout = defaults.JsonRpc.ResponseHeaderTimeout
+		}
+		if u.JsonRpc.TLSHandshakeTimeout == 0 && defaults.JsonRpc.TLSHandshakeTimeout != 0 {
+			u.JsonRpc.TLSHandshakeTimeout = defaults.JsonRpc.TLSHandshakeTimeout
+		}
+		if u.JsonRpc.IdleConnTimeout == 0 && defaults.JsonRpc.IdleConnTimeout != 0 {
+			u.JsonRpc.IdleConnTimeout = defaults.JsonRpc.IdleConnTimeout
+		}
+		if u.JsonRpc.ExpectContinueTimeout == 0 && defaults.JsonRpc.ExpectContinueTimeout != 0 {
+			u.JsonRpc.ExpectContinueTimeout = defaults.JsonRpc.ExpectContinueTimeout
 		}
 	}
 	// Integrity moved under Evm.Integrity

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1491,17 +1491,13 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 	}
 	if u.JsonRpc == nil && defaults.JsonRpc != nil {
 		u.JsonRpc = &JsonRpcUpstreamConfig{
-			SupportsBatch:         defaults.JsonRpc.SupportsBatch,
-			BatchMaxSize:          defaults.JsonRpc.BatchMaxSize,
-			BatchMaxWait:          defaults.JsonRpc.BatchMaxWait,
-			EnableGzip:            defaults.JsonRpc.EnableGzip,
-			ProxyPool:             defaults.JsonRpc.ProxyPool,
-			Headers:               defaults.JsonRpc.Headers,
-			Timeout:               defaults.JsonRpc.Timeout,
-			ResponseHeaderTimeout: defaults.JsonRpc.ResponseHeaderTimeout,
-			TLSHandshakeTimeout:   defaults.JsonRpc.TLSHandshakeTimeout,
-			IdleConnTimeout:       defaults.JsonRpc.IdleConnTimeout,
-			ExpectContinueTimeout: defaults.JsonRpc.ExpectContinueTimeout,
+			SupportsBatch:      defaults.JsonRpc.SupportsBatch,
+			BatchMaxSize:       defaults.JsonRpc.BatchMaxSize,
+			BatchMaxWait:       defaults.JsonRpc.BatchMaxWait,
+			EnableGzip:         defaults.JsonRpc.EnableGzip,
+			ProxyPool:          defaults.JsonRpc.ProxyPool,
+			Headers:            defaults.JsonRpc.Headers,
+			HTTPClientTimeouts: defaults.JsonRpc.HTTPClientTimeouts,
 		}
 	} else if u.JsonRpc != nil && defaults.JsonRpc != nil {
 		// Merge individual fields from defaults if not set on upstream
@@ -1523,21 +1519,7 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 		if u.JsonRpc.Headers == nil && defaults.JsonRpc.Headers != nil {
 			u.JsonRpc.Headers = defaults.JsonRpc.Headers
 		}
-		if u.JsonRpc.Timeout == 0 && defaults.JsonRpc.Timeout != 0 {
-			u.JsonRpc.Timeout = defaults.JsonRpc.Timeout
-		}
-		if u.JsonRpc.ResponseHeaderTimeout == 0 && defaults.JsonRpc.ResponseHeaderTimeout != 0 {
-			u.JsonRpc.ResponseHeaderTimeout = defaults.JsonRpc.ResponseHeaderTimeout
-		}
-		if u.JsonRpc.TLSHandshakeTimeout == 0 && defaults.JsonRpc.TLSHandshakeTimeout != 0 {
-			u.JsonRpc.TLSHandshakeTimeout = defaults.JsonRpc.TLSHandshakeTimeout
-		}
-		if u.JsonRpc.IdleConnTimeout == 0 && defaults.JsonRpc.IdleConnTimeout != 0 {
-			u.JsonRpc.IdleConnTimeout = defaults.JsonRpc.IdleConnTimeout
-		}
-		if u.JsonRpc.ExpectContinueTimeout == 0 && defaults.JsonRpc.ExpectContinueTimeout != 0 {
-			u.JsonRpc.ExpectContinueTimeout = defaults.JsonRpc.ExpectContinueTimeout
-		}
+		u.JsonRpc.HTTPClientTimeouts.MergeFrom(&defaults.JsonRpc.HTTPClientTimeouts)
 	}
 	// Integrity moved under Evm.Integrity
 	if u.Evm != nil && defaults.Evm != nil {

--- a/common/duration.go
+++ b/common/duration.go
@@ -50,3 +50,12 @@ func (d Duration) String() string {
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return SonicCfg.Marshal(time.Duration(d).String())
 }
+
+// WithDefault returns the duration value if it's positive, otherwise returns the default value.
+// This simplifies the common pattern of applying defaults to optional duration configs.
+func (d Duration) WithDefault(defaultVal time.Duration) time.Duration {
+	if d > 0 {
+		return time.Duration(d)
+	}
+	return defaultVal
+}

--- a/common/validation.go
+++ b/common/validation.go
@@ -243,6 +243,12 @@ func (p *ProxyPoolConfig) Validate() error {
 			return fmt.Errorf("proxyPool.*.urls under proxyPool.*.id '%s' must be valid HTTP, HTTPS, or SOCKS5 URLs, got: %s", p.ID, url)
 		}
 	}
+
+	// Validate HTTP client timeout settings
+	if err := p.HTTPClientTimeouts.Validate(fmt.Sprintf("proxyPool '%s': ", p.ID)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1187,6 +1193,12 @@ func (j *JsonRpcUpstreamConfig) Validate(c *Config) error {
 			return fmt.Errorf("jsonRpc.proxyPool '%s' does not exist in configured proxyPools, must be one of: %v", j.ProxyPool, allIds)
 		}
 	}
+
+	// Validate HTTP client timeout settings
+	if err := j.HTTPClientTimeouts.Validate("jsonRpc: "); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add configurable timeout settings to `JsonRpcUpstreamConfig` and `ProxyPoolConfig`
- Previously hardcoded HTTP transport timeouts (30s ResponseHeaderTimeout, 60s client timeout) now configurable
- Defaults preserved for backward compatibility

## Problem
HTTP client timeouts were hardcoded in `clients/http_json_rpc_client.go` and `clients/proxy_pool_registry.go`:
- `ResponseHeaderTimeout: 30s` 
- `Timeout: 60s`

This caused issues with slow upstreams where requests would timeout at the transport layer (30s) before the configurable failsafe timeout (e.g., 120s) could apply.

## Solution
Added the following configurable fields to both `JsonRpcUpstreamConfig` and `ProxyPoolConfig`:
- `timeout` - Total request timeout (default: 60s)
- `responseHeaderTimeout` - Time to wait for response headers (default: 30s)
- `tlsHandshakeTimeout` - TLS handshake timeout (default: 10s)
- `idleConnTimeout` - Idle connection timeout (default: 90s)
- `expectContinueTimeout` - Expect-continue timeout (default: 1s)

## Example Configuration
```yaml
upstreams:
  - id: slow-upstream
    endpoint: https://rpc.example.com
    jsonRpc:
      timeout: "120s"
      responseHeaderTimeout: "90s"
```