### PR TITLE
fix: bound continueAsyncRefresh goroutine lifetime

### DIFF
--- a/data/shared_state_variable.go
+++ b/data/shared_state_variable.go
@@ -503,14 +503,28 @@ func (c *counterInt64) applyRefreshResult(initialVal int64, r refreshResult) (in
 
 func (c *counterInt64) continueAsyncRefresh(resultCh <-chan refreshResult) {
 	go func() {
-		r, ok := <-resultCh
-		if !ok {
+		// Bound the helper's lifetime. The paired refresh worker is capped by
+		// fnCtx (fallbackTimeout), but if a downstream call ignores its context
+		// the worker may never send and this goroutine would leak permanently.
+		// Cap at fallbackTimeout + a small buffer; drop the eventual value in
+		// the pathological case — the next TryUpdateIfStale will refresh again.
+		timer := time.NewTimer(c.registry.fallbackTimeout + time.Second)
+		defer timer.Stop()
+
+		select {
+		case r, ok := <-resultCh:
+			if !ok {
+				return
+			}
+			// Apply result locally; remote push is scheduled async and MUST NOT block request flow.
+			c.updateMu.Lock()
+			_, _ = c.applyRefreshResult(c.value.Load(), r)
+			c.updateMu.Unlock()
+		case <-timer.C:
+			return
+		case <-c.registry.appCtx.Done():
 			return
 		}
-		// Apply result locally; remote push is scheduled async and MUST NOT block request flow.
-		c.updateMu.Lock()
-		_, _ = c.applyRefreshResult(c.value.Load(), r)
-		c.updateMu.Unlock()
 	}()
 }
 

--- a/data/shared_state_variable_timeout_test.go
+++ b/data/shared_state_variable_timeout_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -228,4 +229,55 @@ func TestBackgroundPushIsDeduped(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, int64(20), ctr.GetValue())
 	c.AssertExpectations(t)
+}
+
+// TestContinueAsyncRefresh_DoesNotLeakOnStuckWorker proves the helper
+// goroutine exits even when the refresh function blocks past its context.
+// Before the fix, the helper read from resultCh with no deadline; a worker
+// that ignored its context would leak the helper for the process lifetime.
+func TestContinueAsyncRefresh_DoesNotLeakOnStuckWorker(t *testing.T) {
+	cfg := &common.SharedStateConfig{
+		ClusterKey:      "test",
+		FallbackTimeout: common.Duration(100 * time.Millisecond),
+		LockTtl:         common.Duration(1 * time.Second),
+		LockMaxWait:     common.Duration(10 * time.Millisecond),
+		UpdateMaxWait:   common.Duration(10 * time.Millisecond),
+	}
+	r, c := setupMockRegistry(t, cfg)
+
+	// Background reconcile paths may fire; allow but don't require them.
+	lock := &MockLock{}
+	lock.On("Unlock", mock.Anything).Return(nil).Maybe()
+	c.On("Lock", mock.Anything, mock.Anything, mock.Anything).Return(lock, nil).Maybe()
+	c.On("Get", mock.Anything, ConnectorMainIndex, mock.Anything, "value", nil).Return([]byte(""), errors.New("not found")).Maybe()
+	c.On("Set", mock.Anything, mock.Anything, "value", mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.On("PublishCounterInt64", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	ctr := &counterInt64{registry: r, key: "test/stuck", ignoreRollbackOf: 1024}
+	ctr.value.Store(1)
+
+	// Worker that ignores its context and only unblocks when we say so.
+	release := make(chan struct{})
+	defer close(release)
+
+	before := runtime.NumGoroutine()
+
+	// Foreground returns quickly via updateMaxWait; worker keeps running.
+	val, err := ctr.TryUpdateIfStale(context.Background(), 1*time.Millisecond, func(ctx context.Context) (int64, error) {
+		<-release
+		return 42, nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), val, "foreground should return stale value")
+
+	// Helper is now waiting on resultCh. Wait longer than FallbackTimeout plus
+	// the 1s buffer so the helper's bounded timer fires.
+	time.Sleep(cfg.FallbackTimeout.Duration() + 1500*time.Millisecond)
+
+	// Helper must have exited even though the worker is still blocked.
+	// Exactly one lingering goroutine is expected (the stuck worker); the
+	// helper and any transient goroutines must be gone.
+	after := runtime.NumGoroutine()
+	assert.LessOrEqual(t, after-before, 1,
+		"expected at most the stuck worker to remain; got delta=%d", after-before)
 }

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/failsafe-go/failsafe-go v0.6.8 => github.com/aramalipoor/failsafe-go v0.0.0-20260223183747-e5f7847e3689
+replace github.com/failsafe-go/failsafe-go v0.6.8 => github.com/aramalipoor/failsafe-go v0.0.0-20260420113751-603cec9ae381
 
 replace github.com/blockchain-data-standards/manifesto v0.0.0 => github.com/blockchain-data-standards/manifesto v0.0.0-20260417185455-377cced2b921
 

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alicebob/miniredis/v2 v2.36.1 h1:Dvc5oAnNOr7BIfPn7tF269U8DvRW1dBG2D5n0WrfYMI=
 github.com/alicebob/miniredis/v2 v2.36.1/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
-github.com/aramalipoor/failsafe-go v0.0.0-20260223183747-e5f7847e3689 h1:QiQB+hLuAOzKTnbATxCfF8Hu1mvbY0hJ/47WTRmdy6s=
-github.com/aramalipoor/failsafe-go v0.0.0-20260223183747-e5f7847e3689/go.mod h1:4Y0ElBvDejSTmE59wFOHPwJomW6UaSlE/EZHYtJ99UQ=
+github.com/aramalipoor/failsafe-go v0.0.0-20260420113751-603cec9ae381 h1:ilAHXv3pbJD9xVnf0bBh7Xr8t2qRZdiwy8swC+kmxmc=
+github.com/aramalipoor/failsafe-go v0.0.0-20260420113751-603cec9ae381/go.mod h1:4Y0ElBvDejSTmE59wFOHPwJomW6UaSlE/EZHYtJ99UQ=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
continueAsyncRefresh spawns a helper goroutine that reads the eventual result of a slow TryUpdateIfStale refresh. The receive on resultCh had no deadline, so if the paired refresh worker blocked past its fnCtx (fallbackTimeout) — for example when a downstream call ignores its context — the helper would wait forever. Under sustained load these helpers accumulate without bound.

Wrap the receive in a select that also watches the registry appCtx and a timer capped at fallbackTimeout + 1s. In the pathological case the eventual value is dropped; a subsequent TryUpdateIfStale will refresh again.

Add TestContinueAsyncRefresh_DoesNotLeakOnStuckWorker which blocks the refresh worker indefinitely and asserts the helper goroutine still exits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency/timeout behavior in `TryUpdateIfStale`’s async refresh path; incorrect timing could drop late refresh results or subtly change update propagation, but the change is localized and covered by a new test.
> 
> **Overview**
> Prevents `counterInt64.continueAsyncRefresh` from leaking goroutines by bounding the helper’s wait on `resultCh` with a timer (`fallbackTimeout` + 1s) and `appCtx` cancellation; late refresh results are intentionally dropped in the pathological case.
> 
> Adds `TestContinueAsyncRefresh_DoesNotLeakOnStuckWorker` to simulate a refresh worker that ignores context and assert the helper goroutine still exits (using `runtime.NumGoroutine`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aee27c662c8a5629df11d5518fca320d3e09e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->