### PR TITLE
fix: return HTTP 200 for JSON-RPC request-too-large errors

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1104,9 +1104,6 @@ func determineResponseStatusCode(res interface{}) int {
 	// 404 Not Found - resource not found
 	case common.HasErrorCode(err, common.ErrCodeProjectNotFound, common.ErrCodeNetworkNotFound, common.ErrCodeNetworkNotSupported):
 		return http.StatusNotFound
-	// 413 Request Entity Too Large
-	case common.HasErrorCode(err, common.ErrCodeEndpointRequestTooLarge):
-		return http.StatusRequestEntityTooLarge
 	// 429 Too Many Requests - rate limiting
 	case common.HasErrorCode(err,
 		common.ErrCodeAuthRateLimitRuleExceeded,
@@ -1279,9 +1276,6 @@ func handleErrorResponse(
 	// 404 Not Found - resource not found at HTTP level
 	case common.HasErrorCode(err, common.ErrCodeProjectNotFound, common.ErrCodeNetworkNotFound, common.ErrCodeNetworkNotSupported):
 		statusCode = http.StatusNotFound
-	// 413 Request Entity Too Large
-	case common.HasErrorCode(err, common.ErrCodeEndpointRequestTooLarge):
-		statusCode = http.StatusRequestEntityTooLarge
 	// 429 Too Many Requests - rate limiting (critical for client retry logic)
 	case common.HasErrorCode(err,
 		common.ErrCodeAuthRateLimitRuleExceeded,


### PR DESCRIPTION
## Summary
- Removed HTTP 413 status code mapping for `ErrCodeEndpointRequestTooLarge` (getLogs range too wide, etc.)
- These are JSON-RPC application errors and should return HTTP 200 with the error in the response body
- Clients like graph-node expect HTTP 200 for all JSON-RPC responses and parse the error from the body to retry with a smaller range; HTTP 413 causes them to treat it as a transport failure

## Test plan
- [x] Existing `TestHttp_EvmGetLogs_SplitOnError_MergedResponse` already asserts HTTP 200 on this path
- [x] Verify with a graph-node subgraph that getLogs range errors no longer return 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)