### PR TITLE
fix: skip wrong-empty punishment for upstreams with out-of-range block availability

### DIFF
--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -25,6 +25,9 @@ type EvmUpstream interface {
 	// EvmEffectiveFinalizedBlock returns the finalized block adjusted for the upstream's upper availability bound.
 	// If the upstream has a blockAvailability.upper config, this returns min(finalizedBlock, upperBound).
 	EvmEffectiveFinalizedBlock() int64
+	// EvmBlockAvailabilityBounds returns the resolved [min, max] block range this upstream
+	// is configured to serve. Returns (math.MinInt64, math.MaxInt64) for unbounded sides.
+	EvmBlockAvailabilityBounds() (int64, int64)
 }
 
 type AvailbilityConfidence int

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -150,6 +151,21 @@ func (u *FakeUpstream) EvmEffectiveFinalizedBlock() int64 {
 		return 0
 	}
 	return u.evmStatePoller.FinalizedBlock()
+}
+
+func (u *FakeUpstream) EvmBlockAvailabilityBounds() (int64, int64) {
+	cfg := u.Config()
+	if cfg == nil || cfg.Evm == nil || cfg.Evm.BlockAvailability == nil {
+		return math.MinInt64, math.MaxInt64
+	}
+	minVal, maxVal := int64(math.MinInt64), int64(math.MaxInt64)
+	if cfg.Evm.BlockAvailability.Lower != nil && cfg.Evm.BlockAvailability.Lower.ExactBlock != nil {
+		minVal = *cfg.Evm.BlockAvailability.Lower.ExactBlock
+	}
+	if cfg.Evm.BlockAvailability.Upper != nil && cfg.Evm.BlockAvailability.Upper.ExactBlock != nil {
+		maxVal = *cfg.Evm.BlockAvailability.Upper.ExactBlock
+	}
+	return minVal, maxVal
 }
 
 type FakeEvmStatePoller struct {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -847,6 +848,14 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	if execErr == nil && !isEmpty {
 		n.enrichStatePoller(ctx, method, req, resp)
 
+		// Extract block number from successful response for block availability bounds check below.
+		var respBlockNumber int64
+		if n.cfg.Architecture == common.ArchitectureEvm {
+			if _, bn, err := evm.ExtractBlockReferenceFromResponse(ctx, resp); err == nil && bn > 0 {
+				respBlockNumber = bn
+			}
+		}
+
 		// If response is not empty, but at least one upstream responded empty we track in a metric.
 		// Derived from ErrorsByUpstream entries with ErrEndpointMissingData code.
 		req.ErrorsByUpstream.Range(func(key, value any) bool {
@@ -866,9 +875,23 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				req.UserId(),
 				req.AgentName(),
 			).Inc()
+
+			// If the response block number is known, check if it falls outside
+			// this upstream's configured block availability range.
+			// If so, the empty response was expected — skip misbehavior recording.
+			if respBlockNumber > 0 {
+				minBound, maxBound := upstream.EvmBlockAvailabilityBounds()
+				if (minBound != math.MinInt64 && respBlockNumber < minBound) ||
+					(maxBound != math.MaxInt64 && respBlockNumber > maxBound) {
+					return true
+				}
+			}
+
+			// Wrong-empty is a misbehavior (data disagreement with other upstreams),
+			// not an error. The upstream responded correctly, it just lacked data
+			// that others had. Only record misbehavior, not failure.
 			if upstream != nil {
 				if mt := upstream.MetricsTracker(); mt != nil {
-					mt.RecordUpstreamFailure(upstream, method, upstreamErr)
 					mt.RecordUpstreamMisbehavior(upstream, method)
 				}
 			}

--- a/erpc/networks_retry_missing_data_test.go
+++ b/erpc/networks_retry_missing_data_test.go
@@ -1381,6 +1381,301 @@ func TestNetworkForward_UpstreamReselection_WrongEmptyStillTracked(t *testing.T)
 	})
 }
 
+// Test: wrong-empty punishment respects block availability bounds.
+// When an upstream with blockAvailability config returns empty for a request
+// whose response block number falls outside the upstream's configured range,
+// the upstream should NOT be punished (no misbehavior recorded).
+func TestNetworkForward_WrongEmpty_SkipPunishment_BlockAvailabilityBounds(t *testing.T) {
+	txHash := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	// Block 200 in hex = 0xC8
+	txReceiptResult := map[string]interface{}{
+		"blockHash":   "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"blockNumber": "0xC8",
+		"from":        "0x1111111111111111111111111111111111111111",
+		"to":          "0x2222222222222222222222222222222222222222",
+		"hash":        txHash,
+	}
+	int64Ptr := func(v int64) *int64 { return &v }
+
+	t.Run("BoundedUpstream_BlockOutOfRange_NoPunishment", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		// rpc1 returns null (block 200 is above its upper bound of 100)
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  nil,
+			})
+
+		// rpc2 returns transaction data with blockNumber 200
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  txReceiptResult,
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithCustomUpstreams(t, ctx,
+			[]*common.UpstreamConfig{
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc1",
+					Endpoint: "http://rpc1.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+						BlockAvailability: &common.EvmBlockAvailabilityConfig{
+							Upper: &common.EvmAvailabilityBoundConfig{
+								ExactBlock: int64Ptr(100),
+							},
+						},
+					},
+				},
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc2",
+					Endpoint: "http://rpc2.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+					},
+				},
+			},
+			&common.DirectiveDefaultsConfig{RetryEmpty: util.BoolPtr(true)},
+			&common.RetryPolicyConfig{MaxAttempts: 3, EmptyResultAccept: []string{}},
+		)
+		upstream.ReorderUpstreams(network.upstreamsRegistry, "rpc1", "rpc2")
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByHash","params":["` + txHash + `"]}`)
+		req := common.NewNormalizedRequest(requestBytes)
+		req.ApplyDirectiveDefaults(network.cfg.DirectiveDefaults)
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// rpc1 should be in ErrorsByUpstream (for observability)
+		emptyCount := 0
+		req.ErrorsByUpstream.Range(func(key, value interface{}) bool {
+			if err, ok := value.(error); ok {
+				if common.HasErrorCode(err, common.ErrCodeEndpointMissingData) {
+					emptyCount++
+				}
+			}
+			return true
+		})
+		assert.Equal(t, 1, emptyCount, "rpc1 should still be tracked in ErrorsByUpstream")
+
+		// But rpc1 should NOT be punished — block 200 is outside its upper bound of 100
+		ups := network.upstreamsRegistry.GetAllUpstreams()
+		var rpc1 *upstream.Upstream
+		for _, u := range ups {
+			if u.Id() == "rpc1" {
+				rpc1 = u
+				break
+			}
+		}
+		require.NotNil(t, rpc1)
+		metrics := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getTransactionByHash")
+		assert.Equal(t, int64(0), metrics.MisbehaviorsTotal.Load(),
+			"rpc1 should NOT have misbehavior recorded — block 200 is outside its upper bound of 100")
+	})
+
+	t.Run("BoundedUpstream_BlockInRange_MisbehaviorRecorded", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		// rpc1 returns null (block 200 is within its upper bound of 300)
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  nil,
+			})
+
+		// rpc2 returns transaction data with blockNumber 200
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  txReceiptResult,
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithCustomUpstreams(t, ctx,
+			[]*common.UpstreamConfig{
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc1",
+					Endpoint: "http://rpc1.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+						BlockAvailability: &common.EvmBlockAvailabilityConfig{
+							Upper: &common.EvmAvailabilityBoundConfig{
+								ExactBlock: int64Ptr(300),
+							},
+						},
+					},
+				},
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc2",
+					Endpoint: "http://rpc2.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+					},
+				},
+			},
+			&common.DirectiveDefaultsConfig{RetryEmpty: util.BoolPtr(true)},
+			&common.RetryPolicyConfig{MaxAttempts: 3, EmptyResultAccept: []string{}},
+		)
+		upstream.ReorderUpstreams(network.upstreamsRegistry, "rpc1", "rpc2")
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByHash","params":["` + txHash + `"]}`)
+		req := common.NewNormalizedRequest(requestBytes)
+		req.ApplyDirectiveDefaults(network.cfg.DirectiveDefaults)
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// rpc1 SHOULD be punished — block 200 is within its upper bound of 300
+		ups := network.upstreamsRegistry.GetAllUpstreams()
+		var rpc1 *upstream.Upstream
+		for _, u := range ups {
+			if u.Id() == "rpc1" {
+				rpc1 = u
+				break
+			}
+		}
+		require.NotNil(t, rpc1)
+		metrics := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getTransactionByHash")
+		assert.True(t, metrics.MisbehaviorsTotal.Load() > 0,
+			"rpc1 SHOULD have misbehavior recorded — block 200 is within its upper bound of 300")
+		assert.Equal(t, int64(0), metrics.ErrorsTotal.Load(),
+			"rpc1 should NOT have errors recorded — wrong-empty only records misbehavior, not failure")
+	})
+
+	t.Run("UnboundedUpstream_MisbehaviorRecorded", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		// rpc1 returns null (no block availability configured)
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  nil,
+			})
+
+		// rpc2 returns transaction data
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionByHash")
+			}).
+			Times(1).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  txReceiptResult,
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithCustomUpstreams(t, ctx,
+			[]*common.UpstreamConfig{
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc1",
+					Endpoint: "http://rpc1.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+					},
+				},
+				{
+					Type:     common.UpstreamTypeEvm,
+					Id:       "rpc2",
+					Endpoint: "http://rpc2.localhost",
+					Evm: &common.EvmUpstreamConfig{
+						ChainId: 123,
+					},
+				},
+			},
+			&common.DirectiveDefaultsConfig{RetryEmpty: util.BoolPtr(true)},
+			&common.RetryPolicyConfig{MaxAttempts: 3, EmptyResultAccept: []string{}},
+		)
+		upstream.ReorderUpstreams(network.upstreamsRegistry, "rpc1", "rpc2")
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByHash","params":["` + txHash + `"]}`)
+		req := common.NewNormalizedRequest(requestBytes)
+		req.ApplyDirectiveDefaults(network.cfg.DirectiveDefaults)
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// rpc1 SHOULD be punished — no block availability config means unbounded
+		ups := network.upstreamsRegistry.GetAllUpstreams()
+		var rpc1 *upstream.Upstream
+		for _, u := range ups {
+			if u.Id() == "rpc1" {
+				rpc1 = u
+				break
+			}
+		}
+		require.NotNil(t, rpc1)
+		metrics := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getTransactionByHash")
+		assert.True(t, metrics.MisbehaviorsTotal.Load() > 0,
+			"rpc1 SHOULD have misbehavior recorded — no block availability bounds configured")
+		assert.Equal(t, int64(0), metrics.ErrorsTotal.Load(),
+			"rpc1 should NOT have errors recorded — wrong-empty only records misbehavior, not failure")
+	})
+}
+
 // Test: blockUnavailableDelay applied after full round of all upstreams
 // reporting block unavailable. The request targets a future block that the
 // state poller hasn't seen yet, so the pre-flight check skips all upstreams.
@@ -2469,4 +2764,75 @@ func setupTestNetworkForMissingDataRetry(
 ) *Network {
 	t.Helper()
 	return setupTestNetworkWithRetryConfig(t, ctx, directiveDefaults, retryConfig)
+}
+
+func setupTestNetworkWithCustomUpstreams(
+	t *testing.T,
+	ctx context.Context,
+	upstreamConfigs []*common.UpstreamConfig,
+	directiveDefaults *common.DirectiveDefaultsConfig,
+	retryConfig *common.RetryPolicyConfig,
+) *Network {
+	t.Helper()
+
+	networkConfig := &common.NetworkConfig{
+		Architecture:      common.ArchitectureEvm,
+		DirectiveDefaults: directiveDefaults,
+		Evm: &common.EvmNetworkConfig{
+			ChainId: 123,
+		},
+		Failsafe: []*common.FailsafeConfig{{
+			Retry: retryConfig,
+		}},
+	}
+
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	require.NoError(t, err)
+
+	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
+
+	vr := thirdparty.NewVendorsRegistry()
+	pr, err := thirdparty.NewProvidersRegistry(&log.Logger, vr, []*common.ProviderConfig{}, nil)
+	require.NoError(t, err)
+
+	ssr, err := data.NewSharedStateRegistry(ctx, &log.Logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: "memory",
+			Memory: &common.MemoryConnectorConfig{
+				MaxItems:     100_000,
+				MaxTotalSize: "1GB",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	upstreamsRegistry := upstream.NewUpstreamsRegistry(
+		ctx,
+		&log.Logger,
+		"test",
+		upstreamConfigs,
+		ssr,
+		rateLimitersRegistry,
+		vr,
+		pr,
+		nil,
+		metricsTracker,
+		time.Second,
+		nil,
+		nil,
+	)
+
+	upstreamsRegistry.Bootstrap(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	network, err := NewNetwork(ctx, &log.Logger, "test", networkConfig, rateLimitersRegistry, upstreamsRegistry, metricsTracker)
+	require.NoError(t, err)
+
+	err = upstreamsRegistry.PrepareUpstreamsForNetwork(ctx, networkConfig.NetworkId())
+	require.NoError(t, err)
+
+	err = network.Bootstrap(ctx)
+	require.NoError(t, err)
+
+	return network
 }

--- a/upstream/failsafe_test.go
+++ b/upstream/failsafe_test.go
@@ -3,6 +3,7 @@ package upstream
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/erpc/erpc/architecture/evm"
@@ -78,6 +79,10 @@ func (m *mockUpstreamForRetry) EvmEffectiveLatestBlock() int64 {
 
 func (m *mockUpstreamForRetry) EvmEffectiveFinalizedBlock() int64 {
 	return 0
+}
+
+func (m *mockUpstreamForRetry) EvmBlockAvailabilityBounds() (int64, int64) {
+	return math.MinInt64, math.MaxInt64
 }
 
 // Test helper to execute retry policy

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1074,6 +1074,15 @@ func (u *Upstream) EvmEffectiveFinalizedBlock() int64 {
 	return finalizedBlock
 }
 
+// EvmBlockAvailabilityBounds returns the resolved [min, max] block availability bounds
+// for this upstream based on its BlockAvailability configuration.
+// Returns (math.MinInt64, math.MaxInt64) when unbounded on either side.
+// This is used post-forward to determine if an upstream's MissingData response
+// is expected (block outside configured range) vs. a genuine wrong-empty misbehavior.
+func (u *Upstream) EvmBlockAvailabilityBounds() (int64, int64) {
+	return u.resolveAvailabilityBounds()
+}
+
 // assertUpstreamLowerBound checks if a full node can handle a block based on its lower bound.
 // It returns whether the block is within the available range and records metrics if not.
 func (u *Upstream) assertUpstreamLowerBound(ctx context.Context, statePoller common.EvmStatePoller, blockNumber int64, maxAvailableRecentBlocks int64, forMethod string, confidence common.AvailbilityConfidence) (available bool, err error) {


### PR DESCRIPTION
When upstreams have blockAvailability config and receive requests with unknown block numbers (e.g., eth_getTransactionByHash), they may return empty because the actual block falls outside their configured range. Previously these upstreams were incorrectly punished.

Two changes:
1. Wrong-empty only records misbehavior (not failure) since the upstream responded correctly — it just lacked data that others had.
2. If the successful response's block number falls outside the upstream's configured block availability bounds, skip punishment entirely.