### PR TITLE
fix: stop retrying sendRawTransaction balance errors

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -335,13 +335,31 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 		}
 
 		//----------------------------------------------------------------
-		// "Transaction rejected" or "Insufficient funds" or "out of gas" errors
-		// Note: This comes AFTER nonce/duplicate detection to avoid masking those errors
+		// "Insufficient funds / balance" errors
+		// Note: This comes AFTER nonce/duplicate detection to avoid masking those errors.
+		// For eth_sendRawTransaction these are treated as deterministic client-side state
+		// failures, so they should not be retried across upstreams by default.
+		//----------------------------------------------------------------
+
+		if strings.Contains(msg, "insufficient funds") ||
+			strings.Contains(msg, "insufficient balance") {
+			return common.NewErrEndpointExecutionException(
+				common.NewErrJsonRpcExceptionInternal(
+					int(code),
+					common.JsonRpcErrorTransactionRejected,
+					err.Message,
+					nil,
+					details,
+				),
+			)
+		}
+
+		//----------------------------------------------------------------
+		// "Transaction rejected" or "out of gas" errors
+		// Note: This comes AFTER nonce/duplicate detection to avoid masking those errors.
 		//----------------------------------------------------------------
 
 		if code == common.JsonRpcErrorTransactionRejected ||
-			strings.Contains(msg, "insufficient funds") ||
-			strings.Contains(msg, "insufficient balance") ||
 			strings.Contains(msg, "out of gas") ||
 			strings.Contains(msg, "gas too low") ||
 			strings.Contains(msg, "IntrinsicGas") {

--- a/erpc/networks_sendrawtx_test.go
+++ b/erpc/networks_sendrawtx_test.go
@@ -714,15 +714,15 @@ func TestNetwork_SendRawTransaction_Idempotency(t *testing.T) {
 		assert.Contains(t, jrr.GetResultString(), "0x")
 	})
 
-	// Insufficient funds is retryable across upstreams
-	t.Run("InsufficientFundsIsRetryableAcrossUpstreams", func(t *testing.T) {
+	// Insufficient funds should fail fast instead of retrying across upstreams.
+	t.Run("InsufficientFundsIsNotRetriedAcrossUpstreams", func(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
 
 		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleSignedTx + `"]}`)
 
-		// First upstream returns "insufficient funds" - might be stale balance check
+		// Single upstream returns "insufficient funds"
 		gock.New("http://rpc1.localhost").
 			Post("").
 			Filter(func(r *http.Request) bool {
@@ -739,38 +739,41 @@ func TestNetwork_SendRawTransaction_Idempotency(t *testing.T) {
 				},
 			})
 
-		// Second upstream succeeds (has more up-to-date balance)
-		gock.New("http://rpc2.localhost").
-			Post("").
-			Filter(func(r *http.Request) bool {
-				body := util.SafeReadBody(r)
-				return strings.Contains(body, "eth_sendRawTransaction")
-			}).
-			Reply(200).
-			JSON(map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"result":  expectedTxHash,
-			})
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		network := setupSendRawTxTestNetworkWithRetry(t, ctx, &common.RetryPolicyConfig{
-			MaxAttempts: 3,
-			Delay:       common.Duration(10 * time.Millisecond),
-		})
+		upstreamConfigs := []*common.UpstreamConfig{{
+			Type:     common.UpstreamTypeEvm,
+			Id:       "rpc1",
+			Endpoint: "http://rpc1.localhost",
+			Evm: &common.EvmUpstreamConfig{
+				ChainId: 123,
+			},
+		}}
+		networkConfig := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm: &common.EvmNetworkConfig{
+				ChainId: 123,
+			},
+			Failsafe: []*common.FailsafeConfig{{
+				Retry: &common.RetryPolicyConfig{
+					MaxAttempts: 3,
+					Delay:       common.Duration(10 * time.Millisecond),
+				},
+			}},
+		}
+		network := setupSendRawTxNetwork(t, ctx, upstreamConfigs, networkConfig)
 
 		req := common.NewNormalizedRequest(requestBytes)
 		resp, err := network.Forward(ctx, req)
 
-		// Should succeed - retried to second upstream
-		require.NoError(t, err, "insufficient funds should be retryable to other upstreams")
-		require.NotNil(t, resp)
-
-		jrr, err := resp.JsonRpcResponse()
-		require.NoError(t, err)
-		assert.Contains(t, jrr.GetResultString(), expectedTxHash)
+		// Should fail fast with the deterministic balance error and never retry the same upstream.
+		require.Error(t, err, "insufficient funds should not be retried to other upstreams")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeEndpointExecutionException),
+			"expected ErrCodeEndpointExecutionException but got: %v", err)
+		assert.Nil(t, resp)
+		assert.Equal(t, util.EvmBlockTrackerMocks, len(gock.Pending()),
+			"insufficient funds should not trigger retry attempts")
 	})
 
 	// Verification call returns error (not null) - should return original nonce error


### PR DESCRIPTION
## Summary
- treat `insufficient funds` / `insufficient balance` as non-retryable for `eth_sendRawTransaction`
- update send-raw tests

## Test
- `go test ./erpc -run 'TestNetwork_SendRawTransaction_Idempotency/(InsufficientFundsIsNotRetriedAcrossUpstreams|AllUpstreamsRevertReturnsRevertError)$'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/failover behavior for transaction submission, which can affect reliability and user-facing errors if the new classification is too broad or upstream messages differ.
> 
> **Overview**
> Stops treating `eth_sendRawTransaction` `insufficient funds` / `insufficient balance` responses as retryable across upstreams by splitting balance errors out of the generic transaction-rejected/out-of-gas bucket in `architecture/evm/error_normalizer.go`.
> 
> Updates the send-raw transaction idempotency tests to expect a deterministic `ErrEndpointExecutionException` and verify no retry attempts are made when an upstream returns an insufficient-funds error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e055659f1339a55bbe46b8d51b0788435e7037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->