### PR TITLE
fix: mark consensus dispute/low-participants errors as non-retryable

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -2499,7 +2499,8 @@ var NewErrConsensusDispute = func(message string, participants []ParticipantInfo
 			Message: message,
 			Cause:   errors.Join(causes...),
 			Details: map[string]interface{}{
-				"participants": participants,
+				"participants":           participants,
+				"retryableTowardNetwork": false,
 			},
 		},
 	}
@@ -2533,7 +2534,8 @@ var NewErrConsensusLowParticipants = func(message string, participants []Partici
 			Message: message,
 			Cause:   errors.Join(causes...),
 			Details: map[string]interface{}{
-				"participants": participants,
+				"participants":           participants,
+				"retryableTowardNetwork": false,
 			},
 		},
 	}

--- a/common/errors_retry_test.go
+++ b/common/errors_retry_test.go
@@ -268,6 +268,39 @@ func TestIsRetryableTowardNetwork_UserReportedScenario(t *testing.T) {
 	})
 }
 
+func TestIsRetryableTowardNetwork_ConsensusErrors(t *testing.T) {
+	t.Run("ErrConsensusDispute_NotRetryable", func(t *testing.T) {
+		disputeErr := NewErrConsensusDispute(
+			"not enough agreement among responses",
+			[]ParticipantInfo{
+				{Upstream: "up-1", ResultHash: "hash1"},
+				{Upstream: "up-2", ResultHash: "hash2"},
+			},
+			nil,
+		)
+
+		result := IsRetryableTowardNetwork(disputeErr)
+
+		assert.False(t, result,
+			"ErrConsensusDispute should NOT be retryable — retrying spawns another consensus round that exhausts the same upstream pool")
+	})
+
+	t.Run("ErrConsensusLowParticipants_NotRetryable", func(t *testing.T) {
+		lowErr := NewErrConsensusLowParticipants(
+			"not enough participants",
+			[]ParticipantInfo{
+				{Upstream: "up-1", ErrSummary: "timeout"},
+			},
+			nil,
+		)
+
+		result := IsRetryableTowardNetwork(lowErr)
+
+		assert.False(t, result,
+			"ErrConsensusLowParticipants should NOT be retryable — if upstreams were unavailable, immediate retry won't help")
+	})
+}
+
 func TestHasErrorCode_NestedErrors(t *testing.T) {
 	t.Run("FindsCodeInNestedError", func(t *testing.T) {
 		innerErr := NewErrJsonRpcExceptionInternal(-32000, -32014, "missing trie node", nil, nil)


### PR DESCRIPTION
## Summary
- Set `retryableTowardNetwork: false` on `ErrConsensusDispute` and `ErrConsensusLowParticipants`
- Prevents the retry policy from re-executing entire consensus rounds when consensus cannot reach agreement, which cascades upstream pressure

## Test plan
- [x] Unit test: `ErrConsensusDispute` is not retryable toward network
- [x] Unit test: `ErrConsensusLowParticipants` is not retryable toward network
- [x] All existing `IsRetryableTowardNetwork` tests pass (no regression)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes retry classification for two consensus error constructors and adds unit coverage; behavior change is limited to reducing network-level retries in these specific failure modes.
> 
> **Overview**
> Prevents network-level retries from re-running full consensus rounds when consensus cannot be reached.
> 
> `NewErrConsensusDispute` and `NewErrConsensusLowParticipants` now set `details.retryableTowardNetwork=false`, making `IsRetryableTowardNetwork` treat these consensus outcomes as non-retryable. Adds unit tests asserting both consensus errors are not retryable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb958de218f53c0cd1d8c64f1ff4721e40761f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->