### PR TITLE
feat: config-driven label drop for histograms

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -2010,6 +2010,18 @@ type MetricsConfig struct {
 	Port             *int      `yaml:"port" json:"port"`
 	ErrorLabelMode   LabelMode `yaml:"errorLabelMode,omitempty" json:"errorLabelMode"`
 	HistogramBuckets string    `yaml:"histogramBuckets,omitempty" json:"histogramBuckets"`
+
+	// HistogramDropLabels removes these labels from every histogram. Counters
+	// and gauges are unaffected. Useful to cap per-instance /metrics response
+	// size when high-cardinality labels (e.g. "user") push a scrape past the
+	// managed scraper's sample/body limits.
+	HistogramDropLabels []string `yaml:"histogramDropLabels,omitempty" json:"histogramDropLabels,omitempty"`
+
+	// HistogramLabelOverrides re-adds labels for specific histograms even if
+	// they appear in HistogramDropLabels. Key is the metric Name (without the
+	// "erpc_" namespace prefix), e.g. "network_request_duration_seconds".
+	// Value is the list of label names to keep for that metric.
+	HistogramLabelOverrides map[string][]string `yaml:"histogramLabelOverrides,omitempty" json:"histogramLabelOverrides,omitempty"`
 }
 
 // GetProjectConfig returns the project configuration by the specified project ID.

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -42,11 +42,15 @@ func Init(
 	}
 
 	//
-	// 2) Set the right histogram buckets
+	// 2) Set the right histogram buckets and label filter
 	//
 	bucketStr := ""
-	if cfg.Metrics != nil && cfg.Metrics.HistogramBuckets != "" {
-		bucketStr = cfg.Metrics.HistogramBuckets
+	if cfg.Metrics != nil {
+		if cfg.Metrics.HistogramBuckets != "" {
+			bucketStr = cfg.Metrics.HistogramBuckets
+		}
+		// Must run before SetHistogramBuckets so the new Vecs are built with the filter applied.
+		telemetry.SetHistogramLabelFilter(cfg.Metrics.HistogramDropLabels, cfg.Metrics.HistogramLabelOverrides)
 	}
 	if err := telemetry.SetHistogramBuckets(bucketStr); err != nil {
 		logger.Warn().Err(err).Msg("failed to set histogram buckets, using defaults")

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -79,8 +79,16 @@ func GaugeHandle(gv *prometheus.GaugeVec, labels ...string) prometheus.Gauge {
 
 // ObserverHandle returns a cached child observer for the given labels.
 // hv may be *prometheus.HistogramVec or *LabeledHistogram.
+//
+// When hv is a *LabeledHistogram with active filtering, the cache key uses
+// the post-filter label values so multiple full-label tuples that resolve
+// to the same underlying observer share a single cache entry.
 func ObserverHandle(hv HistogramObservable, labels ...string) prometheus.Observer {
-	k := observerKey{vec: hv, key: labelsKey(labels)}
+	keyLabels := labels
+	if lh, ok := hv.(*LabeledHistogram); ok {
+		keyLabels = lh.ActiveLabelValues(labels)
+	}
+	k := observerKey{vec: hv, key: labelsKey(keyLabels)}
 	if v, ok := observerHandleCache.Load(k); ok {
 		return v.(prometheus.Observer)
 	}

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -20,8 +20,14 @@ type gaugeKey struct {
 	key string
 }
 
+// HistogramObservable is satisfied by both *prometheus.HistogramVec and
+// *LabeledHistogram, so ObserverHandle can cache handles for either.
+type HistogramObservable interface {
+	WithLabelValues(labels ...string) prometheus.Observer
+}
+
 type observerKey struct {
-	vec *prometheus.HistogramVec
+	vec any // holds a comparable pointer (*prometheus.HistogramVec or *LabeledHistogram)
 	key string
 }
 
@@ -72,7 +78,8 @@ func GaugeHandle(gv *prometheus.GaugeVec, labels ...string) prometheus.Gauge {
 }
 
 // ObserverHandle returns a cached child observer for the given labels.
-func ObserverHandle(hv *prometheus.HistogramVec, labels ...string) prometheus.Observer {
+// hv may be *prometheus.HistogramVec or *LabeledHistogram.
+func ObserverHandle(hv HistogramObservable, labels ...string) prometheus.Observer {
 	k := observerKey{vec: hv, key: labelsKey(labels)}
 	if v, ok := observerHandleCache.Load(k); ok {
 		return v.(prometheus.Observer)

--- a/telemetry/labeled_histogram.go
+++ b/telemetry/labeled_histogram.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HistogramLabelFilter decides which labels a HistogramVec exposes.
+//
+// Global `drop` removes labels from every histogram; per-metric `keepOverrides`
+// re-add labels for specific metric names (identified by the Prometheus metric
+// Name, e.g. "network_request_duration_seconds", without the namespace prefix).
+type HistogramLabelFilter struct {
+	drop          map[string]struct{}
+	keepOverrides map[string]map[string]struct{}
+}
+
+var (
+	filterMu      sync.RWMutex
+	currentFilter = &HistogramLabelFilter{drop: map[string]struct{}{}}
+)
+
+// SetHistogramLabelFilter installs a filter used by subsequent NewLabeledHistogram
+// calls. Typically invoked once at startup from config, before SetHistogramBuckets.
+func SetHistogramLabelFilter(dropLabels []string, keepOverrides map[string][]string) {
+	f := &HistogramLabelFilter{
+		drop:          make(map[string]struct{}, len(dropLabels)),
+		keepOverrides: make(map[string]map[string]struct{}, len(keepOverrides)),
+	}
+	for _, l := range dropLabels {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			f.drop[l] = struct{}{}
+		}
+	}
+	for metricName, keep := range keepOverrides {
+		metricName = strings.TrimSpace(metricName)
+		if metricName == "" {
+			continue
+		}
+		set := make(map[string]struct{}, len(keep))
+		for _, l := range keep {
+			l = strings.TrimSpace(l)
+			if l != "" {
+				set[l] = struct{}{}
+			}
+		}
+		f.keepOverrides[metricName] = set
+	}
+	filterMu.Lock()
+	currentFilter = f
+	filterMu.Unlock()
+}
+
+// activeIndices returns the positions from `schema` retained under the filter.
+func (f *HistogramLabelFilter) activeIndices(metricName string, schema []string) []int {
+	overrides := f.keepOverrides[metricName]
+	out := make([]int, 0, len(schema))
+	for i, l := range schema {
+		if _, dropped := f.drop[l]; dropped {
+			if _, kept := overrides[l]; !kept {
+				continue
+			}
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// LabeledHistogram wraps a prometheus.HistogramVec whose label set is the
+// intersection of a canonical schema and the current HistogramLabelFilter.
+// Call sites always pass values for the full schema (in schema order); the
+// wrapper forwards only the retained positions to the underlying Vec.
+type LabeledHistogram struct {
+	metricName string
+	schema     []string
+	activeIdx  []int
+	vec        *prometheus.HistogramVec
+}
+
+// NewLabeledHistogram creates a HistogramVec using the current filter.
+// The caller is responsible for registering it with prometheus.Registerer
+// (use Register/Unregister helpers below to match the existing vec lifecycle).
+func NewLabeledHistogram(opts prometheus.HistogramOpts, schema []string) *LabeledHistogram {
+	filterMu.RLock()
+	idx := currentFilter.activeIndices(opts.Name, schema)
+	filterMu.RUnlock()
+	active := make([]string, len(idx))
+	for i, j := range idx {
+		active[i] = schema[j]
+	}
+	return &LabeledHistogram{
+		metricName: opts.Name,
+		schema:     schema,
+		activeIdx:  idx,
+		vec:        prometheus.NewHistogramVec(opts, active),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (lh *LabeledHistogram) Describe(ch chan<- *prometheus.Desc) { lh.vec.Describe(ch) }
+
+// Collect implements prometheus.Collector.
+func (lh *LabeledHistogram) Collect(ch chan<- prometheus.Metric) { lh.vec.Collect(ch) }
+
+// WithLabelValues accepts values for the FULL schema and filters internally to
+// the labels retained by the current filter. Panics on length mismatch to
+// surface miswired call sites immediately.
+func (lh *LabeledHistogram) WithLabelValues(vals ...string) prometheus.Observer {
+	if len(vals) != len(lh.schema) {
+		panic(fmt.Sprintf("labeled_histogram: %s expected %d label values (%v), got %d",
+			lh.metricName, len(lh.schema), lh.schema, len(vals)))
+	}
+	if len(lh.activeIdx) == len(lh.schema) {
+		return lh.vec.WithLabelValues(vals...)
+	}
+	active := make([]string, len(lh.activeIdx))
+	for i, idx := range lh.activeIdx {
+		active[i] = vals[idx]
+	}
+	return lh.vec.WithLabelValues(active...)
+}
+
+// Reset clears the underlying HistogramVec.
+func (lh *LabeledHistogram) Reset() { lh.vec.Reset() }

--- a/telemetry/labeled_histogram.go
+++ b/telemetry/labeled_histogram.go
@@ -126,3 +126,22 @@ func (lh *LabeledHistogram) WithLabelValues(vals ...string) prometheus.Observer 
 
 // Reset clears the underlying HistogramVec.
 func (lh *LabeledHistogram) Reset() { lh.vec.Reset() }
+
+// ActiveLabelValues projects full-schema values down to the retained subset.
+// Useful for callers that want to key their own caches on the effective
+// (post-filter) labels so multiple full-label tuples that resolve to the same
+// underlying series share a single cache entry.
+func (lh *LabeledHistogram) ActiveLabelValues(vals []string) []string {
+	if len(vals) != len(lh.schema) {
+		panic(fmt.Sprintf("labeled_histogram: %s expected %d label values (%v), got %d",
+			lh.metricName, len(lh.schema), lh.schema, len(vals)))
+	}
+	if len(lh.activeIdx) == len(lh.schema) {
+		return vals
+	}
+	active := make([]string, len(lh.activeIdx))
+	for i, idx := range lh.activeIdx {
+		active[i] = vals[idx]
+	}
+	return active
+}

--- a/telemetry/labeled_histogram.go
+++ b/telemetry/labeled_histogram.go
@@ -81,9 +81,24 @@ type LabeledHistogram struct {
 	vec        *prometheus.HistogramVec
 }
 
-// NewLabeledHistogram creates a HistogramVec using the current filter.
-// The caller is responsible for registering it with prometheus.Registerer
-// (use Register/Unregister helpers below to match the existing vec lifecycle).
+// RegisterOrReplaceHistogram is the canonical way to declare an erpc histogram:
+// it unregisters the previous instance (if any), creates a LabeledHistogram
+// honoring the current filter, registers it with prometheus.DefaultRegisterer,
+// and returns it. Use this for every histogram so the filter applies
+// uniformly. Safe to call multiple times — makes SetHistogramBuckets
+// idempotent for tests and hot-reloads.
+func RegisterOrReplaceHistogram(old *LabeledHistogram, opts prometheus.HistogramOpts, schema []string) *LabeledHistogram {
+	if old != nil {
+		prometheus.DefaultRegisterer.Unregister(old)
+	}
+	lh := NewLabeledHistogram(opts, schema)
+	prometheus.MustRegister(lh)
+	return lh
+}
+
+// NewLabeledHistogram creates a HistogramVec using the current filter without
+// registering it. Prefer RegisterOrReplaceHistogram unless you need custom
+// registration (e.g. a private registry in tests).
 func NewLabeledHistogram(opts prometheus.HistogramOpts, schema []string) *LabeledHistogram {
 	filterMu.RLock()
 	idx := currentFilter.activeIndices(opts.Name, schema)

--- a/telemetry/labeled_histogram.go
+++ b/telemetry/labeled_histogram.go
@@ -115,10 +115,7 @@ func NewLabeledHistogram(opts prometheus.HistogramOpts, schema []string) *Labele
 	}
 }
 
-// Describe implements prometheus.Collector.
 func (lh *LabeledHistogram) Describe(ch chan<- *prometheus.Desc) { lh.vec.Describe(ch) }
-
-// Collect implements prometheus.Collector.
 func (lh *LabeledHistogram) Collect(ch chan<- prometheus.Metric) { lh.vec.Collect(ch) }
 
 // WithLabelValues accepts values for the FULL schema and filters internally to
@@ -139,7 +136,6 @@ func (lh *LabeledHistogram) WithLabelValues(vals ...string) prometheus.Observer 
 	return lh.vec.WithLabelValues(active...)
 }
 
-// Reset clears the underlying HistogramVec.
 func (lh *LabeledHistogram) Reset() { lh.vec.Reset() }
 
 // ActiveLabelValues projects full-schema values down to the retained subset.

--- a/telemetry/labeled_histogram_test.go
+++ b/telemetry/labeled_histogram_test.go
@@ -134,3 +134,85 @@ func TestHistogramLabelFilter_SizeAndCardinality(t *testing.T) {
 			netOverride, netBase)
 	}
 }
+
+// emitAllHistograms hits every filter-aware histogram (all 13) so a filter
+// change is observable across the full set, not just the three that carry
+// a "user" label.
+func emitAllHistograms(methods, networks int) {
+	for m := 0; m < methods; m++ {
+		method := fmt.Sprintf("m-%d", m)
+		for n := 0; n < networks; n++ {
+			network := fmt.Sprintf("net-%d", n)
+			// 3 user-carrying histograms
+			MetricUpstreamRequestDuration.WithLabelValues("standard", "vendorA", network, "up-1", method, "none", "finalized", "user-1").Observe(0.1)
+			MetricNetworkRequestDuration.WithLabelValues("standard", network, "vendorA", "up-1", method, "finalized", "user-1").Observe(0.1)
+			MetricNetworkEvmGetLogsRangeRequested.WithLabelValues("standard", network, method, "user-1", "finalized").Observe(100)
+			// 10 historically-unfiltered histograms (now filter-aware after refactor)
+			MetricNetworkHedgeDelaySeconds.WithLabelValues("standard", network, method, "finalized").Observe(0.05)
+			MetricConsensusResponsesCollected.WithLabelValues("standard", network, method, "vA", "false", "finalized").Observe(3)
+			MetricConsensusAgreementCount.WithLabelValues("standard", network, method, "finalized").Observe(2)
+			MetricX402FacilitatorRequestDuration.WithLabelValues("standard", network, "facA", "verify", "ok").Observe(0.1)
+			MetricConsensusDuration.WithLabelValues("standard", network, method, "ok", "finalized").Observe(0.1)
+			MetricCacheSetSuccessDuration.WithLabelValues("standard", network, method, "conn", "pol", "60").Observe(0.01)
+			MetricCacheSetErrorDuration.WithLabelValues("standard", network, method, "conn", "pol", "60", "err").Observe(0.01)
+			MetricCacheGetSuccessHitDuration.WithLabelValues("standard", network, method, "conn", "pol", "60").Observe(0.01)
+			MetricCacheGetSuccessMissDuration.WithLabelValues("standard", network, method, "conn", "pol", "60").Observe(0.01)
+			MetricCacheGetErrorDuration.WithLabelValues("standard", network, method, "conn", "pol", "60", "err").Observe(0.01)
+		}
+	}
+}
+
+// TestHistogramLabelFilter_AllHistogramsObeyFilter verifies the refactor: a
+// global drop on a shared label now affects every histogram, not only the
+// three that previously used LabeledHistogram.
+func TestHistogramLabelFilter_AllHistogramsObeyFilter(t *testing.T) {
+	run := func(drop []string) map[string]int {
+		reg := prometheus.NewRegistry()
+		prometheus.DefaultRegisterer = reg
+		SetHistogramLabelFilter(drop, nil)
+		if err := SetHistogramBuckets(""); err != nil {
+			t.Fatalf("SetHistogramBuckets: %v", err)
+		}
+		emitAllHistograms(5, 4) // 5 methods × 4 networks = 20 combos per histogram
+		_, perMetric, _ := scrapeMetricsOutput(t, reg)
+		return perMetric
+	}
+
+	baseline := run(nil)
+	dropped := run([]string{"category"}) // "category" (= method) is present on most histograms
+
+	// Every histogram that has the "category" label should shrink.
+	// (x402_facilitator_request_duration_seconds has no "category" label — skip it.)
+	withCategory := []string{
+		"erpc_upstream_request_duration_seconds_bucket",
+		"erpc_network_request_duration_seconds_bucket",
+		"erpc_network_evm_get_logs_range_requested_bucket",
+		"erpc_network_hedge_delay_seconds_bucket",
+		"erpc_consensus_responses_collected_bucket",
+		"erpc_consensus_agreement_count_bucket",
+		"erpc_consensus_duration_seconds_bucket",
+		"erpc_cache_set_success_duration_seconds_bucket",
+		"erpc_cache_set_error_duration_seconds_bucket",
+		"erpc_cache_get_success_hit_duration_seconds_bucket",
+		"erpc_cache_get_success_miss_duration_seconds_bucket",
+		"erpc_cache_get_error_duration_seconds_bucket",
+	}
+
+	t.Logf("metric                                                          | baseline | drop-category")
+	t.Logf("----------------------------------------------------------------+----------+--------------")
+	for _, m := range withCategory {
+		t.Logf("  %-60s  | %8d | %13d", m, baseline[m], dropped[m])
+		if dropped[m] >= baseline[m] {
+			t.Errorf("%s: dropping 'category' did not reduce cardinality (baseline=%d drop=%d)",
+				m, baseline[m], dropped[m])
+		}
+	}
+
+	// x402 has no "category" label — it must be unaffected.
+	const x402 = "erpc_x402_facilitator_request_duration_seconds_bucket"
+	t.Logf("  %-60s  | %8d | %13d  (no 'category' label)", x402, baseline[x402], dropped[x402])
+	if dropped[x402] != baseline[x402] {
+		t.Errorf("%s: should be unaffected by dropping 'category'; baseline=%d drop=%d",
+			x402, baseline[x402], dropped[x402])
+	}
+}

--- a/telemetry/labeled_histogram_test.go
+++ b/telemetry/labeled_histogram_test.go
@@ -1,0 +1,136 @@
+package telemetry
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// scrapeMetricsOutput returns the full /metrics body and a per-metric line count.
+func scrapeMetricsOutput(t *testing.T, reg *prometheus.Registry) (body string, linesByMetric map[string]int, totalLines int) {
+	t.Helper()
+	srv := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	defer srv.Close()
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("scrape failed: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	body = string(b)
+	linesByMetric = map[string]int{}
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		totalLines++
+		// metric_name{labels} value
+		if i := strings.IndexAny(line, "{ "); i > 0 {
+			linesByMetric[line[:i]]++
+		}
+	}
+	return
+}
+
+// emitSynthetic drives the three filter-aware histograms with a fixed cross
+// product so label-vs-bytes math is deterministic.
+func emitSynthetic(users, networks, upstreams int) {
+	for u := 0; u < users; u++ {
+		user := fmt.Sprintf("user-%d", u)
+		for n := 0; n < networks; n++ {
+			network := fmt.Sprintf("net-%d", n)
+			for up := 0; up < upstreams; up++ {
+				upstream := fmt.Sprintf("ups-%d", up)
+				MetricUpstreamRequestDuration.WithLabelValues(
+					"standard", "vendorA", network, upstream, "eth_call", "none", "finalized", user,
+				).Observe(0.123)
+				MetricNetworkRequestDuration.WithLabelValues(
+					"standard", network, "vendorA", upstream, "eth_call", "finalized", user,
+				).Observe(0.200)
+			}
+			// getLogs histogram: network+user only (no upstream dim)
+			MetricNetworkEvmGetLogsRangeRequested.WithLabelValues(
+				"standard", network, "eth_getLogs", user, "finalized",
+			).Observe(1000)
+		}
+	}
+}
+
+func runScenario(t *testing.T, name string, drop []string, overrides map[string][]string) (bytes int, lines int, perMetric map[string]int) {
+	t.Helper()
+	// Fresh registry so counts reflect only this run's emissions.
+	reg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = reg
+	SetHistogramLabelFilter(drop, overrides)
+	if err := SetHistogramBuckets(""); err != nil {
+		t.Fatalf("%s: SetHistogramBuckets: %v", name, err)
+	}
+	emitSynthetic(50, 10, 5) // 50 users × 10 networks × 5 upstreams = 2500 combos
+	body, perMetric, lines := scrapeMetricsOutput(t, reg)
+	return len(body), lines, perMetric
+}
+
+func TestHistogramLabelFilter_SizeAndCardinality(t *testing.T) {
+	// Scenario: 50 users × 10 networks × 5 upstreams
+	// Expected: dropping "user" should reduce upstream_request_duration and
+	// network_request_duration series by ~50x (one row per user collapses to
+	// one row total per (network, upstream, method, ...) tuple).
+
+	baseBytes, baseLines, basePer := runScenario(t, "baseline", nil, nil)
+	dropBytes, dropLines, dropPer := runScenario(t, "drop-user", []string{"user"}, nil)
+	overrideBytes, overrideLines, overridePer := runScenario(t, "drop-user-keep-on-network", []string{"user"},
+		map[string][]string{"network_request_duration_seconds": {"user"}})
+	dropBothBytes, dropBothLines, dropBothPer := runScenario(t, "drop-user-and-composite", []string{"user", "composite"}, nil)
+
+	reportMetrics := []string{
+		"erpc_upstream_request_duration_seconds_bucket",
+		"erpc_upstream_request_duration_seconds_count",
+		"erpc_network_request_duration_seconds_bucket",
+		"erpc_network_request_duration_seconds_count",
+		"erpc_network_evm_get_logs_range_requested_bucket",
+		"erpc_network_evm_get_logs_range_requested_count",
+	}
+
+	t.Logf("scenario                       | total lines | total bytes")
+	t.Logf("-------------------------------+-------------+------------")
+	t.Logf("baseline                       | %11d | %10d", baseLines, baseBytes)
+	t.Logf("drop user                      | %11d | %10d  (-%d%%)", dropLines, dropBytes, int(100-100*float64(dropBytes)/float64(baseBytes)))
+	t.Logf("drop user, keep on network_rd  | %11d | %10d  (-%d%%)", overrideLines, overrideBytes, int(100-100*float64(overrideBytes)/float64(baseBytes)))
+	t.Logf("drop user + composite          | %11d | %10d  (-%d%%)", dropBothLines, dropBothBytes, int(100-100*float64(dropBothBytes)/float64(baseBytes)))
+	t.Logf("")
+	t.Logf("per-metric series counts (baseline → drop-user → drop+override → drop-both):")
+	for _, m := range reportMetrics {
+		t.Logf("  %-55s %6d → %6d → %6d → %6d", m, basePer[m], dropPer[m], overridePer[m], dropBothPer[m])
+	}
+
+	// Invariants that must hold for the feature to work.
+	if dropBytes >= baseBytes {
+		t.Fatalf("drop-user scenario produced %d bytes >= baseline %d", dropBytes, baseBytes)
+	}
+	upBase := basePer["erpc_upstream_request_duration_seconds_bucket"]
+	upDrop := dropPer["erpc_upstream_request_duration_seconds_bucket"]
+	if upDrop == 0 || upDrop >= upBase/10 {
+		t.Fatalf("expected upstream_request_duration_bucket to shrink by >10x after dropping user; got baseline=%d drop=%d", upBase, upDrop)
+	}
+
+	// Override must preserve user on network_request_duration (cardinality stays).
+	netOverride := overridePer["erpc_network_request_duration_seconds_bucket"]
+	netDrop := dropPer["erpc_network_request_duration_seconds_bucket"]
+	if netOverride <= netDrop {
+		t.Fatalf("override should keep user on network_request_duration; override=%d drop=%d",
+			netOverride, netDrop)
+	}
+	netBase := basePer["erpc_network_request_duration_seconds_bucket"]
+	if netOverride != netBase {
+		t.Fatalf("override should match baseline for network_request_duration; override=%d baseline=%d",
+			netOverride, netBase)
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -190,9 +190,6 @@ var (
 		Help:      "Total number of hedged requests discarded towards a network (i.e. attempt > 1 means wasted requests).",
 	}, []string{"project", "network", "upstream", "category", "attempt", "hedge", "finality", "user", "agent_name"})
 
-	// MetricNetworkHedgeDelaySeconds is built in SetHistogramBuckets (see below)
-	// so the label filter applies.
-
 	MetricNetworkFailedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_failed_request_total",
@@ -350,9 +347,6 @@ var (
 		Help:      "Total number of consensus operations attempted.",
 	}, []string{"project", "network", "category", "outcome", "finality"})
 
-	// MetricConsensusResponsesCollected and MetricConsensusAgreementCount are built
-	// in SetHistogramBuckets so the label filter applies.
-
 	MetricConsensusMisbehaviorDetected = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_misbehavior_detected_total",
@@ -401,9 +395,6 @@ var (
 		Help:      "Total requests observed by block-number buckets for heatmap.",
 	}, []string{"project", "network", "vendor", "upstream", "category", "user", "finality", "bucket", "size"})
 
-	// MetricX402FacilitatorRequestDuration is built in SetHistogramBuckets so the
-	// label filter applies.
-
 	MetricX402FacilitatorRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "x402_facilitator_request_total",
@@ -431,9 +422,7 @@ var EvmBlockRangeBucketSize int64 = 100000
 // Histogram buckets for eth_getLogs requested block-range sizes
 var EvmGetLogsRangeHistogramBuckets = []float64{1, 10, 100, 500, 1000, 5000, 10000, 30000}
 
-// All histograms are built in SetHistogramBuckets so the HistogramLabelFilter
-// applies uniformly. Declare them here as nil pointers; the init function
-// populates them.
+// Histograms are populated by SetHistogramBuckets so the label filter applies.
 var (
 	MetricUpstreamRequestDuration         *LabeledHistogram
 	MetricNetworkRequestDuration          *LabeledHistogram
@@ -485,10 +474,8 @@ func GetScoreMetricsMode() ScoreMetricsMode {
 	return currentScoreMetricsMode
 }
 
-// init registers every histogram with default buckets and no filter so tests
-// (and any code path that observes before SetHistogramBuckets runs) always
-// see non-nil metric vecs. The main binary calls SetHistogramBuckets at
-// startup to rebuild them with config-driven buckets + label filter.
+// init ensures every histogram is non-nil for code that observes before
+// SetHistogramBuckets runs (tests, early startup paths).
 func init() {
 	_ = SetHistogramBuckets("")
 }
@@ -496,8 +483,7 @@ func init() {
 func SetHistogramBuckets(bucketsStr string) error {
 	buckets, parseErr := ParseHistogramBuckets(bucketsStr)
 	if parseErr != nil {
-		// Fall through with defaults so filter-aware histograms always get
-		// initialized; the caller still receives parseErr for logging.
+		// Fall through with defaults so histograms still initialize on parse failure.
 		buckets = DefaultHistogramBuckets
 	}
 

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -190,12 +190,8 @@ var (
 		Help:      "Total number of hedged requests discarded towards a network (i.e. attempt > 1 means wasted requests).",
 	}, []string{"project", "network", "upstream", "category", "attempt", "hedge", "finality", "user", "agent_name"})
 
-	MetricNetworkHedgeDelaySeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "network_hedge_delay_seconds",
-		Help:      "Hedge delay used for requests (seconds).",
-		Buckets:   []float64{0.01, 0.03, 0.05, 0.2, 0.3, 0.5, 0.7, 1, 3},
-	}, []string{"project", "network", "category", "finality"})
+	// MetricNetworkHedgeDelaySeconds is built in SetHistogramBuckets (see below)
+	// so the label filter applies.
 
 	MetricNetworkFailedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
@@ -354,19 +350,8 @@ var (
 		Help:      "Total number of consensus operations attempted.",
 	}, []string{"project", "network", "category", "outcome", "finality"})
 
-	MetricConsensusResponsesCollected = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "consensus_responses_collected",
-		Help:      "Number of responses collected before consensus decision.",
-		Buckets:   prometheus.LinearBuckets(1, 1, 10),
-	}, []string{"project", "network", "category", "vendors", "short_circuited", "finality"})
-
-	MetricConsensusAgreementCount = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "consensus_agreement_count",
-		Help:      "Number of upstreams agreeing on the most common result.",
-		Buckets:   prometheus.LinearBuckets(1, 1, 10),
-	}, []string{"project", "network", "category", "finality"})
+	// MetricConsensusResponsesCollected and MetricConsensusAgreementCount are built
+	// in SetHistogramBuckets so the label filter applies.
 
 	MetricConsensusMisbehaviorDetected = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
@@ -416,13 +401,8 @@ var (
 		Help:      "Total requests observed by block-number buckets for heatmap.",
 	}, []string{"project", "network", "vendor", "upstream", "category", "user", "finality", "bucket", "size"})
 
-	// x402 facilitator metrics
-	MetricX402FacilitatorRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "x402_facilitator_request_duration_seconds",
-		Help:      "Duration of HTTP requests to x402 facilitator endpoints (verify, settle, supported).",
-		Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
-	}, []string{"project", "network", "facilitator", "operation", "status"})
+	// MetricX402FacilitatorRequestDuration is built in SetHistogramBuckets so the
+	// label filter applies.
 
 	MetricX402FacilitatorRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
@@ -436,10 +416,6 @@ var (
 		Help:      "Total number of x402 payments processed (verified, settled, rejected).",
 	}, []string{"project", "network", "facilitator", "outcome"})
 )
-
-// MetricNetworkEvmGetLogsRangeRequested is created in SetHistogramBuckets alongside
-// the other filter-aware histograms so the HistogramLabelFilter can apply to it.
-var MetricNetworkEvmGetLogsRangeRequested *LabeledHistogram
 
 var DefaultHistogramBuckets = []float64{
 	0.05,
@@ -455,16 +431,23 @@ var EvmBlockRangeBucketSize int64 = 100000
 // Histogram buckets for eth_getLogs requested block-range sizes
 var EvmGetLogsRangeHistogramBuckets = []float64{1, 10, 100, 500, 1000, 5000, 10000, 30000}
 
+// All histograms are built in SetHistogramBuckets so the HistogramLabelFilter
+// applies uniformly. Declare them here as nil pointers; the init function
+// populates them.
 var (
-	MetricUpstreamRequestDuration *LabeledHistogram
-	MetricNetworkRequestDuration  *LabeledHistogram
-
-	MetricCacheSetSuccessDuration,
-	MetricCacheSetErrorDuration,
-	MetricCacheGetSuccessHitDuration,
-	MetricCacheGetSuccessMissDuration,
-	MetricCacheGetErrorDuration,
-	MetricConsensusDuration *prometheus.HistogramVec
+	MetricUpstreamRequestDuration         *LabeledHistogram
+	MetricNetworkRequestDuration          *LabeledHistogram
+	MetricNetworkEvmGetLogsRangeRequested *LabeledHistogram
+	MetricNetworkHedgeDelaySeconds        *LabeledHistogram
+	MetricConsensusResponsesCollected     *LabeledHistogram
+	MetricConsensusAgreementCount         *LabeledHistogram
+	MetricX402FacilitatorRequestDuration  *LabeledHistogram
+	MetricConsensusDuration               *LabeledHistogram
+	MetricCacheSetSuccessDuration         *LabeledHistogram
+	MetricCacheSetErrorDuration           *LabeledHistogram
+	MetricCacheGetSuccessHitDuration      *LabeledHistogram
+	MetricCacheGetSuccessMissDuration     *LabeledHistogram
+	MetricCacheGetErrorDuration           *LabeledHistogram
 )
 
 // ScoreMetricsMode controls how score metrics are emitted.
@@ -502,6 +485,14 @@ func GetScoreMetricsMode() ScoreMetricsMode {
 	return currentScoreMetricsMode
 }
 
+// init registers every histogram with default buckets and no filter so tests
+// (and any code path that observes before SetHistogramBuckets runs) always
+// see non-nil metric vecs. The main binary calls SetHistogramBuckets at
+// startup to rebuild them with config-driven buckets + label filter.
+func init() {
+	_ = SetHistogramBuckets("")
+}
+
 func SetHistogramBuckets(bucketsStr string) error {
 	buckets, parseErr := ParseHistogramBuckets(bucketsStr)
 	if parseErr != nil {
@@ -510,82 +501,96 @@ func SetHistogramBuckets(bucketsStr string) error {
 		buckets = DefaultHistogramBuckets
 	}
 
-	if MetricUpstreamRequestDuration != nil {
-		prometheus.DefaultRegisterer.Unregister(MetricUpstreamRequestDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricNetworkRequestDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricNetworkEvmGetLogsRangeRequested)
-		prometheus.DefaultRegisterer.Unregister(MetricCacheSetSuccessDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricCacheSetErrorDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricCacheGetSuccessHitDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricCacheGetSuccessMissDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricCacheGetErrorDuration)
-		prometheus.DefaultRegisterer.Unregister(MetricConsensusDuration)
-	}
-	MetricUpstreamRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
+	MetricUpstreamRequestDuration = RegisterOrReplaceHistogram(MetricUpstreamRequestDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_duration_seconds",
 		Help:      "Duration of actual requests towards upstreams.",
 		Buckets:   buckets,
 	}, []string{"project", "vendor", "network", "upstream", "category", "composite", "finality", "user"})
-	prometheus.MustRegister(MetricUpstreamRequestDuration)
 
-	MetricNetworkRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
+	MetricNetworkRequestDuration = RegisterOrReplaceHistogram(MetricNetworkRequestDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_request_duration_seconds",
 		Help:      "Duration of requests for a network.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "vendor", "upstream", "category", "finality", "user"})
-	prometheus.MustRegister(MetricNetworkRequestDuration)
 
-	MetricNetworkEvmGetLogsRangeRequested = NewLabeledHistogram(prometheus.HistogramOpts{
+	MetricNetworkEvmGetLogsRangeRequested = RegisterOrReplaceHistogram(MetricNetworkEvmGetLogsRangeRequested, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_range_requested",
 		Help:      "eth_getLogs requested block-range sizes.",
 		Buckets:   EvmGetLogsRangeHistogramBuckets,
 	}, []string{"project", "network", "category", "user", "finality"})
-	prometheus.MustRegister(MetricNetworkEvmGetLogsRangeRequested)
 
-	MetricCacheSetSuccessDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricNetworkHedgeDelaySeconds = RegisterOrReplaceHistogram(MetricNetworkHedgeDelaySeconds, prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "network_hedge_delay_seconds",
+		Help:      "Hedge delay used for requests (seconds).",
+		Buckets:   []float64{0.01, 0.03, 0.05, 0.2, 0.3, 0.5, 0.7, 1, 3},
+	}, []string{"project", "network", "category", "finality"})
+
+	MetricConsensusResponsesCollected = RegisterOrReplaceHistogram(MetricConsensusResponsesCollected, prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "consensus_responses_collected",
+		Help:      "Number of responses collected before consensus decision.",
+		Buckets:   prometheus.LinearBuckets(1, 1, 10),
+	}, []string{"project", "network", "category", "vendors", "short_circuited", "finality"})
+
+	MetricConsensusAgreementCount = RegisterOrReplaceHistogram(MetricConsensusAgreementCount, prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "consensus_agreement_count",
+		Help:      "Number of upstreams agreeing on the most common result.",
+		Buckets:   prometheus.LinearBuckets(1, 1, 10),
+	}, []string{"project", "network", "category", "finality"})
+
+	MetricX402FacilitatorRequestDuration = RegisterOrReplaceHistogram(MetricX402FacilitatorRequestDuration, prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "x402_facilitator_request_duration_seconds",
+		Help:      "Duration of HTTP requests to x402 facilitator endpoints (verify, settle, supported).",
+		Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
+	}, []string{"project", "network", "facilitator", "operation", "status"})
+
+	MetricConsensusDuration = RegisterOrReplaceHistogram(MetricConsensusDuration, prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "consensus_duration_seconds",
+		Help:      "Duration of consensus operations.",
+		Buckets:   buckets,
+	}, []string{"project", "network", "category", "outcome", "finality"})
+
+	MetricCacheSetSuccessDuration = RegisterOrReplaceHistogram(MetricCacheSetSuccessDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_success_duration_seconds",
 		Help:      "Duration of cache set operations.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheSetErrorDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricCacheSetErrorDuration = RegisterOrReplaceHistogram(MetricCacheSetErrorDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_error_duration_seconds",
 		Help:      "Duration of cache set errors.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl", "error"})
 
-	MetricCacheGetSuccessHitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricCacheGetSuccessHitDuration = RegisterOrReplaceHistogram(MetricCacheGetSuccessHitDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_success_hit_duration_seconds",
 		Help:      "Duration of cache get hits.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetSuccessMissDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricCacheGetSuccessMissDuration = RegisterOrReplaceHistogram(MetricCacheGetSuccessMissDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_success_miss_duration_seconds",
 		Help:      "Duration of cache get misses.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetErrorDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricCacheGetErrorDuration = RegisterOrReplaceHistogram(MetricCacheGetErrorDuration, prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_error_duration_seconds",
 		Help:      "Duration of cache get errors.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl", "error"})
-
-	MetricConsensusDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "consensus_duration_seconds",
-		Help:      "Duration of consensus operations.",
-		Buckets:   buckets,
-	}, []string{"project", "network", "category", "outcome", "finality"})
 
 	// Clear cached handles since the Vecs were re-created.
 	ResetHandleCache()

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -435,14 +435,11 @@ var (
 		Name:      "x402_payment_total",
 		Help:      "Total number of x402 payments processed (verified, settled, rejected).",
 	}, []string{"project", "network", "facilitator", "outcome"})
-
-	MetricNetworkEvmGetLogsRangeRequested = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "erpc",
-		Name:      "network_evm_get_logs_range_requested",
-		Help:      "eth_getLogs requested block-range sizes.",
-		Buckets:   EvmGetLogsRangeHistogramBuckets,
-	}, []string{"project", "network", "category", "user", "finality"})
 )
+
+// MetricNetworkEvmGetLogsRangeRequested is created in SetHistogramBuckets alongside
+// the other filter-aware histograms so the HistogramLabelFilter can apply to it.
+var MetricNetworkEvmGetLogsRangeRequested *LabeledHistogram
 
 var DefaultHistogramBuckets = []float64{
 	0.05,
@@ -459,8 +456,9 @@ var EvmBlockRangeBucketSize int64 = 100000
 var EvmGetLogsRangeHistogramBuckets = []float64{1, 10, 100, 500, 1000, 5000, 10000, 30000}
 
 var (
-	MetricUpstreamRequestDuration,
-	MetricNetworkRequestDuration,
+	MetricUpstreamRequestDuration *LabeledHistogram
+	MetricNetworkRequestDuration  *LabeledHistogram
+
 	MetricCacheSetSuccessDuration,
 	MetricCacheSetErrorDuration,
 	MetricCacheGetSuccessHitDuration,
@@ -513,6 +511,7 @@ func SetHistogramBuckets(bucketsStr string) error {
 	if MetricUpstreamRequestDuration != nil {
 		prometheus.DefaultRegisterer.Unregister(MetricUpstreamRequestDuration)
 		prometheus.DefaultRegisterer.Unregister(MetricNetworkRequestDuration)
+		prometheus.DefaultRegisterer.Unregister(MetricNetworkEvmGetLogsRangeRequested)
 		prometheus.DefaultRegisterer.Unregister(MetricCacheSetSuccessDuration)
 		prometheus.DefaultRegisterer.Unregister(MetricCacheSetErrorDuration)
 		prometheus.DefaultRegisterer.Unregister(MetricCacheGetSuccessHitDuration)
@@ -520,19 +519,29 @@ func SetHistogramBuckets(bucketsStr string) error {
 		prometheus.DefaultRegisterer.Unregister(MetricCacheGetErrorDuration)
 		prometheus.DefaultRegisterer.Unregister(MetricConsensusDuration)
 	}
-	MetricUpstreamRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricUpstreamRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_duration_seconds",
 		Help:      "Duration of actual requests towards upstreams.",
 		Buckets:   buckets,
 	}, []string{"project", "vendor", "network", "upstream", "category", "composite", "finality", "user"})
+	prometheus.MustRegister(MetricUpstreamRequestDuration)
 
-	MetricNetworkRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	MetricNetworkRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_request_duration_seconds",
 		Help:      "Duration of requests for a network.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "vendor", "upstream", "category", "finality", "user"})
+	prometheus.MustRegister(MetricNetworkRequestDuration)
+
+	MetricNetworkEvmGetLogsRangeRequested = NewLabeledHistogram(prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "network_evm_get_logs_range_requested",
+		Help:      "eth_getLogs requested block-range sizes.",
+		Buckets:   EvmGetLogsRangeHistogramBuckets,
+	}, []string{"project", "network", "category", "user", "finality"})
+	prometheus.MustRegister(MetricNetworkEvmGetLogsRangeRequested)
 
 	MetricCacheSetSuccessDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "erpc",

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -503,9 +503,11 @@ func GetScoreMetricsMode() ScoreMetricsMode {
 }
 
 func SetHistogramBuckets(bucketsStr string) error {
-	buckets, err := ParseHistogramBuckets(bucketsStr)
-	if err != nil {
-		return err
+	buckets, parseErr := ParseHistogramBuckets(bucketsStr)
+	if parseErr != nil {
+		// Fall through with defaults so filter-aware histograms always get
+		// initialized; the caller still receives parseErr for logging.
+		buckets = DefaultHistogramBuckets
 	}
 
 	if MetricUpstreamRequestDuration != nil {
@@ -588,7 +590,7 @@ func SetHistogramBuckets(bucketsStr string) error {
 	// Clear cached handles since the Vecs were re-created.
 	ResetHandleCache()
 
-	return nil
+	return parseErr
 }
 
 func ParseHistogramBuckets(bucketsStr string) ([]float64, error) {


### PR DESCRIPTION
Adds two optional `metrics` config fields to reduce histogram cardinality:

```yaml
metrics:
  histogramDropLabels: [user, composite]      # drop from all histograms
  histogramLabelOverrides:                     # exceptions per metric
    network_request_duration_seconds: [user]   # keep user here
```

Default (no config): unchanged — all labels remain.

Per-user attribution stays on the counters (`erpc_upstream_request_total`, etc.).

Applies to histograms: `upstream_request_duration_seconds`, `network_request_duration_seconds`, `network_evm_get_logs_range_requested`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Prometheus histograms are constructed/registered and can alter emitted label sets/series cardinality, which may impact dashboards/alerts even though it’s config-gated.
> 
> **Overview**
> Adds config-driven histogram label filtering via new `metrics.histogramDropLabels` and per-metric `metrics.histogramLabelOverrides`, allowing high-cardinality labels to be dropped from histogram series while leaving counters/gauges unchanged.
> 
> Implements a new `telemetry.LabeledHistogram` wrapper + global filter, refactors all eRPC histograms to be (re)created through `SetHistogramBuckets()` so the filter is applied uniformly, and updates handle caching to dedupe observers based on post-filter labels. Startup now installs the filter before rebuilding histograms, and new tests validate reduced `/metrics` size/cardinality and override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0fc32488fb7b797ccd3f0ff00c134dd4675ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->