### PR TITLE
chore: use multi-ecosystem-groups for single combined dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,121 +1,102 @@
 version: 2
+
+multi-ecosystem-groups:
+  all-updates:
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "kasrakhosravi"
+      - "aramalipoor"
+    labels:
+      - "dependencies"
+
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-actions:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-docker:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: docker
-    directory: /docs
-    schedule:
-      interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/docs"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-docker-docs:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: npm
-    directory: /docs
-    schedule:
-      interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/monitoring"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-npm-docs:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-go:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: docker
-    directory: /monitoring
-    schedule:
-      interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-docker-monitoring:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-npm-root:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: npm
-    directory: /test/util
-    schedule:
-      interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/test/util"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-npm-test:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: npm
-    directory: /typescript/cli
-    schedule:
-      interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/typescript/cli"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-npm-cli:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"
 
-  - package-ecosystem: npm
-    directory: /typescript/config
-    schedule:
-      interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/typescript/config"
+    patterns:
+      - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    groups:
-      all-npm-config:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "all-updates"


### PR DESCRIPTION
## Summary
- Convert 10 separate per-manifest Dependabot entries into one `multi-ecosystem-group` so all dependency updates (github-actions, docker, gomod, npm) land in **a single weekly PR**
- Keeps existing `ignore` for major version bumps

## Test plan
- [ ] Merge and verify Dependabot opens a single combined PR on the next weekly cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e4426e03f674a2f329b617412ad2c77fb9032239. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->