### PR TITLE
fix: downgrade auth rate limit log level from warn to debug

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1088,6 +1088,7 @@ func processErrorBody(logger *zerolog.Logger, startedAt *time.Time, nq *common.N
 			common.ErrCodeInvalidUrlPath,
 			common.ErrCodeInvalidRequest,
 			common.ErrCodeAuthUnauthorized,
+			common.ErrCodeAuthRateLimitRuleExceeded,
 			common.ErrCodeJsonRpcRequestUnmarshal,
 			common.ErrCodeProjectNotFound,
 		) {


### PR DESCRIPTION
ErrAuthRateLimitRuleExceeded was being logged at warn level, causing ~93% of all ClickHouse log ingestion (~20M rows/day, almost entirely from evm:143/Monad). These are expected client-side errors that should be at debug level, consistent with ErrAuthUnauthorized which is already in the debug list.

This only changes log verbosity — HTTP 429 responses and rate limiting behavior are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition change to logging level for a specific error code; no auth or rate limiting behavior is modified.
> 
> **Overview**
> Treats `ErrCodeAuthRateLimitRuleExceeded` as a client-side error in `processErrorBody` so it logs at **debug** (alongside `ErrCodeAuthUnauthorized`) instead of escalating to warn-level logging.
> 
> No behavioral changes to rate limiting or HTTP responses; this only reduces log noise/ingestion volume for expected 429-style auth rate limit failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9a23045e1ea01994b0f07377847b75b247c9eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->