### PR TITLE
feat: add domain allowlist support to api keys

### DIFF
--- a/auth/authorizer.go
+++ b/auth/authorizer.go
@@ -125,6 +125,9 @@ func (a *Authorizer) acquireRateLimitPermit(ctx context.Context, req *common.Nor
 	if effectiveBudget == "" {
 		return nil
 	}
+	if a.rateLimitersRegistry == nil {
+		return nil
+	}
 
 	rlb, errNetLimit := a.rateLimitersRegistry.GetBudget(effectiveBudget)
 	if errNetLimit != nil {

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
@@ -70,12 +71,13 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 			continue
 		}
 
-		// Attach user to the request early so downstream labels (user/agent) can be populated
+		if err := enforceOriginAllowlist(az.logger, req, user); err != nil {
+			return nil, err
+		}
+
+		// Attach user to the request only after full auth success (credential + origin)
 		if user != nil && req != nil {
 			req.SetUser(user)
-		}
-		if err := enforceOriginAllowlist(az.logger, req, user); err != nil {
-			return user, err
 		}
 		// If authentication is passed then apply and consume the rate limit
 		if err := az.acquireRateLimitPermit(ctx, req, method); err != nil {
@@ -105,14 +107,14 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 
 	origin := ""
 	if req != nil {
-		origin = req.RequestOrigin()
+		origin = strings.ToLower(req.RequestOrigin())
 	}
 	if origin == "" {
 		return common.NewErrAuthUnauthorized("origin", "missing request origin")
 	}
 
 	for _, allowedOrigin := range user.AllowedOrigins {
-		match, err := common.WildcardMatch(allowedOrigin, origin)
+		match, err := common.WildcardMatch(strings.ToLower(allowedOrigin), origin)
 		if err != nil {
 			if logger != nil {
 				logger.Warn().

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -122,7 +122,14 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 	}
 
 	for _, allowedOrigin := range user.AllowedOrigins {
-		match, err := common.WildcardMatch(strings.ToLower(allowedOrigin), origin)
+		lowered := strings.ToLower(allowedOrigin)
+		if !strings.ContainsAny(lowered, "*?!") {
+			if lowered == origin {
+				return nil
+			}
+			continue
+		}
+		match, err := common.WildcardMatch(lowered, origin)
 		if err != nil {
 			if logger != nil {
 				logger.Warn().

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -74,6 +74,9 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		if user != nil && req != nil {
 			req.SetUser(user)
 		}
+		if err := enforceOriginAllowlist(req, user); err != nil {
+			return user, err
+		}
 		// If authentication is passed then apply and consume the rate limit
 		if err := az.acquireRateLimitPermit(ctx, req, method); err != nil {
 			return user, err
@@ -93,6 +96,32 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 
 	// If no strategy matched or succeeded, consider the request unauthorized
 	return nil, common.NewErrAuthUnauthorized("n/a", errors.Join(errs...).Error())
+}
+
+func enforceOriginAllowlist(req *common.NormalizedRequest, user *common.User) error {
+	if user == nil || len(user.AllowedOrigins) == 0 {
+		return nil
+	}
+
+	origin := ""
+	if req != nil {
+		origin = req.RequestOrigin()
+	}
+	if origin == "" {
+		return common.NewErrAuthUnauthorized("origin", "missing request origin")
+	}
+
+	for _, allowedOrigin := range user.AllowedOrigins {
+		match, err := common.WildcardMatch(allowedOrigin, origin)
+		if err != nil {
+			continue
+		}
+		if match {
+			return nil
+		}
+	}
+
+	return common.NewErrAuthUnauthorized("origin", "request origin is not allowed")
 }
 
 // FindDatabaseConnector finds a database connector by ID from the strategies

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -78,7 +78,7 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		// credential already identified the user, so the origin constraint applies
 		// to that specific user. Trying another strategy with the same credential
 		// but a different origin config would be semantically incorrect.
-		if err := enforceOriginAllowlist(az.logger, req, user); err != nil {
+		if err := enforceOriginAllowlist(az.logger, req, user, string(az.cfg.Type)); err != nil {
 			return nil, err
 		}
 
@@ -107,7 +107,7 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 	return nil, common.NewErrAuthUnauthorized("n/a", errors.Join(errs...).Error())
 }
 
-func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedRequest, user *common.User) error {
+func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedRequest, user *common.User, strategyType string) error {
 	if user == nil || len(user.AllowedOrigins) == 0 {
 		return nil
 	}
@@ -117,7 +117,7 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 		origin = strings.ToLower(req.RequestOrigin())
 	}
 	if origin == "" {
-		recordOriginFailureMetric(req, "missing_origin")
+		recordOriginFailureMetric(req, strategyType, "missing_origin")
 		return common.NewErrAuthUnauthorized("origin", "missing request origin")
 	}
 
@@ -146,11 +146,11 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 		}
 	}
 
-	recordOriginFailureMetric(req, "origin_not_allowed")
+	recordOriginFailureMetric(req, strategyType, "origin_not_allowed")
 	return common.NewErrAuthUnauthorized("origin", "request origin is not allowed")
 }
 
-func recordOriginFailureMetric(req *common.NormalizedRequest, reason string) {
+func recordOriginFailureMetric(req *common.NormalizedRequest, strategy string, reason string) {
 	project := "n/a"
 	network := "n/a"
 	agent := "unknown"
@@ -166,7 +166,7 @@ func recordOriginFailureMetric(req *common.NormalizedRequest, reason string) {
 	telemetry.MetricAuthFailedTotal.WithLabelValues(
 		project,
 		network,
-		"origin",
+		strategy,
 		reason,
 		agent,
 	).Inc()

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -74,7 +74,7 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		if user != nil && req != nil {
 			req.SetUser(user)
 		}
-		if err := enforceOriginAllowlist(req, user); err != nil {
+		if err := enforceOriginAllowlist(az.logger, req, user); err != nil {
 			return user, err
 		}
 		// If authentication is passed then apply and consume the rate limit
@@ -98,7 +98,7 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 	return nil, common.NewErrAuthUnauthorized("n/a", errors.Join(errs...).Error())
 }
 
-func enforceOriginAllowlist(req *common.NormalizedRequest, user *common.User) error {
+func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedRequest, user *common.User) error {
 	if user == nil || len(user.AllowedOrigins) == 0 {
 		return nil
 	}
@@ -114,6 +114,14 @@ func enforceOriginAllowlist(req *common.NormalizedRequest, user *common.User) er
 	for _, allowedOrigin := range user.AllowedOrigins {
 		match, err := common.WildcardMatch(allowedOrigin, origin)
 		if err != nil {
+			if logger != nil {
+				logger.Warn().
+					Str("userId", user.Id).
+					Str("pattern", allowedOrigin).
+					Str("origin", origin).
+					Err(err).
+					Msg("invalid allowedOrigins pattern, skipping")
+			}
 			continue
 		}
 		if match {

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -71,6 +71,12 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 			continue
 		}
 
+		// Origin check runs after credential validation. On failure we return
+		// immediately instead of continuing to the next strategy (unlike credential
+		// failures which append to errs and continue). This is intentional: the
+		// credential already identified the user, so the origin constraint applies
+		// to that specific user. Trying another strategy with the same credential
+		// but a different origin config would be semantically incorrect.
 		if err := enforceOriginAllowlist(az.logger, req, user); err != nil {
 			return nil, err
 		}

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/upstream"
 	"github.com/rs/zerolog"
 )
@@ -116,6 +117,7 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 		origin = strings.ToLower(req.RequestOrigin())
 	}
 	if origin == "" {
+		recordOriginFailureMetric(req, "missing_origin")
 		return common.NewErrAuthUnauthorized("origin", "missing request origin")
 	}
 
@@ -137,7 +139,30 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 		}
 	}
 
+	recordOriginFailureMetric(req, "origin_not_allowed")
 	return common.NewErrAuthUnauthorized("origin", "request origin is not allowed")
+}
+
+func recordOriginFailureMetric(req *common.NormalizedRequest, reason string) {
+	project := "n/a"
+	network := "n/a"
+	agent := "unknown"
+	if req != nil {
+		if n := req.Network(); n != nil {
+			project = n.ProjectId()
+			network = req.NetworkLabel()
+		} else {
+			network = req.NetworkId()
+		}
+		agent = req.AgentName()
+	}
+	telemetry.MetricAuthFailedTotal.WithLabelValues(
+		project,
+		network,
+		"origin",
+		reason,
+		agent,
+	).Inc()
 }
 
 // FindDatabaseConnector finds a database connector by ID from the strategies

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -123,7 +123,7 @@ func enforceOriginAllowlist(logger *zerolog.Logger, req *common.NormalizedReques
 
 	for _, allowedOrigin := range user.AllowedOrigins {
 		lowered := strings.ToLower(allowedOrigin)
-		if !strings.ContainsAny(lowered, "*?!") {
+		if !strings.ContainsAny(lowered, "*?!|&() ") {
 			if lowered == origin {
 				return nil
 			}

--- a/auth/registry_test.go
+++ b/auth/registry_test.go
@@ -94,7 +94,7 @@ func TestAuthRegistryAuthenticate_RejectsDisallowedOriginBeforeRateLimit(t *test
 		Secret: &SecretPayload{Value: "secret-value"},
 	})
 	require.Error(t, err)
-	assert.NotNil(t, user)
+	assert.Nil(t, user)
 	assert.True(t, common.HasErrorCode(err, common.ErrCodeAuthUnauthorized))
 	assert.False(t, common.HasErrorCode(err, common.ErrCodeAuthRateLimitRuleExceeded))
 }

--- a/auth/registry_test.go
+++ b/auth/registry_test.go
@@ -205,12 +205,13 @@ func TestDatabaseStrategyAuthenticate_LoadsAllowedOriginsFromRecordAndCacheInval
 	disallowedReq := newOriginAwareRequest(http.Header{
 		"Origin": []string{"https://new.example.com"},
 	})
-	_, err = registry.Authenticate(context.Background(), disallowedReq, "eth_call", &AuthPayload{
-		Type:   common.AuthTypeDatabase,
-		Secret: &SecretPayload{Value: "db-secret"},
-	})
-	require.Error(t, err)
-	assert.True(t, common.HasErrorCode(err, common.ErrCodeAuthUnauthorized))
+	require.Eventually(t, func() bool {
+		_, err = registry.Authenticate(context.Background(), disallowedReq, "eth_call", &AuthPayload{
+			Type:   common.AuthTypeDatabase,
+			Secret: &SecretPayload{Value: "db-secret"},
+		})
+		return common.HasErrorCode(err, common.ErrCodeAuthUnauthorized)
+	}, time.Second, 10*time.Millisecond)
 
 	authorizer := registry.strategies[0]
 	dbStrategy, ok := authorizer.strategy.(*DatabaseStrategy)

--- a/auth/registry_test.go
+++ b/auth/registry_test.go
@@ -196,6 +196,13 @@ func TestDatabaseStrategyAuthenticate_LoadsAllowedOriginsFromRecordAndCacheInval
 	assert.Equal(t, []string{"https://app.example.com"}, user.AllowedOrigins)
 	assert.Equal(t, "db-budget", user.RateLimitBudget)
 
+	authorizer := registry.strategies[0]
+	dbStrategy, ok := authorizer.strategy.(*DatabaseStrategy)
+	require.True(t, ok)
+	if dbStrategy.cache != nil {
+		dbStrategy.cache.Wait()
+	}
+
 	writeDatabaseUserRecord(t, connector, "db-secret", map[string]interface{}{
 		"userId":         "db-user",
 		"enabled":        true,
@@ -205,18 +212,17 @@ func TestDatabaseStrategyAuthenticate_LoadsAllowedOriginsFromRecordAndCacheInval
 	disallowedReq := newOriginAwareRequest(http.Header{
 		"Origin": []string{"https://new.example.com"},
 	})
-	require.Eventually(t, func() bool {
-		_, err = registry.Authenticate(context.Background(), disallowedReq, "eth_call", &AuthPayload{
-			Type:   common.AuthTypeDatabase,
-			Secret: &SecretPayload{Value: "db-secret"},
-		})
-		return common.HasErrorCode(err, common.ErrCodeAuthUnauthorized)
-	}, time.Second, 10*time.Millisecond)
+	_, err = registry.Authenticate(context.Background(), disallowedReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeDatabase,
+		Secret: &SecretPayload{Value: "db-secret"},
+	})
+	require.Error(t, err)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeAuthUnauthorized))
 
-	authorizer := registry.strategies[0]
-	dbStrategy, ok := authorizer.strategy.(*DatabaseStrategy)
-	require.True(t, ok)
 	dbStrategy.InvalidateCache("db-secret")
+	if dbStrategy.cache != nil {
+		dbStrategy.cache.Wait()
+	}
 
 	refreshedReq := newOriginAwareRequest(http.Header{
 		"Origin": []string{"https://new.example.com"},

--- a/auth/registry_test.go
+++ b/auth/registry_test.go
@@ -1,0 +1,268 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/upstream"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthRegistryAuthenticate_AllowsMatchingOriginForSecretStrategy(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestAuthRegistry(t, &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeSecret,
+			Secret: &common.SecretStrategyConfig{
+				Id:             "secret-user",
+				Value:          "secret-value",
+				AllowedOrigins: []string{"https://app.example.com"},
+			},
+		}},
+	}, nil)
+
+	req := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://app.example.com"},
+	})
+
+	user, err := registry.Authenticate(context.Background(), req, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{Value: "secret-value"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, "secret-user", user.Id)
+	assert.Equal(t, []string{"https://app.example.com"}, user.AllowedOrigins)
+	assert.Equal(t, user, req.User())
+}
+
+func TestAuthRegistryAuthenticate_RejectsDisallowedOriginBeforeRateLimit(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.New(io.Discard)
+	rateLimiters, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
+		Store: &common.RateLimitStoreConfig{
+			Driver: "memory",
+		},
+		Budgets: []*common.RateLimitBudgetConfig{{
+			Id: "auth-budget",
+			Rules: []*common.RateLimitRuleConfig{{
+				Method:   "*",
+				MaxCount: 1,
+				Period:   common.RateLimitPeriodMinute,
+				PerUser:  true,
+			}},
+		}},
+	}, &logger)
+	require.NoError(t, err)
+
+	registry := newTestAuthRegistry(t, &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeSecret,
+			Secret: &common.SecretStrategyConfig{
+				Id:             "secret-user",
+				Value:          "secret-value",
+				AllowedOrigins: []string{"https://app.example.com"},
+			},
+			RateLimitBudget: "auth-budget",
+		}},
+	}, rateLimiters)
+
+	firstReq := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://app.example.com"},
+	})
+	_, err = registry.Authenticate(context.Background(), firstReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{Value: "secret-value"},
+	})
+	require.NoError(t, err)
+
+	secondReq := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://evil.example.com"},
+	})
+	user, err := registry.Authenticate(context.Background(), secondReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{Value: "secret-value"},
+	})
+	require.Error(t, err)
+	assert.NotNil(t, user)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeAuthUnauthorized))
+	assert.False(t, common.HasErrorCode(err, common.ErrCodeAuthRateLimitRuleExceeded))
+}
+
+func TestAuthRegistryAuthenticate_UsesRefererFallback(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestAuthRegistry(t, &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeSecret,
+			Secret: &common.SecretStrategyConfig{
+				Id:             "secret-user",
+				Value:          "secret-value",
+				AllowedOrigins: []string{"https://app.example.com"},
+			},
+		}},
+	}, nil)
+
+	req := newOriginAwareRequest(http.Header{
+		"Referer": []string{"https://app.example.com/dashboard?tab=rpc"},
+	})
+
+	user, err := registry.Authenticate(context.Background(), req, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{Value: "secret-value"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, "https://app.example.com", req.RequestOrigin())
+}
+
+func TestAuthRegistryAuthenticate_EmptyAllowedOriginsRemainUnrestricted(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestAuthRegistry(t, &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeSecret,
+			Secret: &common.SecretStrategyConfig{
+				Id:    "secret-user",
+				Value: "secret-value",
+			},
+		}},
+	}, nil)
+
+	req := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://anywhere.example.com"},
+	})
+
+	user, err := registry.Authenticate(context.Background(), req, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeSecret,
+		Secret: &SecretPayload{Value: "secret-value"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Empty(t, user.AllowedOrigins)
+}
+
+func TestDatabaseStrategyAuthenticate_LoadsAllowedOriginsFromRecordAndCacheInvalidation(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestAuthRegistry(t, &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeDatabase,
+			Database: &common.DatabaseStrategyConfig{
+				Connector: &common.ConnectorConfig{
+					Id:     "auth-db",
+					Driver: common.DriverMemory,
+					Memory: &common.MemoryConnectorConfig{
+						MaxItems:     100,
+						MaxTotalSize: "1MB",
+					},
+				},
+				Cache: &common.DatabaseStrategyCacheConfig{
+					TTL: durationPtr(time.Minute),
+				},
+			},
+		}},
+	}, nil)
+
+	connector, err := registry.FindDatabaseConnector("auth-db")
+	require.NoError(t, err)
+
+	writeDatabaseUserRecord(t, connector, "db-secret", map[string]interface{}{
+		"userId":          "db-user",
+		"enabled":         true,
+		"allowedOrigins":  []string{"https://app.example.com"},
+		"rateLimitBudget": "db-budget",
+	})
+
+	allowedReq := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://app.example.com"},
+	})
+	user, err := registry.Authenticate(context.Background(), allowedReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeDatabase,
+		Secret: &SecretPayload{Value: "db-secret"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, []string{"https://app.example.com"}, user.AllowedOrigins)
+	assert.Equal(t, "db-budget", user.RateLimitBudget)
+
+	writeDatabaseUserRecord(t, connector, "db-secret", map[string]interface{}{
+		"userId":         "db-user",
+		"enabled":        true,
+		"allowedOrigins": []string{"https://new.example.com"},
+	})
+
+	disallowedReq := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://new.example.com"},
+	})
+	_, err = registry.Authenticate(context.Background(), disallowedReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeDatabase,
+		Secret: &SecretPayload{Value: "db-secret"},
+	})
+	require.Error(t, err)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeAuthUnauthorized))
+
+	authorizer := registry.strategies[0]
+	dbStrategy, ok := authorizer.strategy.(*DatabaseStrategy)
+	require.True(t, ok)
+	dbStrategy.InvalidateCache("db-secret")
+
+	refreshedReq := newOriginAwareRequest(http.Header{
+		"Origin": []string{"https://new.example.com"},
+	})
+	user, err = registry.Authenticate(context.Background(), refreshedReq, "eth_call", &AuthPayload{
+		Type:   common.AuthTypeDatabase,
+		Secret: &SecretPayload{Value: "db-secret"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, []string{"https://new.example.com"}, user.AllowedOrigins)
+}
+
+func newTestAuthRegistry(t *testing.T, cfg *common.AuthConfig, rateLimiters *upstream.RateLimitersRegistry) *AuthRegistry {
+	t.Helper()
+
+	for _, strategy := range cfg.Strategies {
+		require.NoError(t, strategy.SetDefaults())
+	}
+
+	logger := zerolog.New(io.Discard)
+	registry, err := NewAuthRegistry(context.Background(), &logger, "test-project", cfg, rateLimiters)
+	require.NoError(t, err)
+	return registry
+}
+
+func newOriginAwareRequest(headers http.Header) *common.NormalizedRequest {
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_call","params":[],"id":1}`))
+	req.EnrichFromHttp(headers, nil, common.UserAgentTrackingModeSimplified)
+	return req
+}
+
+func writeDatabaseUserRecord(t *testing.T, connector data.Connector, apiKey string, payload map[string]interface{}) {
+	t.Helper()
+
+	value, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	err = connector.Set(context.Background(), apiKey, "*", value, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, getErr := connector.Get(context.Background(), data.ConnectorMainIndex, apiKey, "*", nil)
+		return getErr == nil
+	}, time.Second, 10*time.Millisecond)
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}

--- a/auth/strategy_database.go
+++ b/auth/strategy_database.go
@@ -188,7 +188,16 @@ func (s *DatabaseStrategy) Authenticate(ctx context.Context, req *common.Normali
 			user.RateLimitBudget = userData.RateLimitBudget
 		}
 		if len(userData.AllowedOrigins) > 0 {
-			user.AllowedOrigins = userData.AllowedOrigins
+			if len(userData.AllowedOrigins) > common.MaxAllowedOriginsPerKey {
+				s.logger.Warn().
+					Str("apiKey", apiKey).
+					Int("count", len(userData.AllowedOrigins)).
+					Int("max", common.MaxAllowedOriginsPerKey).
+					Msg("allowedOrigins exceeds maximum, truncating")
+				user.AllowedOrigins = userData.AllowedOrigins[:common.MaxAllowedOriginsPerKey]
+			} else {
+				user.AllowedOrigins = userData.AllowedOrigins
+			}
 		}
 		return &authFetchResult{user: user, err: nil, neg: false}, nil
 	})

--- a/auth/strategy_database.go
+++ b/auth/strategy_database.go
@@ -292,6 +292,10 @@ func (s *DatabaseStrategy) ClearCache() {
 		s.cache.Clear()
 		s.logger.Info().Msg("cleared all API key cache entries")
 	}
+	if s.negCache != nil {
+		s.negCache.Clear()
+		s.logger.Info().Msg("cleared all API key negative cache entries")
+	}
 }
 
 // Close closes the cache and performs cleanup

--- a/auth/strategy_database.go
+++ b/auth/strategy_database.go
@@ -159,9 +159,10 @@ func (s *DatabaseStrategy) Authenticate(ctx context.Context, req *common.Normali
 		}
 
 		var userData struct {
-			UserId          string `json:"userId"`
-			Enabled         *bool  `json:"enabled,omitempty"`
-			RateLimitBudget string `json:"rateLimitBudget,omitempty"`
+			UserId          string   `json:"userId"`
+			Enabled         *bool    `json:"enabled,omitempty"`
+			RateLimitBudget string   `json:"rateLimitBudget,omitempty"`
+			AllowedOrigins  []string `json:"allowedOrigins,omitempty"`
 		}
 		if err := json.Unmarshal(valueBytes, &userData); err != nil {
 			s.logger.Error().Err(err).Str("apiKey", apiKey).RawJSON("data", valueBytes).Msg("failed to parse user data from database")
@@ -185,6 +186,9 @@ func (s *DatabaseStrategy) Authenticate(ctx context.Context, req *common.Normali
 		user := &common.User{Id: userData.UserId}
 		if userData.RateLimitBudget != "" {
 			user.RateLimitBudget = userData.RateLimitBudget
+		}
+		if len(userData.AllowedOrigins) > 0 {
+			user.AllowedOrigins = userData.AllowedOrigins
 		}
 		return &authFetchResult{user: user, err: nil, neg: false}, nil
 	})
@@ -275,6 +279,10 @@ func (s *DatabaseStrategy) InvalidateCache(apiKey string) {
 	if s.cache != nil {
 		s.cache.Del(apiKey)
 		s.logger.Debug().Str("apiKey", apiKey).Msg("invalidated API key cache entry")
+	}
+	if s.negCache != nil {
+		s.negCache.Del(apiKey)
+		s.logger.Debug().Str("apiKey", apiKey).Msg("invalidated API key negative cache entry")
 	}
 }
 

--- a/auth/strategy_database.go
+++ b/auth/strategy_database.go
@@ -188,16 +188,28 @@ func (s *DatabaseStrategy) Authenticate(ctx context.Context, req *common.Normali
 			user.RateLimitBudget = userData.RateLimitBudget
 		}
 		if len(userData.AllowedOrigins) > 0 {
-			if len(userData.AllowedOrigins) > common.MaxAllowedOriginsPerKey {
+			origins := userData.AllowedOrigins
+			if len(origins) > common.MaxAllowedOriginsPerKey {
 				s.logger.Warn().
 					Str("apiKey", apiKey).
-					Int("count", len(userData.AllowedOrigins)).
+					Int("count", len(origins)).
 					Int("max", common.MaxAllowedOriginsPerKey).
 					Msg("allowedOrigins exceeds maximum, truncating")
-				user.AllowedOrigins = userData.AllowedOrigins[:common.MaxAllowedOriginsPerKey]
-			} else {
-				user.AllowedOrigins = userData.AllowedOrigins
+				origins = origins[:common.MaxAllowedOriginsPerKey]
 			}
+			valid := make([]string, 0, len(origins))
+			for _, pattern := range origins {
+				if err := common.ValidatePattern(pattern); err != nil {
+					s.logger.Warn().
+						Str("apiKey", apiKey).
+						Str("pattern", pattern).
+						Err(err).
+						Msg("dropping invalid allowedOrigins pattern from DB record")
+					continue
+				}
+				valid = append(valid, pattern)
+			}
+			user.AllowedOrigins = valid
 		}
 		return &authFetchResult{user: user, err: nil, neg: false}, nil
 	})

--- a/auth/strategy_secret.go
+++ b/auth/strategy_secret.go
@@ -29,5 +29,8 @@ func (s *SecretStrategy) Authenticate(ctx context.Context, req *common.Normalize
 	if s.cfg.RateLimitBudget != "" {
 		user.RateLimitBudget = s.cfg.RateLimitBudget
 	}
+	if len(s.cfg.AllowedOrigins) > 0 {
+		user.AllowedOrigins = s.cfg.AllowedOrigins
+	}
 	return user, nil
 }

--- a/common/config.go
+++ b/common/config.go
@@ -1747,14 +1747,19 @@ type SecretStrategyConfig struct {
 	AllowedOrigins  []string `yaml:"allowedOrigins,omitempty" json:"allowedOrigins,omitempty"`
 }
 
-// custom json marshaller to redact the secret value
+// custom json marshaller to redact the secret value while respecting omitempty semantics
 func (s *SecretStrategyConfig) MarshalJSON() ([]byte, error) {
-	return sonic.Marshal(map[string]interface{}{
-		"id":              s.Id,
-		"value":           "REDACTED",
-		"rateLimitBudget": s.RateLimitBudget,
-		"allowedOrigins":  s.AllowedOrigins,
-	})
+	m := map[string]interface{}{
+		"id":    s.Id,
+		"value": "REDACTED",
+	}
+	if s.RateLimitBudget != "" {
+		m["rateLimitBudget"] = s.RateLimitBudget
+	}
+	if len(s.AllowedOrigins) > 0 {
+		m["allowedOrigins"] = s.AllowedOrigins
+	}
+	return sonic.Marshal(m)
 }
 
 type DatabaseStrategyConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -832,8 +832,8 @@ func (c *JsonRpcUpstreamConfig) Copy() *JsonRpcUpstreamConfig {
 }
 
 type EvmUpstreamConfig struct {
-	ChainId                            int64                       `yaml:"chainId" json:"chainId"`
-	StatePollerInterval                Duration                    `yaml:"statePollerInterval,omitempty" json:"statePollerInterval" tstype:"Duration"`
+	ChainId             int64    `yaml:"chainId" json:"chainId"`
+	StatePollerInterval Duration `yaml:"statePollerInterval,omitempty" json:"statePollerInterval" tstype:"Duration"`
 	// StatePollerDebounce overrides the debounce interval for the state poller.
 	// When 0 (default), the interval is dynamically inferred from the chain's
 	// observed block time, falling back to the network-level
@@ -1739,7 +1739,8 @@ type SecretStrategyConfig struct {
 	Id    string `yaml:"id" json:"id"`
 	Value string `yaml:"value" json:"value"`
 	// RateLimitBudget, if set, is applied to the authenticated user from this strategy
-	RateLimitBudget string `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget,omitempty"`
+	RateLimitBudget string   `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget,omitempty"`
+	AllowedOrigins  []string `yaml:"allowedOrigins,omitempty" json:"allowedOrigins,omitempty"`
 }
 
 // custom json marshaller to redact the secret value

--- a/common/config.go
+++ b/common/config.go
@@ -1749,8 +1749,11 @@ type SecretStrategyConfig struct {
 
 // custom json marshaller to redact the secret value
 func (s *SecretStrategyConfig) MarshalJSON() ([]byte, error) {
-	return sonic.Marshal(map[string]string{
-		"value": "REDACTED",
+	return sonic.Marshal(map[string]interface{}{
+		"id":              s.Id,
+		"value":           "REDACTED",
+		"rateLimitBudget": s.RateLimitBudget,
+		"allowedOrigins":  s.AllowedOrigins,
 	})
 }
 

--- a/common/request.go
+++ b/common/request.go
@@ -641,10 +641,12 @@ func hasDirectiveInQueryParams(queryArgs url.Values) bool {
 	return false
 }
 
-func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Values, mode UserAgentTrackingMode) {
-	hasDirectives := hasDirectiveInHeaders(headers) || hasDirectiveInQueryParams(queryArgs)
-
-	// Extract user agent (always needed)
+// EnrichTransportFromHttp records Origin / Referer-derived origin and User-Agent before authentication
+// or directive merging. Full EnrichFromHttp still runs later (after network directive defaults).
+func (r *NormalizedRequest) EnrichTransportFromHttp(headers http.Header, queryArgs url.Values, mode UserAgentTrackingMode) {
+	if r == nil {
+		return
+	}
 	userAgent := r.getUserAgent(headers, queryArgs)
 	if userAgent != "" {
 		if mode == UserAgentTrackingModeRaw {
@@ -659,6 +661,12 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 	} else if refererOrigin := extractRefererOrigin(headers.Get("Referer")); refererOrigin != "" {
 		r.refererOrigin.Store(refererOrigin)
 	}
+}
+
+func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Values, mode UserAgentTrackingMode) {
+	hasDirectives := hasDirectiveInHeaders(headers) || hasDirectiveInQueryParams(queryArgs)
+
+	r.EnrichTransportFromHttp(headers, queryArgs, mode)
 
 	if !hasDirectives {
 		return

--- a/common/request.go
+++ b/common/request.go
@@ -326,6 +326,10 @@ type NormalizedRequest struct {
 
 	// Resolved client IP (set by HTTP ingress using trusted forwarders)
 	clientIP atomic.Value
+
+	// HTTP origin metadata captured during ingress enrichment for auth enforcement.
+	origin        atomic.Value
+	refererOrigin atomic.Value
 }
 
 func NewNormalizedRequest(body []byte) *NormalizedRequest {
@@ -648,6 +652,12 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 		} else {
 			r.agentName.Store(r.simplifyAgentName(userAgent))
 		}
+	}
+
+	if origin := strings.TrimSpace(headers.Get("Origin")); origin != "" {
+		r.origin.Store(origin)
+	} else if refererOrigin := extractRefererOrigin(headers.Get("Referer")); refererOrigin != "" {
+		r.refererOrigin.Store(refererOrigin)
 	}
 
 	if !hasDirectives {
@@ -981,6 +991,40 @@ func (r *NormalizedRequest) ClientIP() string {
 	return "n/a"
 }
 
+func (r *NormalizedRequest) Origin() string {
+	if r == nil {
+		return ""
+	}
+	if v := r.origin.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func (r *NormalizedRequest) RefererOrigin() string {
+	if r == nil {
+		return ""
+	}
+	if v := r.refererOrigin.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func (r *NormalizedRequest) RequestOrigin() string {
+	if r == nil {
+		return ""
+	}
+	if origin := r.Origin(); origin != "" {
+		return origin
+	}
+	return r.RefererOrigin()
+}
+
 // TODO Move evm specific data to RequestMetadata struct so we can have multiple architectures besides evm
 func (r *NormalizedRequest) EvmBlockRef() interface{} {
 	if r == nil {
@@ -1142,6 +1186,12 @@ func (r *NormalizedRequest) CopyHttpContextFrom(source *NormalizedRequest) {
 	// Copy the user agent information
 	if agentName := source.agentName.Load(); agentName != nil {
 		r.agentName.Store(agentName)
+	}
+	if origin := source.Origin(); origin != "" {
+		r.origin.Store(origin)
+	}
+	if refererOrigin := source.RefererOrigin(); refererOrigin != "" {
+		r.refererOrigin.Store(refererOrigin)
 	}
 
 	// Also copy the user if it exists
@@ -1309,6 +1359,17 @@ func (r *NormalizedRequest) simplifyAgentName(userAgent string) string {
 	}
 
 	return "other"
+}
+
+func extractRefererOrigin(referer string) string {
+	if referer == "" {
+		return ""
+	}
+	parsed, err := url.Parse(strings.TrimSpace(referer))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	return parsed.Scheme + "://" + parsed.Host
 }
 
 func (r *NormalizedRequest) NextUpstream() (Upstream, error) {

--- a/common/request.go
+++ b/common/request.go
@@ -644,6 +644,7 @@ func hasDirectiveInQueryParams(queryArgs url.Values) bool {
 
 // EnrichTransportFromHttp records Origin / Referer-derived origin and User-Agent before authentication
 // or directive merging. Full EnrichFromHttp still runs later (after network directive defaults).
+// Safe to call multiple times; origin/referer are only stored on the first call.
 func (r *NormalizedRequest) EnrichTransportFromHttp(headers http.Header, queryArgs url.Values, mode UserAgentTrackingMode) {
 	if r == nil {
 		return
@@ -655,6 +656,10 @@ func (r *NormalizedRequest) EnrichTransportFromHttp(headers http.Header, queryAr
 		} else {
 			r.agentName.Store(r.simplifyAgentName(userAgent))
 		}
+	}
+
+	if r.origin.Load() != nil || r.refererOrigin.Load() != nil {
+		return
 	}
 
 	if origin := strings.TrimSpace(headers.Get("Origin")); origin != "" {

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -62,6 +62,29 @@ func TestUpstreamSelection_NonRetryableError_Skipped(t *testing.T) {
 	}
 }
 
+func TestNormalizedRequest_RequestOriginFromOriginHeader(t *testing.T) {
+	req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+	req.EnrichFromHttp(http.Header{
+		"Origin":  []string{"https://app.example.com"},
+		"Referer": []string{"https://ignored.example.com/path"},
+	}, nil, UserAgentTrackingModeSimplified)
+
+	if got := req.RequestOrigin(); got != "https://app.example.com" {
+		t.Fatalf("expected origin header to win, got %q", got)
+	}
+}
+
+func TestNormalizedRequest_RequestOriginFromRefererHeader(t *testing.T) {
+	req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+	req.EnrichFromHttp(http.Header{
+		"Referer": []string{"https://app.example.com/dashboard?tab=rpc"},
+	}, nil, UserAgentTrackingModeSimplified)
+
+	if got := req.RequestOrigin(); got != "https://app.example.com" {
+		t.Fatalf("expected referer origin fallback, got %q", got)
+	}
+}
+
 // TestUpstreamSelection_RetryableError_ClearedInSameCall tests that retryable errors
 // are cleared and upstream is returned in the SAME call (no wasted attempts).
 // This implements "try others first, then come back to retry" within a single NextUpstream call.

--- a/common/user.go
+++ b/common/user.go
@@ -3,4 +3,5 @@ package common
 type User struct {
 	Id              string
 	RateLimitBudget string
+	AllowedOrigins  []string
 }

--- a/common/validation.go
+++ b/common/validation.go
@@ -793,6 +793,11 @@ func (s *SecretStrategyConfig) Validate() error {
 	if len(s.AllowedOrigins) > MaxAllowedOriginsPerKey {
 		return fmt.Errorf("auth.*.secret.allowedOrigins exceeds maximum of %d entries", MaxAllowedOriginsPerKey)
 	}
+	for i, pattern := range s.AllowedOrigins {
+		if err := ValidatePattern(pattern); err != nil {
+			return fmt.Errorf("auth.*.secret.allowedOrigins[%d] has invalid pattern %q: %w", i, pattern, err)
+		}
+	}
 	return nil
 }
 

--- a/common/validation.go
+++ b/common/validation.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const MaxAllowedOriginsPerKey = 50
+
 func (c *Config) Validate() error {
 	if c.Server != nil {
 		if err := c.Server.Validate(); err != nil {
@@ -787,6 +789,9 @@ func (s *NetworkStrategyConfig) Validate() error {
 func (s *SecretStrategyConfig) Validate() error {
 	if s.Value == "" {
 		return fmt.Errorf("auth.*.secret.value is required")
+	}
+	if len(s.AllowedOrigins) > MaxAllowedOriginsPerKey {
+		return fmt.Errorf("auth.*.secret.allowedOrigins exceeds maximum of %d entries", MaxAllowedOriginsPerKey)
 	}
 	return nil
 }

--- a/docs/pages/config/auth.mdx
+++ b/docs/pages/config/auth.mdx
@@ -12,6 +12,7 @@ Each project can have one or more authentication strategies enabled. When any au
 
 The appropriate strategy will be activated based on request payload. For example if "token" is present as a query string then "secret" strategy will be activated. These are currently supported strategies:
 - [`secret`](#secret)
+- [`database`](#database)
 - [`network`](#network)
 - [`jwt`](#jwt)
 - [`siwe`](#siwe)
@@ -271,6 +272,9 @@ projects:
         secret:
           id: "custom-id-for-metrics"
           value: "some-random-secret-value" # To use env vars: ${MY_SECRET_VALUE}
+          allowedOrigins:
+          - "https://app.example.com"
+          - "https://*.example.com"
     upstreams:
     # ...
 rateLimiters:
@@ -305,6 +309,10 @@ export default createConfig({
             secret: {
               id: "custom-id-for-metrics",
               value: "some-random-secret-value", // To use env vars: process.env.MY_SECRET_VALUE
+              allowedOrigins: [
+                "https://app.example.com",
+                "https://*.example.com",
+              ],
             },
           },
         ],
@@ -334,6 +342,12 @@ export default createConfig({
 </Tabs.Tab>
 </Tabs>
 
+If `secret.allowedOrigins` is provided, eRPC only accepts requests whose `Origin` header matches one of the configured patterns. When `Origin` is missing, eRPC falls back to the `Referer` header and matches against its `scheme://host` portion. Wildcards use the same matcher as project CORS config, so patterns like `https://*.example.com` are supported.
+
+<Callout type="warning">
+    An empty `allowedOrigins` list means "no restriction". If you do configure it, non-browser clients must still send either an `Origin` header or a `Referer` header that resolves to an allowed origin, otherwise authentication will be rejected.
+</Callout>
+
 The client must provide this value either via a query string parameter:
 ```bash
 curl -X POST https://localhost:4000/main/evm/42161?secret=some-random-secret-value \
@@ -346,6 +360,89 @@ curl -X POST https://localhost:4000 \
   -H "X-ERPC-Secret-Token: some-random-secret-value"
   # ...
 ```
+
+## `database` strategy
+
+Use `database` strategy when API keys should be looked up from a connector instead of being hard-coded in config. This is useful when you want to add, disable, or update keys without rolling out config changes.
+
+<Callout type="info">
+    Database-backed API keys support the same runtime per-key fields as static secrets, including `rateLimitBudget` and `allowedOrigins`.
+</Callout>
+
+The auth strategy itself only configures where eRPC should read keys from:
+
+<Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
+  <Tabs.Tab>
+```yaml filename="erpc.yaml"
+projects:
+  - id: main
+    auth:
+      strategies:
+      - type: database
+        database:
+          connector:
+            id: auth-db
+            driver: postgresql
+            postgresql:
+              connectionUri: ${AUTH_DB_URI}
+          cache:
+            ttl: 1m
+    upstreams:
+    # ...
+```
+</Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="erpc.ts"
+import { createConfig } from "@erpc-cloud/config";
+
+export default createConfig({
+  projects: [
+    {
+      id: "main",
+      auth: {
+        strategies: [
+          {
+            type: "database",
+            database: {
+              connector: {
+                id: "auth-db",
+                driver: "postgresql",
+                postgresql: {
+                  connectionUri: process.env.AUTH_DB_URI!,
+                },
+              },
+              cache: {
+                ttl: "1m",
+              },
+            },
+          },
+        ],
+      },
+      upstreams: [
+        // ...
+      ],
+    },
+  ],
+});
+```
+</Tabs.Tab>
+</Tabs>
+
+Each API key record can then carry `userId`, `enabled`, and optional per-key controls such as `rateLimitBudget` and `allowedOrigins`:
+
+```json
+{
+  "userId": "customer-123",
+  "enabled": true,
+  "rateLimitBudget": "premium",
+  "allowedOrigins": [
+    "https://app.example.com",
+    "https://admin.example.com"
+  ]
+}
+```
+
+For database-backed keys, changing `allowedOrigins` is just a record update. After the cached entry is invalidated or expires, subsequent auth requests will enforce the new allowlist immediately.
 
 ## `network` strategy
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -445,6 +445,15 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 				method, _ := nq.Method()
 				rlg := lg.With().Str("method", method).Logger()
 
+				// Origin / Referer must be on the request before auth (e.g. API key origin allowlists).
+				if project != nil {
+					uaMode := common.UserAgentTrackingModeSimplified
+					if project.Config.UserAgentMode != "" {
+						uaMode = project.Config.UserAgentMode
+					}
+					nq.EnrichTransportFromHttp(headers, queryArgs, uaMode)
+				}
+
 				var ap *auth.AuthPayload
 				var err error
 

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -931,6 +931,7 @@ export interface SecretStrategyConfig {
      * RateLimitBudget, if set, is applied to the authenticated user from this strategy
      */
     rateLimitBudget?: string;
+    allowedOrigins?: string[];
 }
 export interface DatabaseStrategyConfig {
     connector?: ConnectorConfig;
@@ -1079,5 +1080,6 @@ export type Upstream = any;
 export interface User {
     id: string;
     ratelimitbudget: string;
+    allowedOrigins?: string[];
 }
 //# sourceMappingURL=generated.d.ts.map

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -938,6 +938,7 @@ export interface SecretStrategyConfig {
    * RateLimitBudget, if set, is applied to the authenticated user from this strategy
    */
   rateLimitBudget?: string;
+  allowedOrigins?: string[];
 }
 export interface DatabaseStrategyConfig {
   connector?: ConnectorConfig;
@@ -1104,4 +1105,5 @@ export type Upstream = any;
 export interface User {
   id: string;
   ratelimitbudget: string;
+  allowedOrigins?: string[];
 }


### PR DESCRIPTION
## Summary
- add per-key allowed origin support to secret and database auth users
- enforce request origin or referer-derived origin in auth before rate limiting
- cover secret, database, fallback, and ordering behavior with targeted auth/common tests

## Validation
- go test ./auth/... ./common/...
- go vet ./auth/... ./common/...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new origin-based authorization checks to the authentication flow, which can block previously-working clients (especially non-browser callers) if `Origin`/`Referer` is missing or misconfigured. Also changes auth ordering (origin checked before rate limiting) and touches request ingress enrichment, so regressions would surface early in request handling.
> 
> **Overview**
> Adds per-API-key origin allowlisting via `allowedOrigins` for `secret`-configured keys and database-backed keys, enforcing matches against the request `Origin` (with `Referer` scheme/host fallback) using wildcard patterns.
> 
> Auth flow now validates origin *after* credential validation but *before* attaching the user to the request and before consuming rate limits; origin failures emit `MetricAuthFailedTotal` with specific reasons. Request ingestion captures origin/referer earlier (`EnrichTransportFromHttp`) so auth can enforce it, and database strategy parsing now loads/validates/truncates `allowedOrigins` plus clears negative cache entries on invalidation.
> 
> Updates config/schema + TypeScript generated types, adds validation limits (`MaxAllowedOriginsPerKey`), and documents/testing coverage for secret/database origin enforcement, referer fallback, and rate-limit ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54e62f40bc4b8ae791a252eb7b01fbf13931f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->