### PR TITLE
enh: reduce `user` cardinality for IP CIDR authorization strategies

### DIFF
--- a/auth/strategy_network.go
+++ b/auth/strategy_network.go
@@ -12,6 +12,7 @@ type NetworkStrategy struct {
 	cfg          *common.NetworkStrategyConfig
 	allowedIPs   []*net.IP
 	allowedCIDRs []*net.IPNet
+	ipAsUser     bool
 }
 
 var _ AuthStrategy = &NetworkStrategy{}
@@ -19,6 +20,7 @@ var _ AuthStrategy = &NetworkStrategy{}
 func NewNetworkStrategy(cfg *common.NetworkStrategyConfig) (*NetworkStrategy, error) {
 	s := &NetworkStrategy{
 		cfg: cfg,
+		ipAsUser: cfg.IPAsUser,
 	}
 
 	// Parse and store allowed IPs
@@ -80,7 +82,10 @@ func (s *NetworkStrategy) Authenticate(ctx context.Context, req *common.Normaliz
 	// Check against allowed CIDRs
 	for _, cidr := range s.allowedCIDRs {
 		if cidr.Contains(clientIP) {
-			user := &common.User{Id: clientIP.String()}
+			user := &common.User{Id: cidr.String()}
+			if (s.ipAsUser) {
+				user.Id = clientIP.String()
+			}
 			if s.cfg.RateLimitBudget != "" {
 				user.RateLimitBudget = s.cfg.RateLimitBudget
 			}

--- a/common/config.go
+++ b/common/config.go
@@ -1755,6 +1755,7 @@ type NetworkStrategyConfig struct {
 	TrustedProxies []string `yaml:"trustedProxies" json:"trustedProxies"`
 	// RateLimitBudget, if set, is applied to the authenticated user (client IP)
 	RateLimitBudget string `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget,omitempty"`
+	IPAsUser        bool   `yaml:"ipAsUser,omitempty" json:"ipAsUser,omitempty"`
 }
 
 type LabelMode string


### PR DESCRIPTION
On private networks with many clients, allowing large CIDR ranges can lead to many IPs being used as metric labels, causing significant cardinality in metrics like `erpc_network_evm_block_range_requested_total`, `erpc_network_failed_request_total`, `erpc_network_multiplexed_request_total`, `erpc_network_request_duration_seconds_bucket`.

This PR adds a configuration option `ipCidrLabelMode` on network auth strategies that changes the `user` label to the IP cidr instead of the IP address when set to `cidr`. Default behaviour is unchanged

📖  We may want to update docs, I'm not sure which page to update