### PR TITLE
fix: use correct tag for logic-diagram-action

### DIFF
--- a/.github/workflows/logic-diagram.yml
+++ b/.github/workflows/logic-diagram.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Logic Diagram Action
-        uses: with-logic/logic-diagram-action@v1
+        uses: with-logic/logic-diagram-action@beta
         with:
           document_id: 80090265-b8f3-4019-b0ff-5d1bc8577e70
         env:

--- a/.github/workflows/logic-diagram.yml
+++ b/.github/workflows/logic-diagram.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Logic Diagram Action
         uses: with-logic/logic-diagram-action@beta
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           document_id: 80090265-b8f3-4019-b0ff-5d1bc8577e70
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOGIC_API_TOKEN: ${{ secrets.LOGIC_API_KEY }}


### PR DESCRIPTION
The only published tag is `beta`, not `v1`. Fixes the action resolution error.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that fixes a GitHub Action reference and adjusts token wiring; impact is limited to the diagram-generation job.
> 
> **Overview**
> Updates the Logic Diagram GitHub Actions workflow to use `with-logic/logic-diagram-action@beta` (instead of the non-existent `@v1`) so the action resolves correctly.
> 
> Also switches `GITHUB_TOKEN` from an `env` var to the action’s `with.github_token` input, leaving `LOGIC_API_TOKEN` in `env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d938eb52ba3de680a95fda59fc3dc64e69d7a7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->