### PR TITLE
fix: enhance error normalization to include "historical state missing" as missing data

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -375,7 +375,9 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 				strings.Contains(msg, "Header") ||
 				strings.Contains(msg, "Block") ||
 				strings.Contains(msg, "transaction") ||
-				strings.Contains(msg, "Transaction") {
+				strings.Contains(msg, "Transaction") ||
+				strings.Contains(msg, "state") ||
+				strings.Contains(msg, "State") {
 				return common.NewErrEndpointMissingData(
 					common.NewErrJsonRpcExceptionInternal(
 						int(code),

--- a/architecture/evm/util.go
+++ b/architecture/evm/util.go
@@ -41,6 +41,7 @@ func IsMissingDataError(err error) bool {
 		strings.Contains(txt, "cannot find transaction") ||
 		strings.Contains(txt, "after last accepted block") ||
 		strings.Contains(txt, "No state available") ||
+		(strings.Contains(txt, "historical state") && strings.Contains(txt, "is not available")) ||
 		strings.Contains(txt, "trie does not") ||
 		strings.Contains(txt, "greater than latest") ||
 		strings.Contains(txt, "not currently canonical") ||


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive string-match changes that only affect how certain upstream errors are categorized and retried.
> 
> **Overview**
> Improves EVM error normalization so responses indicating missing **state** data are classified as `ErrEndpointMissingData`.
> 
> This extends the "not found / not available" message heuristics in `error_normalizer.go` to include `state/State`, and expands `IsMissingDataError` in `util.go` to recognize "historical state … is not available" as a missing-data condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 003472748d0aa90cc91a9118e498734d78811555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->