### PR TITLE
fix: restore Clone() in getLogs split to prevent race with cache SET goroutine

### DIFF
--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -783,12 +783,16 @@ func executeGetLogsSubRequests(ctx context.Context, n common.Network, r *common.
 				r.UserId(),
 				r.AgentName(),
 			).Inc()
-			responses[i] = jrr
+			jrrc, err := jrr.Clone()
+			if err != nil {
+				errs = append(errs, err)
+				mu.Unlock()
+				rs.Release()
+				return
+			}
+			responses[i] = jrrc
 			fromCacheSr[i] = rs.FromCache()
 			mu.Unlock()
-			// Detach the jrr before releasing so Release() won't call jrr.Free().
-			// This avoids cloning the entire result bytes for each sub-response.
-			rs.WithJsonRpcResponse(nil)
 			rs.Release()
 		}(sr, idx)
 	}


### PR DESCRIPTION
The optimization in 6a0221d replaced jrr.Clone() with a detach-and-release pattern (rs.WithJsonRpcResponse(nil) + rs.Release()) to avoid copying response bytes. This races with the background cache SET goroutine spawned by Network.Forward(), which still holds a reference to the response via AddRef().

When all sub-requests return empty results (e.g. eth_getLogs for an address with no events), the main goroutine detaches the JSON-RPC response before the cache SET goroutine reads it, causing the goroutine to operate on nil data and hang. Release() blocks on pendingOps.Wait() indefinitely, which blocks wg.Wait() in executeGetLogsSubRequests, hanging the entire parent request.

Non-empty responses masked this because their larger I/O gives the cache SET goroutine time to read before detach occurs.

Restoring Clone() eliminates the race entirely.

Fixes infinite hang on proactively-split eth_getLogs when all sub-requests return empty results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to response lifetime management plus a targeted regression test; main risk is minor performance regression from reintroducing cloning on split responses.
> 
> **Overview**
> Fixes a concurrency bug in proactively split `eth_getLogs` by restoring `JsonRpcResponse.Clone()` for each sub-response before releasing the underlying `NormalizedResponse`, avoiding races with background ref-holders (e.g., cache set) that could lead to deadlocks/corruption.
> 
> Adds a regression test that simulates a background goroutine reading an all-empty sub-response after a delay and asserts the split request completes without hanging and the response remains intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ef5d82d12ae3d8fc50d6ea8fec97e6680e6c0ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->