### PR TITLE
hotfix(metrics): prevent double-registration panic with label filter

### DIFF
--- a/telemetry/labeled_histogram_production_test.go
+++ b/telemetry/labeled_histogram_production_test.go
@@ -1,0 +1,23 @@
+package telemetry
+
+import (
+	"testing"
+)
+
+// TestProductionFlow exercises the exact init sequence erpc.Init uses WITHOUT
+// swapping the default registry. On main this panicked because package init
+// pre-registered histograms with the empty filter, leaving dimHashesByName
+// populated; the fix creates init-time wrappers without registering them and
+// has SetHistogramBuckets do the one authoritative register.
+func TestProductionFlow_SetFilterThenRegister(t *testing.T) {
+	// Intentionally DO NOT reset prometheus.DefaultRegisterer — we want to
+	// catch regressions where init() and SetHistogramBuckets collide in the
+	// same registry, which is the production configuration.
+	SetHistogramLabelFilter(
+		[]string{"user", "composite"},
+		map[string][]string{"network_request_duration_seconds": {"user"}},
+	)
+	if err := SetHistogramBuckets(""); err != nil {
+		t.Fatalf("SetHistogramBuckets: %v", err)
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -474,114 +474,167 @@ func GetScoreMetricsMode() ScoreMetricsMode {
 	return currentScoreMetricsMode
 }
 
-// init ensures every histogram is non-nil for code that observes before
-// SetHistogramBuckets runs (tests, early startup paths).
-func init() {
-	_ = SetHistogramBuckets("")
-}
-
-func SetHistogramBuckets(bucketsStr string) error {
+// buildFilterAwareHistograms creates every LabeledHistogram using the current
+// filter. It does NOT register them — SetHistogramBuckets does that. init()
+// calls this without registering so metric globals are non-nil for any code
+// that observes before erpc.Init runs (tests, early startup paths).
+func buildFilterAwareHistograms(bucketsStr string) error {
 	buckets, parseErr := ParseHistogramBuckets(bucketsStr)
 	if parseErr != nil {
-		// Fall through with defaults so histograms still initialize on parse failure.
 		buckets = DefaultHistogramBuckets
 	}
 
-	MetricUpstreamRequestDuration = RegisterOrReplaceHistogram(MetricUpstreamRequestDuration, prometheus.HistogramOpts{
+	MetricUpstreamRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_duration_seconds",
 		Help:      "Duration of actual requests towards upstreams.",
 		Buckets:   buckets,
 	}, []string{"project", "vendor", "network", "upstream", "category", "composite", "finality", "user"})
 
-	MetricNetworkRequestDuration = RegisterOrReplaceHistogram(MetricNetworkRequestDuration, prometheus.HistogramOpts{
+	MetricNetworkRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_request_duration_seconds",
 		Help:      "Duration of requests for a network.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "vendor", "upstream", "category", "finality", "user"})
 
-	MetricNetworkEvmGetLogsRangeRequested = RegisterOrReplaceHistogram(MetricNetworkEvmGetLogsRangeRequested, prometheus.HistogramOpts{
+	MetricNetworkEvmGetLogsRangeRequested = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_range_requested",
 		Help:      "eth_getLogs requested block-range sizes.",
 		Buckets:   EvmGetLogsRangeHistogramBuckets,
 	}, []string{"project", "network", "category", "user", "finality"})
 
-	MetricNetworkHedgeDelaySeconds = RegisterOrReplaceHistogram(MetricNetworkHedgeDelaySeconds, prometheus.HistogramOpts{
+	MetricNetworkHedgeDelaySeconds = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "network_hedge_delay_seconds",
 		Help:      "Hedge delay used for requests (seconds).",
 		Buckets:   []float64{0.01, 0.03, 0.05, 0.2, 0.3, 0.5, 0.7, 1, 3},
 	}, []string{"project", "network", "category", "finality"})
 
-	MetricConsensusResponsesCollected = RegisterOrReplaceHistogram(MetricConsensusResponsesCollected, prometheus.HistogramOpts{
+	MetricConsensusResponsesCollected = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "consensus_responses_collected",
 		Help:      "Number of responses collected before consensus decision.",
 		Buckets:   prometheus.LinearBuckets(1, 1, 10),
 	}, []string{"project", "network", "category", "vendors", "short_circuited", "finality"})
 
-	MetricConsensusAgreementCount = RegisterOrReplaceHistogram(MetricConsensusAgreementCount, prometheus.HistogramOpts{
+	MetricConsensusAgreementCount = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "consensus_agreement_count",
 		Help:      "Number of upstreams agreeing on the most common result.",
 		Buckets:   prometheus.LinearBuckets(1, 1, 10),
 	}, []string{"project", "network", "category", "finality"})
 
-	MetricX402FacilitatorRequestDuration = RegisterOrReplaceHistogram(MetricX402FacilitatorRequestDuration, prometheus.HistogramOpts{
+	MetricX402FacilitatorRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "x402_facilitator_request_duration_seconds",
 		Help:      "Duration of HTTP requests to x402 facilitator endpoints (verify, settle, supported).",
 		Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
 	}, []string{"project", "network", "facilitator", "operation", "status"})
 
-	MetricConsensusDuration = RegisterOrReplaceHistogram(MetricConsensusDuration, prometheus.HistogramOpts{
+	MetricConsensusDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "consensus_duration_seconds",
 		Help:      "Duration of consensus operations.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "outcome", "finality"})
 
-	MetricCacheSetSuccessDuration = RegisterOrReplaceHistogram(MetricCacheSetSuccessDuration, prometheus.HistogramOpts{
+	MetricCacheSetSuccessDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_success_duration_seconds",
 		Help:      "Duration of cache set operations.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheSetErrorDuration = RegisterOrReplaceHistogram(MetricCacheSetErrorDuration, prometheus.HistogramOpts{
+	MetricCacheSetErrorDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_error_duration_seconds",
 		Help:      "Duration of cache set errors.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl", "error"})
 
-	MetricCacheGetSuccessHitDuration = RegisterOrReplaceHistogram(MetricCacheGetSuccessHitDuration, prometheus.HistogramOpts{
+	MetricCacheGetSuccessHitDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_success_hit_duration_seconds",
 		Help:      "Duration of cache get hits.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetSuccessMissDuration = RegisterOrReplaceHistogram(MetricCacheGetSuccessMissDuration, prometheus.HistogramOpts{
+	MetricCacheGetSuccessMissDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_success_miss_duration_seconds",
 		Help:      "Duration of cache get misses.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetErrorDuration = RegisterOrReplaceHistogram(MetricCacheGetErrorDuration, prometheus.HistogramOpts{
+	MetricCacheGetErrorDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_error_duration_seconds",
 		Help:      "Duration of cache get errors.",
 		Buckets:   buckets,
 	}, []string{"project", "network", "category", "connector", "policy", "ttl", "error"})
 
+	return parseErr
+}
+
+// init bootstraps non-nil LabeledHistogram pointers with the empty filter
+// (unregistered). This lets observations from tests or early-startup code
+// complete without NPE. erpc.Init later calls SetHistogramBuckets which
+// replaces these with filter-applied wrappers and registers them.
+func init() {
+	_ = buildFilterAwareHistograms("")
+}
+
+// SetHistogramBuckets builds every filter-aware histogram under the current
+// filter and registers them with prometheus.DefaultRegisterer. After this
+// call, metric globals point at the registered wrapper.
+//
+// Idempotent in the same-labels case (re-calls on the same registry with an
+// unchanged filter reuse the existing registration). Calling again with a
+// changed filter panics — Prometheus does not allow a metric's label set to
+// change once registered. Tests that need a clean slate should swap in a
+// fresh prometheus.DefaultRegisterer first.
+func SetHistogramBuckets(bucketsStr string) error {
+	parseErr := buildFilterAwareHistograms(bucketsStr)
+
+	MetricUpstreamRequestDuration = registerOrReuse(MetricUpstreamRequestDuration)
+	MetricNetworkRequestDuration = registerOrReuse(MetricNetworkRequestDuration)
+	MetricNetworkEvmGetLogsRangeRequested = registerOrReuse(MetricNetworkEvmGetLogsRangeRequested)
+	MetricNetworkHedgeDelaySeconds = registerOrReuse(MetricNetworkHedgeDelaySeconds)
+	MetricConsensusResponsesCollected = registerOrReuse(MetricConsensusResponsesCollected)
+	MetricConsensusAgreementCount = registerOrReuse(MetricConsensusAgreementCount)
+	MetricX402FacilitatorRequestDuration = registerOrReuse(MetricX402FacilitatorRequestDuration)
+	MetricConsensusDuration = registerOrReuse(MetricConsensusDuration)
+	MetricCacheSetSuccessDuration = registerOrReuse(MetricCacheSetSuccessDuration)
+	MetricCacheSetErrorDuration = registerOrReuse(MetricCacheSetErrorDuration)
+	MetricCacheGetSuccessHitDuration = registerOrReuse(MetricCacheGetSuccessHitDuration)
+	MetricCacheGetSuccessMissDuration = registerOrReuse(MetricCacheGetSuccessMissDuration)
+	MetricCacheGetErrorDuration = registerOrReuse(MetricCacheGetErrorDuration)
+
 	// Clear cached handles since the Vecs were re-created.
 	ResetHandleCache()
 
 	return parseErr
+}
+
+// registerOrReuse registers lh with prometheus.DefaultRegisterer. If a
+// collector with the same name and identical label set is already registered
+// (typical for repeat calls), it returns the existing collector so callers
+// keep using the one prometheus actually knows about. Panics on any other
+// registration error (including label-set mismatch, which means the filter
+// changed after the first registration — not supported by Prometheus).
+func registerOrReuse(lh *LabeledHistogram) *LabeledHistogram {
+	err := prometheus.Register(lh)
+	if err == nil {
+		return lh
+	}
+	if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		if existing, ok := are.ExistingCollector.(*LabeledHistogram); ok {
+			return existing
+		}
+	}
+	panic(err)
 }
 
 func ParseHistogramBuckets(bucketsStr string) ([]float64, error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes histogram initialization/registration behavior in `telemetry` and introduces a new idempotent registration path; mistakes could still cause startup panics or missing histogram series, but scope is limited to metrics.
> 
> **Overview**
> Prevents a production startup panic caused by histograms being registered during package `init()` with an unfiltered label set and then re-registered later after `SetHistogramLabelFilter` changes labels.
> 
> `metrics.go` now builds unregistered, filter-aware `LabeledHistogram` wrappers in `init()` (via `buildFilterAwareHistograms`) and makes `SetHistogramBuckets` the single authoritative registration point, using `registerOrReuse` to reuse existing collectors on repeat calls and to hard-fail on label-set mismatches.
> 
> Adds `TestProductionFlow_SetFilterThenRegister` to exercise the real production sequence against the default Prometheus registry (no registry swap) to catch regressions in init/register ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ae1390964100987aa9984f8eb8bea58b5f8607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->