### PR TITLE
chore: add citrea mainnet to alchemy provider

### DIFF
--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -126,6 +126,7 @@ var defaultAlchemyNetworkSubdomains = map[int64]string{
 	988:        "stable-mainnet",
 	2201:       "stable-testnet",
 	510525:     "clankermon-mainnet",
+	4114:       "citrea-mainnet",
 	5115:       "citrea-testnet",
 	5042002:    "arc-testnet",
 	1284:       "moonbeam-mainnet",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant/map entry addition; low chance of impacting other networks beyond potential chain ID mapping mistakes.
> 
> **Overview**
> Adds Alchemy subdomain mapping for **Citrea mainnet** by registering chain ID `4114` as `citrea-mainnet` in `defaultAlchemyNetworkSubdomains`, enabling Alchemy endpoint generation/support for that network.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f85c546977e3a5b71372669ccc9ab18ef242ebb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->