### PR TITLE
fix: default preferLargerResponses to false in consensus policy

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -2319,7 +2319,7 @@ func (c *ConsensusPolicyConfig) SetDefaults() error {
 		c.PreferNonEmpty = util.BoolPtr(true)
 	}
 	if c.PreferLargerResponses == nil {
-		c.PreferLargerResponses = util.BoolPtr(true)
+		c.PreferLargerResponses = util.BoolPtr(false)
 	}
 
 	// Destination defaults


### PR DESCRIPTION
## Summary
- Change default for `preferLargerResponses` from `true` to `false`
- When `true`, the `unassailable_lead` short-circuit is disabled — consensus waits for all participants even when the agreement threshold is already met
- Defaulting to `false` allows consensus to short-circuit as soon as threshold is reached, reducing latency and upstream pressure
- Chains that explicitly set `preferLargerResponses: true` in their config are unaffected

Follow-up: design a bounded `maxWait` mechanism so `preferLargerResponses` can be re-enabled without blocking indefinitely on slow participants.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default consensus selection behavior for responses when `PreferLargerResponses` is unset, which can alter request/consensus completion timing and returned data shape for existing deployments relying on the prior implicit default.
> 
> **Overview**
> Updates `ConsensusPolicyConfig.SetDefaults` to default `PreferLargerResponses` from `true` to `false` when not explicitly configured, allowing consensus to complete without waiting for larger/late participant responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec280d5c14a449c1d51f963a35b629acb29bf97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->