### PR TITLE
fix(evm): normalize Alchemy/DRPC/Infura 'eth_getLogs too large' errors

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -97,7 +97,11 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 				),
 				common.EvmBlockRangeTooLarge,
 			)
-		} else if strings.Contains(msg, "specify less number of address") {
+		} else if strings.Contains(msg, "specify less number of address") ||
+			// Alchemy/DRPC: "exceed max addresses or topics per search position"
+			strings.Contains(msg, "addresses or topics per search position") ||
+			// Infura: "This query contains N filters. The current limit is 5000."
+			(strings.Contains(msg, "filters") && strings.Contains(msg, "current limit is")) {
 			return common.NewErrEndpointRequestTooLarge(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),

--- a/architecture/evm/error_normalizer_test.go
+++ b/architecture/evm/error_normalizer_test.go
@@ -1,0 +1,57 @@
+package evm
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+)
+
+// TestExtractJsonRpcError_RequestTooLargeNormalization verifies that
+// provider-specific "eth_getLogs too large" error messages are normalized to
+// ErrEndpointRequestTooLarge so that network-level getLogsSplitOnError can
+// split the request and retry across upstreams.
+func TestExtractJsonRpcError_RequestTooLargeNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "existing: specify less number of address",
+			message: "please specify less number of address in the getLogs query",
+		},
+		{
+			name:    "alchemy/drpc: exceed max addresses or topics per search position",
+			message: "exceed max addresses or topics per search position",
+		},
+		{
+			name:    "infura: filters limit",
+			message: "This query contains 5006 filters. The current limit is 5000.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &http.Response{StatusCode: 200, Header: http.Header{}}
+			jrErr := common.NewErrJsonRpcExceptionExternal(
+				int(common.JsonRpcErrorServerSideException),
+				tc.message,
+				"",
+			)
+			jr := common.MustNewJsonRpcResponse(1, nil, jrErr)
+
+			err := ExtractJsonRpcError(r, nil, jr, nil)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !common.HasErrorCode(err, common.ErrCodeEndpointRequestTooLarge) {
+				t.Fatalf("expected ErrEndpointRequestTooLarge, got %T: %v", err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Normalize three additional provider-specific `eth_getLogs` too-large error shapes to `ErrEndpointRequestTooLarge` so `network.evm.getLogsSplitOnError` actually fires
- Add a focused test covering both the existing phrase and the two new ones

## Motivation

While operating an eRPC instance backed by a mixed pool (Alchemy, Infura, DRPC, Ankr, Tenderly, Envio HyperRPC), I observed sustained `eth_getLogs` failures that should have been auto-split via \`getLogsSplitOnError\`, but weren't, because the error messages don't match any of the substrings in \`architecture/evm/error_normalizer.go\`:

- Alchemy / DRPC (code \`-32000\`, status \`200\`):
  \`exceed max addresses or topics per search position\`
- Infura (code \`-32005\` / \`-32600\`):
  \`This query contains 5006 filters. The current limit is 5000.\`

Both are functionally the same problem the existing \`specify less number of address\` branch handles: the upstream is telling us the address/topic fanout is too big. Instead of being classified as \`ErrEndpointRequestTooLarge\`, they fall through to \`ErrEndpointServerSideException\`, so the network-level splitter never runs.

## Change

`architecture/evm/error_normalizer.go`: extend the existing \`specify less number of address\` branch to also match:

- \`addresses or topics per search position\` (Alchemy, DRPC)
- \`filters\` + \`current limit is\` (Infura)

Both are classified as \`EvmAddressesTooLarge\`, consistent with the existing branch, because \`TooLargeComplaint\` has no finer-grained variant today. Block-range messages still hit the dedicated \`EvmBlockRangeTooLarge\` branch.

## Test

New \`architecture/evm/error_normalizer_test.go\` covers:

- Existing: \`please specify less number of address in the getLogs query\`
- New: \`exceed max addresses or topics per search position\`
- New: \`This query contains 5006 filters. The current limit is 5000.\`

All three assert that \`ExtractJsonRpcError\` returns an error with code \`ErrEndpointRequestTooLarge\`.

Local run:

\`\`\`
go test ./architecture/evm/... -count=1
ok  github.com/erpc/erpc/architecture/evm  0.357s
\`\`\`

## Impact

- Enables \`getLogsSplitOnError: true\` to auto-split on Alchemy, DRPC and Infura upstreams
- No change in behavior when the knob is off
- No new complaint types or config surface