### PR TITLE
fix: drop 'user' label from duration histograms to bound cardinality

### DIFF
--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -120,7 +120,6 @@ func projectPreForward_eth_getLogs(ctx context.Context, n common.Network, nq *co
 				n.ProjectId(),
 				n.Label(),
 				"eth_getLogs",
-				nq.UserId(),
 				finalityStr,
 			).
 			Observe(rangeSize)

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -213,7 +213,6 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 			upstreamId,
 			method,
 			finality.String(),
-			nq.UserId(),
 		).Observe(dur.Seconds())
 		return resp, err
 	} else {
@@ -244,7 +243,6 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 			"<error>",
 			method,
 			finality.String(),
-			nq.UserId(),
 		).Observe(time.Since(start).Seconds())
 	}
 

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -197,10 +197,11 @@ type urdoKey struct {
 	category  string
 	composite string
 	finality  string
-	user      string
 }
 
-func (t *Tracker) getUpstreamRequestDurationObserver(up common.Upstream, method, composite string, finality common.DataFinalityState, userId string) prometheus.Observer {
+// userId is accepted but ignored: "user" was dropped from the histogram labels
+// to bound cardinality. Per-user attribution is preserved on the counters.
+func (t *Tracker) getUpstreamRequestDurationObserver(up common.Upstream, method, composite string, finality common.DataFinalityState, _ string) prometheus.Observer {
 	key := urdoKey{
 		project:   t.projectId,
 		vendor:    up.VendorName(),
@@ -209,13 +210,12 @@ func (t *Tracker) getUpstreamRequestDurationObserver(up common.Upstream, method,
 		category:  method,
 		composite: composite,
 		finality:  finality.String(),
-		user:      userId,
 	}
 	if v, ok := t.urdObsCache.Load(key); ok {
 		return v.(prometheus.Observer)
 	}
 	obs := telemetry.MetricUpstreamRequestDuration.WithLabelValues(
-		key.project, key.vendor, key.network, key.upstream, key.category, key.composite, key.finality, key.user,
+		key.project, key.vendor, key.network, key.upstream, key.category, key.composite, key.finality,
 	)
 	actual, _ := t.urdObsCache.LoadOrStore(key, obs)
 	return actual.(prometheus.Observer)

--- a/health/tracker_benchmark_test.go
+++ b/health/tracker_benchmark_test.go
@@ -76,7 +76,7 @@ func buildCombos(project string, upstreams int, methods []string, users []string
 func prewarmPerCall(combos []labelCombo, project string) {
 	for _, c := range combos {
 		telemetry.MetricUpstreamRequestDuration.
-			WithLabelValues(project, c.up.vendor, c.up.networkLabel, c.up.id, c.method, c.comp, c.final.String(), c.user).
+			WithLabelValues(project, c.up.vendor, c.up.networkLabel, c.up.id, c.method, c.comp, c.final.String()).
 			Observe(0.001)
 	}
 }
@@ -112,7 +112,7 @@ func BenchmarkMetricUpstreamRequestDuration_PerCall(b *testing.B) {
 		for pb.Next() {
 			c := combos[idx]
 			telemetry.MetricUpstreamRequestDuration.
-				WithLabelValues(project, c.up.vendor, c.up.networkLabel, c.up.id, c.method, c.comp, c.final.String(), c.user).
+				WithLabelValues(project, c.up.vendor, c.up.networkLabel, c.up.id, c.method, c.comp, c.final.String()).
 				Observe(0.003)
 			idx++
 			if idx >= len(combos) {

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -441,7 +441,7 @@ var (
 		Name:      "network_evm_get_logs_range_requested",
 		Help:      "eth_getLogs requested block-range sizes.",
 		Buckets:   EvmGetLogsRangeHistogramBuckets,
-	}, []string{"project", "network", "category", "user", "finality"})
+	}, []string{"project", "network", "category", "finality"})
 )
 
 var DefaultHistogramBuckets = []float64{
@@ -525,14 +525,14 @@ func SetHistogramBuckets(bucketsStr string) error {
 		Name:      "upstream_request_duration_seconds",
 		Help:      "Duration of actual requests towards upstreams.",
 		Buckets:   buckets,
-	}, []string{"project", "vendor", "network", "upstream", "category", "composite", "finality", "user"})
+	}, []string{"project", "vendor", "network", "upstream", "category", "composite", "finality"})
 
 	MetricNetworkRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_request_duration_seconds",
 		Help:      "Duration of requests for a network.",
 		Buckets:   buckets,
-	}, []string{"project", "network", "vendor", "upstream", "category", "finality", "user"})
+	}, []string{"project", "network", "vendor", "upstream", "category", "finality"})
 
 	MetricCacheSetSuccessDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "erpc",


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 62c7b610a638b96a860c6ec844f03eaeb8a339f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->