### PR TITLE
feat: dynamic quantile-based timeout policy

### DIFF
--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -446,12 +446,6 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 		// Each request's own ctx carries the policy-driven cause (e.g.
 		// ErrDynamicTimeoutExceeded), while the shared batch ctx only has the
 		// earliest-deadline plain DeadlineExceeded. Prefer the per-request cause
-		// so the sentinel survives upstream-level error classification. Give the
-		// req.ctx a brief moment to propagate its cancellation if it has the same
-		// deadline as batchCtx (they fire within microseconds of each other).
-		// Each request's own ctx carries the policy-driven cause (e.g.
-		// ErrDynamicTimeoutExceeded), while the shared batch ctx only has the
-		// earliest-deadline plain DeadlineExceeded. Prefer the per-request cause
 		// so the sentinel survives upstream-level error classification.
 		for _, req := range requests {
 			reqErr := err

--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -179,10 +179,16 @@ func (c *GenericHttpJsonRpcClient) SendRequest(ctx context.Context, req *common.
 	case err := <-errChan:
 		return nil, err
 	case <-ctx.Done():
-		err := ctx.Err()
+		// Prefer context.Cause so policy-driven sentinels (e.g. ErrDynamicTimeoutExceeded)
+		// survive upstream-level error translation instead of being flattened to plain
+		// context.DeadlineExceeded.
+		err := context.Cause(ctx)
+		if err == nil {
+			err = ctx.Err()
+		}
 		// TODO For both of these conditions failsafe library can introduce carrying
 		//      the "cause" so we know this cancellation is due to Hedge policy for example.
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
 			err = common.NewErrEndpointRequestTimeout(time.Since(startedAt), err)
 		} else if errors.Is(err, context.Canceled) {
 			err = common.NewErrEndpointRequestCanceled(err)
@@ -225,8 +231,11 @@ func (c *GenericHttpJsonRpcClient) queueRequest(id interface{}, req *batchReques
 	// If the request context is already canceled, fail it immediately and do not queue
 	if err := req.ctx.Err(); err != nil {
 		c.batchMu.Unlock()
-		// propagate a normalized error
-		if errors.Is(err, context.DeadlineExceeded) {
+		// Prefer context.Cause so policy-driven sentinels survive.
+		if cause := context.Cause(req.ctx); cause != nil {
+			err = cause
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
 			req.err <- common.NewErrEndpointRequestTimeout(0, err)
 		} else {
 			req.err <- common.NewErrEndpointRequestCanceled(err)
@@ -246,7 +255,7 @@ func (c *GenericHttpJsonRpcClient) queueRequest(id interface{}, req *batchReques
 	c.batchRequests[id] = req
 	ctxd, ok := req.ctx.Deadline()
 	if ctxd.After(time.Now()) && ok {
-		// Use the earliest deadline among queued requests so the batch cancels promptly
+		// Use the earliest deadline among queued requests so the batch cancels promptly.
 		if c.batchDeadline == nil || ctxd.Before(*c.batchDeadline) {
 			duration := time.Until(ctxd)
 			c.logger.Trace().Dur("deadline", duration).Msgf("setting batch deadline to earliest request deadline")
@@ -331,7 +340,10 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 	for id, br := range requests {
 		if err := br.ctx.Err(); err != nil {
 			delete(requests, id)
-			if errors.Is(err, context.DeadlineExceeded) {
+			if cause := context.Cause(br.ctx); cause != nil {
+				err = cause
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
 				br.err <- common.NewErrEndpointRequestTimeout(0, err)
 			} else {
 				br.err <- common.NewErrEndpointRequestCanceled(err)
@@ -422,26 +434,36 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 	// pick the client from the proxy pool registry (if configured) or fallback
 	resp, err := c.getHttpClient().Do(httpReq)
 	if err != nil {
-		cause := context.Cause(batchCtx)
-		if cause == nil {
-			cause = batchCtx.Err()
+		batchCause := context.Cause(batchCtx)
+		if batchCause == nil {
+			batchCause = batchCtx.Err()
 		}
-		if cause != nil {
-			err = cause
+		if batchCause != nil {
+			err = batchCause
 		}
 		// TODO For both of these conditions failsafe library can introduce carrying
 		//      the "cause" so we know this cancellation is due to Hedge policy for example.
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
-			for _, req := range requests {
-				req.err <- common.NewErrEndpointRequestTimeout(time.Since(reqStartTime), err)
+		// Each request's own ctx carries the policy-driven cause (e.g.
+		// ErrDynamicTimeoutExceeded), while the shared batch ctx only has the
+		// earliest-deadline plain DeadlineExceeded. Prefer the per-request cause
+		// so the sentinel survives upstream-level error classification. Give the
+		// req.ctx a brief moment to propagate its cancellation if it has the same
+		// deadline as batchCtx (they fire within microseconds of each other).
+		// Each request's own ctx carries the policy-driven cause (e.g.
+		// ErrDynamicTimeoutExceeded), while the shared batch ctx only has the
+		// earliest-deadline plain DeadlineExceeded. Prefer the per-request cause
+		// so the sentinel survives upstream-level error classification.
+		for _, req := range requests {
+			reqErr := err
+			if rc := context.Cause(req.ctx); rc != nil {
+				reqErr = rc
 			}
-		} else if errors.Is(err, context.Canceled) {
-			for _, req := range requests {
-				req.err <- common.NewErrEndpointRequestCanceled(err)
-			}
-		} else {
-			for _, req := range requests {
-				req.err <- common.NewErrEndpointTransportFailure(c.Url, err)
+			if errors.Is(reqErr, context.DeadlineExceeded) || errors.Is(reqErr, common.ErrDynamicTimeoutExceeded) {
+				req.err <- common.NewErrEndpointRequestTimeout(time.Since(reqStartTime), reqErr)
+			} else if errors.Is(reqErr, context.Canceled) {
+				req.err <- common.NewErrEndpointRequestCanceled(reqErr)
+			} else {
+				req.err <- common.NewErrEndpointTransportFailure(c.Url, reqErr)
 			}
 		}
 		return

--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -431,7 +431,7 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 		}
 		// TODO For both of these conditions failsafe library can introduce carrying
 		//      the "cause" so we know this cancellation is due to Hedge policy for example.
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
 			for _, req := range requests {
 				req.err <- common.NewErrEndpointRequestTimeout(time.Since(reqStartTime), err)
 			}
@@ -713,7 +713,7 @@ func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *c
 		common.SetTraceSpanError(span, err)
 		// TODO For both of these conditions failsafe library can introduce carrying
 		//      the "cause" so we know this cancellation is due to Hedge policy for example.
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
 			return nil, common.NewErrEndpointRequestTimeout(time.Since(reqStartTime), err)
 		} else if errors.Is(err, context.Canceled) {
 			return nil, common.NewErrEndpointRequestCanceled(err)

--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -67,6 +67,17 @@ type batchRequest struct {
 
 // (gzip pooling implemented via util.GzipReaderPool)
 
+// effectiveCause returns context.Cause(ctx) if set, otherwise ctx.Err(). Use
+// whenever the code needs the reason a ctx was canceled or expired, so
+// policy-driven sentinels (e.g. common.ErrDynamicTimeoutExceeded) are
+// preferred over the generic context.DeadlineExceeded.
+func effectiveCause(ctx context.Context) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return ctx.Err()
+}
+
 func NewGenericHttpJsonRpcClient(
 	appCtx context.Context,
 	logger *zerolog.Logger,
@@ -179,13 +190,7 @@ func (c *GenericHttpJsonRpcClient) SendRequest(ctx context.Context, req *common.
 	case err := <-errChan:
 		return nil, err
 	case <-ctx.Done():
-		// Prefer context.Cause so policy-driven sentinels (e.g. ErrDynamicTimeoutExceeded)
-		// survive upstream-level error translation instead of being flattened to plain
-		// context.DeadlineExceeded.
-		err := context.Cause(ctx)
-		if err == nil {
-			err = ctx.Err()
-		}
+		err := effectiveCause(ctx)
 		// TODO For both of these conditions failsafe library can introduce carrying
 		//      the "cause" so we know this cancellation is due to Hedge policy for example.
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, common.ErrDynamicTimeoutExceeded) {
@@ -434,11 +439,7 @@ func (c *GenericHttpJsonRpcClient) processBatch(alreadyLocked bool) {
 	// pick the client from the proxy pool registry (if configured) or fallback
 	resp, err := c.getHttpClient().Do(httpReq)
 	if err != nil {
-		batchCause := context.Cause(batchCtx)
-		if batchCause == nil {
-			batchCause = batchCtx.Err()
-		}
-		if batchCause != nil {
+		if batchCause := effectiveCause(batchCtx); batchCause != nil {
 			err = batchCause
 		}
 		// TODO For both of these conditions failsafe library can introduce carrying
@@ -718,10 +719,7 @@ func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *c
 
 	resp, err := c.getHttpClient().Do(httpReq)
 	if err != nil {
-		cause := context.Cause(ctx)
-		if cause == nil {
-			cause = ctx.Err()
-		}
+		cause := effectiveCause(ctx)
 		c.logger.Debug().Err(err).Object("request", req).AnErr("contextError", cause).Msg("transport failure while sending single request")
 		if cause != nil {
 			err = cause

--- a/common/config.go
+++ b/common/config.go
@@ -1153,7 +1153,10 @@ func (c *CircuitBreakerPolicyConfig) Copy() *CircuitBreakerPolicyConfig {
 }
 
 type TimeoutPolicyConfig struct {
-	Duration Duration `yaml:"duration,omitempty" json:"duration" tstype:"Duration"`
+	Duration    Duration `yaml:"duration,omitempty" json:"duration" tstype:"Duration"`
+	Quantile    float64  `yaml:"quantile,omitempty" json:"quantile"`
+	MinDuration Duration `yaml:"minDuration,omitempty" json:"minDuration" tstype:"Duration"`
+	MaxDuration Duration `yaml:"maxDuration,omitempty" json:"maxDuration" tstype:"Duration"`
 }
 
 func (c *TimeoutPolicyConfig) Copy() *TimeoutPolicyConfig {

--- a/common/errors.go
+++ b/common/errors.go
@@ -2000,6 +2000,11 @@ func (e *ErrEndpointServerSideException) ErrorStatusCode() int {
 	return http.StatusInternalServerError
 }
 
+// ErrDynamicTimeoutExceeded is the sentinel set as context cause by the
+// timeout policy's context.WithTimeoutCause. It distinguishes policy-driven
+// timeouts from parent-context deadlines (e.g. HTTP server timeouts).
+var ErrDynamicTimeoutExceeded = errors.New("dynamic timeout exceeded")
+
 type ErrEndpointRequestTimeout struct{ BaseError }
 
 const ErrCodeEndpointRequestTimeout = "ErrEndpointRequestTimeout"

--- a/common/validation.go
+++ b/common/validation.go
@@ -1064,8 +1064,18 @@ func (f *FailsafeConfig) Validate() error {
 }
 
 func (t *TimeoutPolicyConfig) Validate() error {
-	if t.Duration == 0 {
+	if t.Quantile > 0 {
+		if t.Quantile > 1 {
+			return fmt.Errorf("upstream.*.failsafe.timeout.quantile must be between 0 and 1")
+		}
+		if t.Duration == 0 && t.MaxDuration == 0 {
+			return fmt.Errorf("upstream.*.failsafe.timeout.duration or maxDuration is required when quantile is set")
+		}
+	} else if t.Duration == 0 {
 		return fmt.Errorf("upstream.*.failsafe.timeout.duration is required")
+	}
+	if t.MinDuration > 0 && t.MaxDuration > 0 && t.MinDuration > t.MaxDuration {
+		return fmt.Errorf("upstream.*.failsafe.timeout.minDuration must be less than or equal to maxDuration")
 	}
 	return nil
 }

--- a/docs/pages/config/failsafe.mdx
+++ b/docs/pages/config/failsafe.mdx
@@ -132,6 +132,12 @@ export default createConfig({
 
 Sets a timeout for requests. Network-level timeout applies to the entire request lifecycle (including retries), while upstream-level timeout applies to each individual attempt.
 
+Timeout supports two modes: **fixed** (static duration) and **dynamic** (quantile-based, adapts to real latency).
+
+### Fixed timeout
+
+The simplest configuration — a static duration that applies to all requests matching the policy.
+
 <Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
   <Tabs.Tab>
 ```yaml filename="erpc.yaml"
@@ -181,6 +187,90 @@ export default createConfig({
 ```
   </Tabs.Tab>
 </Tabs>
+
+### Dynamic quantile-based timeout
+
+<Callout type="info">
+  **Quantile-based timeout** (recommended) computes the timeout from real latency percentiles per method, so it automatically adapts to your traffic. Works similarly to [quantile-based hedging](/config/failsafe#hedge-policy).
+</Callout>
+
+When `quantile` is set, the timeout is computed dynamically from the DDSketch latency distribution for each RPC method. For example, `quantile: 0.99` means "set the timeout at the p99 of observed latencies" — only the slowest 1% of requests would be timed out.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `duration` | Duration | Cold-start fallback used until enough latency data is collected. Also serves as the fallback when `maxDuration` is not set. |
+| `quantile` | float | Percentile of latency distribution to use as timeout (e.g., `0.99` for p99). Must be between 0 and 1. |
+| `minDuration` | Duration | *(Optional)* Floor for the computed timeout. Prevents false timeouts when latencies are very low. |
+| `maxDuration` | Duration | *(Optional)* Ceiling for the computed timeout. Can be used as the cold-start fallback when `duration` is omitted. |
+
+<Callout type="tip">
+  For most use cases, just `duration` + `quantile` is sufficient. Use `quantile: 0.99` to timeout only truly stuck requests while letting the system self-tune. The `minDuration` and `maxDuration` fields are optional guard rails.
+</Callout>
+
+<Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
+  <Tabs.Tab>
+```yaml filename="erpc.yaml"
+projects:
+  - id: main
+    networks:
+      - architecture: evm
+        evm:
+          chainId: 1
+        failsafe:
+          # Recommended: pure dynamic timeout with p99
+          - matchMethod: "eth_call|eth_getLogs"
+            timeout:
+              duration: 30s        # Cold-start fallback
+              quantile: 0.99       # Timeout at p99 of observed latencies
+          
+          # With optional guard rails
+          - matchMethod: "*"
+            timeout:
+              duration: 60s        # Cold-start fallback
+              quantile: 0.99
+              minDuration: 200ms   # Never timeout faster than this
+              maxDuration: 60s     # Never wait longer than this
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="erpc.ts"
+import { createConfig } from "@erpc-cloud/config";
+
+export default createConfig({
+  projects: [{
+    id: "main",
+    networks: [{
+      architecture: "evm",
+      evm: { chainId: 1 },
+      failsafe: [
+        // Recommended: pure dynamic timeout with p99
+        {
+          matchMethod: "eth_call|eth_getLogs",
+          timeout: {
+            duration: "30s",       // Cold-start fallback
+            quantile: 0.99         // Timeout at p99 of observed latencies
+          }
+        },
+        // With optional guard rails
+        {
+          matchMethod: "*",
+          timeout: {
+            duration: "60s",       // Cold-start fallback
+            quantile: 0.99,
+            minDuration: "200ms",  // Never timeout faster than this
+            maxDuration: "60s"     // Never wait longer than this
+          }
+        }
+      ]
+    }]
+  }]
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+Monitor the computed timeout values via Prometheus metric:
+- `erpc_network_timeout_duration_seconds` — histogram of dynamically computed timeout durations per method
 
 ## `retry` policy
 

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -788,6 +788,11 @@ func TestHttpServer_ManualTimeoutScenarios(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Contains(t, body, "timeout policy exceeded on upstream-level")
+		// Lock in the error code too, not just the message. The sentinel-cause
+		// propagation through batch mode is what makes this classification
+		// survive — a string-only check would silently pass if the wording
+		// changed or the code regressed to a generic transport failure.
+		assert.Contains(t, body, string(common.ErrCodeFailsafeTimeoutExceeded))
 	})
 
 	t.Run("UpstreamRequestTimeoutBatchingDisabled", func(t *testing.T) {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -527,15 +527,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			if failsafeExecutor.timeout != nil {
 				if td := failsafeExecutor.timeout(execSpanCtx, effectiveReq); td != nil {
 					var cancelFn context.CancelFunc
-					execSpanCtx, cancelFn = context.WithTimeoutCause(
-						execSpanCtx,
-						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
-						//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
-						//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
-						//      but allow the failsafe execution to fail with timeout first for proper error handling.
-						*td+5*time.Millisecond,
-						upstream.ErrDynamicTimeoutExceeded,
-					)
+					execSpanCtx, cancelFn = context.WithTimeoutCause(execSpanCtx, *td, upstream.ErrDynamicTimeoutExceeded)
 					defer cancelFn()
 				}
 			}
@@ -751,6 +743,16 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	defer req.RUnlock()
 
 	if execErr != nil {
+		if errors.Is(execErr, upstream.ErrDynamicTimeoutExceeded) {
+			finality := req.Finality(ctx)
+			telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
+				n.projectId,
+				req.NetworkLabel(),
+				method,
+				finality.String(),
+				string(common.ScopeNetwork),
+			).Inc()
+		}
 		translatedErr := upstream.TranslateFailsafeError(common.ScopeNetwork, "", method, execErr, &startTime)
 		// Don't override consensus results with last valid response from individual upstreams
 		// For example if 1 upstream gives empty response another 3 give "reverted" error,

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -752,17 +752,19 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 
 	if execErr != nil {
 		// When the lifecycle ctx fires, failsafe may return plain context.DeadlineExceeded
-		// with no sentinel in the Unwrap chain. Substitute the ctx cause so
-		// TranslateFailsafeError can classify it as ErrFailsafeTimeoutExceeded.
+		// with no sentinel in the Unwrap chain. Substitute only when the ctx cause
+		// is OUR sentinel — accepting any non-DeadlineExceeded cause would leak
+		// parent-scope causes (e.g. http_timeout.go's ErrHandlerTimeout) through
+		// TranslateFailsafeError unclassified.
 		if _, ok := execErr.(common.StandardError); !ok && errors.Is(execErr, context.DeadlineExceeded) {
-			if cause := context.Cause(ectx); cause != nil && !errors.Is(cause, context.DeadlineExceeded) {
+			if cause := context.Cause(ectx); errors.Is(cause, common.ErrDynamicTimeoutExceeded) {
 				execErr = cause
 			}
 		}
 		// Guard on HasErrorCode so upstream-scope timeouts that already incremented
 		// the counter with scope=upstream do not double-count at scope=network when
 		// they bubble up wrapped as ErrFailsafeTimeoutExceeded.
-		if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+		if failsafeExecutor.timeout != nil && errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 			finality := req.Finality(ctx)
 			telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 				n.projectId,
@@ -772,7 +774,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				string(common.ScopeNetwork),
 			).Inc()
 		}
-		translatedErr := upstream.TranslateFailsafeError(common.ScopeNetwork, "", method, execErr, &startTime)
+		translatedErr := upstream.TranslateFailsafeError(common.ScopeNetwork, "", method, execErr, &startTime, failsafeExecutor.timeout != nil)
 		// Don't override consensus results with last valid response from individual upstreams
 		// For example if 1 upstream gives empty response another 3 give "reverted" error,
 		// we should still return reverted error, even though there was an empty response before.

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -527,13 +527,14 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			if failsafeExecutor.timeout != nil {
 				if td := failsafeExecutor.timeout(execSpanCtx, effectiveReq); td != nil {
 					var cancelFn context.CancelFunc
-					execSpanCtx, cancelFn = context.WithTimeout(
+					execSpanCtx, cancelFn = context.WithTimeoutCause(
 						execSpanCtx,
 						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
 						//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
 						//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
 						//      but allow the failsafe execution to fail with timeout first for proper error handling.
 						*td+5*time.Millisecond,
+						upstream.ErrDynamicTimeoutExceeded,
 					)
 					defer cancelFn()
 				}

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -28,7 +28,7 @@ type FailsafeExecutor struct {
 	method                 string
 	finalities             []common.DataFinalityState
 	executor               failsafe.Executor[*common.NormalizedResponse]
-	timeout                *time.Duration
+	timeout                upstream.TimeoutFunc
 	consensusPolicyEnabled bool
 	// emptyResultAccept lists methods for which the first emptyish result
 	// short-circuits the upstream loop. Without this the loop tries every
@@ -525,17 +525,18 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				}
 			}
 			if failsafeExecutor.timeout != nil {
-				var cancelFn context.CancelFunc
-				execSpanCtx, cancelFn = context.WithTimeout(
-					execSpanCtx,
-					// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
-					//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
-					//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
-					//      but allow the failsafe execution to fail with timeout first for proper error handling.
-					*failsafeExecutor.timeout+5*time.Millisecond,
-				)
-
-				defer cancelFn()
+				if td := failsafeExecutor.timeout(execSpanCtx, effectiveReq); td != nil {
+					var cancelFn context.CancelFunc
+					execSpanCtx, cancelFn = context.WithTimeout(
+						execSpanCtx,
+						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
+						//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
+						//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
+						//      but allow the failsafe execution to fail with timeout first for proper error handling.
+						*td+5*time.Millisecond,
+					)
+					defer cancelFn()
+				}
 			}
 
 			// Try all upstreams in a single execution before returning to failsafe.

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -470,6 +470,19 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		attribute.String("failsafe.matched_finalities", fmt.Sprintf("%v", failsafeExecutor.finalities)),
 	)
 
+	// Network-level timeout is lifecycle-scoped: it wraps the entire failsafe
+	// execution including retries and hedges. Applying it here (outside the
+	// executor) matches the documented semantics — a network timeout of 5s with
+	// 3 retries still bounds total wall-clock to 5s. Upstream-level timeout,
+	// applied per-attempt inside Upstream.Forward, is independent.
+	if failsafeExecutor.timeout != nil {
+		if td := failsafeExecutor.timeout(ectx, req); td != nil {
+			var cancelFn context.CancelFunc
+			ectx, cancelFn = context.WithTimeoutCause(ectx, *td, common.ErrDynamicTimeoutExceeded)
+			defer cancelFn()
+		}
+	}
+
 	// Track time from failsafe executor start to first callback invocation
 	failsafeStartTime := time.Now()
 
@@ -524,13 +537,8 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 					return nil, ctxErr
 				}
 			}
-			if failsafeExecutor.timeout != nil {
-				if td := failsafeExecutor.timeout(execSpanCtx, effectiveReq); td != nil {
-					var cancelFn context.CancelFunc
-					execSpanCtx, cancelFn = context.WithTimeoutCause(execSpanCtx, *td, upstream.ErrDynamicTimeoutExceeded)
-					defer cancelFn()
-				}
-			}
+			// Network-scope timeout was applied at Forward entry (lifecycle-scoped).
+			// Per-attempt enforcement here would double-apply and break retry budgets.
 
 			// Try all upstreams in a single execution before returning to failsafe.
 			// This ensures delays (emptyResultDelay, blockUnavailableDelay) only
@@ -743,7 +751,18 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	defer req.RUnlock()
 
 	if execErr != nil {
-		if errors.Is(execErr, upstream.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+		// When the lifecycle ctx fires, failsafe may return plain context.DeadlineExceeded
+		// with no sentinel in the Unwrap chain. Substitute the ctx cause so
+		// TranslateFailsafeError can classify it as ErrFailsafeTimeoutExceeded.
+		if _, ok := execErr.(common.StandardError); !ok && errors.Is(execErr, context.DeadlineExceeded) {
+			if cause := context.Cause(ectx); cause != nil && !errors.Is(cause, context.DeadlineExceeded) {
+				execErr = cause
+			}
+		}
+		// Guard on HasErrorCode so upstream-scope timeouts that already incremented
+		// the counter with scope=upstream do not double-count at scope=network when
+		// they bubble up wrapped as ErrFailsafeTimeoutExceeded.
+		if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 			finality := req.Finality(ctx)
 			telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 				n.projectId,

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -743,7 +743,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	defer req.RUnlock()
 
 	if execErr != nil {
-		if errors.Is(execErr, upstream.ErrDynamicTimeoutExceeded) {
+		if errors.Is(execErr, upstream.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 			finality := req.Finality(ctx)
 			telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 				n.projectId,

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/erpc/erpc/upstream"
 	"github.com/erpc/erpc/util"
 	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -761,10 +762,20 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				execErr = cause
 			}
 		}
-		// Guard on HasErrorCode so upstream-scope timeouts that already incremented
-		// the counter with scope=upstream do not double-count at scope=network when
-		// they bubble up wrapped as ErrFailsafeTimeoutExceeded.
-		if failsafeExecutor.timeout != nil && errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+		// Three guards stacked, each closing a distinct misattribution:
+		//   - failsafeExecutor.timeout != nil: parent-scope sentinel inherited
+		//     via ctx propagation must not credit a scope that didn't own a policy.
+		//   - !errors.As(retryExceededErr): mirror TranslateFailsafeError's
+		//     retry-exhausted-wins ordering so retry-tail timeouts are reported
+		//     as retry exhaustion (matching the user-visible classification).
+		//   - !HasErrorCode(ErrCodeFailsafeTimeoutExceeded): an upstream-scope
+		//     timeout already incremented at scope=upstream — don't double-count
+		//     when it bubbles up here.
+		var retryExceededErr retrypolicy.ExceededError
+		if failsafeExecutor.timeout != nil &&
+			!errors.As(execErr, &retryExceededErr) &&
+			errors.Is(execErr, common.ErrDynamicTimeoutExceeded) &&
+			!common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 			finality := req.Finality(ctx)
 			telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 				n.projectId,

--- a/erpc/networks_registry.go
+++ b/erpc/networks_registry.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
@@ -117,9 +116,9 @@ func NewNetwork(
 			}
 			policyArray := upstream.ToPolicyArray(pls, "timeout", "consensus", "retry", "hedge")
 
-			var timeoutDuration *time.Duration
+			var timeoutFn upstream.TimeoutFunc
 			if fsCfg.Timeout != nil {
-				timeoutDuration = fsCfg.Timeout.Duration.DurationPtr()
+				timeoutFn = upstream.NewTimeoutFunc(&lg, fsCfg.Timeout)
 			}
 
 			method := fsCfg.MatchMethod
@@ -136,7 +135,7 @@ func NewNetwork(
 				method:                 method,
 				finalities:             fsCfg.MatchFinality,
 				executor:               failsafe.NewExecutor(policyArray...),
-				timeout:                timeoutDuration,
+				timeout:                timeoutFn,
 				consensusPolicyEnabled: fsCfg.Consensus != nil,
 				emptyResultAccept:      emptyAccept,
 			})

--- a/erpc/networks_registry.go
+++ b/erpc/networks_registry.go
@@ -115,7 +115,7 @@ func NewNetwork(
 			if err != nil {
 				return nil, err
 			}
-			policyArray := upstream.ToPolicyArray(pls, "timeout", "consensus", "retry", "hedge")
+			policyArray := upstream.ToPolicyArray(pls, "consensus", "retry", "hedge")
 
 			var timeoutFn upstream.TimeoutFunc
 			if fsCfg.Timeout != nil {

--- a/erpc/networks_registry.go
+++ b/erpc/networks_registry.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"

--- a/erpc/networks_timeout_test.go
+++ b/erpc/networks_timeout_test.go
@@ -1,0 +1,342 @@
+package erpc
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetwork_TimeoutPolicy(t *testing.T) {
+	t.Run("FixedTimeout_BackwardCompatible", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(50 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Fixed timeout with no quantile — backward compatible behavior
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(5 * time.Second),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+		resp, err := network.Forward(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x1111")
+	})
+
+	t.Run("FixedTimeout_RequestExceedsTimeout", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Short timeout that the request should exceed
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(200 * time.Millisecond),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+		_, err := network.Forward(ctx, req)
+
+		require.Error(t, err)
+	})
+
+	t.Run("QuantileTimeout_DynamicComputation", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		// Set up mocks for metric building phase (10 requests with varying latencies)
+		for i := 0; i < 10; i++ {
+			gock.New("http://rpc1.localhost").
+				Post("").
+				Filter(func(r *http.Request) bool {
+					body := util.SafeReadBody(r)
+					return strings.Contains(body, "eth_getBalance")
+				}).
+				Times(1).
+				Reply(200).
+				Delay(time.Duration(20+i*5) * time.Millisecond). // 20-65ms
+				JSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x1111",
+				})
+		}
+
+		// Then a fast request that should succeed within the dynamic timeout
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(20 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x2222",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Quantile-based timeout: p90 of latencies (~60ms), clamped to [200ms, 5s]
+		// minDuration ensures timeout is at least 200ms even though p90 is ~60ms
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration:    common.Duration(1 * time.Second), // fallback
+			Quantile:    0.9,
+			MinDuration: common.Duration(200 * time.Millisecond),
+			MaxDuration: common.Duration(5 * time.Second),
+		})
+
+		// Build up metrics
+		for i := 0; i < 10; i++ {
+			req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+			resp, err := network.Forward(ctx, req)
+			require.NoError(t, err)
+			resp.Release()
+		}
+
+		// Now test with built-up metrics — should succeed since 20ms < dynamic timeout (min 200ms)
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x2222")
+	})
+
+	t.Run("QuantileTimeout_MinDurationBoundary", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		// Build metrics with very fast responses
+		for i := 0; i < 5; i++ {
+			gock.New("http://rpc1.localhost").
+				Post("").
+				Filter(func(r *http.Request) bool {
+					body := util.SafeReadBody(r)
+					return strings.Contains(body, "eth_getBalance")
+				}).
+				Reply(200).
+				Delay(5 * time.Millisecond). // Very fast
+				JSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x1111",
+				})
+		}
+
+		// Request that takes longer than the raw quantile but less than minDuration
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(80 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x2222",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// p10 of very fast responses would be ~5ms, but minDuration is 200ms
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Quantile:    0.1,
+			MinDuration: common.Duration(200 * time.Millisecond),
+			MaxDuration: common.Duration(5 * time.Second),
+		})
+
+		// Build metrics
+		for i := 0; i < 5; i++ {
+			req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+			resp, err := network.Forward(ctx, req)
+			require.NoError(t, err)
+			resp.Release()
+		}
+
+		// Should succeed because minDuration (200ms) > actual latency (80ms)
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x2222")
+	})
+
+	t.Run("QuantileTimeout_ColdStartFallback", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(50 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Quantile-based timeout with Duration as cold start fallback
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration:    common.Duration(5 * time.Second), // fallback during cold start
+			Quantile:    0.9,
+			MinDuration: common.Duration(100 * time.Millisecond),
+			MaxDuration: common.Duration(10 * time.Second),
+		})
+
+		// First request — no metrics yet, should use Duration fallback (5s)
+		req := common.NewNormalizedRequest(requestBytes)
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x1111")
+	})
+
+	t.Run("QuantileTimeout_ColdStartFallbackToMaxDuration", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(50 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// No Duration set — should fall back to MaxDuration during cold start
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Quantile:    0.9,
+			MinDuration: common.Duration(100 * time.Millisecond),
+			MaxDuration: common.Duration(10 * time.Second),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x1111")
+	})
+}
+
+// Helper to set up network with timeout policy
+func setupTestNetworkWithTimeoutPolicy(t *testing.T, ctx context.Context, timeoutConfig *common.TimeoutPolicyConfig) *Network {
+	t.Helper()
+
+	upstreamConfigs := []*common.UpstreamConfig{
+		{
+			Type:     common.UpstreamTypeEvm,
+			Id:       "rpc1",
+			Endpoint: "http://rpc1.localhost",
+			Evm: &common.EvmUpstreamConfig{
+				ChainId: 123,
+			},
+		},
+	}
+
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm: &common.EvmNetworkConfig{
+			ChainId: 123,
+		},
+		Failsafe: []*common.FailsafeConfig{{
+			Timeout: timeoutConfig,
+		}},
+	}
+
+	return setupTestNetwork(t, ctx, upstreamConfigs, networkConfig)
+}

--- a/erpc/networks_timeout_test.go
+++ b/erpc/networks_timeout_test.go
@@ -459,11 +459,14 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 			&common.RetryPolicyConfig{MaxAttempts: 3, Delay: common.Duration(10 * time.Millisecond)},
 		)
 
+		upstreamBefore := timeoutFiredCounterValue(t, "upstream")
+		networkBefore := timeoutFiredCounterValue(t, "network")
+
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
 		_, err := network.Forward(ctx, req)
 
 		require.Error(t, err)
-		// The key invariant: retry-exhausted must NOT be misclassified as
+		// Invariant 1: retry-exhausted must NOT be misclassified as
 		// FailsafeTimeoutExceeded at the top level, even though the last
 		// attempt's underlying cause is a timeout.
 		assert.False(t,
@@ -471,6 +474,14 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 			"retry exhaustion with timeout-on-last-attempt must not surface as FailsafeTimeoutExceeded; got top-level code %s in chain: %v",
 			topLevelErrorCode(err), err,
 		)
+		// Invariant 2: the timeout-fired counter must NOT increment when retry
+		// is the user-visible classification. errors.Is walks the Unwrap chain
+		// and would match the sentinel inside retrypolicy.ExceededError.LastError
+		// without the errors.As guard.
+		assert.Equal(t, upstreamBefore, timeoutFiredCounterValue(t, "upstream"),
+			"upstream timeout counter must not fire on retry-exhausted-with-timeout-tail")
+		assert.Equal(t, networkBefore, timeoutFiredCounterValue(t, "network"),
+			"network timeout counter must not fire on retry-exhausted-with-timeout-tail")
 	})
 
 	t.Run("UpstreamTimeout_DoesNotDoubleCountNetworkFiredCounter", func(t *testing.T) {

--- a/erpc/networks_timeout_test.go
+++ b/erpc/networks_timeout_test.go
@@ -504,21 +504,66 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 			Duration: common.Duration(100 * time.Millisecond),
 		})
 
-		before := timeoutFiredCounterValue(t, "upstream") + timeoutFiredCounterValue(t, "network")
+		upstreamBefore := timeoutFiredCounterValue(t, "upstream")
+		networkBefore := timeoutFiredCounterValue(t, "network")
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
 		_, err := network.Forward(ctx, req)
 		require.Error(t, err)
 
-		upstreamAfter := timeoutFiredCounterValue(t, "upstream")
-		networkAfter := timeoutFiredCounterValue(t, "network")
+		// Split assertions: each invariant checked independently so a regression
+		// in one direction can't pass by compensating in the other.
+		assert.Equal(t, upstreamBefore+1, timeoutFiredCounterValue(t, "upstream"),
+			"upstream-scope counter must fire exactly once for an upstream-configured timeout")
+		assert.Equal(t, networkBefore, timeoutFiredCounterValue(t, "network"),
+			"network-scope counter must not increment when the timeout was already classified at upstream scope")
+	})
 
-		// Upstream-scope should have fired exactly once; network-scope must not
-		// have fired (the guard suppresses the already-classified timeout).
-		assert.Greater(t, upstreamAfter, uint64(0), "upstream timeout counter must fire")
-		assert.Equal(t, before, networkAfter+upstreamAfter-1,
-			"network-scope counter must not double-count an upstream-originated timeout; before=%d upstream=%d network=%d",
-			before, upstreamAfter, networkAfter,
-		)
+	t.Run("NetworkOnlyTimeout_FiresAtNetworkScopeNotUpstream", func(t *testing.T) {
+		// Regression lock: when only the network scope has a timeout policy
+		// and the upstream has none, the lifecycle sentinel propagates via
+		// ctx inheritance into the upstream's error chain. Both the counter
+		// and error classification at upstream scope must be guarded on
+		// `failsafeExecutor.timeout != nil` so the scope attribution stays
+		// truthful — the timeout was the NETWORK's policy firing, not the
+		// upstream's.
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Timeout at NETWORK only; upstream has no timeout.
+		network := setupTestNetworkWithTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(100 * time.Millisecond),
+		})
+
+		upstreamBefore := timeoutFiredCounterValue(t, "upstream")
+		networkBefore := timeoutFiredCounterValue(t, "network")
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		_, err := network.Forward(ctx, req)
+		require.Error(t, err)
+
+		assert.Equal(t, upstreamBefore, timeoutFiredCounterValue(t, "upstream"),
+			"upstream counter must not fire when upstream has no timeout policy (sentinel is inherited from network scope)")
+		assert.Equal(t, networkBefore+1, timeoutFiredCounterValue(t, "network"),
+			"network-scope counter must fire exactly once for a network-configured timeout")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeFailsafeTimeoutExceeded),
+			"error should classify as ErrFailsafeTimeoutExceeded, got: %v", err)
 	})
 }
 

--- a/erpc/networks_timeout_test.go
+++ b/erpc/networks_timeout_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() { util.ConfigureTestLogger() }
+
 func TestNetwork_TimeoutPolicy(t *testing.T) {
 	t.Run("FixedTimeout_BackwardCompatible", func(t *testing.T) {
 		util.ResetGock()
@@ -146,6 +148,7 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
 
 		// Set up mocks for metric building phase (10 requests with varying latencies)
 		for i := 0; i < 10; i++ {
@@ -215,6 +218,7 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
 
 		// Build metrics with very fast responses
 		for i := 0; i < 5; i++ {
@@ -362,6 +366,160 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, jrr.GetResultString(), "0x1111")
 	})
+
+	t.Run("NetworkTimeoutIsLifecycleScoped_BoundsRetryBudget", func(t *testing.T) {
+		// Regression lock: a 500ms network timeout with 3 retries must bound
+		// total wall-clock to ~500ms, not 500ms × 3 attempts. Applying the
+		// timeout inside the per-attempt callback would silently blow this
+		// budget; this test fails unless the timeout wraps the entire executor.
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		// Each upstream attempt delays 2s. With per-attempt timeout semantics,
+		// 3 retries would take up to 6s. With lifecycle semantics, the 500ms
+		// network timeout fires once and stops everything.
+		for i := 0; i < 5; i++ {
+			gock.New("http://rpc1.localhost").
+				Post("").
+				Filter(func(r *http.Request) bool {
+					body := util.SafeReadBody(r)
+					return strings.Contains(body, "eth_getBalance")
+				}).
+				Reply(200).
+				Delay(2 * time.Second).
+				JSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x1111",
+				})
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithTimeoutAndRetry(t, ctx,
+			&common.TimeoutPolicyConfig{Duration: common.Duration(500 * time.Millisecond)},
+			&common.RetryPolicyConfig{MaxAttempts: 3, Delay: common.Duration(10 * time.Millisecond)},
+		)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		start := time.Now()
+		_, err := network.Forward(ctx, req)
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		assert.True(t,
+			common.HasErrorCode(err, common.ErrCodeFailsafeTimeoutExceeded),
+			"expected lifecycle timeout to wrap as ErrFailsafeTimeoutExceeded, got: %v", err,
+		)
+		assert.Less(t, elapsed, 1500*time.Millisecond,
+			"lifecycle timeout should bound total wall-clock near 500ms, not 500ms*retries; got %s", elapsed,
+		)
+	})
+
+	t.Run("RetryExhaustedWithTimeoutOnLastAttempt_NotMisclassifiedAsTimeout", func(t *testing.T) {
+		// Regression lock for pc-001: if retry policy exhausts and the last
+		// attempt hit a timeout, the classifier must NOT surface it as
+		// ErrFailsafeTimeoutExceeded — the retry-exhausted branch owns the
+		// final classification. Without the isRetryExceeded guard in
+		// TranslateFailsafeError, errors.Is would walk through the Unwrap
+		// chain of retrypolicy.ExceededError and incorrectly match the
+		// dynamic-timeout sentinel branch first.
+		//
+		// We put retry+timeout both at the upstream level so the failsafe
+		// exhaustion surfaces as a raw retrypolicy.ExceededError without the
+		// ErrUpstreamsExhausted short-circuit that kicks in at network scope.
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		// 3 attempts × always-slow mock → retry exhausts with timeout on last.
+		for i := 0; i < 6; i++ {
+			gock.New("http://rpc1.localhost").
+				Post("").
+				Filter(func(r *http.Request) bool {
+					body := util.SafeReadBody(r)
+					return strings.Contains(body, "eth_getBalance")
+				}).
+				Reply(200).
+				Delay(2 * time.Second).
+				JSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x1111",
+				})
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithUpstreamTimeoutAndRetry(t, ctx,
+			&common.TimeoutPolicyConfig{Duration: common.Duration(50 * time.Millisecond)},
+			&common.RetryPolicyConfig{MaxAttempts: 3, Delay: common.Duration(10 * time.Millisecond)},
+		)
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		_, err := network.Forward(ctx, req)
+
+		require.Error(t, err)
+		// The key invariant: retry-exhausted must NOT be misclassified as
+		// FailsafeTimeoutExceeded at the top level, even though the last
+		// attempt's underlying cause is a timeout.
+		assert.False(t,
+			topLevelErrorCode(err) == string(common.ErrCodeFailsafeTimeoutExceeded),
+			"retry exhaustion with timeout-on-last-attempt must not surface as FailsafeTimeoutExceeded; got top-level code %s in chain: %v",
+			topLevelErrorCode(err), err,
+		)
+	})
+
+	t.Run("UpstreamTimeout_DoesNotDoubleCountNetworkFiredCounter", func(t *testing.T) {
+		// Regression lock: when an upstream-scope timeout bubbles up as
+		// ErrFailsafeTimeoutExceeded, the network-scope counter check must
+		// see HasErrorCode(ErrCodeFailsafeTimeoutExceeded) and skip the
+		// increment. Otherwise every upstream timeout produces two fires
+		// (scope=upstream at upstream.go + scope=network at networks.go).
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithUpstreamTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(100 * time.Millisecond),
+		})
+
+		before := timeoutFiredCounterValue(t, "upstream") + timeoutFiredCounterValue(t, "network")
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		_, err := network.Forward(ctx, req)
+		require.Error(t, err)
+
+		upstreamAfter := timeoutFiredCounterValue(t, "upstream")
+		networkAfter := timeoutFiredCounterValue(t, "network")
+
+		// Upstream-scope should have fired exactly once; network-scope must not
+		// have fired (the guard suppresses the already-classified timeout).
+		assert.Greater(t, upstreamAfter, uint64(0), "upstream timeout counter must fire")
+		assert.Equal(t, before, networkAfter+upstreamAfter-1,
+			"network-scope counter must not double-count an upstream-originated timeout; before=%d upstream=%d network=%d",
+			before, upstreamAfter, networkAfter,
+		)
+	})
 }
 
 func TestUpstream_TimeoutPolicy(t *testing.T) {
@@ -411,6 +569,7 @@ func TestUpstream_TimeoutPolicy(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
 
 		for i := 0; i < 10; i++ {
 			gock.New("http://rpc1.localhost").
@@ -518,6 +677,89 @@ func setupTestNetworkWithUpstreamTimeoutPolicy(t *testing.T, ctx context.Context
 	}
 
 	return setupTestNetwork(t, ctx, upstreamConfigs, networkConfig)
+}
+
+// timeoutFiredCounterValue returns the total MetricNetworkTimeoutFiredTotal
+// count for the given scope label across all other label combinations.
+func timeoutFiredCounterValue(t *testing.T, scope string) uint64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var total uint64
+	for _, mf := range mfs {
+		if mf.GetName() != "erpc_network_timeout_fired_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var mScope string
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "scope" {
+					mScope = lp.GetValue()
+				}
+			}
+			if mScope != scope {
+				continue
+			}
+			if c := m.GetCounter(); c != nil {
+				total += uint64(c.GetValue())
+			}
+		}
+	}
+	return total
+}
+
+// setupTestNetworkWithTimeoutAndRetry attaches both a timeout and retry policy
+// at the network level — used to verify lifecycle semantics.
+func setupTestNetworkWithTimeoutAndRetry(t *testing.T, ctx context.Context, timeoutConfig *common.TimeoutPolicyConfig, retryConfig *common.RetryPolicyConfig) *Network {
+	t.Helper()
+	upstreamConfigs := []*common.UpstreamConfig{{
+		Type:     common.UpstreamTypeEvm,
+		Id:       "rpc1",
+		Endpoint: "http://rpc1.localhost",
+		Evm:      &common.EvmUpstreamConfig{ChainId: 123},
+	}}
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm:          &common.EvmNetworkConfig{ChainId: 123},
+		Failsafe: []*common.FailsafeConfig{{
+			Timeout: timeoutConfig,
+			Retry:   retryConfig,
+		}},
+	}
+	return setupTestNetwork(t, ctx, upstreamConfigs, networkConfig)
+}
+
+// setupTestNetworkWithUpstreamTimeoutAndRetry attaches both timeout and retry
+// at the upstream level. Used to verify retry-exhaust classification when the
+// last attempt is a timeout: failsafe exhaustion surfaces here as a raw
+// retrypolicy.ExceededError without the ErrUpstreamsExhausted wrapping that
+// network scope adds around upstream iteration.
+func setupTestNetworkWithUpstreamTimeoutAndRetry(t *testing.T, ctx context.Context, timeoutConfig *common.TimeoutPolicyConfig, retryConfig *common.RetryPolicyConfig) *Network {
+	t.Helper()
+	upstreamConfigs := []*common.UpstreamConfig{{
+		Type:     common.UpstreamTypeEvm,
+		Id:       "rpc1",
+		Endpoint: "http://rpc1.localhost",
+		Evm:      &common.EvmUpstreamConfig{ChainId: 123},
+		Failsafe: []*common.FailsafeConfig{{
+			Timeout: timeoutConfig,
+			Retry:   retryConfig,
+		}},
+	}}
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm:          &common.EvmNetworkConfig{ChainId: 123},
+	}
+	return setupTestNetwork(t, ctx, upstreamConfigs, networkConfig)
+}
+
+// topLevelErrorCode returns the ErrorCode of the outermost StandardError in
+// the chain, or "" if err is not a StandardError.
+func topLevelErrorCode(err error) string {
+	if se, ok := err.(common.StandardError); ok {
+		return string(se.Base().Code)
+	}
+	return ""
 }
 
 // Helper to set up network with timeout policy

--- a/erpc/networks_timeout_test.go
+++ b/erpc/networks_timeout_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/util"
 	"github.com/h2non/gock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,6 +90,56 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 		_, err := network.Forward(ctx, req)
 
 		require.Error(t, err)
+		assert.True(t,
+			common.HasErrorCode(err, common.ErrCodeFailsafeTimeoutExceeded),
+			"expected ErrFailsafeTimeoutExceeded, got: %v", err,
+		)
+	})
+
+	t.Run("ParentContextDeadline_NotMisclassifiedAsTimeoutPolicy", func(t *testing.T) {
+		// When the caller's context deadline fires (e.g. HTTP server timeout),
+		// the error must NOT be wrapped as ErrFailsafeTimeoutExceeded — it must
+		// propagate as a plain context.DeadlineExceeded so the HTTP layer can
+		// surface it correctly. This locks in the sentinel-cause design.
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		// Policy timeout is generous — setup uses background so chain-id detection
+		// completes; the Forward uses a short caller-deadline that should fire first.
+		setupCtx, cancelSetup := context.WithCancel(context.Background())
+		defer cancelSetup()
+		network := setupTestNetworkWithTimeoutPolicy(t, setupCtx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(10 * time.Second),
+		})
+
+		parentCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		req := common.NewNormalizedRequest(requestBytes)
+		_, err := network.Forward(parentCtx, req)
+
+		require.Error(t, err)
+		assert.False(t,
+			common.HasErrorCode(err, common.ErrCodeFailsafeTimeoutExceeded),
+			"parent context deadline must not be misclassified as failsafe timeout policy; got: %v", err,
+		)
 	})
 
 	t.Run("QuantileTimeout_DynamicComputation", func(t *testing.T) {
@@ -311,6 +362,162 @@ func TestNetwork_TimeoutPolicy(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, jrr.GetResultString(), "0x1111")
 	})
+}
+
+func TestUpstream_TimeoutPolicy(t *testing.T) {
+	t.Run("UpstreamLevelFixedTimeout_ExceededWrapsAsFailsafeTimeout", func(t *testing.T) {
+		// Verifies the unified context.WithTimeoutCause path also fires at the
+		// upstream scope (not just network scope).
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x1111",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithUpstreamTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration: common.Duration(150 * time.Millisecond),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+		_, err := network.Forward(ctx, req)
+
+		require.Error(t, err)
+		assert.True(t,
+			common.HasErrorCode(err, common.ErrCodeFailsafeTimeoutExceeded),
+			"expected upstream-level timeout to wrap as ErrFailsafeTimeoutExceeded, got: %v", err,
+		)
+	})
+
+	t.Run("UpstreamLevelQuantileTimeout_HistogramEmits", func(t *testing.T) {
+		// Verifies that NewTimeoutFunc emits erpc_network_timeout_duration_seconds
+		// when used at the upstream scope (not only network scope).
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		for i := 0; i < 10; i++ {
+			gock.New("http://rpc1.localhost").
+				Post("").
+				Filter(func(r *http.Request) bool {
+					body := util.SafeReadBody(r)
+					return strings.Contains(body, "eth_getBalance")
+				}).
+				Times(1).
+				Reply(200).
+				Delay(time.Duration(30+i*5) * time.Millisecond).
+				JSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x1111",
+				})
+		}
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(20 * time.Millisecond).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  "0x2222",
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithUpstreamTimeoutPolicy(t, ctx, &common.TimeoutPolicyConfig{
+			Duration:    common.Duration(1 * time.Second),
+			Quantile:    0.9,
+			MinDuration: common.Duration(200 * time.Millisecond),
+			MaxDuration: common.Duration(5 * time.Second),
+		})
+
+		for i := 0; i < 10; i++ {
+			req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+			resp, err := network.Forward(ctx, req)
+			require.NoError(t, err)
+			resp.Release()
+		}
+
+		before := testutilCounterValue(t)
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`))
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		after := testutilCounterValue(t)
+
+		assert.Greater(t, after, before,
+			"histogram should have observed at least one sample after the 11th upstream-scoped dynamic-timeout request")
+	})
+}
+
+// testutilCounterValue returns the total number of observations across all
+// label combinations of the MetricNetworkTimeoutDurationSeconds histogram.
+// Used to verify the histogram emits regardless of label values.
+func testutilCounterValue(t *testing.T) uint64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var total uint64
+	for _, mf := range mfs {
+		if mf.GetName() != "erpc_network_timeout_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if h := m.GetHistogram(); h != nil {
+				total += h.GetSampleCount()
+			}
+		}
+	}
+	return total
+}
+
+// Helper to set up network with UPSTREAM-level timeout policy
+func setupTestNetworkWithUpstreamTimeoutPolicy(t *testing.T, ctx context.Context, timeoutConfig *common.TimeoutPolicyConfig) *Network {
+	t.Helper()
+
+	upstreamConfigs := []*common.UpstreamConfig{
+		{
+			Type:     common.UpstreamTypeEvm,
+			Id:       "rpc1",
+			Endpoint: "http://rpc1.localhost",
+			Evm: &common.EvmUpstreamConfig{
+				ChainId: 123,
+			},
+			Failsafe: []*common.FailsafeConfig{{
+				Timeout: timeoutConfig,
+			}},
+		},
+	}
+
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm: &common.EvmNetworkConfig{
+			ChainId: 123,
+		},
+	}
+
+	return setupTestNetwork(t, ctx, upstreamConfigs, networkConfig)
 }
 
 // Helper to set up network with timeout policy

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -2266,6 +2266,121 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "description": "Dynamic timeout duration computed per request from method latency percentiles. Shows how the quantile-based timeout adapts to real traffic patterns.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 8,
+            "x": 8,
+            "y": 820
+          },
+          "id": 200,
+          "interval": "1m",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "rate(erpc_network_timeout_duration_seconds_sum{network=~\"${network:regex}\",category=~\"${category:regex}\",project=~\"${project:regex}\",finality=~\"${finality:regex}\"}[5m]) / rate(erpc_network_timeout_duration_seconds_count{network=~\"${network:regex}\",category=~\"${category:regex}\",project=~\"${project:regex}\",finality=~\"${finality:regex}\"}[5m])",
+              "interval": "",
+              "legendFormat": "avg {{project}}, {{network}}, {{category}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, rate(erpc_network_timeout_duration_seconds_bucket{network=~\"${network:regex}\",category=~\"${category:regex}\",project=~\"${project:regex}\",finality=~\"${finality:regex}\"}[5m]))",
+              "interval": "",
+              "legendFormat": "p99 {{project}}, {{network}}, {{category}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Dynamic Timeout Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "description": "Total hedge requests fired due to initial upstream being slow",
           "fieldConfig": {
             "defaults": {

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -453,6 +453,7 @@ var (
 	MetricNetworkEvmGetLogsRangeRequested     *LabeledHistogram
 	MetricNetworkEvmTraceFilterRangeRequested *LabeledHistogram
 	MetricNetworkHedgeDelaySeconds            *LabeledHistogram
+	MetricNetworkTimeoutDurationSeconds       *LabeledHistogram
 	MetricConsensusResponsesCollected         *LabeledHistogram
 	MetricConsensusAgreementCount             *LabeledHistogram
 	MetricX402FacilitatorRequestDuration      *LabeledHistogram
@@ -542,6 +543,13 @@ func buildFilterAwareHistograms(bucketsStr string) error {
 		Name:      "network_hedge_delay_seconds",
 		Help:      "Hedge delay used for requests (seconds).",
 		Buckets:   []float64{0.01, 0.03, 0.05, 0.2, 0.3, 0.5, 0.7, 1, 3},
+	}, []string{"project", "network", "category", "finality"})
+
+	MetricNetworkTimeoutDurationSeconds = NewLabeledHistogram(prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "network_timeout_duration_seconds",
+		Help:      "Dynamic timeout duration computed for requests (seconds).",
+		Buckets:   []float64{0.05, 0.1, 0.3, 0.5, 1, 3, 5, 10, 30},
 	}, []string{"project", "network", "category", "finality"})
 
 	MetricConsensusResponsesCollected = NewLabeledHistogram(prometheus.HistogramOpts{
@@ -635,6 +643,7 @@ func SetHistogramBuckets(bucketsStr string) error {
 	MetricNetworkEvmGetLogsRangeRequested = registerOrReuse(MetricNetworkEvmGetLogsRangeRequested)
 	MetricNetworkEvmTraceFilterRangeRequested = registerOrReuse(MetricNetworkEvmTraceFilterRangeRequested)
 	MetricNetworkHedgeDelaySeconds = registerOrReuse(MetricNetworkHedgeDelaySeconds)
+	MetricNetworkTimeoutDurationSeconds = registerOrReuse(MetricNetworkTimeoutDurationSeconds)
 	MetricConsensusResponsesCollected = registerOrReuse(MetricConsensusResponsesCollected)
 	MetricConsensusAgreementCount = registerOrReuse(MetricConsensusAgreementCount)
 	MetricX402FacilitatorRequestDuration = registerOrReuse(MetricX402FacilitatorRequestDuration)

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -214,6 +214,12 @@ var (
 		Help:      "Total number of hedged requests discarded towards a network (i.e. attempt > 1 means wasted requests).",
 	}, []string{"project", "network", "upstream", "category", "attempt", "hedge", "finality", "user", "agent_name"})
 
+	MetricNetworkTimeoutFiredTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_timeout_fired_total",
+		Help:      "Total number of requests that were killed by the timeout policy (fixed or quantile-based).",
+	}, []string{"project", "network", "category", "finality", "scope"})
+
 	MetricNetworkFailedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_failed_request_total",

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -630,6 +630,9 @@ export interface CircuitBreakerPolicyConfig {
 }
 export interface TimeoutPolicyConfig {
     duration?: Duration;
+    quantile?: number;
+    minDuration?: Duration;
+    maxDuration?: Duration;
 }
 export interface HedgePolicyConfig {
     delay?: Duration;

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -643,6 +643,9 @@ export interface CircuitBreakerPolicyConfig {
 }
 export interface TimeoutPolicyConfig {
   duration?: Duration;
+  quantile?: number /* float64 */;
+  minDuration?: Duration;
+  maxDuration?: Duration;
 }
 export interface HedgePolicyConfig {
   delay?: Duration;

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -32,7 +32,7 @@ func CreateFailSafePolicies(appCtx context.Context, logger *zerolog.Logger, scop
 
 	lg := logger.With().Str("scope", string(scope)).Str("entity", entity).Logger()
 
-	if fsCfg.Timeout != nil {
+	if fsCfg.Timeout != nil && fsCfg.Timeout.Quantile == 0 {
 		plc, err := createTimeoutPolicy(logger, fsCfg.Timeout)
 		if err != nil {
 			return nil, common.NewErrFailsafeConfiguration(
@@ -786,16 +786,9 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig, dynami
 }
 
 func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) (failsafe.Policy[*common.NormalizedResponse], error) {
-	// When quantile-based timeout is configured, the failsafe-go timeout policy
-	// acts as a safety net. It must be at least as large as any value NewTimeoutFunc
-	// can return (including Duration used as cold-start fallback) so it never
-	// silently truncates the dynamic or fallback timeout.
 	dur := cfg.Duration.Duration()
-	if cfg.Quantile > 0 {
-		maxDur := cfg.MaxDuration.Duration()
-		if maxDur > dur {
-			dur = maxDur
-		}
+	if dur <= 0 {
+		return nil, fmt.Errorf("timeout duration must be positive, got %v", dur)
 	}
 
 	builder := timeout.Builder[*common.NormalizedResponse](dur)

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -16,7 +16,6 @@ import (
 	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/failsafe-go/failsafe-go/hedgepolicy"
 	"github.com/failsafe-go/failsafe-go/retrypolicy"
-	"github.com/failsafe-go/failsafe-go/timeout"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -32,21 +31,10 @@ func CreateFailSafePolicies(appCtx context.Context, logger *zerolog.Logger, scop
 
 	lg := logger.With().Str("scope", string(scope)).Str("entity", entity).Logger()
 
-	if fsCfg.Timeout != nil && fsCfg.Timeout.Quantile == 0 {
-		plc, err := createTimeoutPolicy(logger, fsCfg.Timeout)
-		if err != nil {
-			return nil, common.NewErrFailsafeConfiguration(
-				err,
-				map[string]interface{}{
-					"scope":    scope,
-					"entity":   entity,
-					"policy":   "timeout",
-					"provider": fsCfg.Timeout,
-				},
-			)
-		}
-		policies["timeout"] = plc
-	}
+	// Timeout is applied via context.WithTimeoutCause at the request path
+	// (see Network.Forward and Upstream.Forward). We intentionally do not
+	// register a failsafe-go timeout.Policy — a single mechanism keeps error
+	// translation consistent for both fixed and quantile-based timeouts.
 
 	if fsCfg.Retry != nil {
 		p, err := createRetryPolicy(scope, fsCfg.Retry, dynamicBlockUnavailableDelay)
@@ -785,23 +773,6 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig, dynami
 	return builder.Build(), nil
 }
 
-func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) (failsafe.Policy[*common.NormalizedResponse], error) {
-	dur := cfg.Duration.Duration()
-	if dur <= 0 {
-		return nil, fmt.Errorf("timeout duration must be positive, got %v", dur)
-	}
-
-	builder := timeout.Builder[*common.NormalizedResponse](dur)
-
-	if logger.GetLevel() == zerolog.TraceLevel {
-		builder.OnTimeoutExceeded(func(event failsafe.ExecutionDoneEvent[*common.NormalizedResponse]) {
-			logger.Trace().Msgf("failsafe timeout policy: %v (start time: %v, elapsed: %v, attempts: %d, retries: %d, hedges: %d)", event.Error, event.StartTime().Format(time.RFC3339), event.ElapsedTime().String(), event.Attempts(), event.Retries(), event.Hedges())
-		})
-	}
-
-	return builder.Build(), nil
-}
-
 func coldStartFallback(fixedDur, maxDur time.Duration) *time.Duration {
 	fallback := fixedDur
 	if fallback == 0 {
@@ -813,9 +784,10 @@ func coldStartFallback(fixedDur, maxDur time.Duration) *time.Duration {
 	return nil
 }
 
-// NewTimeoutFunc builds a TimeoutFunc from config. When Quantile > 0, the
-// timeout is computed dynamically from method latency percentiles. Otherwise
-// it returns the fixed Duration.
+// NewTimeoutFunc builds a TimeoutFunc from config. The returned function is
+// applied at request time via context.WithTimeoutCause (see Network.Forward
+// and Upstream.Forward). When Quantile > 0 the timeout is computed per request
+// from method latency percentiles; otherwise it returns the fixed Duration.
 func NewTimeoutFunc(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) TimeoutFunc {
 	if cfg.Quantile > 0 {
 		fixedDur := cfg.Duration.Duration()
@@ -935,11 +907,15 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 	var err error
 	var retryExceededErr retrypolicy.ExceededError
 
-	// Our own standard error is returned when failsafe execution is returned and for example retry policy
-	// logic above decided it does not need to retry (e.g. reverted transaction error).
-	// Another case is an UpstreamExhausted error which is not going to be retried due to all errors being unretryable.
-	// In those cases we return the standard error object as is.
-	if serr, ok := execErr.(common.StandardError); ok {
+	// Timeout-policy firing takes precedence over StandardError short-circuiting.
+	// When the dynamic timeout fires mid-HTTP-request, the client wraps the
+	// cause as ErrEndpointTransportFailure (a StandardError), which would
+	// otherwise hide the timeout classification from the user. The sentinel
+	// cause is only ever set by our own context.WithTimeoutCause, so matching
+	// on it never picks up parent-context deadlines.
+	if errors.Is(execErr, ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
+	} else if serr, ok := execErr.(common.StandardError); ok {
 		err = serr
 	} else if errors.As(execErr, &retryExceededErr) {
 		// When retry policy is exceeded (i.e. we wanted to retry based on the policy but it ultimately failed)
@@ -969,8 +945,6 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
-	} else if errors.Is(execErr, timeout.ErrExceeded) || errors.Is(execErr, ErrDynamicTimeoutExceeded) {
-		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
 	} else if errors.Is(execErr, circuitbreaker.ErrOpen) {
 		// Simply translate the failsafe library circuit breaker error type to our own standard error type.
 		// And keep the original error as "cause" so it can be logged.

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -903,7 +903,14 @@ func createConsensusPolicy(logger *zerolog.Logger, cfg *common.ConsensusPolicyCo
 	return p, nil
 }
 
-func TranslateFailsafeError(scope common.Scope, upstreamId string, method string, execErr error, startTime *time.Time) error {
+// TranslateFailsafeError maps internal failsafe-go errors and context-cancellation
+// sentinels to erpc's public StandardError types.
+//
+// scopeOwnsTimeout must be true only when THIS scope actually configured a
+// timeout policy. A parent scope's ErrDynamicTimeoutExceeded sentinel leaks
+// into child contexts via inheritance, and without this guard the child scope
+// would re-classify it as if its own policy had fired.
+func TranslateFailsafeError(scope common.Scope, upstreamId string, method string, execErr error, startTime *time.Time, scopeOwnsTimeout bool) error {
 	var err error
 	var retryExceededErr retrypolicy.ExceededError
 
@@ -922,7 +929,7 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 		}
 		var translatedCause error
 		if ler != nil {
-			translatedCause = TranslateFailsafeError(scope, "", "", ler, startTime)
+			translatedCause = TranslateFailsafeError(scope, "", "", ler, startTime, scopeOwnsTimeout)
 		}
 		if exr, ok := translatedCause.(*common.ErrUpstreamsExhausted); ok {
 			// In this case we already have a grouping of all errors encountered via upstreams,
@@ -938,11 +945,14 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
-	} else if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+	} else if scopeOwnsTimeout && errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 		// Timeout-policy sentinel takes precedence over StandardError so that a
 		// timeout wrapped as ErrEndpointTransportFailure is still classified as a
 		// timeout. The sentinel is only set by our own context.WithTimeoutCause,
-		// so it never picks up parent-context deadlines.
+		// so it never picks up parent-context deadlines. The scopeOwnsTimeout
+		// guard ensures a parent scope's sentinel, inherited via ctx propagation,
+		// is NOT re-classified here as a child-scope timeout — it must flow up
+		// to the scope whose policy actually fired.
 		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
 	} else if serr, ok := execErr.(common.StandardError); ok {
 		err = serr

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -787,11 +787,15 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig, dynami
 
 func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) (failsafe.Policy[*common.NormalizedResponse], error) {
 	// When quantile-based timeout is configured, the failsafe-go timeout policy
-	// acts as a safety net using MaxDuration (or Duration as fallback). The actual
-	// dynamic timeout is enforced via context.WithTimeout in the executor callback.
+	// acts as a safety net. It must be at least as large as any value NewTimeoutFunc
+	// can return (including Duration used as cold-start fallback) so it never
+	// silently truncates the dynamic or fallback timeout.
 	dur := cfg.Duration.Duration()
-	if cfg.Quantile > 0 && cfg.MaxDuration.Duration() > 0 {
-		dur = cfg.MaxDuration.Duration()
+	if cfg.Quantile > 0 {
+		maxDur := cfg.MaxDuration.Duration()
+		if maxDur > dur {
+			dur = maxDur
+		}
 	}
 
 	builder := timeout.Builder[*common.NormalizedResponse](dur)

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -938,7 +938,7 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
-	} else if errors.Is(execErr, ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+	} else if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
 		// Timeout-policy sentinel takes precedence over StandardError so that a
 		// timeout wrapped as ErrEndpointTransportFailure is still classified as a
 		// timeout. The sentinel is only set by our own context.WithTimeoutCause,

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -969,7 +969,7 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
-	} else if errors.Is(execErr, timeout.ErrExceeded) || errors.Is(execErr, context.DeadlineExceeded) {
+	} else if errors.Is(execErr, timeout.ErrExceeded) || errors.Is(execErr, ErrDynamicTimeoutExceeded) {
 		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
 	} else if errors.Is(execErr, circuitbreaker.ErrOpen) {
 		// Simply translate the failsafe library circuit breaker error type to our own standard error type.

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -809,6 +809,17 @@ func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig
 	return builder.Build(), nil
 }
 
+func coldStartFallback(fixedDur, maxDur time.Duration) *time.Duration {
+	fallback := fixedDur
+	if fallback == 0 {
+		fallback = maxDur
+	}
+	if fallback > 0 {
+		return &fallback
+	}
+	return nil
+}
+
 // NewTimeoutFunc builds a TimeoutFunc from config. When Quantile > 0, the
 // timeout is computed dynamically from method latency percentiles. Otherwise
 // it returns the fixed Duration.
@@ -821,44 +832,43 @@ func NewTimeoutFunc(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) Tim
 
 		return func(ctx context.Context, req *common.NormalizedRequest) *time.Duration {
 			ntw := req.Network()
-			if ntw != nil {
-				m, _ := req.Method()
-				if m != "" {
-					mt := ntw.GetMethodMetrics(m)
-					if mt != nil {
-						qt := mt.GetResponseQuantiles()
-						dr := qt.GetQuantile(quantile)
-						if dr > 0 {
-							// Clamp to [minDur, maxDur]
-							if minDur > 0 && dr < minDur {
-								dr = minDur
-							}
-							if maxDur > 0 && dr > maxDur {
-								dr = maxDur
-							}
-							finality := req.Finality(ctx)
-							telemetry.ObserverHandle(
-								telemetry.MetricNetworkTimeoutDurationSeconds,
-								ntw.ProjectId(),
-								req.NetworkLabel(),
-								m,
-								finality.String(),
-							).Observe(dr.Seconds())
-							logger.Trace().Object("request", req).Dur("timeout", dr).Msgf("calculated dynamic timeout")
-							return &dr
-						}
-					}
-				}
+			if ntw == nil {
+				logger.Debug().Object("request", req).Msg("quantile timeout: no network on request, using fallback")
+				return coldStartFallback(fixedDur, maxDur)
 			}
-			// Cold start fallback: use Duration if set, otherwise MaxDuration.
-			fallback := fixedDur
-			if fallback == 0 {
-				fallback = maxDur
+			m, _ := req.Method()
+			if m == "" {
+				logger.Debug().Object("request", req).Msg("quantile timeout: empty method, using fallback")
+				return coldStartFallback(fixedDur, maxDur)
 			}
-			if fallback > 0 {
-				return &fallback
+			mt := ntw.GetMethodMetrics(m)
+			if mt == nil {
+				logger.Debug().Object("request", req).Str("method", m).Msg("quantile timeout: no metrics tracker, using fallback")
+				return coldStartFallback(fixedDur, maxDur)
 			}
-			return nil
+			qt := mt.GetResponseQuantiles()
+			dr := qt.GetQuantile(quantile)
+			if dr <= 0 {
+				logger.Debug().Object("request", req).Str("method", m).Msg("quantile timeout: no latency data yet, using fallback")
+				return coldStartFallback(fixedDur, maxDur)
+			}
+
+			if minDur > 0 && dr < minDur {
+				dr = minDur
+			}
+			if maxDur > 0 && dr > maxDur {
+				dr = maxDur
+			}
+			finality := req.Finality(ctx)
+			telemetry.ObserverHandle(
+				telemetry.MetricNetworkTimeoutDurationSeconds,
+				ntw.ProjectId(),
+				req.NetworkLabel(),
+				m,
+				finality.String(),
+			).Observe(dr.Seconds())
+			logger.Trace().Object("request", req).Dur("timeout", dr).Msgf("calculated dynamic timeout")
+			return &dr
 		}
 	}
 

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -969,9 +969,7 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
-	} else if errors.Is(execErr, timeout.ErrExceeded) {
-		// Simply translate the failsafe library timeout error type to our own standard error type.
-		// And keep the original error as "cause" so it can be logged.
+	} else if errors.Is(execErr, timeout.ErrExceeded) || errors.Is(execErr, context.DeadlineExceeded) {
 		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
 	} else if errors.Is(execErr, circuitbreaker.ErrOpen) {
 		// Simply translate the failsafe library circuit breaker error type to our own standard error type.

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -786,7 +786,15 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig, dynami
 }
 
 func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) (failsafe.Policy[*common.NormalizedResponse], error) {
-	builder := timeout.Builder[*common.NormalizedResponse](cfg.Duration.Duration())
+	// When quantile-based timeout is configured, the failsafe-go timeout policy
+	// acts as a safety net using MaxDuration (or Duration as fallback). The actual
+	// dynamic timeout is enforced via context.WithTimeout in the executor callback.
+	dur := cfg.Duration.Duration()
+	if cfg.Quantile > 0 && cfg.MaxDuration.Duration() > 0 {
+		dur = cfg.MaxDuration.Duration()
+	}
+
+	builder := timeout.Builder[*common.NormalizedResponse](dur)
 
 	if logger.GetLevel() == zerolog.TraceLevel {
 		builder.OnTimeoutExceeded(func(event failsafe.ExecutionDoneEvent[*common.NormalizedResponse]) {
@@ -795,6 +803,69 @@ func createTimeoutPolicy(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig
 	}
 
 	return builder.Build(), nil
+}
+
+// NewTimeoutFunc builds a TimeoutFunc from config. When Quantile > 0, the
+// timeout is computed dynamically from method latency percentiles. Otherwise
+// it returns the fixed Duration.
+func NewTimeoutFunc(logger *zerolog.Logger, cfg *common.TimeoutPolicyConfig) TimeoutFunc {
+	if cfg.Quantile > 0 {
+		fixedDur := cfg.Duration.Duration()
+		minDur := cfg.MinDuration.Duration()
+		maxDur := cfg.MaxDuration.Duration()
+		quantile := cfg.Quantile
+
+		return func(ctx context.Context, req *common.NormalizedRequest) *time.Duration {
+			ntw := req.Network()
+			if ntw != nil {
+				m, _ := req.Method()
+				if m != "" {
+					mt := ntw.GetMethodMetrics(m)
+					if mt != nil {
+						qt := mt.GetResponseQuantiles()
+						dr := qt.GetQuantile(quantile)
+						if dr > 0 {
+							// Clamp to [minDur, maxDur]
+							if minDur > 0 && dr < minDur {
+								dr = minDur
+							}
+							if maxDur > 0 && dr > maxDur {
+								dr = maxDur
+							}
+							finality := req.Finality(ctx)
+							telemetry.ObserverHandle(
+								telemetry.MetricNetworkTimeoutDurationSeconds,
+								ntw.ProjectId(),
+								req.NetworkLabel(),
+								m,
+								finality.String(),
+							).Observe(dr.Seconds())
+							logger.Trace().Object("request", req).Dur("timeout", dr).Msgf("calculated dynamic timeout")
+							return &dr
+						}
+					}
+				}
+			}
+			// Cold start fallback: use Duration if set, otherwise MaxDuration.
+			fallback := fixedDur
+			if fallback == 0 {
+				fallback = maxDur
+			}
+			if fallback > 0 {
+				return &fallback
+			}
+			return nil
+		}
+	}
+
+	// Fixed timeout: return the configured duration.
+	dur := cfg.Duration.Duration()
+	if dur == 0 {
+		return nil
+	}
+	return func(_ context.Context, _ *common.NormalizedRequest) *time.Duration {
+		return &dur
+	}
 }
 
 func createConsensusPolicy(logger *zerolog.Logger, cfg *common.ConsensusPolicyConfig) (failsafe.Policy[*common.NormalizedResponse], error) {

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -907,17 +907,10 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 	var err error
 	var retryExceededErr retrypolicy.ExceededError
 
-	// Timeout-policy firing takes precedence over StandardError short-circuiting.
-	// When the dynamic timeout fires mid-HTTP-request, the client wraps the
-	// cause as ErrEndpointTransportFailure (a StandardError), which would
-	// otherwise hide the timeout classification from the user. The sentinel
-	// cause is only ever set by our own context.WithTimeoutCause, so matching
-	// on it never picks up parent-context deadlines.
-	if errors.Is(execErr, ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
-		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
-	} else if serr, ok := execErr.(common.StandardError); ok {
-		err = serr
-	} else if errors.As(execErr, &retryExceededErr) {
+	// Retry-exceeded must be checked before the sentinel so that exhausted
+	// retries whose last attempt timed out are classified as retry-exceeded
+	// (with the timeout as the translated cause) rather than as a bare timeout.
+	if errors.As(execErr, &retryExceededErr) {
 		// When retry policy is exceeded (i.e. we wanted to retry based on the policy but it ultimately failed)
 		// we want to fetch the "last error" from the retry policy and wrap in our own standard error type of FailsafeRetryExceeded.
 		// This allows consistent error handling on http server level.
@@ -945,6 +938,14 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 				err = common.NewErrFailsafeRetryExceeded(scope, translatedCause, startTime)
 			}
 		}
+	} else if errors.Is(execErr, ErrDynamicTimeoutExceeded) && !common.HasErrorCode(execErr, common.ErrCodeFailsafeTimeoutExceeded) {
+		// Timeout-policy sentinel takes precedence over StandardError so that a
+		// timeout wrapped as ErrEndpointTransportFailure is still classified as a
+		// timeout. The sentinel is only set by our own context.WithTimeoutCause,
+		// so it never picks up parent-context deadlines.
+		err = common.NewErrFailsafeTimeoutExceeded(scope, execErr, startTime)
+	} else if serr, ok := execErr.(common.StandardError); ok {
+		err = serr
 	} else if errors.Is(execErr, circuitbreaker.ErrOpen) {
 		// Simply translate the failsafe library circuit breaker error type to our own standard error type.
 		// And keep the original error as "cause" so it can be logged.

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -677,7 +677,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 					string(common.ScopeUpstream),
 				).Inc()
 			}
-			return nil, TranslateFailsafeError(common.ScopeUpstream, u.config.Id, method, execErr, &startTime)
+			return nil, TranslateFailsafeError(common.ScopeUpstream, u.config.Id, method, execErr, &startTime, failsafeExecutor.timeout != nil)
 		}
 
 		return resp, nil

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -29,6 +29,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// ErrDynamicTimeoutExceeded is the cause set via context.WithTimeoutCause when
+// a quantile-based dynamic timeout fires. Used to distinguish from parent
+// context deadlines (e.g. HTTP server timeouts) in TranslateFailsafeError.
+var ErrDynamicTimeoutExceeded = errors.New("dynamic timeout exceeded")
+
 // TimeoutFunc computes the timeout for a request. Returns nil when no timeout applies.
 type TimeoutFunc func(ctx context.Context, req *common.NormalizedRequest) *time.Duration
 
@@ -641,13 +646,14 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 				if failsafeExecutor.timeout != nil {
 					if td := failsafeExecutor.timeout(ectx, nrq); td != nil {
 						var cancelFn context.CancelFunc
-						ectx, cancelFn = context.WithTimeout(
+						ectx, cancelFn = context.WithTimeoutCause(
 							ectx,
 							// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
 							//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
 							//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
 							//      but allow the failsafe execution to fail with timeout first for proper error handling.
 							*td+5*time.Millisecond,
+							ErrDynamicTimeoutExceeded,
 						)
 						defer cancelFn()
 					}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -29,12 +29,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// TimeoutFunc computes the timeout for a request. Returns nil when no timeout applies.
+type TimeoutFunc func(ctx context.Context, req *common.NormalizedRequest) *time.Duration
+
 // FailsafeExecutor wraps a failsafe executor with method and finality filters
 type FailsafeExecutor struct {
 	method     string
 	finalities []common.DataFinalityState
 	executor   failsafe.Executor[*common.NormalizedResponse]
-	timeout    *time.Duration
+	timeout    TimeoutFunc
 }
 
 type Upstream struct {
@@ -83,9 +86,9 @@ func NewUpstream(
 			}
 			policiesArray := ToPolicyArray(policiesMap, "retry", "circuitBreaker", "hedge", "timeout")
 
-			var timeoutDuration *time.Duration
+			var timeoutFn TimeoutFunc
 			if fsCfg.Timeout != nil {
-				timeoutDuration = fsCfg.Timeout.Duration.DurationPtr()
+				timeoutFn = NewTimeoutFunc(&lg, fsCfg.Timeout)
 			}
 
 			method := fsCfg.MatchMethod
@@ -96,7 +99,7 @@ func NewUpstream(
 				method:     method,
 				finalities: fsCfg.MatchFinality,
 				executor:   failsafe.NewExecutor(policiesArray...),
-				timeout:    timeoutDuration,
+				timeout:    timeoutFn,
 			})
 		}
 	}
@@ -636,16 +639,18 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 					}
 				}
 				if failsafeExecutor.timeout != nil {
-					var cancelFn context.CancelFunc
-					ectx, cancelFn = context.WithTimeout(
-						ectx,
-						// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
-						//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
-						//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
-						//      but allow the failsafe execution to fail with timeout first for proper error handling.
-						*failsafeExecutor.timeout+5*time.Millisecond,
-					)
-					defer cancelFn()
+					if td := failsafeExecutor.timeout(ectx, nrq); td != nil {
+						var cancelFn context.CancelFunc
+						ectx, cancelFn = context.WithTimeout(
+							ectx,
+							// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
+							//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
+							//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
+							//      but allow the failsafe execution to fail with timeout first for proper error handling.
+							*td+5*time.Millisecond,
+						)
+						defer cancelFn()
+					}
 				}
 
 				nr, err := tryForward(ectx, exec)

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -29,10 +29,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ErrDynamicTimeoutExceeded is the cause set via context.WithTimeoutCause when
-// a quantile-based dynamic timeout fires. Used to distinguish from parent
-// context deadlines (e.g. HTTP server timeouts) in TranslateFailsafeError.
-var ErrDynamicTimeoutExceeded = errors.New("dynamic timeout exceeded")
+// ErrDynamicTimeoutExceeded re-exports the common sentinel for backward
+// compatibility with callers that reference upstream.ErrDynamicTimeoutExceeded.
+var ErrDynamicTimeoutExceeded = common.ErrDynamicTimeoutExceeded
 
 // TimeoutFunc computes the timeout for a request. Returns nil when no timeout applies.
 type TimeoutFunc func(ctx context.Context, req *common.NormalizedRequest) *time.Duration
@@ -89,7 +88,7 @@ func NewUpstream(
 			if err != nil {
 				return nil, err
 			}
-			policiesArray := ToPolicyArray(policiesMap, "retry", "circuitBreaker", "hedge", "timeout")
+			policiesArray := ToPolicyArray(policiesMap, "retry", "circuitBreaker", "hedge")
 
 			var timeoutFn TimeoutFunc
 			if fsCfg.Timeout != nil {
@@ -646,15 +645,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 				if failsafeExecutor.timeout != nil {
 					if td := failsafeExecutor.timeout(ectx, nrq); td != nil {
 						var cancelFn context.CancelFunc
-						ectx, cancelFn = context.WithTimeoutCause(
-							ectx,
-							// TODO Carrying the timeout helps setting correct timeout on actual http request to upstream (during batch mode).
-							//      Is there a way to do this cleanly? e.g. if failsafe lib works via context rather than Ticker?
-							//      5ms is a workaround to ensure context carries the timeout deadline (used when calling upstreams),
-							//      but allow the failsafe execution to fail with timeout first for proper error handling.
-							*td+5*time.Millisecond,
-							ErrDynamicTimeoutExceeded,
-						)
+						ectx, cancelFn = context.WithTimeoutCause(ectx, *td, ErrDynamicTimeoutExceeded)
 						defer cancelFn()
 					}
 				}
@@ -680,6 +671,16 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 
 		if execErr != nil {
 			common.SetTraceSpanError(span, execErr)
+			if errors.Is(execErr, ErrDynamicTimeoutExceeded) {
+				finality := nrq.Finality(ctx)
+				telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
+					u.ProjectId,
+					nrq.NetworkLabel(),
+					method,
+					finality.String(),
+					string(common.ScopeUpstream),
+				).Inc()
+			}
 			return nil, TranslateFailsafeError(common.ScopeUpstream, u.config.Id, method, execErr, &startTime)
 		}
 

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -24,6 +24,7 @@ import (
 	"github.com/erpc/erpc/thirdparty"
 	"github.com/erpc/erpc/util"
 	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -667,7 +668,14 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 
 		if execErr != nil {
 			common.SetTraceSpanError(span, execErr)
-			if failsafeExecutor.timeout != nil && errors.Is(execErr, common.ErrDynamicTimeoutExceeded) {
+			// Mirror TranslateFailsafeError's retry-exhausted-wins ordering: if the
+			// retry policy exhausted on a timeout-tail attempt, the user-visible
+			// classification is ErrFailsafeRetryExceeded — counting that as a
+			// timeout fire would contradict the metric's own description.
+			var retryExceededErr retrypolicy.ExceededError
+			if failsafeExecutor.timeout != nil &&
+				!errors.As(execErr, &retryExceededErr) &&
+				errors.Is(execErr, common.ErrDynamicTimeoutExceeded) {
 				finality := nrq.Finality(ctx)
 				telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 					u.ProjectId,

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -29,10 +29,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ErrDynamicTimeoutExceeded re-exports the common sentinel for backward
-// compatibility with callers that reference upstream.ErrDynamicTimeoutExceeded.
-var ErrDynamicTimeoutExceeded = common.ErrDynamicTimeoutExceeded
-
 // TimeoutFunc computes the timeout for a request. Returns nil when no timeout applies.
 type TimeoutFunc func(ctx context.Context, req *common.NormalizedRequest) *time.Duration
 
@@ -645,7 +641,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 				if failsafeExecutor.timeout != nil {
 					if td := failsafeExecutor.timeout(ectx, nrq); td != nil {
 						var cancelFn context.CancelFunc
-						ectx, cancelFn = context.WithTimeoutCause(ectx, *td, ErrDynamicTimeoutExceeded)
+						ectx, cancelFn = context.WithTimeoutCause(ectx, *td, common.ErrDynamicTimeoutExceeded)
 						defer cancelFn()
 					}
 				}
@@ -671,7 +667,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 
 		if execErr != nil {
 			common.SetTraceSpanError(span, execErr)
-			if errors.Is(execErr, ErrDynamicTimeoutExceeded) {
+			if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) {
 				finality := nrq.Finality(ctx)
 				telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 					u.ProjectId,

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -667,7 +667,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 
 		if execErr != nil {
 			common.SetTraceSpanError(span, execErr)
-			if errors.Is(execErr, common.ErrDynamicTimeoutExceeded) {
+			if failsafeExecutor.timeout != nil && errors.Is(execErr, common.ErrDynamicTimeoutExceeded) {
 				finality := nrq.Finality(ctx)
 				telemetry.MetricNetworkTimeoutFiredTotal.WithLabelValues(
 					u.ProjectId,


### PR DESCRIPTION
## Summary

- Extends `TimeoutPolicyConfig` with `Quantile`, `MinDuration`, `MaxDuration` fields — same shape as the hedge config.
- When `Quantile > 0`, timeout is computed dynamically from method latency percentiles (DDSketch p-quantile) at both network and upstream levels.
- When `Quantile` is 0 or omitted, behavior is unchanged (backward compatible).
- Cold start (no metrics yet) falls back to `Duration`, then `MaxDuration`.
- Adds `erpc_network_timeout_duration_seconds` histogram and `erpc_network_timeout_fired_total` counter.
- TypeScript config types updated.

## Architecture

**One path, not two.** Both fixed and quantile-based timeouts are applied via `context.WithTimeoutCause(ErrDynamicTimeoutExceeded)` at the request entry point in `Network.Forward` and `Upstream.Forward`. The failsafe-go `timeout.Policy` is no longer registered — previously it was used for fixed timeouts only, creating two parallel code paths and two error types to translate. Unifying the paths removes the `+5ms` race workaround and the dual error-matching in `TranslateFailsafeError`.

**Sentinel cause distinguishes policy firing from parent deadlines.** `common.ErrDynamicTimeoutExceeded` is set as the context cause exclusively by the timeout policy. The HTTP client and `TranslateFailsafeError` both match on this sentinel to route policy-driven timeouts to `ErrFailsafeTimeoutExceeded` (504), while parent-context deadlines (HTTP server timeouts, caller cancellation) pass through unchanged.

**`Duration` as fallback, not additive.** Unlike hedge where `Delay` is added to the quantile, `Duration` is used purely as a cold-start fallback. Timeout represents a total wait budget, not an offset.

**`TimeoutFunc` on `FailsafeExecutor`.** Replaces `*time.Duration` to allow per-request computation.

## Test plan

- [x] Fixed timeout backward compatibility (wraps as `ErrFailsafeTimeoutExceeded`)
- [x] Fixed timeout exceeding at both network and upstream scope
- [x] Quantile-based dynamic computation with histogram emission at both scopes
- [x] MinDuration boundary enforcement
- [x] Cold start fallback to Duration
- [x] Cold start fallback to MaxDuration (no Duration set)
- [x] Parent-context deadline does NOT get misclassified as policy timeout
- [x] Existing hedge and upstream tests pass (no regressions)
- [x] `go vet` clean

Closes ERPC-356

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request forwarding/timeout/error-translation paths at both network and upstream scope (including batching), so regressions could change timeout behavior, classification, or retry budgets despite strong new test coverage.
> 
> **Overview**
> Adds a **dynamic (quantile-based) timeout mode** to the `timeout` failsafe policy by extending `TimeoutPolicyConfig` with `quantile`, `minDuration`, and `maxDuration`, including validation and updated TypeScript config types.
> 
> Unifies timeout enforcement for both network- and upstream-scope by applying `context.WithTimeoutCause(..., common.ErrDynamicTimeoutExceeded)` in `Network.Forward` and `Upstream.Forward` (removing failsafe-go’s timeout policy), and updates HTTP JSON-RPC client (single + batch) to propagate `context.Cause` so policy-driven timeout classification survives batching and transport error paths.
> 
> Introduces new observability for dynamic timeouts: `erpc_network_timeout_duration_seconds` histogram (computed timeout values) and `erpc_network_timeout_fired_total` counter with scope attribution, plus docs and Grafana dashboard updates; adds comprehensive tests covering fixed backward-compat, quantile computation, cold-start fallbacks, lifecycle-scoped network timeouts, and misclassification/double-counting regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2345a9c3bcccc5492ad369846c51b408ad2a60ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->