### PR TITLE
ci: add Logic Diagram Action for PR architecture diagrams

### DIFF
--- a/.github/workflows/logic-diagram.yml
+++ b/.github/workflows/logic-diagram.yml
@@ -1,0 +1,26 @@
+name: Logic Diagram
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  diagram:
+    if: |
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association) &&
+      (contains(github.event.comment.body, '/generate-diagram') ||
+       contains(github.event.comment.body, '/refresh-diagram'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Logic Diagram Action
+        uses: with-logic/logic-diagram-action@v1
+        with:
+          document_id: 80090265-b8f3-4019-b0ff-5d1bc8577e70
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOGIC_API_TOKEN: ${{ secrets.LOGIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that generates architecture diagrams from PR diffs using Logic.inc
- Triggered by commenting `/generate-diagram` or `/refresh-diagram` on any PR
- Restricted to org owners and members only (external contributors cannot trigger it)

## Setup

Requires `LOGIC_API_KEY` secret to be configured in repo settings (already done).

## Test plan

- [ ] Merge this PR, then comment `/generate-diagram` on an existing PR to verify the diagram is generated

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `issue_comment`-triggered workflow that runs a third-party action and uses repo secrets; while restricted to org `OWNER`/`MEMBER`, it still introduces CI supply-chain and secret-exposure considerations.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/logic-diagram.yml`) that listens for PR comments containing `/generate-diagram` or `/refresh-diagram` and runs `with-logic/logic-diagram-action@v1` to generate/update a diagram for a specific `document_id`.
> 
> The job is gated to org `OWNER`/`MEMBER` commenters and requests `pull-requests: write` permission, passing `GITHUB_TOKEN` and `LOGIC_API_KEY` into the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5204a2877c831d5b92e49180e96cea14d9079b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->