### PR TITLE
fix: stop discarding valid consensus results on context cancellation

### DIFF
--- a/consensus/analysis.go
+++ b/consensus/analysis.go
@@ -138,6 +138,18 @@ func newConsensusAnalysis(lg *zerolog.Logger, exec failsafe.Execution[*common.No
 		}
 	}
 
+	// Pre-populate all cached accessors so the struct is effectively
+	// immutable after construction. This is critical: after the analyzer
+	// goroutine sends the outcome to the caller via outcomeCh (see
+	// executor.go runAnalyzer), both goroutines may read the analysis
+	// concurrently. Lazy-init under concurrent reads would be a data race.
+	analysis.getValidGroups()
+	analysis.getBestNonEmpty()
+	analysis.getBestEmpty()
+	analysis.getBestError()
+	analysis.getBestByCount()
+	analysis.getBestBySize()
+
 	return analysis
 }
 

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -213,13 +213,18 @@ func (e *executor) executeConsensus(
 
 	// outcomeCh is buffered so the analyzer can signal the caller and
 	// continue to tracking/release without blocking on the caller still being
-	// there. If the caller abandons on ctx.Done() before receiving, the
-	// buffered value is simply left behind and garbage-collected.
+	// there. If the caller abandons on ctx.Done() before receiving, a drain
+	// goroutine takes the buffered value and releases the winner.
 	outcomeCh := make(chan consensusOutcome, 1)
+	// analyzerDone closes when the analyzer has finished every read of the
+	// winner (tracking, misbehavior export, releaseNonWinningResponses). The
+	// abandon-path drain goroutine waits on this before releasing the winner
+	// to avoid racing trackAndPunishMisbehavingUpstreams on winner.Result.
+	analyzerDone := make(chan struct{})
 	go e.runAnalyzer(
 		lg, originalReq, labels, parentExecution,
 		responseChan, attempts, maxToSpawn, cancelRemaining,
-		outcomeCh, collectionSpan,
+		outcomeCh, analyzerDone, collectionSpan,
 	)
 
 	// Caller's select: prefer winner when available; bail on ctx cancel.
@@ -236,9 +241,40 @@ func (e *executor) executeConsensus(
 			e.recordMetricsAndTracing(originalReq, startTime, outcome.winner, outcome.analysis, labels, consensusSpan)
 			return outcome.winner
 		default:
+			// Caller abandoned before the analyzer published an outcome.
+			// The analyzer is still going to publish exactly one outcome to
+			// the (buffered) outcomeCh and then finish its own cleanup.
+			// Since we will NOT return the winner up the stack, nobody else
+			// will call winner.Result.Release() — the winner is explicitly
+			// skipped by releaseNonWinningResponses. Leaking the winner
+			// means leaking the response body/JSON-RPC buffer. Spawn a
+			// drain goroutine that waits for the analyzer to finish reading
+			// the winner (analyzerDone), then releases it.
+			go e.drainAbandonedOutcome(outcomeCh, analyzerDone)
 			return e.handleCallerAbandoned(lg, originalReq, labels, startTime, consensusSpan, ctx.Err())
 		}
 	}
+}
+
+// drainAbandonedOutcome releases the winner response when the caller has
+// abandoned consensus before receiving. It waits for analyzerDone to be
+// closed so analyzer-side reads of winner.Result (misbehavior tracking,
+// buildMisbehaviorRecord, releaseNonWinningResponses skip-check) have
+// completed before we free the underlying buffers.
+func (e *executor) drainAbandonedOutcome(
+	outcomeCh <-chan consensusOutcome,
+	analyzerDone <-chan struct{},
+) {
+	outcome := <-outcomeCh
+	<-analyzerDone
+	if outcome.winner == nil {
+		return
+	}
+	wr, ok := any(outcome.winner.Result).(*common.NormalizedResponse)
+	if !ok || wr == nil {
+		return
+	}
+	wr.Release()
 }
 
 // handleCallerAbandoned records caller-abandon metrics and returns an error
@@ -290,6 +326,7 @@ func (e *executor) runAnalyzer(
 	maxToSpawn int,
 	cancelRemaining func(),
 	outcomeCh chan<- consensusOutcome,
+	analyzerDone chan<- struct{},
 	collectionSpan trace.Span,
 ) {
 	outcomeSent := false
@@ -300,6 +337,11 @@ func (e *executor) runAnalyzer(
 		outcomeCh <- o // non-blocking: outcomeCh is buffered size 1
 		outcomeSent = true
 	}
+
+	// analyzerDone is closed LAST (defers run LIFO). This signals to the
+	// abandon-path drain goroutine that all analyzer-side reads of
+	// winner.Result have completed and releasing it is now safe.
+	defer close(analyzerDone)
 
 	defer func() {
 		// Recover from any panic before ending the span so a panic in

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -213,18 +213,13 @@ func (e *executor) executeConsensus(
 
 	// outcomeCh is buffered so the analyzer can signal the caller and
 	// continue to tracking/release without blocking on the caller still being
-	// there. If the caller abandons on ctx.Done() before receiving, a drain
-	// goroutine takes the buffered value and releases the winner.
+	// there. If the caller abandons on ctx.Done() before receiving, the
+	// buffered value is simply left behind and garbage-collected.
 	outcomeCh := make(chan consensusOutcome, 1)
-	// analyzerDone closes when the analyzer has finished every read of the
-	// winner (tracking, misbehavior export, releaseNonWinningResponses). The
-	// abandon-path drain goroutine waits on this before releasing the winner
-	// to avoid racing trackAndPunishMisbehavingUpstreams on winner.Result.
-	analyzerDone := make(chan struct{})
 	go e.runAnalyzer(
 		lg, originalReq, labels, parentExecution,
 		responseChan, attempts, maxToSpawn, cancelRemaining,
-		outcomeCh, analyzerDone, collectionSpan,
+		outcomeCh, collectionSpan,
 	)
 
 	// Caller's select: prefer winner when available; bail on ctx cancel.
@@ -241,40 +236,9 @@ func (e *executor) executeConsensus(
 			e.recordMetricsAndTracing(originalReq, startTime, outcome.winner, outcome.analysis, labels, consensusSpan)
 			return outcome.winner
 		default:
-			// Caller abandoned before the analyzer published an outcome.
-			// The analyzer is still going to publish exactly one outcome to
-			// the (buffered) outcomeCh and then finish its own cleanup.
-			// Since we will NOT return the winner up the stack, nobody else
-			// will call winner.Result.Release() — the winner is explicitly
-			// skipped by releaseNonWinningResponses. Leaking the winner
-			// means leaking the response body/JSON-RPC buffer. Spawn a
-			// drain goroutine that waits for the analyzer to finish reading
-			// the winner (analyzerDone), then releases it.
-			go e.drainAbandonedOutcome(outcomeCh, analyzerDone)
 			return e.handleCallerAbandoned(lg, originalReq, labels, startTime, consensusSpan, ctx.Err())
 		}
 	}
-}
-
-// drainAbandonedOutcome releases the winner response when the caller has
-// abandoned consensus before receiving. It waits for analyzerDone to be
-// closed so analyzer-side reads of winner.Result (misbehavior tracking,
-// buildMisbehaviorRecord, releaseNonWinningResponses skip-check) have
-// completed before we free the underlying buffers.
-func (e *executor) drainAbandonedOutcome(
-	outcomeCh <-chan consensusOutcome,
-	analyzerDone <-chan struct{},
-) {
-	outcome := <-outcomeCh
-	<-analyzerDone
-	if outcome.winner == nil {
-		return
-	}
-	wr, ok := any(outcome.winner.Result).(*common.NormalizedResponse)
-	if !ok || wr == nil {
-		return
-	}
-	wr.Release()
 }
 
 // handleCallerAbandoned records caller-abandon metrics and returns an error
@@ -326,7 +290,6 @@ func (e *executor) runAnalyzer(
 	maxToSpawn int,
 	cancelRemaining func(),
 	outcomeCh chan<- consensusOutcome,
-	analyzerDone chan<- struct{},
 	collectionSpan trace.Span,
 ) {
 	outcomeSent := false
@@ -337,11 +300,6 @@ func (e *executor) runAnalyzer(
 		outcomeCh <- o // non-blocking: outcomeCh is buffered size 1
 		outcomeSent = true
 	}
-
-	// analyzerDone is closed LAST (defers run LIFO). This signals to the
-	// abandon-path drain goroutine that all analyzer-side reads of
-	// winner.Result have completed and releasing it is now safe.
-	defer close(analyzerDone)
 
 	defer func() {
 		// Recover from any panic before ending the span so a panic in

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -30,22 +30,6 @@ var (
 	errPanicInConsensus  = errors.New("panic in consensus execution")
 )
 
-// drainResponsesInBackground spawns a goroutine to drain remaining responses from the channel
-// and release any results to avoid memory retention. This is called when short-circuiting
-// or when the context is cancelled.
-func drainResponsesInBackground(responseChan <-chan *execResult, startIdx, maxToSpawn int) {
-	go func() {
-		for j := startIdx; j < maxToSpawn; j++ {
-			er := <-responseChan
-			if er != nil && er.Result != nil {
-				if releasable, ok := any(er.Result).(interface{ Release() }); ok && releasable != nil {
-					releasable.Release()
-				}
-			}
-		}
-	}()
-}
-
 type metricsLabels struct {
 	method      string
 	category    string
@@ -113,8 +97,18 @@ type execResult struct {
 	Index int
 }
 
-// Apply is the main entry point for the consensus policy. It orchestrates the collection,
-// analysis, and decision phases.
+// consensusOutcome is the atomic handoff from the analyzer goroutine to the
+// caller's select. All fields must be fully populated before the send so the
+// caller always receives a consistent snapshot.
+type consensusOutcome struct {
+	winner         *failsafeCommon.PolicyResult[*common.NormalizedResponse]
+	analysis       *consensusAnalysis
+	shortCircuited bool
+}
+
+// Apply is the main entry point for the consensus policy. It delegates to
+// executeConsensus which decouples caller-visible latency from analysis
+// completion (see runAnalyzer).
 func (e *executor) Apply(innerFn func(failsafe.Execution[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse]) func(failsafe.Execution[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
 	return func(exec failsafe.Execution[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
 		startTime := time.Now()
@@ -137,46 +131,31 @@ func (e *executor) Apply(innerFn func(failsafe.Execution[*common.NormalizedRespo
 			Str("networkId", labels.networkId).
 			Logger()
 
-		winner, analysis := e.executeConsensus(
+		return e.executeConsensus(
 			ctx,
 			&lg,
 			originalReq,
 			labels,
 			exec.(policy.ExecutionInternal[*common.NormalizedResponse]),
 			innerFn,
+			startTime,
+			consensusSpan,
 		)
-
-		// Track misbehaviors while responses are still available
-		e.trackAndPunishMisbehavingUpstreams(&lg, originalReq, labels, winner, analysis)
-
-		// Now release non-winning responses to free memory
-		if analysis != nil {
-			var winnerResp *common.NormalizedResponse
-			if winner != nil {
-				if wr, ok := any(winner.Result).(*common.NormalizedResponse); ok {
-					winnerResp = wr
-				}
-			}
-			// Release responses from the groups in analysis
-			for _, group := range analysis.groups {
-				for _, result := range group.Results {
-					if result != nil && result.Result != nil {
-						// Only release if it's not the winner
-						if result.Result != winnerResp {
-							result.Result.Release()
-						}
-					}
-				}
-			}
-		}
-
-		// --- Finalization ---
-		e.recordMetricsAndTracing(originalReq, startTime, winner, analysis, labels, consensusSpan)
-
-		return winner
 	}
 }
 
+// executeConsensus decouples two distinct concerns:
+//
+//  1. Caller-visible latency: the caller must return promptly when its context
+//     is cancelled (HTTP disconnect, upstream deadline, shutdown).
+//  2. Analysis completeness: misbehavior tracking and metrics must see every
+//     participant's response, even ones that arrive after the caller gave up.
+//
+// The analyzer goroutine owns (2); the caller's select owns (1). They
+// communicate through a single-buffered outcomeCh so neither side blocks the
+// other. Analyzer lifetime is bounded by the slowest participant's lifetime,
+// which is already bounded by failsafe policy timeouts and HTTP client
+// timeouts — no new magic-number budget is required.
 func (e *executor) executeConsensus(
 	ctx context.Context,
 	lg *zerolog.Logger,
@@ -184,9 +163,14 @@ func (e *executor) executeConsensus(
 	labels metricsLabels,
 	parentExecution policy.ExecutionInternal[*common.NormalizedResponse],
 	innerFn func(failsafe.Execution[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse],
-) (*failsafeCommon.PolicyResult[*common.NormalizedResponse], *consensusAnalysis) {
+	startTime time.Time,
+	consensusSpan trace.Span,
+) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
 	ctx, collectionSpan := common.StartDetailSpan(ctx, "Consensus.CollectResponses")
-	defer collectionSpan.End()
+	// NOTE: collectionSpan.End() is owned by runAnalyzer (in its deferred
+	// cleanup), not this function. The analyzer outlives executeConsensus on
+	// the caller-cancel path, and ending the span here would drop late
+	// attributes (short_circuited, responses.collected).
 
 	// For fire-and-forget mode, detach from parent context cancellation so background
 	// requests continue even after the HTTP response is sent. This is critical for
@@ -214,8 +198,6 @@ func (e *executor) executeConsensus(
 		}
 	}()
 
-	var shortCircuited bool
-
 	// Spawn only as many participants as configured by policy
 	maxToSpawn := e.maxParticipants
 	if maxToSpawn <= 0 {
@@ -229,85 +211,172 @@ func (e *executor) executeConsensus(
 		go e.executeParticipant(cancellableCtx, lg, attempts[i], labels, innerFn, i, responseChan)
 	}
 
+	// outcomeCh is buffered so the analyzer can signal the caller and
+	// continue to tracking/release without blocking on the caller still being
+	// there. If the caller abandons on ctx.Done() before receiving, the
+	// buffered value is simply left behind and garbage-collected.
+	outcomeCh := make(chan consensusOutcome, 1)
+	go e.runAnalyzer(
+		lg, originalReq, labels, parentExecution,
+		responseChan, attempts, maxToSpawn, cancelRemaining,
+		outcomeCh, collectionSpan,
+	)
+
+	// Caller's select: prefer winner when available; bail on ctx cancel.
+	select {
+	case outcome := <-outcomeCh:
+		e.recordMetricsAndTracing(originalReq, startTime, outcome.winner, outcome.analysis, labels, consensusSpan)
+		return outcome.winner
+	case <-ctx.Done():
+		// Close the race where outcomeCh was sent to but Go's select picked
+		// ctx.Done() first (both cases ready → random choice). Non-blocking
+		// try-receive: if the analyzer already has a winner, take it.
+		select {
+		case outcome := <-outcomeCh:
+			e.recordMetricsAndTracing(originalReq, startTime, outcome.winner, outcome.analysis, labels, consensusSpan)
+			return outcome.winner
+		default:
+			return e.handleCallerAbandoned(lg, originalReq, labels, startTime, consensusSpan, ctx.Err())
+		}
+	}
+}
+
+// handleCallerAbandoned records caller-abandon metrics and returns an error
+// result to the caller. The analyzer goroutine continues in the background
+// and will emit MetricConsensusResponsesCollected / MetricConsensusShortCircuit
+// plus run trackAndPunishMisbehavingUpstreams when all participants finish.
+func (e *executor) handleCallerAbandoned(
+	lg *zerolog.Logger,
+	_ *common.NormalizedRequest,
+	labels metricsLabels,
+	startTime time.Time,
+	consensusSpan trace.Span,
+	cancelErr error,
+) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
+	telemetry.MetricConsensusCancellations.
+		WithLabelValues(labels.projectId, labels.networkId, labels.category, "caller_abandoned", labels.finalityStr).
+		Inc()
+	telemetry.MetricConsensusTotal.
+		WithLabelValues(labels.projectId, labels.networkId, labels.category, "caller_abandoned", labels.finalityStr).
+		Inc()
+	telemetry.MetricConsensusDuration.
+		WithLabelValues(labels.projectId, labels.networkId, labels.category, "caller_abandoned", labels.finalityStr).
+		Observe(time.Since(startTime).Seconds())
+	common.SetTraceSpanError(consensusSpan, cancelErr)
+	consensusSpan.SetAttributes(attribute.String("consensus.outcome", "caller_abandoned"))
+	lg.Warn().Err(cancelErr).Msg("consensus caller abandoned; analysis continues in background")
+	return &failsafeCommon.PolicyResult[*common.NormalizedResponse]{Error: cancelErr}
+}
+
+// runAnalyzer owns all consensus work downstream of participant dispatch:
+// collection, analysis, winner determination, misbehavior tracking, and
+// response memory release. It always runs to completion regardless of caller
+// context state.
+//
+// Its lifetime is bounded by the slowest participant's lifetime, which is
+// itself bounded by the failsafe timeout policy and the HTTP client timeout
+// (see clients/http_json_rpc_client.go). No new budget is introduced.
+//
+// INVARIANT: exactly one consensusOutcome is sent to outcomeCh before this
+// function returns, so the caller's select never deadlocks. The deferred
+// panic handler preserves this invariant.
+func (e *executor) runAnalyzer(
+	lg *zerolog.Logger,
+	originalReq *common.NormalizedRequest,
+	labels metricsLabels,
+	parentExecution policy.ExecutionInternal[*common.NormalizedResponse],
+	responseChan <-chan *execResult,
+	attempts []policy.ExecutionInternal[*common.NormalizedResponse],
+	maxToSpawn int,
+	cancelRemaining func(),
+	outcomeCh chan<- consensusOutcome,
+	collectionSpan trace.Span,
+) {
+	outcomeSent := false
+	sendOutcomeOnce := func(o consensusOutcome) {
+		if outcomeSent {
+			return
+		}
+		outcomeCh <- o // non-blocking: outcomeCh is buffered size 1
+		outcomeSent = true
+	}
+
+	defer func() {
+		// Recover from any panic before ending the span so a panic in
+		// analysis doesn't leak the span and — critically — doesn't
+		// deadlock the caller waiting on outcomeCh.
+		if r := recover(); r != nil {
+			lg.Error().
+				Interface("panic", r).
+				Str("stack", string(debug.Stack())).
+				Msg("panic in consensus analyzer")
+			telemetry.MetricConsensusPanics.
+				WithLabelValues(labels.projectId, labels.networkId, labels.category, labels.finalityStr).
+				Inc()
+			sendOutcomeOnce(consensusOutcome{
+				winner: &failsafeCommon.PolicyResult[*common.NormalizedResponse]{Error: errPanicInConsensus},
+			})
+		}
+		collectionSpan.End()
+	}()
+
 	responses := make([]*execResult, 0, maxToSpawn)
-	var shortCircuitReason string
-	var analysis *consensusAnalysis
 	var winner *failsafeCommon.PolicyResult[*common.NormalizedResponse]
+	var analysis *consensusAnalysis
+	var shortCircuitReason string
+	shortCircuited := false
 
-collectLoop:
+	// Collect all responses. Every participant is guaranteed to write exactly
+	// once to responseChan (see executeParticipant: all exit paths + panic
+	// recovery write; channel is buffered to maxToSpawn so writes never block).
 	for i := 0; i < maxToSpawn; i++ {
-		var resp *execResult
+		resp := <-responseChan
+		if resp == nil {
+			continue
+		}
+		responses = append(responses, resp)
 
-		if e.config.fireAndForget {
-			// Fire-and-forget: participants use context.WithoutCancel so they won't see
-			// parent cancellation. We still need ctx.Done() to return to the caller
-			// promptly while background requests complete naturally.
-			select {
-			case resp = <-responseChan:
-			case <-ctx.Done():
-				lg.Warn().Err(ctx.Err()).Msg("Context cancelled during response collection")
-				telemetry.MetricConsensusCancellations.
-					WithLabelValues(labels.projectId, labels.networkId, labels.category, "collection", labels.finalityStr).
-					Inc()
-				lg.Debug().
-					Int("remaining", maxToSpawn-i).
-					Msg("fire-and-forget mode: letting remaining requests complete despite parent cancellation")
-				drainResponsesInBackground(responseChan, i, maxToSpawn)
-				break collectLoop
-			}
-		} else {
-			// Normal mode: read directly from the channel without racing ctx.Done().
-			// Every participant is guaranteed to write exactly once to responseChan
-			// (see executeParticipant: all exit paths write, panic recovery writes,
-			// channel is buffered to maxToSpawn so writes never block).
-			// After parent context cancellation, participants see it via propagation
-			// (cancellableCtx is a child of ctx) and complete quickly.
-			resp = <-responseChan
+		if shortCircuited {
+			continue // still draining for memory release; analysis is frozen
 		}
 
-		if resp != nil {
-			responses = append(responses, resp)
-			if !shortCircuited {
-				analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
-				winner = e.determineWinner(lg, analysis)
-				if reason, ok := e.shouldShortCircuit(winner, analysis); ok {
-					shortCircuited = true
-					shortCircuitReason = reason
+		analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
+		winner = e.determineWinner(lg, analysis)
+		if reason, ok := e.shouldShortCircuit(winner, analysis); ok {
+			shortCircuited = true
+			shortCircuitReason = reason
 
-					if e.config.fireAndForget {
-						lg.Debug().
-							Str("reason", reason).
-							Int("remaining", maxToSpawn-i-1).
-							Msg("fire-and-forget mode: letting remaining requests complete in background")
-						drainResponsesInBackground(responseChan, i+1, maxToSpawn)
-					} else {
-						cancelRemaining()
-						for ai := range attempts {
-							if attempts[ai] != nil {
-								attempts[ai].Cancel(nil)
-							}
-						}
-						drainResponsesInBackground(responseChan, i+1, maxToSpawn)
+			// Release caller immediately. The winner won't change even if
+			// more responses arrive, matching pre-refactor short-circuit
+			// semantics for the winner returned to the caller.
+			sendOutcomeOnce(consensusOutcome{winner: winner, analysis: analysis, shortCircuited: true})
+
+			if e.config.fireAndForget {
+				lg.Debug().
+					Str("reason", reason).
+					Int("remaining", maxToSpawn-i-1).
+					Msg("fire-and-forget mode: remaining requests complete in background")
+			} else {
+				cancelRemaining()
+				for ai := range attempts {
+					if attempts[ai] != nil {
+						attempts[ai].Cancel(nil)
 					}
-					break collectLoop
 				}
 			}
 		}
 	}
 
-	// Track if context was cancelled during collection (observability).
-	if ctx.Err() != nil && !shortCircuited && !e.config.fireAndForget {
-		lg.Warn().Err(ctx.Err()).Msg("Context was cancelled during response collection")
-		telemetry.MetricConsensusCancellations.
-			WithLabelValues(labels.projectId, labels.networkId, labels.category, "collection", labels.finalityStr).
-			Inc()
-	}
-
+	// All participants accounted for. If no short-circuit fired, compute the
+	// final analysis and send the winner now.
 	if analysis == nil {
 		analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
 		winner = e.determineWinner(lg, analysis)
 	}
+	sendOutcomeOnce(consensusOutcome{winner: winner, analysis: analysis, shortCircuited: shortCircuited})
 
+	// Emit collection-phase attributes and metrics. These run after the
+	// outcome has been sent, so they don't block the caller.
 	collectionSpan.SetAttributes(
 		attribute.Bool("short_circuited", shortCircuited),
 		attribute.Int("responses.collected", len(responses)),
@@ -321,7 +390,6 @@ collectLoop:
 	}
 	sort.Strings(vendorNames)
 
-	// Record how many responses were collected and whether we short-circuited
 	telemetry.MetricConsensusResponsesCollected.
 		WithLabelValues(
 			labels.projectId,
@@ -342,7 +410,38 @@ collectLoop:
 			Inc()
 	}
 
-	return winner, analysis
+	// Track misbehavior with the final winner + analysis. Previously this
+	// ran synchronously in Apply(). Moving it here guarantees it sees every
+	// response, even ones that arrived after the caller abandoned.
+	e.trackAndPunishMisbehavingUpstreams(lg, originalReq, labels, winner, analysis)
+
+	// Release non-winning response objects. Previously inlined in Apply().
+	e.releaseNonWinningResponses(analysis, winner)
+}
+
+// releaseNonWinningResponses releases the Result pointers on every non-winning
+// execResult in analysis.groups. Extracted verbatim from the previous inline
+// loop in Apply() so behavior is preserved.
+func (e *executor) releaseNonWinningResponses(
+	analysis *consensusAnalysis,
+	winner *failsafeCommon.PolicyResult[*common.NormalizedResponse],
+) {
+	if analysis == nil {
+		return
+	}
+	var winnerResp *common.NormalizedResponse
+	if winner != nil {
+		if wr, ok := any(winner.Result).(*common.NormalizedResponse); ok {
+			winnerResp = wr
+		}
+	}
+	for _, group := range analysis.groups {
+		for _, result := range group.Results {
+			if result != nil && result.Result != nil && result.Result != winnerResp {
+				result.Result.Release()
+			}
+		}
+	}
 }
 
 // executeParticipant runs a single upstream request within a goroutine.

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -381,18 +381,13 @@ func (e *executor) executeParticipant(
 	// Execute using the pre-created cancellable attempt execution
 	result := innerFn(attemptExecution)
 
-	// Check for cancellation after execution; release any produced result before dropping it
+	// Track post-execution cancellations for observability, but do NOT discard the result.
+	// The result is still valid and should participate in consensus analysis.
+	// Discarding here caused 0 groups → ErrConsensusLowParticipants "participants: null".
 	if ctx.Err() != nil {
 		telemetry.MetricConsensusCancellations.
 			WithLabelValues(labels.projectId, labels.networkId, labels.category, "after_execution", labels.finalityStr).
 			Inc()
-		if result != nil {
-			if releasable, ok := any(result.Result).(interface{ Release() }); ok && releasable != nil {
-				releasable.Release()
-			}
-		}
-		responseChan <- nil
-		return
 	}
 
 	if result == nil {

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -236,89 +236,71 @@ func (e *executor) executeConsensus(
 
 collectLoop:
 	for i := 0; i < maxToSpawn; i++ {
-		select {
-		case resp := <-responseChan:
-			if resp != nil {
-				responses = append(responses, resp)
-				if !shortCircuited {
-					analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
-					winner = e.determineWinner(lg, analysis)
-					if reason, ok := e.shouldShortCircuit(winner, analysis); ok {
-						shortCircuited = true
-						shortCircuitReason = reason
+		var resp *execResult
 
-						// In fire-and-forget mode, let remaining requests complete in background
-						// without cancelling them. This is useful for write operations like
-						// eth_sendRawTransaction where we want to broadcast to all nodes.
-						if e.config.fireAndForget {
-							lg.Debug().
-								Str("reason", reason).
-								Int("remaining", maxToSpawn-i-1).
-								Msg("fire-and-forget mode: letting remaining requests complete in background")
-
-							// Drain remaining responses in background without cancelling
-							// The HTTP requests will complete naturally
-							drainResponsesInBackground(responseChan, i+1, maxToSpawn)
-						} else {
-							// Normal mode: cancel remaining requests immediately to save resources
-							cancelRemaining()
-							// Explicitly cancel all outstanding attempt executions to abort in-flight work
-							for ai := range attempts {
-								if attempts[ai] != nil {
-									attempts[ai].Cancel(nil)
-								}
-							}
-							drainResponsesInBackground(responseChan, i+1, maxToSpawn)
-						}
-						break collectLoop
-					}
-				}
-			}
-		case <-ctx.Done():
-			lg.Warn().Err(ctx.Err()).Msg("Context cancelled during response collection")
-			// Record collection phase cancellation
-			telemetry.MetricConsensusCancellations.
-				WithLabelValues(labels.projectId, labels.networkId, labels.category, "collection", labels.finalityStr).
-				Inc()
-
-			// In fire-and-forget mode, let remaining requests complete in background
-			// even when parent context is cancelled. This is critical for transaction
-			// broadcasting where we want all nodes to receive the transaction regardless
-			// of whether the client's HTTP connection dropped.
-			if e.config.fireAndForget {
+		if e.config.fireAndForget {
+			// Fire-and-forget: participants use context.WithoutCancel so they won't see
+			// parent cancellation. We still need ctx.Done() to return to the caller
+			// promptly while background requests complete naturally.
+			select {
+			case resp = <-responseChan:
+			case <-ctx.Done():
+				lg.Warn().Err(ctx.Err()).Msg("Context cancelled during response collection")
+				telemetry.MetricConsensusCancellations.
+					WithLabelValues(labels.projectId, labels.networkId, labels.category, "collection", labels.finalityStr).
+					Inc()
 				lg.Debug().
 					Int("remaining", maxToSpawn-i).
 					Msg("fire-and-forget mode: letting remaining requests complete despite parent cancellation")
 				drainResponsesInBackground(responseChan, i, maxToSpawn)
-			} else {
-				// Normal mode: cancel remaining requests to save resources
-				cancelRemaining()
-				for ai := range attempts {
-					if attempts[ai] != nil {
-						attempts[ai].Cancel(nil)
-					}
-				}
+				break collectLoop
+			}
+		} else {
+			// Normal mode: read directly from the channel without racing ctx.Done().
+			// Every participant is guaranteed to write exactly once to responseChan
+			// (see executeParticipant: all exit paths write, panic recovery writes,
+			// channel is buffered to maxToSpawn so writes never block).
+			// After parent context cancellation, participants see it via propagation
+			// (cancellableCtx is a child of ctx) and complete quickly.
+			resp = <-responseChan
+		}
 
-				// Brief wait to salvage responses from participants that are completing.
-				// After cancel, in-flight executions finish quickly. Without this,
-				// ctx.Done() racing responseChan means we can exit with 0 responses
-				// even though participants are about to send valid results.
-				deadline := time.After(100 * time.Millisecond)
-				for j := i; j < maxToSpawn; j++ {
-					select {
-					case resp := <-responseChan:
-						i++
-						if resp != nil {
-							responses = append(responses, resp)
+		if resp != nil {
+			responses = append(responses, resp)
+			if !shortCircuited {
+				analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
+				winner = e.determineWinner(lg, analysis)
+				if reason, ok := e.shouldShortCircuit(winner, analysis); ok {
+					shortCircuited = true
+					shortCircuitReason = reason
+
+					if e.config.fireAndForget {
+						lg.Debug().
+							Str("reason", reason).
+							Int("remaining", maxToSpawn-i-1).
+							Msg("fire-and-forget mode: letting remaining requests complete in background")
+						drainResponsesInBackground(responseChan, i+1, maxToSpawn)
+					} else {
+						cancelRemaining()
+						for ai := range attempts {
+							if attempts[ai] != nil {
+								attempts[ai].Cancel(nil)
+							}
 						}
-					case <-deadline:
-						drainResponsesInBackground(responseChan, i, maxToSpawn)
-						break collectLoop
+						drainResponsesInBackground(responseChan, i+1, maxToSpawn)
 					}
+					break collectLoop
 				}
 			}
-			break collectLoop
 		}
+	}
+
+	// Track if context was cancelled during collection (observability).
+	if ctx.Err() != nil && !shortCircuited && !e.config.fireAndForget {
+		lg.Warn().Err(ctx.Err()).Msg("Context was cancelled during response collection")
+		telemetry.MetricConsensusCancellations.
+			WithLabelValues(labels.projectId, labels.networkId, labels.category, "collection", labels.finalityStr).
+			Inc()
 	}
 
 	if analysis == nil {

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -298,7 +298,24 @@ collectLoop:
 						attempts[ai].Cancel(nil)
 					}
 				}
-				drainResponsesInBackground(responseChan, i, maxToSpawn)
+
+				// Brief wait to salvage responses from participants that are completing.
+				// After cancel, in-flight executions finish quickly. Without this,
+				// ctx.Done() racing responseChan means we can exit with 0 responses
+				// even though participants are about to send valid results.
+				deadline := time.After(100 * time.Millisecond)
+				for j := i; j < maxToSpawn; j++ {
+					select {
+					case resp := <-responseChan:
+						i++
+						if resp != nil {
+							responses = append(responses, resp)
+						}
+					case <-deadline:
+						drainResponsesInBackground(responseChan, i, maxToSpawn)
+						break collectLoop
+					}
+				}
 			}
 			break collectLoop
 		}

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -334,11 +334,19 @@ func (e *executor) runAnalyzer(
 		if resp == nil {
 			continue
 		}
-		responses = append(responses, resp)
 
 		if shortCircuited {
-			continue // still draining for memory release; analysis is frozen
+			// Analysis is frozen at the short-circuit moment. Any response
+			// that arrives after is NOT in analysis.groups, so
+			// releaseNonWinningResponses won't cover it. Release it here,
+			// mirroring the old drainResponsesInBackground behavior.
+			if resp.Result != nil {
+				resp.Result.Release()
+			}
+			continue
 		}
+
+		responses = append(responses, resp)
 
 		analysis = newConsensusAnalysis(e.logger, parentExecution, e.config, responses)
 		winner = e.determineWinner(lg, analysis)
@@ -1052,6 +1060,28 @@ func (e *executor) startConsensusSpan(ctx context.Context, labels metricsLabels,
 }
 
 func (e *executor) recordMetricsAndTracing(req *common.NormalizedRequest, startTime time.Time, result *failsafeCommon.PolicyResult[*common.NormalizedResponse], analysis *consensusAnalysis, labels metricsLabels, span trace.Span) {
+	// Defensive: analysis is nil on the catastrophic-path where the analyzer
+	// goroutine panicked before any responses could be classified. Emit
+	// minimal metrics and mark the span error rather than nil-dereferencing.
+	if analysis == nil {
+		outcome := "generic_error"
+		if result != nil && result.Error != nil {
+			common.SetTraceSpanError(span, result.Error)
+		}
+		span.SetAttributes(attribute.String("consensus.outcome", outcome))
+		duration := time.Since(startTime).Seconds()
+		telemetry.MetricConsensusTotal.
+			WithLabelValues(labels.projectId, labels.networkId, labels.category, outcome, labels.finalityStr).
+			Inc()
+		telemetry.MetricConsensusDuration.
+			WithLabelValues(labels.projectId, labels.networkId, labels.category, outcome, labels.finalityStr).
+			Observe(duration)
+		telemetry.MetricConsensusErrors.
+			WithLabelValues(labels.projectId, labels.networkId, labels.category, outcome, labels.finalityStr).
+			Inc()
+		return
+	}
+
 	// Determine if consensus was achieved based on the highest count group
 	best := analysis.getBestByCount()
 	hasConsensus := best != nil && best.Count >= e.agreementThreshold

--- a/consensus/executor_race_test.go
+++ b/consensus/executor_race_test.go
@@ -1,0 +1,936 @@
+package consensus
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/failsafe-go/failsafe-go"
+	failsafeCommon "github.com/failsafe-go/failsafe-go/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// Test Suite: Low-Participant Count Race Conditions
+//
+// These tests form a contract for correctness of the consensus mechanism
+// under low participant counts (N=1..3) and concurrent context cancellation.
+// Any valid fix for the race condition must pass all of them; any regression
+// turns at least one red.
+//
+// Invariants tested:
+//   I1: A completed innerFn result is NEVER silently discarded.
+//   I2: The caller NEVER blocks indefinitely (no deadlock on outcomeCh).
+//   I3: ErrConsensusLowParticipants is returned ONLY when validParticipants
+//       is genuinely below the agreement threshold.
+//   I4: Post-short-circuit and post-cancel responses are Release()d.
+//   I5: The analyzer always runs to completion regardless of caller context.
+// ---------------------------------------------------------------------------
+
+// ===== SCENARIO A: N=1 — the minimal reproduction =========================
+
+// TestRace_SingleParticipant_CancelAfterExecution is the minimal reproduction
+// of the original bug. With N=1 and threshold=1, the sole participant completes
+// innerFn, then context is cancelled. The old code discarded this result,
+// producing ErrConsensusLowParticipants with "participants: null". This MUST
+// return the valid consensus winner or context.Canceled — never low-participants.
+//
+// Why N=1 is special: there is no short-circuit (lead=1, remaining=0 → fires
+// immediately), so the outcome channel races directly with ctx.Done(). Any bug
+// in the double-select retry logic or in participant result forwarding shows
+// up deterministically here.
+func TestRace_SingleParticipant_CancelAfterExecution(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(1).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	started := make(chan struct{})
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			close(started)
+			<-completeInnerFn
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	<-started
+	cancel()
+	close(completeInnerFn)
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"N=1: must not report ErrConsensusLowParticipants when 1 valid response exists: %v", r.err,
+			)
+			require.Truef(t,
+				errors.Is(r.err, context.Canceled),
+				"N=1: only acceptable error is context.Canceled, got: %v", r.err,
+			)
+		} else {
+			require.NotNil(t, r.resp, "N=1: should return a valid response")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("N=1: deadlock — consensus did not return within 2s")
+	}
+}
+
+// TestRace_SingleParticipant_CancelBeforeExecution verifies the correct
+// low-participants case: context is cancelled before the sole participant
+// enters innerFn. The participant sends nil → 0 groups → low-participants
+// is the correct outcome.
+func TestRace_SingleParticipant_CancelBeforeExecution(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(1).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before any execution
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	var called atomic.Int32
+	_, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		called.Add(1)
+		return validResponse(), nil
+	})
+
+	require.Error(t, err)
+	assert.True(t,
+		common.HasErrorCode(err, common.ErrCodeConsensusLowParticipants) ||
+			errors.Is(err, context.Canceled),
+		"N=1 pre-cancel: expected LowParticipants or Canceled, got: %v", err,
+	)
+}
+
+// ===== SCENARIO B: N=2, threshold=2 — staggered completion ================
+
+// TestRace_TwoParticipants_CancelBetweenCompletions exercises the scenario
+// where participant 1 completes, context is cancelled, then participant 2
+// completes. With the old code, participant 2's result was discarded
+// (post-execution cancel check). With N=2, threshold=2, losing ONE result
+// means the analyzer sees only 1 valid → low-participants or dispute.
+//
+// The correct behavior: both results reach the analyzer. Either the caller
+// gets a valid consensus (if the analyzer wins the select) or context.Canceled
+// (if ctx.Done() wins). Never low-participants when 2 valid responses exist.
+func TestRace_TwoParticipants_CancelBetweenCompletions(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(2).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var started atomic.Int32
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			n := started.Add(1)
+			if n == 1 {
+				close(firstStarted)
+				<-releaseFirst
+			} else {
+				close(secondStarted)
+				<-releaseSecond
+			}
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	// Sequence: first completes → cancel → second completes.
+	<-firstStarted
+	close(releaseFirst)
+	time.Sleep(5 * time.Millisecond) // tiny gap for goroutine scheduling
+	<-secondStarted
+	cancel()
+	close(releaseSecond)
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"N=2: must not report LowParticipants when both participants completed with valid responses: %v", r.err,
+			)
+			require.Truef(t,
+				errors.Is(r.err, context.Canceled),
+				"N=2: only acceptable error is context.Canceled, got: %v", r.err,
+			)
+		} else {
+			require.NotNil(t, r.resp)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("N=2: deadlock — consensus did not return within 2s")
+	}
+}
+
+// TestRace_TwoParticipants_BothCompleteBeforeCancel_ThresholdTwo ensures
+// that when both N=2 participants complete and THEN cancel fires, the
+// analyzer has both responses. This is the N=2 analog of the N=3 test
+// already on the branch but specifically tests the minimum for all-must-agree.
+func TestRace_TwoParticipants_BothCompleteBeforeCancel_ThresholdTwo(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(2).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var started atomic.Int32
+	allStarted := make(chan struct{})
+	completeAll := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if started.Add(1) == 2 {
+				close(allStarted)
+			}
+			<-completeAll
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	<-allStarted
+	cancel()
+	close(completeAll)
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"N=2 both-complete: must not report LowParticipants: %v", r.err,
+			)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("N=2 both-complete: deadlock")
+	}
+}
+
+// ===== SCENARIO C: N=2, threshold=1 — short-circuit + late arrival ========
+
+// TestRace_TwoParticipants_ShortCircuit_LateArrivalReleased verifies that
+// when N=2, threshold=1, the first response triggers short-circuit and the
+// second (late) response is properly handled. A naive implementation might:
+//  1. Never Release() the late response → memory leak, or
+//  2. Try to add it to the frozen analysis → panic/data corruption.
+//
+// We verify the caller gets a winner promptly and the late participant
+// completes without panicking.
+func TestRace_TwoParticipants_ShortCircuit_LateArrivalReleased(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(2).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var callCount atomic.Int32
+	slowRelease := make(chan struct{})
+
+	ctx := context.WithValue(context.Background(), common.RequestContextKey, req)
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	start := time.Now()
+	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return validResponse(), nil
+		}
+		<-slowRelease
+		return validResponse(), nil
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"N=2/threshold=1: short-circuit should fire after first response")
+
+	close(slowRelease)
+
+	// Give the analyzer goroutine time to drain and release the late arrival.
+	// If the release panics, the test process will crash.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// ===== SCENARIO D: Mixed participation — partial valid + partial nil =======
+
+// TestRace_ThreeParticipants_OneCancelledBeforeExec_TwoValid exercises the
+// scenario where one participant is cancelled before executing innerFn (sends
+// nil) and two complete with valid matching responses. With threshold=2, the
+// two valid responses should produce consensus. The nil must NOT inflate
+// totalParticipants in a way that triggers low-participants.
+func TestRace_ThreeParticipants_OneCancelledBeforeExec_TwoValid(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				// First participant: signal readiness, then wait for cancel to
+				// happen. By the time we return, ctx is cancelled but our result
+				// is still valid.
+				close(gate)
+				time.Sleep(20 * time.Millisecond) // give cancel a head start
+			}
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	// Cancel after first participant has started but (hopefully) before all
+	// three have passed the pre-execution ctx.Err() check. This creates
+	// a mix of nil and valid responses.
+	<-gate
+	cancel()
+
+	select {
+	case r := <-resultCh:
+		// If the two valid responses reached the analyzer, we get consensus.
+		// If cancel races unfavorably, context.Canceled is acceptable.
+		// ErrConsensusLowParticipants is ONLY correct if truly < 2 valid
+		// responses — but given N=3 with at least 1 guaranteed valid, and
+		// the innerFn is fast, at least 2 should complete in most runs.
+		if r.err != nil {
+			// Allow low-participants ONLY if context.Canceled is also present
+			// (meaning the caller abandoned before the analyzer could report).
+			if common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants) {
+				// This is acceptable ONLY in the true-positive case
+				t.Logf("low-participants returned — acceptable if some participants were genuinely pre-cancelled")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("mixed participation: deadlock")
+	}
+}
+
+// ===== SCENARIO E: outcomeCh vs ctx.Done() select race ====================
+
+// TestRace_OutcomeAndCancelSimultaneous forces both outcomeCh and ctx.Done()
+// to be ready at ~the same moment, exercising the double-select retry.
+// Run 100 times to increase the probability of hitting the problematic
+// scheduling order.
+//
+// With N=1, threshold=1: the single participant completes instantly, so
+// outcomeCh is ready almost immediately. Cancel fires at the same time.
+// Without the non-blocking retry in the ctx.Done() branch, ~50% of runs
+// would return context.Canceled when a valid winner was available.
+//
+// We track whether innerFn was actually called. If it was, then a valid
+// response exists and ErrConsensusLowParticipants must not appear. If
+// cancel beat the participant to the pre-execution check, nil was sent
+// and LowParticipants is genuinely correct.
+func TestRace_OutcomeAndCancelSimultaneous(t *testing.T) {
+	var falseLowPart atomic.Int32
+	const iterations = 100
+
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			logger := zerolog.Nop()
+
+			pol := NewConsensusPolicyBuilder().
+				WithMaxParticipants(1).
+				WithAgreementThreshold(1).
+				WithLogger(&logger).
+				Build()
+
+			req := newTestRequest()
+
+			var innerFnCalled atomic.Bool
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+			fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+			type result struct {
+				resp *common.NormalizedResponse
+				err  error
+			}
+			resultCh := make(chan result, 1)
+
+			// Fire cancel and execution simultaneously.
+			go func() {
+				resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+					innerFnCalled.Store(true)
+					return validResponse(), nil
+				})
+				resultCh <- result{resp, err}
+			}()
+
+			// Cancel immediately — races with the participant.
+			cancel()
+
+			select {
+			case r := <-resultCh:
+				if r.err != nil && common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants) {
+					if innerFnCalled.Load() {
+						// innerFn ran and produced a valid response, but
+						// the system still reported low-participants. This
+						// is the bug we're catching.
+						falseLowPart.Add(1)
+					}
+					// If innerFn was NOT called, cancel beat the participant
+					// to the pre-execution ctx.Err() check → genuinely 0
+					// responses → LowParticipants is correct.
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("iter %d: deadlock", iter)
+			}
+		}()
+	}
+
+	require.Equal(t, int32(0), falseLowPart.Load(),
+		"ErrConsensusLowParticipants must not appear when innerFn actually produced a valid response")
+}
+
+// ===== SCENARIO F: N=2, threshold=2, one infra error + one valid ==========
+
+// TestRace_TwoParticipants_OneInfraError_CorrectlyLowParticipants verifies
+// that when one participant returns an infrastructure error and one returns a
+// valid response, the system correctly identifies validParticipants=1 < threshold=2
+// and returns ErrConsensusLowParticipants (or the low-participants fallback
+// behavior). This is a CORRECT low-participants case — it must not be
+// misidentified as a consensus or a dispute.
+func TestRace_TwoParticipants_OneInfraError_CorrectlyLowParticipants(t *testing.T) {
+	lg := zerolog.Nop()
+
+	cfg := &config{
+		maxParticipants:         2,
+		agreementThreshold:      2,
+		lowParticipantsBehavior: common.ConsensusLowParticipantsBehaviorReturnError,
+	}
+
+	// Build the analysis directly. classifyAndHashResponse requires a non-nil
+	// failsafe Execution for the success path, so we pre-classify manually.
+	analysis := &consensusAnalysis{
+		config:            cfg,
+		groups:            make(map[string]*responseGroup),
+		totalParticipants: 2,
+		validParticipants: 1, // 1 valid (non-empty), 1 infra error
+		method:            "eth_getLogs",
+	}
+
+	// Valid response group
+	validResult := &execResult{
+		Result:             validResponse(),
+		Index:              0,
+		CachedHash:         "hash:valid",
+		CachedResponseType: ResponseTypeNonEmpty,
+		CachedResponseSize: 10,
+	}
+	analysis.groups["hash:valid"] = &responseGroup{
+		Hash:          "hash:valid",
+		Results:       []*execResult{validResult},
+		Count:         1,
+		ResponseType:  ResponseTypeNonEmpty,
+		ResponseSize:  10,
+		LargestResult: validResult.Result,
+		HasResult:     true,
+	}
+
+	// Infra error group
+	infraResult := &execResult{
+		Err:                errors.New("connection refused"),
+		Index:              1,
+		CachedHash:         "error:generic",
+		CachedResponseType: ResponseTypeInfrastructureError,
+	}
+	analysis.groups["error:generic"] = &responseGroup{
+		Hash:         "error:generic",
+		Results:      []*execResult{infraResult},
+		Count:        1,
+		ResponseType: ResponseTypeInfrastructureError,
+		FirstError:   infraResult.Err,
+	}
+
+	require.Equal(t, 1, analysis.validParticipants,
+		"only 1 of 2 participants returned a valid response")
+	require.True(t, analysis.isLowParticipants(cfg.agreementThreshold),
+		"validParticipants=1 < threshold=2 is low-participants")
+
+	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
+	winner := e.determineWinner(&lg, analysis)
+
+	require.NotNil(t, winner)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusLowParticipants),
+		"should return ErrConsensusLowParticipants, got: %v", winner.Error)
+}
+
+// ===== SCENARIO G: Analyzer panic → caller doesn't deadlock ===============
+
+// TestRace_AnalyzerPanic_CallerReceivesErrorNotDeadlock verifies invariant I2:
+// if the analyzer goroutine panics at any point, the deferred recovery must
+// still send exactly one outcome to outcomeCh so the caller's select never
+// blocks forever.
+//
+// We test this at the unit level by directly calling runAnalyzer with a
+// responseChan that will cause a panic (by sending a response that triggers
+// a nil-pointer dereference in analysis, simulated via a custom setup).
+//
+// However, since we can't easily inject a panic into the production code
+// path, we test the contract indirectly: the handleCallerAbandoned path
+// returns promptly, and the nil-analysis guard in recordMetricsAndTracing
+// doesn't panic.
+func TestRace_AnalyzerPanic_NilAnalysis_CallerSafe(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	e := &executor{
+		consensusPolicy: &consensusPolicy{
+			config: &config{agreementThreshold: 1},
+			logger: &logger,
+		},
+	}
+
+	labels := metricsLabels{
+		projectId:   "test-proj",
+		networkId:   "test-net",
+		category:    "eth_getLogs",
+		finalityStr: "latest",
+		method:      "eth_getLogs",
+	}
+
+	// Simulate the catastrophic path: analyzer panicked, so outcome has nil analysis.
+	panicResult := &failsafeCommon.PolicyResult[*common.NormalizedResponse]{
+		Error: errPanicInConsensus,
+	}
+
+	require.NotPanics(t, func() {
+		e.recordMetricsAndTracing(newTestRequest(), time.Now(), panicResult, nil, labels,
+			trace.SpanFromContext(context.Background()))
+	}, "recordMetricsAndTracing must handle nil analysis without panicking")
+
+	// Also verify releaseNonWinningResponses handles nil analysis.
+	require.NotPanics(t, func() {
+		e.releaseNonWinningResponses(nil, panicResult)
+	}, "releaseNonWinningResponses must handle nil analysis without panicking")
+
+	// And nil winner.
+	require.NotPanics(t, func() {
+		e.releaseNonWinningResponses(&consensusAnalysis{
+			config: &config{},
+			groups: map[string]*responseGroup{
+				"hash1": {Results: []*execResult{{Result: validResponse()}}},
+			},
+		}, nil)
+	}, "releaseNonWinningResponses must handle nil winner without panicking")
+}
+
+// ===== SCENARIO H: N=3, threshold=2, cancel after 1 of 3 completes =======
+
+// TestRace_ThreeParticipants_CancelAfterFirstComplete exercises the scenario
+// where one of three participants completes, cancel fires, and the remaining
+// two complete after cancel. The old collector's `select` on `ctx.Done()`
+// would exit after seeing only the first response. With the new analyzer,
+// all three should be collected. Since all return the same value and
+// threshold=2, consensus should be reached.
+func TestRace_ThreeParticipants_CancelAfterFirstComplete(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var started atomic.Int32
+	firstDone := make(chan struct{})
+	releaseRest := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			n := started.Add(1)
+			if n == 1 {
+				close(firstDone)
+			} else {
+				<-releaseRest
+			}
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	<-firstDone
+	time.Sleep(5 * time.Millisecond) // let first response flow to analyzer
+	cancel()
+	close(releaseRest)
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"N=3/cancel-after-first: must not report LowParticipants when all 3 responses are valid: %v", r.err,
+			)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("N=3/cancel-after-first: deadlock")
+	}
+}
+
+// ===== SCENARIO I: Zero responses (all nil) → correct low-participants =====
+
+// TestRace_AllParticipantsReturnNil_LowParticipants verifies the analysis
+// layer's behavior when the analyzer receives zero non-nil responses. This
+// happens when all participants are cancelled before execution. The analyzer
+// must produce ErrConsensusLowParticipants with 0 groups, not panic.
+func TestRace_AllParticipantsReturnNil_LowParticipants(t *testing.T) {
+	lg := zerolog.Nop()
+
+	cfg := &config{
+		maxParticipants:    3,
+		agreementThreshold: 2,
+	}
+
+	// Zero responses — simulates all participants cancelled before execution.
+	analysis := &consensusAnalysis{
+		config:            cfg,
+		groups:            make(map[string]*responseGroup),
+		totalParticipants: 0,
+	}
+
+	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
+	winner := e.determineWinner(&lg, analysis)
+
+	require.NotNil(t, winner)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusLowParticipants),
+		"0 responses must produce ErrConsensusLowParticipants, got: %v", winner.Error)
+}
+
+// ===== SCENARIO J: Repeated concurrent runs stress test ====================
+
+// TestRace_StressN2Threshold2_NeverFalseLowParticipants runs the N=2,
+// threshold=2 cancel-after-execution scenario many times to flush out
+// scheduling-dependent races. Each iteration: both participants start, cancel
+// fires, both complete, check the result. Over 200 iterations, if any
+// scheduling order produces false ErrConsensusLowParticipants, this test
+// catches it.
+func TestRace_StressN2Threshold2_NeverFalseLowParticipants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test skipped in -short mode")
+	}
+
+	var lowPartCount atomic.Int32
+	var canceledCount atomic.Int32
+	var successCount atomic.Int32
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(iterations)
+
+	for iter := 0; iter < iterations; iter++ {
+		go func(iter int) {
+			defer wg.Done()
+
+			logger := zerolog.Nop()
+
+			pol := NewConsensusPolicyBuilder().
+				WithMaxParticipants(2).
+				WithAgreementThreshold(2).
+				WithLogger(&logger).
+				Build()
+
+			req := newTestRequest()
+
+			var started atomic.Int32
+			allStarted := make(chan struct{})
+			completeAll := make(chan struct{})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+			fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+			type result struct {
+				resp *common.NormalizedResponse
+				err  error
+			}
+			resultCh := make(chan result, 1)
+
+			go func() {
+				resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+					if started.Add(1) == 2 {
+						close(allStarted)
+					}
+					<-completeAll
+					return validResponse(), nil
+				})
+				resultCh <- result{resp, err}
+			}()
+
+			<-allStarted
+			cancel()
+			close(completeAll)
+
+			select {
+			case r := <-resultCh:
+				if r.err != nil {
+					if common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants) {
+						lowPartCount.Add(1)
+					} else if errors.Is(r.err, context.Canceled) {
+						canceledCount.Add(1)
+					}
+				} else {
+					successCount.Add(1)
+				}
+			case <-time.After(5 * time.Second):
+				t.Errorf("iter %d: deadlock", iter)
+			}
+		}(iter)
+	}
+
+	wg.Wait()
+
+	t.Logf("Results over %d iterations: success=%d, canceled=%d, low_participants=%d",
+		iterations, successCount.Load(), canceledCount.Load(), lowPartCount.Load())
+
+	require.Equal(t, int32(0), lowPartCount.Load(),
+		"ErrConsensusLowParticipants must NEVER appear when both participants complete with valid responses")
+}
+
+// ===== SCENARIO K: Short-circuit outcome races with ctx.Done() ============
+
+// TestRace_ShortCircuitOutcomeRacesCancel exercises a specific timing: N=3,
+// threshold=1. The first two participants return instantly (triggering
+// short-circuit), and cancel fires simultaneously. The short-circuit sends
+// the outcome to outcomeCh. If the caller's select picks ctx.Done() first,
+// the double-select retry must recover the already-buffered outcome.
+func TestRace_ShortCircuitOutcomeRacesCancel(t *testing.T) {
+	for iter := 0; iter < 50; iter++ {
+		func() {
+			logger := zerolog.Nop()
+
+			pol := NewConsensusPolicyBuilder().
+				WithMaxParticipants(3).
+				WithAgreementThreshold(1).
+				WithLogger(&logger).
+				Build()
+
+			req := newTestRequest()
+
+			var callCount atomic.Int32
+			slowRelease := make(chan struct{})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+			fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+			type result struct {
+				resp *common.NormalizedResponse
+				err  error
+			}
+			resultCh := make(chan result, 1)
+
+			go func() {
+				resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+					n := callCount.Add(1)
+					if n <= 2 {
+						return validResponse(), nil
+					}
+					<-slowRelease
+					return validResponse(), nil
+				})
+				resultCh <- result{resp, err}
+			}()
+
+			// Cancel immediately to race with short-circuit.
+			cancel()
+
+			select {
+			case r := <-resultCh:
+				if r.err != nil {
+					require.Falsef(t,
+						common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+						"iter %d: short-circuit + cancel race must not produce LowParticipants: %v", iter, r.err,
+					)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("iter %d: deadlock", iter)
+			}
+
+			close(slowRelease) // cleanup
+		}()
+	}
+}
+
+// ===== SCENARIO L: Caller decoupling — analyzer outlives caller ============
+
+// TestRace_AnalyzerCompletesAfterCallerAbandons verifies the core decoupling
+// property: when the caller abandons (ctx cancelled), the analyzer goroutine
+// still runs to completion and all participants finish their work. This is
+// critical for misbehavior tracking and response memory release.
+func TestRace_AnalyzerCompletesAfterCallerAbandons(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(2).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var innerFnCompletes atomic.Int32
+	var started atomic.Int32
+	allStarted := make(chan struct{})
+	completeAll := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	callerReturned := make(chan struct{})
+	go func() {
+		_, _ = fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if started.Add(1) == 2 {
+				close(allStarted)
+			}
+			<-completeAll
+			innerFnCompletes.Add(1)
+			return validResponse(), nil
+		})
+		close(callerReturned)
+	}()
+
+	<-allStarted
+	cancel()
+
+	// Caller should return promptly.
+	select {
+	case <-callerReturned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("caller blocked on stuck participants")
+	}
+
+	// Participants still haven't completed.
+	require.Equal(t, int32(0), innerFnCompletes.Load())
+
+	// Release participants.
+	close(completeAll)
+
+	// Analyzer should drain all responses (invariant I5).
+	require.Eventually(t, func() bool {
+		return innerFnCompletes.Load() == 2
+	}, time.Second, 10*time.Millisecond,
+		"all participants must complete even after caller abandons")
+}
+

--- a/consensus/executor_race_test.go
+++ b/consensus/executor_race_test.go
@@ -392,12 +392,16 @@ func TestRace_ThreeParticipants_OneCancelledBeforeExec_TwoValid(t *testing.T) {
 		// responses — but given N=3 with at least 1 guaranteed valid, and
 		// the innerFn is fast, at least 2 should complete in most runs.
 		if r.err != nil {
-			// Allow low-participants ONLY if context.Canceled is also present
-			// (meaning the caller abandoned before the analyzer could report).
 			if common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants) {
-				// This is acceptable ONLY in the true-positive case
-				t.Logf("low-participants returned — acceptable if some participants were genuinely pre-cancelled")
+				// Low-participants is correct ONLY if fewer than threshold
+				// participants actually entered innerFn. If 2+ ran (and
+				// therefore produced valid responses), reporting low-
+				// participants is the exact regression this PR fixes.
+				completed := callCount.Load()
+				assert.Less(t, completed, int32(2),
+					"ErrConsensusLowParticipants with %d completed participants (>= threshold=2) is a regression", completed)
 			}
+			// context.Canceled is always acceptable (caller abandoned).
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("mixed participation: deadlock")
@@ -856,10 +860,15 @@ func TestRace_ShortCircuitOutcomeRacesCancel(t *testing.T) {
 			select {
 			case r := <-resultCh:
 				if r.err != nil {
-					require.Falsef(t,
-						common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
-						"iter %d: short-circuit + cancel race must not produce LowParticipants: %v", iter, r.err,
-					)
+					if common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants) {
+						// Low-participants is legitimate ONLY if cancel raced
+						// before enough participants entered innerFn. If 2+
+						// participants ran (producing valid matching responses),
+						// reporting low-participants is the regression.
+						completed := callCount.Load()
+						require.Less(t, completed, int32(2),
+							"iter %d: ErrConsensusLowParticipants with %d completed participants (>= threshold) is a regression", iter, completed)
+					}
 				}
 			case <-time.After(2 * time.Second):
 				t.Fatalf("iter %d: deadlock", iter)

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"context"
 	"errors"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,6 +39,84 @@ func newTestRequest() *common.NormalizedRequest {
 func validResponse() *common.NormalizedResponse {
 	jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{"0x1"}, nil)
 	return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc)
+}
+
+func validResponseWithValue(value string) *common.NormalizedResponse {
+	jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{value}, nil)
+	return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc)
+}
+
+type trackingReadCloser struct {
+	closeCount *atomic.Int32
+}
+
+func (t *trackingReadCloser) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (t *trackingReadCloser) Close() error {
+	if t.closeCount != nil {
+		t.closeCount.Add(1)
+	}
+	return nil
+}
+
+func validResponseWithCloser(value string, closeCount *atomic.Int32) *common.NormalizedResponse {
+	return validResponseWithValue(value).WithBody(&trackingReadCloser{closeCount: closeCount})
+}
+
+type stubExecution struct {
+	ctx context.Context
+}
+
+func (s *stubExecution) Context() context.Context { return s.ctx }
+func (s *stubExecution) Attempts() int            { return 1 }
+func (s *stubExecution) Executions() int          { return 1 }
+func (s *stubExecution) Retries() int             { return 0 }
+func (s *stubExecution) Hedges() int              { return 0 }
+func (s *stubExecution) StartTime() time.Time     { return time.Now() }
+func (s *stubExecution) ElapsedTime() time.Duration {
+	return 0
+}
+func (s *stubExecution) LastResult() *common.NormalizedResponse { return nil }
+func (s *stubExecution) LastError() error                       { return nil }
+func (s *stubExecution) IsFirstAttempt() bool                   { return true }
+func (s *stubExecution) IsRetry() bool                          { return false }
+func (s *stubExecution) IsHedge() bool                          { return false }
+func (s *stubExecution) AttemptStartTime() time.Time            { return time.Now() }
+func (s *stubExecution) ElapsedAttemptTime() time.Duration      { return 0 }
+func (s *stubExecution) IsCanceled() bool                       { return s.ctx != nil && s.ctx.Err() != nil }
+func (s *stubExecution) Canceled() <-chan struct{} {
+	if s.ctx == nil {
+		return nil
+	}
+	return s.ctx.Done()
+}
+func (s *stubExecution) RecordResult(result *failsafeCommon.PolicyResult[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
+	return result
+}
+func (s *stubExecution) InitializeRetry() *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
+	return nil
+}
+func (s *stubExecution) Cancel(result *failsafeCommon.PolicyResult[*common.NormalizedResponse]) {}
+func (s *stubExecution) IsCanceledWithResult() (bool, *failsafeCommon.PolicyResult[*common.NormalizedResponse]) {
+	return s.IsCanceled(), nil
+}
+func (s *stubExecution) CopyWithResult(result *failsafeCommon.PolicyResult[*common.NormalizedResponse]) failsafe.Execution[*common.NormalizedResponse] {
+	return s
+}
+func (s *stubExecution) CopyForCancellable() failsafe.Execution[*common.NormalizedResponse] {
+	return s
+}
+func (s *stubExecution) CopyForHedge() failsafe.Execution[*common.NormalizedResponse] {
+	return s
+}
+func (s *stubExecution) CopyForCancellableWithValue(key, value any) failsafe.Execution[*common.NormalizedResponse] {
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &stubExecution{ctx: context.WithValue(ctx, key, value)}
 }
 
 // TestConsensus_ContextCancelAfterExecution_DoesNotReturnLowParticipants verifies
@@ -121,6 +200,51 @@ func TestConsensus_ContextCancelAfterExecution_DoesNotReturnLowParticipants(t *t
 	}
 }
 
+// TestExecuteParticipant_PostExecutionCancel_PreservesResult locks down the
+// exact bug window at the smallest unit boundary: ctx is canceled after the
+// participant finishes innerFn but before executeParticipant decides whether
+// to forward the result. A naive implementation drops the result as nil and
+// creates a false low-participants analysis downstream.
+func TestExecuteParticipant_PostExecutionCancel_PreservesResult(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	e := &executor{
+		consensusPolicy: &consensusPolicy{
+			config: &config{},
+			logger: &logger,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var bodyClosed atomic.Int32
+	expected := validResponseWithCloser("0xfeed", &bodyClosed)
+	responseCh := make(chan *execResult, 1)
+
+	e.executeParticipant(
+		ctx,
+		&logger,
+		&stubExecution{ctx: ctx},
+		metricsLabels{},
+		func(exec failsafe.Execution[*common.NormalizedResponse]) *failsafeCommon.PolicyResult[*common.NormalizedResponse] {
+			cancel()
+			return &failsafeCommon.PolicyResult[*common.NormalizedResponse]{Result: expected}
+		},
+		0,
+		responseCh,
+	)
+
+	select {
+	case got := <-responseCh:
+		require.NotNil(t, got, "post-execution cancellation must still forward the completed result")
+		require.Same(t, expected, got.Result)
+		require.NoError(t, got.Err)
+		require.Equal(t, int32(0), bodyClosed.Load(), "executeParticipant must not release a still-valid result")
+	case <-time.After(time.Second):
+		t.Fatal("executeParticipant did not forward its result within 1s")
+	}
+}
+
 // TestConsensus_CallerAbandons_ParticipantsStillComplete verifies that when the
 // caller abandons the request (ctx cancelled), the analyzer goroutine keeps
 // running and all participants get a chance to execute their innerFn. This is
@@ -186,6 +310,71 @@ func TestConsensus_CallerAbandons_ParticipantsStillComplete(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "all three participants should complete after unblock")
 }
 
+// TestConsensus_TwoParticipants_CancelAfterExecution_DoesNotReturnLowParticipants
+// covers the smallest quorum boundary that still requires agreement. This is
+// the most failure-prone production shape: only two eligible participants, both
+// finish real work, and the caller disconnects before analysis completes.
+func TestConsensus_TwoParticipants_CancelAfterExecution_DoesNotReturnLowParticipants(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(2).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var started atomic.Int32
+	allStarted := make(chan struct{})
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if started.Add(1) == 2 {
+				close(allStarted)
+			}
+			<-completeInnerFn
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	<-allStarted
+	cancel()
+	close(completeInnerFn)
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"must not report ErrConsensusLowParticipants when both 2/2 responses are valid: %v", r.err,
+			)
+			require.True(t,
+				errors.Is(r.err, context.Canceled) || errors.Is(r.err, context.DeadlineExceeded),
+				"unexpected error after caller abandon at 2/2 boundary: %v", r.err,
+			)
+		} else {
+			require.NotNil(t, r.resp)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consensus did not return within 2s at the 2/2 participant boundary")
+	}
+}
+
 // TestConsensus_ShortCircuit_CallerGetsWinnerBeforeSlowParticipants verifies
 // that short-circuit still works under Option D: once enough matching
 // responses arrive to give one group an unassailable lead, the caller
@@ -233,6 +422,49 @@ func TestConsensus_ShortCircuit_CallerGetsWinnerBeforeSlowParticipants(t *testin
 	// Unblock the slow participant so the analyzer can finish in the background
 	// and the test doesn't leak a goroutine.
 	close(slowRelease)
+}
+
+// TestConsensus_ShortCircuit_ReleasesLateResponses verifies the cleanup side of
+// the refactor: once the caller has been released on short-circuit, a later
+// non-winning response still has to be released exactly once. Without this,
+// the branch fixes correctness but leaks response buffers in the background.
+func TestConsensus_ShortCircuit_ReleasesLateResponses(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var callCount atomic.Int32
+	var slowBodyClosed atomic.Int32
+	slowRelease := make(chan struct{})
+
+	ctx := context.WithValue(context.Background(), common.RequestContextKey, req)
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		switch callCount.Add(1) {
+		case 1, 2:
+			return validResponseWithValue("0x1"), nil
+		default:
+			<-slowRelease
+			return validResponseWithCloser("0x2", &slowBodyClosed), nil
+		}
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, int32(0), slowBodyClosed.Load(), "slow response should not be released before it finishes")
+
+	close(slowRelease)
+
+	require.Eventually(t, func() bool {
+		return slowBodyClosed.Load() == 1
+	}, time.Second, 10*time.Millisecond, "late post-short-circuit response should be released exactly once")
 }
 
 // TestConsensus_HappyPath_NoCancel verifies the refactor does not break the

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -444,29 +443,11 @@ func TestConsensus_ShortCircuit_ReleasesLateResponses(t *testing.T) {
 	var slowBodyClosed atomic.Int32
 	slowRelease := make(chan struct{})
 
-	// A start barrier ensures all three participants pass executeParticipant's
-	// ctx.Err() pre-check and actually enter innerFn before any of them
-	// returns. Without this, slow CI schedulers may let participant 1 finish
-	// and short-circuit (cancelling the shared ctx) before participant 3 ever
-	// enters innerFn, causing the pre-check to early-return with nil and the
-	// trackingReadCloser never being constructed — a false negative for this
-	// test's "late response is released" invariant.
-	var started sync.WaitGroup
-	started.Add(3)
-	allStarted := make(chan struct{})
-	go func() {
-		started.Wait()
-		close(allStarted)
-	}()
-
 	ctx := context.WithValue(context.Background(), common.RequestContextKey, req)
 	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
 
 	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
-		n := callCount.Add(1)
-		started.Done()
-		<-allStarted
-		switch n {
+		switch callCount.Add(1) {
 		case 1, 2:
 			return validResponseWithValue("0x1"), nil
 		default:
@@ -483,7 +464,7 @@ func TestConsensus_ShortCircuit_ReleasesLateResponses(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return slowBodyClosed.Load() == 1
-	}, 5*time.Second, 10*time.Millisecond, "late post-short-circuit response should be released exactly once")
+	}, time.Second, 10*time.Millisecond, "late post-short-circuit response should be released exactly once")
 }
 
 // TestConsensus_HappyPath_NoCancel verifies the refactor does not break the
@@ -611,80 +592,6 @@ func TestConsensus_FireAndForget_CallerCancelDoesNotStopParticipants(t *testing.
 	require.Eventually(t, func() bool {
 		return innerFnCompletes.Load() == 3
 	}, time.Second, 10*time.Millisecond, "all fire-and-forget participants should complete after unblock")
-}
-
-// TestConsensus_CallerAbandons_WinnerResponseIsReleased guards against the
-// resource leak where a caller cancels its context before the analyzer
-// publishes an outcome: the analyzer still completes and publishes a winner
-// to the buffered outcomeCh, but nothing up the stack ever calls
-// winner.Result.Release() because the caller isn't returning the winner.
-// Without the abandon-path drain goroutine, the winner's body (JSON-RPC
-// buffer, pooled handles, trackingReadCloser) would never close.
-func TestConsensus_CallerAbandons_WinnerResponseIsReleased(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-
-	pol := NewConsensusPolicyBuilder().
-		WithMaxParticipants(3).
-		WithAgreementThreshold(1).
-		WithLogger(&logger).
-		Build()
-
-	req := newTestRequest()
-
-	var callCount atomic.Int32
-	var winnerBodyClosed atomic.Int32
-	var started sync.WaitGroup
-	started.Add(3)
-	allStarted := make(chan struct{})
-	go func() {
-		started.Wait()
-		close(allStarted)
-	}()
-	completeInnerFn := make(chan struct{})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, common.RequestContextKey, req)
-
-	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
-
-	callerReturned := make(chan struct{})
-	go func() {
-		_, _ = fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
-			n := callCount.Add(1)
-			started.Done()
-			<-allStarted
-			<-completeInnerFn
-			if n == 1 {
-				// First response becomes the winner (threshold=1 →
-				// short-circuit on first valid result).
-				return validResponseWithCloser("0x1", &winnerBodyClosed), nil
-			}
-			return validResponseWithValue("0x1"), nil
-		})
-		close(callerReturned)
-	}()
-
-	<-allStarted
-	cancel() // Abandon before any participant completes.
-
-	select {
-	case <-callerReturned:
-	case <-time.After(time.Second):
-		t.Fatal("caller did not return promptly after ctx cancel")
-	}
-
-	// Caller is gone; nothing up the stack holds a reference to the winner.
-	require.Equal(t, int32(0), winnerBodyClosed.Load(), "winner must not be released until analyzer finishes its reads")
-
-	// Unblock participants; analyzer now processes them, publishes the winner
-	// on outcomeCh, and finishes its cleanup — at which point the drain
-	// goroutine releases the winner.
-	close(completeInnerFn)
-
-	require.Eventually(t, func() bool {
-		return winnerBodyClosed.Load() == 1
-	}, 5*time.Second, 10*time.Millisecond, "abandon-path drain goroutine must release winner exactly once")
 }
 
 // TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic covers the catastrophic

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,13 +18,182 @@ import (
 
 func init() {
 	util.ConfigureTestLogger()
+	// Required: MetricConsensusDuration is a histogram that panics on
+	// WithLabelValues unless buckets have been initialized.
 	_ = telemetry.SetHistogramBuckets("")
 }
 
-// TestConsensus_ContextCancelAfterExecution_DoesNotDiscardResults verifies that
-// cancelling the parent context after participants have executed does not cause
-// ErrConsensusLowParticipants with participants: null.
-func TestConsensus_ContextCancelAfterExecution_DoesNotDiscardResults(t *testing.T) {
+func newTestRequest() *common.NormalizedRequest {
+	return common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
+	))
+}
+
+// validResponse returns a non-empty response so the unassailable_lead
+// short-circuit rule (which requires ResponseTypeNonEmpty) can fire when
+// tests exercise it. The content is arbitrary; only the non-empty shape
+// matters for classification.
+func validResponse() *common.NormalizedResponse {
+	jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{"0x1"}, nil)
+	return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc)
+}
+
+// TestConsensus_ContextCancelAfterExecution_DoesNotReturnLowParticipants verifies
+// the original bug fix: when the parent context is cancelled after every
+// participant has completed innerFn with a valid result, the consensus machinery
+// must NOT report ErrConsensusLowParticipants.
+//
+// Test construction notes:
+//   - agreementThreshold=3 (all participants must agree) prevents short-circuit
+//     from masking the bug — the analyzer is forced to read every response.
+//   - Synchronization uses channels, not time.Sleep, so the test is not flaky
+//     under CI scheduling pressure.
+//   - The cancel fires only after ALL three participants are inside innerFn,
+//     deterministically producing the "post-execution cancel" scenario.
+func TestConsensus_ContextCancelAfterExecution_DoesNotReturnLowParticipants(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(3).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var started atomic.Int32
+	allStarted := make(chan struct{})
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	type result struct {
+		resp *common.NormalizedResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	go func() {
+		resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if started.Add(1) == 3 {
+				close(allStarted)
+			}
+			<-completeInnerFn
+			return validResponse(), nil
+		})
+		resultCh <- result{resp, err}
+	}()
+
+	// Wait until all three participants are inside innerFn. Only then cancel.
+	<-allStarted
+	cancel()
+
+	// Allow participants to finish their work. Their results are valid and
+	// should flow to the analyzer even though ctx is cancelled.
+	close(completeInnerFn)
+
+	select {
+	case r := <-resultCh:
+		// Under Option D, two outcomes are valid:
+		//   1. The analyzer wins the caller select with a valid winner.
+		//   2. The caller wins the select with context.Canceled.
+		// What MUST NOT happen is ErrConsensusLowParticipants — that was the bug.
+		if r.err != nil {
+			require.Falsef(t,
+				common.HasErrorCode(r.err, common.ErrCodeConsensusLowParticipants),
+				"must not report ErrConsensusLowParticipants when 3 valid responses are available: %v", r.err,
+			)
+			require.Truef(t,
+				errors.Is(r.err, context.Canceled) || errors.Is(r.err, context.DeadlineExceeded),
+				"unexpected error after caller abandon: %v", r.err,
+			)
+		} else {
+			require.NotNil(t, r.resp)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consensus did not return within 2s after context cancel")
+	}
+}
+
+// TestConsensus_CallerAbandons_ParticipantsStillComplete verifies that when the
+// caller abandons the request (ctx cancelled), the analyzer goroutine keeps
+// running and all participants get a chance to execute their innerFn. This is
+// the core property of Option D: caller latency is decoupled from analysis
+// completeness.
+func TestConsensus_CallerAbandons_ParticipantsStillComplete(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(3).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var innerFnStarts atomic.Int32
+	var innerFnCompletes atomic.Int32
+	allStarted := make(chan struct{})
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	callerReturned := make(chan struct{})
+	go func() {
+		_, _ = fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if innerFnStarts.Add(1) == 3 {
+				close(allStarted)
+			}
+			<-completeInnerFn
+			innerFnCompletes.Add(1)
+			return validResponse(), nil
+		})
+		close(callerReturned)
+	}()
+
+	<-allStarted
+	cancel()
+
+	// Caller should return promptly without waiting for participants to finish.
+	// Participants are still blocked inside innerFn.
+	select {
+	case <-callerReturned:
+		// Caller returned quickly — this is the Option D guarantee.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("caller did not return within 500ms of ctx cancel — blocked on stuck participants")
+	}
+
+	// Sanity: participants are still running (have started but not completed).
+	require.Equal(t, int32(3), innerFnStarts.Load(), "all participants should have entered innerFn")
+	require.Equal(t, int32(0), innerFnCompletes.Load(), "no participant should have completed innerFn yet")
+
+	// Now let participants finish. The analyzer reads their results even
+	// though the caller is long gone.
+	close(completeInnerFn)
+
+	require.Eventually(t, func() bool {
+		return innerFnCompletes.Load() == 3
+	}, time.Second, 10*time.Millisecond, "all three participants should complete after unblock")
+}
+
+// TestConsensus_ShortCircuit_CallerGetsWinnerBeforeSlowParticipants verifies
+// that short-circuit still works under Option D: once enough matching
+// responses arrive to give one group an unassailable lead, the caller
+// receives the winner without waiting for the remaining slow participants.
+//
+// With maxParticipants=3 and agreementThreshold=1, short-circuit fires after
+// two matching responses (lead=2, remaining=1). So we configure two fast
+// participants and one slow one — after the two fast ones return, the
+// analyzer must short-circuit and hand the caller a winner.
+func TestConsensus_ShortCircuit_CallerGetsWinnerBeforeSlowParticipants(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	pol := NewConsensusPolicyBuilder().
@@ -32,46 +202,160 @@ func TestConsensus_ContextCancelAfterExecution_DoesNotDiscardResults(t *testing.
 		WithLogger(&logger).
 		Build()
 
-	req := common.NewNormalizedRequest([]byte(
-		`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
-	))
+	req := newTestRequest()
 
-	var started atomic.Int32
-	startedCh := make(chan struct{})
+	var callCount atomic.Int32
+	slowRelease := make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = context.WithValue(ctx, common.RequestContextKey, req)
 
-	// Cancel context shortly after participants begin executing
-	go func() {
-		<-startedCh
-		time.Sleep(5 * time.Millisecond)
-		cancel()
-	}()
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
 
-	executor := failsafe.NewExecutor(pol).WithContext(ctx)
-
-	resp, err := executor.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
-		if started.Add(1) == 1 {
-			close(startedCh)
+	start := time.Now()
+	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		n := callCount.Add(1)
+		if n <= 2 {
+			return validResponse(), nil // two fast participants with matching responses
 		}
-		// Small sleep so cancel lands while participants are in-flight
-		time.Sleep(20 * time.Millisecond)
+		<-slowRelease // third participant blocks indefinitely
+		return validResponse(), nil
+	})
+	elapsed := time.Since(start)
 
-		jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{}, nil)
-		return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc), nil
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Less(t, elapsed, 500*time.Millisecond, "short-circuit should fire before the slow participant completes")
+
+	// Unblock the slow participant so the analyzer can finish in the background
+	// and the test doesn't leak a goroutine.
+	close(slowRelease)
+}
+
+// TestConsensus_HappyPath_NoCancel verifies the refactor does not break the
+// normal non-cancelled execution path.
+func TestConsensus_HappyPath_NoCancel(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	ctx := context.WithValue(context.Background(), common.RequestContextKey, req)
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		return validResponse(), nil
 	})
 
-	// The fix: we should NOT get ErrConsensusLowParticipants here.
-	// Before the fix, all participants discarded their valid results on ctx cancel,
-	// producing 0 groups -> "participants: null".
-	if err != nil {
-		assert.False(t,
-			common.HasErrorCode(err, common.ErrCodeConsensusLowParticipants),
-			"should not get ErrConsensusLowParticipants when participants returned valid results: %v", err,
-		)
-	} else {
-		require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestConsensus_CancelBeforeExecution_ReturnsLowParticipants verifies the
+// preserved behavior for the case that is NOT the bug being fixed: when every
+// participant sees the context as already-cancelled before it enters innerFn,
+// there are no results to analyze, and ErrConsensusLowParticipants is the
+// correct response.
+func TestConsensus_CancelBeforeExecution_ReturnsLowParticipants(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(2).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately, before any participant runs
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	var callCount atomic.Int32
+	_, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		callCount.Add(1)
+		return validResponse(), nil
+	})
+
+	// Caller may see either ErrConsensusLowParticipants (if analyzer ran to
+	// completion and saw 0 valid responses) or context.Canceled (if the caller
+	// select hit ctx.Done() before the analyzer sent the outcome). Both are
+	// correct; what matters is that neither a bogus consensus nor a panic
+	// occurs.
+	require.Error(t, err)
+	assert.True(t,
+		common.HasErrorCode(err, common.ErrCodeConsensusLowParticipants) ||
+			errors.Is(err, context.Canceled),
+		"unexpected error when ctx is cancelled before any participant runs: %v", err,
+	)
+}
+
+// TestConsensus_FireAndForget_CallerCancelDoesNotStopParticipants verifies
+// that fire-and-forget mode continues to run participants to completion even
+// after the caller's context is cancelled. This is the critical property for
+// transaction broadcasting: the tx must reach every node regardless of
+// whether the HTTP client disconnected.
+func TestConsensus_FireAndForget_CallerCancelDoesNotStopParticipants(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(3).
+		WithFireAndForget(true).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var innerFnStarts atomic.Int32
+	var innerFnCompletes atomic.Int32
+	allStarted := make(chan struct{})
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	callerReturned := make(chan struct{})
+	go func() {
+		_, _ = fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			if innerFnStarts.Add(1) == 3 {
+				close(allStarted)
+			}
+			<-completeInnerFn
+			innerFnCompletes.Add(1)
+			return validResponse(), nil
+		})
+		close(callerReturned)
+	}()
+
+	<-allStarted
+	cancel()
+
+	// Caller returns quickly.
+	select {
+	case <-callerReturned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fire-and-forget caller did not return promptly after ctx cancel")
 	}
+
+	// Participants have not been cancelled (fire-and-forget uses WithoutCancel).
+	require.Equal(t, int32(0), innerFnCompletes.Load(), "participants must not complete before we release them")
+
+	// Release them; they should all complete.
+	close(completeInnerFn)
+
+	require.Eventually(t, func() bool {
+		return innerFnCompletes.Load() == 3
+	}, time.Second, 10*time.Millisecond, "all fire-and-forget participants should complete after unblock")
 }

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -443,11 +444,29 @@ func TestConsensus_ShortCircuit_ReleasesLateResponses(t *testing.T) {
 	var slowBodyClosed atomic.Int32
 	slowRelease := make(chan struct{})
 
+	// A start barrier ensures all three participants pass executeParticipant's
+	// ctx.Err() pre-check and actually enter innerFn before any of them
+	// returns. Without this, slow CI schedulers may let participant 1 finish
+	// and short-circuit (cancelling the shared ctx) before participant 3 ever
+	// enters innerFn, causing the pre-check to early-return with nil and the
+	// trackingReadCloser never being constructed — a false negative for this
+	// test's "late response is released" invariant.
+	var started sync.WaitGroup
+	started.Add(3)
+	allStarted := make(chan struct{})
+	go func() {
+		started.Wait()
+		close(allStarted)
+	}()
+
 	ctx := context.WithValue(context.Background(), common.RequestContextKey, req)
 	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
 
 	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
-		switch callCount.Add(1) {
+		n := callCount.Add(1)
+		started.Done()
+		<-allStarted
+		switch n {
 		case 1, 2:
 			return validResponseWithValue("0x1"), nil
 		default:
@@ -464,7 +483,7 @@ func TestConsensus_ShortCircuit_ReleasesLateResponses(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return slowBodyClosed.Load() == 1
-	}, time.Second, 10*time.Millisecond, "late post-short-circuit response should be released exactly once")
+	}, 5*time.Second, 10*time.Millisecond, "late post-short-circuit response should be released exactly once")
 }
 
 // TestConsensus_HappyPath_NoCancel verifies the refactor does not break the
@@ -592,6 +611,80 @@ func TestConsensus_FireAndForget_CallerCancelDoesNotStopParticipants(t *testing.
 	require.Eventually(t, func() bool {
 		return innerFnCompletes.Load() == 3
 	}, time.Second, 10*time.Millisecond, "all fire-and-forget participants should complete after unblock")
+}
+
+// TestConsensus_CallerAbandons_WinnerResponseIsReleased guards against the
+// resource leak where a caller cancels its context before the analyzer
+// publishes an outcome: the analyzer still completes and publishes a winner
+// to the buffered outcomeCh, but nothing up the stack ever calls
+// winner.Result.Release() because the caller isn't returning the winner.
+// Without the abandon-path drain goroutine, the winner's body (JSON-RPC
+// buffer, pooled handles, trackingReadCloser) would never close.
+func TestConsensus_CallerAbandons_WinnerResponseIsReleased(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var callCount atomic.Int32
+	var winnerBodyClosed atomic.Int32
+	var started sync.WaitGroup
+	started.Add(3)
+	allStarted := make(chan struct{})
+	go func() {
+		started.Wait()
+		close(allStarted)
+	}()
+	completeInnerFn := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	callerReturned := make(chan struct{})
+	go func() {
+		_, _ = fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+			n := callCount.Add(1)
+			started.Done()
+			<-allStarted
+			<-completeInnerFn
+			if n == 1 {
+				// First response becomes the winner (threshold=1 →
+				// short-circuit on first valid result).
+				return validResponseWithCloser("0x1", &winnerBodyClosed), nil
+			}
+			return validResponseWithValue("0x1"), nil
+		})
+		close(callerReturned)
+	}()
+
+	<-allStarted
+	cancel() // Abandon before any participant completes.
+
+	select {
+	case <-callerReturned:
+	case <-time.After(time.Second):
+		t.Fatal("caller did not return promptly after ctx cancel")
+	}
+
+	// Caller is gone; nothing up the stack holds a reference to the winner.
+	require.Equal(t, int32(0), winnerBodyClosed.Load(), "winner must not be released until analyzer finishes its reads")
+
+	// Unblock participants; analyzer now processes them, publishes the winner
+	// on outcomeCh, and finishes its cleanup — at which point the drain
+	// goroutine releases the winner.
+	close(completeInnerFn)
+
+	require.Eventually(t, func() bool {
+		return winnerBodyClosed.Load() == 1
+	}, 5*time.Second, 10*time.Millisecond, "abandon-path drain goroutine must release winner exactly once")
 }
 
 // TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic covers the catastrophic

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
 	"github.com/failsafe-go/failsafe-go"
+	failsafeCommon "github.com/failsafe-go/failsafe-go/common"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func init() {
@@ -358,4 +360,37 @@ func TestConsensus_FireAndForget_CallerCancelDoesNotStopParticipants(t *testing.
 	require.Eventually(t, func() bool {
 		return innerFnCompletes.Load() == 3
 	}, time.Second, 10*time.Millisecond, "all fire-and-forget participants should complete after unblock")
+}
+
+// TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic covers the catastrophic
+// path where the analyzer goroutine panics before any responses are
+// classified and hands the caller an outcome with nil analysis. The caller
+// must not trigger a secondary nil-pointer dereference when recording
+// metrics — it should emit a minimal outcome and return.
+func TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	e := &executor{
+		consensusPolicy: &consensusPolicy{
+			config: &config{agreementThreshold: 1},
+			logger: &logger,
+		},
+	}
+
+	req := newTestRequest()
+	labels := metricsLabels{
+		projectId:   "test-proj",
+		networkId:   "test-net",
+		category:    "eth_getLogs",
+		finalityStr: "latest",
+		method:      "eth_getLogs",
+	}
+	span := trace.SpanFromContext(context.Background()) // noop span
+
+	result := &failsafeCommon.PolicyResult[*common.NormalizedResponse]{
+		Error: errors.New("simulated analyzer panic"),
+	}
+
+	require.NotPanics(t, func() {
+		e.recordMetricsAndTracing(req, time.Now(), result, nil /* analysis */, labels, span)
+	})
 }

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -1,0 +1,77 @@
+package consensus
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
+	"github.com/erpc/erpc/util"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	util.ConfigureTestLogger()
+	_ = telemetry.SetHistogramBuckets("")
+}
+
+// TestConsensus_ContextCancelAfterExecution_DoesNotDiscardResults verifies that
+// cancelling the parent context after participants have executed does not cause
+// ErrConsensusLowParticipants with participants: null.
+func TestConsensus_ContextCancelAfterExecution_DoesNotDiscardResults(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
+	))
+
+	var started atomic.Int32
+	startedCh := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	// Cancel context shortly after participants begin executing
+	go func() {
+		<-startedCh
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	executor := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	resp, err := executor.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		if started.Add(1) == 1 {
+			close(startedCh)
+		}
+		// Small sleep so cancel lands while participants are in-flight
+		time.Sleep(20 * time.Millisecond)
+
+		jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{}, nil)
+		return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc), nil
+	})
+
+	// The fix: we should NOT get ErrConsensusLowParticipants here.
+	// Before the fix, all participants discarded their valid results on ctx cancel,
+	// producing 0 groups -> "participants: null".
+	if err != nil {
+		assert.False(t,
+			common.HasErrorCode(err, common.ErrCodeConsensusLowParticipants),
+			"should not get ErrConsensusLowParticipants when participants returned valid results: %v", err,
+		)
+	} else {
+		require.NotNil(t, resp)
+	}
+}

--- a/erpc/networks_sendrawtx_test.go
+++ b/erpc/networks_sendrawtx_test.go
@@ -1919,14 +1919,14 @@ func TestNetwork_SendRawTransaction_FireAndForget(t *testing.T) {
 		// FIX: Using context.WithoutCancel() detaches from parent cancellation
 		cancel()
 
-		// Wait for background requests to complete
-		// This is the critical part: even though parent context is cancelled,
-		// fire-and-forget background requests should still complete
-		time.Sleep(700 * time.Millisecond)
-
-		// All mocks should be consumed - proves background requests completed
-		// despite parent context cancellation
-		assert.Equal(t, util.EvmBlockTrackerMocks, len(gock.Pending()),
+		// Wait for background requests to complete. Even though parent
+		// context is cancelled, fire-and-forget background requests should
+		// still complete. We poll instead of sleeping a fixed interval
+		// because CI runners (especially with -race) can add significant
+		// slack on top of the 500 ms mock delay.
+		require.Eventually(t, func() bool {
+			return len(gock.Pending()) == util.EvmBlockTrackerMocks
+		}, 3*time.Second, 50*time.Millisecond,
 			"all sendRawTx mocks should be consumed - background requests must complete even after parent context cancelled")
 	})
 
@@ -2004,13 +2004,13 @@ func TestNetwork_SendRawTransaction_FireAndForget(t *testing.T) {
 		err := <-errChan
 		assert.Error(t, err, "should return error when context cancelled before any response")
 
-		// Wait for ALL background requests to complete despite parent cancellation
-		// This is the key test: fire-and-forget should let all requests finish
-		time.Sleep(900 * time.Millisecond)
-
-		// All mocks should be consumed - proves requests completed even though
-		// parent was cancelled before ANY result was received
-		assert.Equal(t, util.EvmBlockTrackerMocks, len(gock.Pending()),
+		// Poll for ALL background requests to complete despite parent
+		// cancellation. Polling (instead of a fixed sleep) avoids flaking
+		// on loaded CI runners where the slowest 700 ms mock can miss a
+		// tight fixed window.
+		require.Eventually(t, func() bool {
+			return len(gock.Pending()) == util.EvmBlockTrackerMocks
+		}, 3*time.Second, 50*time.Millisecond,
 			"fire-and-forget must broadcast to all nodes even when parent cancelled before short-circuit")
 	})
 }


### PR DESCRIPTION
## Summary

- When a consensus participant's execution completed but the parent context was already cancelled, the valid result was discarded (released + nil sent on response channel)
- If all participants hit this window, the collect loop received zero non-nil responses → 0 groups → `ErrConsensusLowParticipants` with `participants: null`
- Fix: let the result flow through to normal processing. Cleanup is already handled downstream by `drainResponsesInBackground` if the collect loop exited early

## Test plan

- [x] `go build ./consensus/...` compiles clean
- [x] `go test ./consensus/...` passes
- [ ] Deploy to staging and monitor for `ErrConsensusLowParticipants` with `participants: null` — should stop occurring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors consensus execution into a two-goroutine handoff with buffered channel coordination; concurrency and lifecycle changes could introduce subtle deadlocks/leaks or metric/tracing inconsistencies despite extensive new race tests.
> 
> **Overview**
> Fixes a cancellation race where results completed after `ctx` cancellation were dropped, causing false `ErrConsensusLowParticipants` and missing participants.
> 
> Refactors consensus execution to **decouple caller latency from analysis completion**: `executeConsensus` now returns via a buffered `outcomeCh` while a new `runAnalyzer` goroutine collects all participant responses, performs analysis/short-circuiting, records misbehavior, and releases non-winning (and late-arriving) responses.
> 
> Hardens concurrency/telemetry: `consensusAnalysis` eagerly precomputes cached accessors to avoid races, `recordMetricsAndTracing` tolerates `nil` analysis on analyzer panic, and new unit + race tests lock down cancellation/short-circuit/panic invariants across low participant counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9516836a7bdf60291e6561e59b4771db1ff79a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->