### PR TITLE
feat: per-network static responses for RPC methods

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -841,7 +841,7 @@ func (u *UpstreamConfig) MarshalJSON() ([]byte, error) {
 		*UJAlias
 	}{
 		Endpoint: util.RedactEndpoint(u.Endpoint),
-		UJAlias:    (*UJAlias)(u),
+		UJAlias:  (*UJAlias)(u),
 	})
 }
 
@@ -912,8 +912,8 @@ type EvmUpstreamConfig struct {
 	// sub-requests executed concurrently and merged before returning. Zero disables
 	// the feature.
 	TraceFilterAutoSplittingRangeThreshold int64                    `yaml:"traceFilterAutoSplittingRangeThreshold,omitempty" json:"traceFilterAutoSplittingRangeThreshold"`
-	SkipWhenSyncing                    *bool                       `yaml:"skipWhenSyncing,omitempty" json:"skipWhenSyncing"`
-	Integrity                          *UpstreamIntegrityConfig    `yaml:"integrity,omitempty" json:"integrity"`
+	SkipWhenSyncing                        *bool                    `yaml:"skipWhenSyncing,omitempty" json:"skipWhenSyncing"`
+	Integrity                              *UpstreamIntegrityConfig `yaml:"integrity,omitempty" json:"integrity"`
 
 	// @deprecated: use blockAvailability bounds instead; kept for config back-compat only
 	NodeType EvmNodeType `yaml:"nodeType,omitempty" json:"nodeType"`
@@ -1559,6 +1559,33 @@ type NetworkConfig struct {
 	Alias             string                   `yaml:"alias,omitempty" json:"alias"`
 	Methods           *MethodsConfig           `yaml:"methods,omitempty" json:"methods"`
 	Multiplexing      *bool                    `yaml:"multiplexing,omitempty" json:"multiplexing"`
+	StaticResponses   []*StaticResponseConfig  `yaml:"staticResponses,omitempty" json:"staticResponses,omitempty"`
+}
+
+// StaticResponseConfig declares a canned JSON-RPC response for a specific
+// (method, params) pair on a network. When an inbound request matches, the
+// configured response is returned immediately and no upstream is contacted.
+// Useful for chains that deviate from client assumptions (for example, chains
+// whose genesis block is not 0) where probing upstreams would yield errors
+// or inconsistent data.
+type StaticResponseConfig struct {
+	Method   string                    `yaml:"method" json:"method"`
+	Params   []interface{}             `yaml:"params,omitempty" json:"params,omitempty"`
+	Response *StaticResponseBodyConfig `yaml:"response" json:"response"`
+}
+
+// StaticResponseBodyConfig holds the JSON-RPC payload to serve. Exactly one
+// of Result or Error must be set.
+type StaticResponseBodyConfig struct {
+	Result interface{}                `yaml:"result,omitempty" json:"result"`
+	Error  *StaticResponseErrorConfig `yaml:"error,omitempty" json:"error"`
+}
+
+// StaticResponseErrorConfig mirrors a JSON-RPC error object.
+type StaticResponseErrorConfig struct {
+	Code    int         `yaml:"code" json:"code"`
+	Message string      `yaml:"message" json:"message"`
+	Data    interface{} `yaml:"data,omitempty" json:"data"`
 }
 
 func (n *NetworkConfig) MultiplexingEnabled() bool {
@@ -1601,6 +1628,7 @@ func (n *NetworkConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		DirectiveDefaults *DirectiveDefaultsConfig `yaml:"directiveDefaults,omitempty"`
 		Alias             string                   `yaml:"alias,omitempty"`
 		Methods           *MethodsConfig           `yaml:"methods,omitempty"`
+		StaticResponses   []*StaticResponseConfig  `yaml:"staticResponses,omitempty"`
 	}
 
 	var old oldNetworkConfig
@@ -1618,6 +1646,7 @@ func (n *NetworkConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	n.DirectiveDefaults = old.DirectiveDefaults
 	n.Alias = old.Alias
 	n.Methods = old.Methods
+	n.StaticResponses = old.StaticResponses
 
 	if old.Failsafe != nil {
 		// Ensure MatchMethod has a default value for backward compatibility
@@ -1714,10 +1743,10 @@ type EvmNetworkConfig struct {
 	// TraceFilterSplitOnError controls reactive splitting for trace_filter and
 	// arbtrace_filter requests when the upstream returns a range-too-large error.
 	// Nil disables the feature.
-	TraceFilterSplitOnError     *bool               `yaml:"traceFilterSplitOnError,omitempty" json:"traceFilterSplitOnError"`
+	TraceFilterSplitOnError *bool `yaml:"traceFilterSplitOnError,omitempty" json:"traceFilterSplitOnError"`
 	// TraceFilterSplitConcurrency caps in-flight sub-requests when a trace_filter
 	// or arbtrace_filter request is split. Zero falls back to 10.
-	TraceFilterSplitConcurrency int                 `yaml:"traceFilterSplitConcurrency,omitempty" json:"traceFilterSplitConcurrency"`
+	TraceFilterSplitConcurrency int `yaml:"traceFilterSplitConcurrency,omitempty" json:"traceFilterSplitConcurrency"`
 	// EnforceBlockAvailability controls whether the network should enforce per-upstream
 	// block availability bounds (upper/lower) for methods by default. Method-level config may override.
 	// When nil or true, enforcement is enabled.

--- a/common/static_response.go
+++ b/common/static_response.go
@@ -1,0 +1,129 @@
+package common
+
+import (
+	"reflect"
+)
+
+// FindStaticResponseMatch returns the first StaticResponseConfig whose method
+// and params match the given request, or nil if none match.
+//
+// Match semantics:
+//   - method: exact string equality
+//   - params: recursive deep equality treating numeric types equivalently and
+//     comparing maps by key regardless of declared order
+func FindStaticResponseMatch(entries []*StaticResponseConfig, method string, params []interface{}) *StaticResponseConfig {
+	for _, e := range entries {
+		if e == nil || e.Method != method {
+			continue
+		}
+		if paramsEqual(e.Params, params) {
+			return e
+		}
+	}
+	return nil
+}
+
+// paramsEqual compares two param slices from different deserialization paths
+// (YAML config vs JSON request body). It tolerates numeric-type divergence
+// (int vs float64) and compares maps by key regardless of iteration order.
+func paramsEqual(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !valueEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func valueEqual(a, b interface{}) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	// Numbers: JSON decodes integers as float64 while YAML often decodes as int.
+	// Compare as float64 when both are numeric, regardless of concrete type.
+	if fa, ok := toFloat64(a); ok {
+		if fb, ok := toFloat64(b); ok {
+			return fa == fb
+		}
+		return false
+	}
+
+	switch va := a.(type) {
+	case string:
+		vb, ok := b.(string)
+		return ok && va == vb
+	case bool:
+		vb, ok := b.(bool)
+		return ok && va == vb
+	case []interface{}:
+		vb, ok := b.([]interface{})
+		return ok && sliceEqual(va, vb)
+	case map[string]interface{}:
+		vb, ok := b.(map[string]interface{})
+		return ok && mapEqual(va, vb)
+	}
+
+	return reflect.DeepEqual(a, b)
+}
+
+func sliceEqual(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !valueEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func mapEqual(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok {
+			return false
+		}
+		if !valueEqual(va, vb) {
+			return false
+		}
+	}
+	return true
+}
+
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	}
+	return 0, false
+}

--- a/common/static_response_test.go
+++ b/common/static_response_test.go
@@ -1,0 +1,149 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStaticResponseMatch(t *testing.T) {
+	entries := []*StaticResponseConfig{
+		{
+			Method: "eth_getBlockByNumber",
+			Params: []interface{}{"0x0", false},
+			Response: &StaticResponseBodyConfig{
+				Result: map[string]interface{}{"number": "0x0"},
+			},
+		},
+		{
+			Method: "eth_chainId",
+			Params: []interface{}{},
+			Response: &StaticResponseBodyConfig{
+				Result: "0x539",
+			},
+		},
+	}
+
+	t.Run("hit on exact params", func(t *testing.T) {
+		m := FindStaticResponseMatch(entries, "eth_getBlockByNumber", []interface{}{"0x0", false})
+		if assert.NotNil(t, m) {
+			assert.Equal(t, "eth_getBlockByNumber", m.Method)
+		}
+	})
+
+	t.Run("miss on different params", func(t *testing.T) {
+		m := FindStaticResponseMatch(entries, "eth_getBlockByNumber", []interface{}{"0x1", false})
+		assert.Nil(t, m)
+	})
+
+	t.Run("miss on different method", func(t *testing.T) {
+		m := FindStaticResponseMatch(entries, "eth_getBlockByHash", []interface{}{"0x0", false})
+		assert.Nil(t, m)
+	})
+
+	t.Run("hit on empty params", func(t *testing.T) {
+		m := FindStaticResponseMatch(entries, "eth_chainId", []interface{}{})
+		assert.NotNil(t, m)
+	})
+
+	t.Run("nil slice vs empty slice are equivalent", func(t *testing.T) {
+		m := FindStaticResponseMatch(entries, "eth_chainId", nil)
+		assert.NotNil(t, m)
+	})
+
+	t.Run("nil entries returns nil", func(t *testing.T) {
+		assert.Nil(t, FindStaticResponseMatch(nil, "eth_chainId", []interface{}{}))
+	})
+}
+
+func TestParamsEqual_NumericEquivalence(t *testing.T) {
+	// YAML decodes ints as int; JSON decodes numbers as float64. Same logical
+	// value from both sources must compare equal.
+	assert.True(t, paramsEqual([]interface{}{1}, []interface{}{float64(1)}))
+	assert.True(t, paramsEqual([]interface{}{int64(100)}, []interface{}{float64(100)}))
+	assert.False(t, paramsEqual([]interface{}{1}, []interface{}{float64(1.5)}))
+}
+
+func TestParamsEqual_NestedObject(t *testing.T) {
+	// eth_call-style object params with keys in different orders still match.
+	a := []interface{}{
+		map[string]interface{}{"to": "0xabc", "data": "0x01"},
+		"latest",
+	}
+	b := []interface{}{
+		map[string]interface{}{"data": "0x01", "to": "0xabc"},
+		"latest",
+	}
+	assert.True(t, paramsEqual(a, b))
+}
+
+func TestParamsEqual_MismatchedSlice(t *testing.T) {
+	assert.False(t, paramsEqual([]interface{}{"0x0"}, []interface{}{"0x0", false}))
+}
+
+func TestParamsEqual_HexStringCaseSensitive(t *testing.T) {
+	// We do not normalize hex. "0x0" and "0x00" are distinct keys; callers
+	// are responsible for matching the exact form their clients send.
+	assert.False(t, paramsEqual([]interface{}{"0x0"}, []interface{}{"0x00"}))
+}
+
+func TestStaticResponseConfig_Validate(t *testing.T) {
+	t.Run("valid result", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Method:   "eth_chainId",
+			Response: &StaticResponseBodyConfig{Result: "0x1"},
+		}
+		assert.NoError(t, s.Validate())
+	})
+
+	t.Run("valid error", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Method: "some_method",
+			Response: &StaticResponseBodyConfig{
+				Error: &StaticResponseErrorConfig{Code: -32601, Message: "Method not found"},
+			},
+		}
+		assert.NoError(t, s.Validate())
+	})
+
+	t.Run("missing method", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Response: &StaticResponseBodyConfig{Result: "0x1"},
+		}
+		assert.Error(t, s.Validate())
+	})
+
+	t.Run("missing response", func(t *testing.T) {
+		s := &StaticResponseConfig{Method: "eth_chainId"}
+		assert.Error(t, s.Validate())
+	})
+
+	t.Run("both result and error", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Method: "eth_chainId",
+			Response: &StaticResponseBodyConfig{
+				Result: "0x1",
+				Error:  &StaticResponseErrorConfig{Code: -1, Message: "x"},
+			},
+		}
+		assert.Error(t, s.Validate())
+	})
+
+	t.Run("neither result nor error", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Method:   "eth_chainId",
+			Response: &StaticResponseBodyConfig{},
+		}
+		assert.Error(t, s.Validate())
+	})
+
+	t.Run("error missing message", func(t *testing.T) {
+		s := &StaticResponseConfig{
+			Method: "eth_chainId",
+			Response: &StaticResponseBodyConfig{
+				Error: &StaticResponseErrorConfig{Code: -32601},
+			},
+		}
+		assert.Error(t, s.Validate())
+	})
+}

--- a/common/validation.go
+++ b/common/validation.go
@@ -1319,6 +1319,35 @@ func (n *NetworkConfig) Validate(c *Config) error {
 			return fmt.Errorf("network.*.alias '%s' must contain only alphanumeric characters, dash, or underscore", n.Alias)
 		}
 	}
+	for i, sr := range n.StaticResponses {
+		if err := sr.Validate(); err != nil {
+			return fmt.Errorf("network.*.staticResponses[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (s *StaticResponseConfig) Validate() error {
+	if s == nil {
+		return fmt.Errorf("entry is nil")
+	}
+	if s.Method == "" {
+		return fmt.Errorf("method is required")
+	}
+	if s.Response == nil {
+		return fmt.Errorf("response is required")
+	}
+	hasResult := s.Response.Result != nil
+	hasError := s.Response.Error != nil
+	if hasResult && hasError {
+		return fmt.Errorf("response must set exactly one of result or error, got both")
+	}
+	if !hasResult && !hasError {
+		return fmt.Errorf("response must set exactly one of result or error, got neither")
+	}
+	if hasError && s.Response.Error.Message == "" {
+		return fmt.Errorf("response.error.message is required")
+	}
 	return nil
 }
 

--- a/docs/pages/config/projects/networks.mdx
+++ b/docs/pages/config/projects/networks.mdx
@@ -838,6 +838,50 @@ The `preferHighestValueFor` map supports:
   When `preferHighestValueFor` is configured for a method, it takes precedence over normal hash-based consensus. Error responses are ignored; only valid numeric responses are compared.
 </Callout>
 
+## Static responses
+
+Some chains deviate from common client assumptions in ways that make specific RPC requests unanswerable or produce inconsistent responses across upstreams. For example, a chain whose genesis block is at height `1` instead of `0` has no valid answer for `eth_getBlockByNumber("0x0", false)` — clients that probe block 0 will see errors or divergent results, and the upstream may be flagged as misbehaving.
+
+`staticResponses` lets you configure a canned JSON-RPC response for a specific `(method, params)` pair on a network. When an inbound request matches, the configured response is returned immediately and no upstream is contacted.
+
+```yaml
+networks:
+  - architecture: evm
+    evm:
+      chainId: 999
+    staticResponses:
+      # Return a synthetic block for eth_getBlockByNumber("0x0", false)
+      - method: eth_getBlockByNumber
+        params: ["0x0", false]
+        response:
+          result:
+            number: "0x0"
+            hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+            parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+            # ...remaining block fields
+
+      # Or return a JSON-RPC error
+      - method: some_unsupported_method
+        params: []
+        response:
+          error:
+            code: -32601
+            message: "Method not found"
+```
+
+Match semantics:
+
+* The `method` must match the request method exactly.
+* The `params` must match the request params via deep equality. Maps may have keys in any order. Integer and floating-point types of the same numeric value compare equal (for example, config written as `1` in YAML matches an incoming JSON `1.0`). Hex strings are compared literally — `"0x0"` and `"0x00"` are treated as distinct.
+* Entries are checked in declaration order; the first match wins.
+* Exactly one of `response.result` or `response.error` must be set.
+
+Matched requests skip cache, multiplexer, and upstream selection entirely, and the inbound request `id` is echoed in the response. Hits are counted by the `erpc_network_static_response_served_total` metric.
+
+<Callout type='info'>
+  Static responses apply only to user-facing requests on the network. eRPC's internal state pollers (for block number and finality) continue to query upstreams normally.
+</Callout>
+
 ## Name aliasing
 
 You can define friendly aliases for your networks instead of the /architecture/chainId format. For example, instead of using `/main/evm/1`, you can use `/main/ethereum`:

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -304,6 +304,16 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		lg.Debug().Msgf("forwarding request for network")
 	}
 
+	// Static response short-circuit. Checked after method extraction and before
+	// the multiplexer/cache/upstream-selection path so matching requests never
+	// touch any upstream. See StaticResponseConfig for match semantics.
+	if len(n.cfg.StaticResponses) > 0 {
+		if resp, ok := n.tryServeStaticResponse(ctx, &lg, req, method); ok {
+			forwardSpan.SetAttributes(attribute.Bool("static_response.hit", true))
+			return resp, nil
+		}
+	}
+
 	mlx, resp, err := n.handleMultiplexing(ctx, &lg, req, startTime)
 	if err != nil || resp != nil {
 		// When the original request is already fulfilled by multiplexer (follower path)

--- a/erpc/networks_static_responses.go
+++ b/erpc/networks_static_responses.go
@@ -1,0 +1,65 @@
+package erpc
+
+import (
+	"context"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
+	"github.com/rs/zerolog"
+)
+
+// tryServeStaticResponse returns a canned response if the request matches one
+// of the network's configured static entries. It echoes the inbound request's
+// JSON-RPC id into the response and records a metric on hit. Returns (nil,
+// false) when no entry matches or the request cannot be inspected.
+func (n *Network) tryServeStaticResponse(
+	ctx context.Context,
+	lg *zerolog.Logger,
+	req *common.NormalizedRequest,
+	method string,
+) (*common.NormalizedResponse, bool) {
+	jrq, err := req.JsonRpcRequest(ctx)
+	if err != nil {
+		lg.Debug().Err(err).Str("method", method).Msg("skipping static response: cannot inspect request")
+		return nil, false
+	}
+
+	jrq.RLock()
+	params := jrq.Params
+	jrq.RUnlock()
+
+	match := common.FindStaticResponseMatch(n.cfg.StaticResponses, method, params)
+	if match == nil {
+		return nil, false
+	}
+
+	var rpcErr *common.ErrJsonRpcExceptionExternal
+	if match.Response.Error != nil {
+		rpcErr = &common.ErrJsonRpcExceptionExternal{
+			Code:    match.Response.Error.Code,
+			Message: match.Response.Error.Message,
+			Data:    match.Response.Error.Data,
+		}
+	}
+
+	jrr, err := common.NewJsonRpcResponse(req.ID(), match.Response.Result, rpcErr)
+	if err != nil {
+		lg.Error().Err(err).Str("method", method).Msg("failed to build static response")
+		return nil, false
+	}
+
+	resp := common.NewNormalizedResponse().
+		WithRequest(req).
+		WithJsonRpcResponse(jrr)
+
+	telemetry.CounterHandle(
+		telemetry.MetricNetworkStaticResponseServedTotal,
+		n.projectId, n.Label(), method,
+	).Inc()
+
+	if lg.GetLevel() <= zerolog.DebugLevel {
+		lg.Debug().Str("method", method).Msg("served static response (no upstream contacted)")
+	}
+
+	return resp, true
+}

--- a/erpc/networks_static_responses_test.go
+++ b/erpc/networks_static_responses_test.go
@@ -1,0 +1,245 @@
+package erpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStaticResponses verifies that per-network static responses short-circuit
+// request handling: matching requests return the canned payload immediately
+// and no upstream is contacted. Non-matching requests flow through normally.
+func TestStaticResponses(t *testing.T) {
+	t.Run("MatchingRequestServedWithoutContactingUpstream", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		var rpcCalls atomic.Int32
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBlockByNumber")
+			}).
+			Persist().
+			Reply(200).
+			Map(func(r *http.Response) *http.Response { rpcCalls.Add(1); return r }).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"error":   map[string]interface{}{"code": -32000, "message": "block not found"},
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stubResult := map[string]interface{}{
+			"number": "0x0",
+			"hash":   "0xaaaabbbbccccdddd",
+		}
+		netCfg := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm:          &common.EvmNetworkConfig{ChainId: 123},
+			StaticResponses: []*common.StaticResponseConfig{
+				{
+					Method: "eth_getBlockByNumber",
+					Params: []interface{}{"0x0", false},
+					Response: &common.StaticResponseBodyConfig{
+						Result: stubResult,
+					},
+				},
+			},
+		}
+		network := setupTestNetworkSimple(t, ctx, nil, netCfg)
+
+		counter, counterErr := telemetry.MetricNetworkStaticResponseServedTotal.
+			GetMetricWithLabelValues("test", network.Label(), "eth_getBlockByNumber")
+		require.NoError(t, counterErr)
+		before := promUtil.ToFloat64(counter)
+
+		req := common.NewNormalizedRequest([]byte(
+			`{"jsonrpc":"2.0","id":42,"method":"eth_getBlockByNumber","params":["0x0",false]}`,
+		))
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, jrrErr := resp.JsonRpcResponse()
+		require.NoError(t, jrrErr)
+
+		// Inbound id must be echoed (not the stored id from the config).
+		assert.Equal(t, float64(42), toJSONNumber(t, jrr.ID()))
+
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal(jrr.GetResultBytes(), &decoded))
+		assert.Equal(t, "0x0", decoded["number"])
+		assert.Equal(t, "0xaaaabbbbccccdddd", decoded["hash"])
+
+		assert.Equal(t, int32(0), rpcCalls.Load(), "upstream must not be contacted for matched static response")
+		assert.Equal(t, before+1, promUtil.ToFloat64(counter), "static-response counter must increment on hit")
+	})
+
+	t.Run("NonMatchingParamsFallThroughToUpstream", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		var rpcCalls atomic.Int32
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBlockByNumber") && strings.Contains(body, "0x1")
+			}).
+			Persist().
+			Reply(200).
+			Map(func(r *http.Response) *http.Response { rpcCalls.Add(1); return r }).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result":  map[string]interface{}{"number": "0x1"},
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		netCfg := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm:          &common.EvmNetworkConfig{ChainId: 123},
+			StaticResponses: []*common.StaticResponseConfig{
+				{
+					Method:   "eth_getBlockByNumber",
+					Params:   []interface{}{"0x0", false},
+					Response: &common.StaticResponseBodyConfig{Result: map[string]interface{}{"number": "0x0"}},
+				},
+			},
+		}
+		network := setupTestNetworkSimple(t, ctx, nil, netCfg)
+
+		req := common.NewNormalizedRequest([]byte(
+			`{"jsonrpc":"2.0","id":7,"method":"eth_getBlockByNumber","params":["0x1",false]}`,
+		))
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, jrrErr := resp.JsonRpcResponse()
+		require.NoError(t, jrrErr)
+
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal(jrr.GetResultBytes(), &decoded))
+		assert.Equal(t, "0x1", decoded["number"])
+		assert.GreaterOrEqual(t, rpcCalls.Load(), int32(1), "upstream must be contacted when params don't match a static entry")
+	})
+
+	t.Run("ErrorShapedStubReturnsJsonRpcError", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		netCfg := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm:          &common.EvmNetworkConfig{ChainId: 123},
+			StaticResponses: []*common.StaticResponseConfig{
+				{
+					Method: "eth_getBlockByNumber",
+					Params: []interface{}{"0x0", false},
+					Response: &common.StaticResponseBodyConfig{
+						Error: &common.StaticResponseErrorConfig{
+							Code:    -32000,
+							Message: "block not found",
+						},
+					},
+				},
+			},
+		}
+		network := setupTestNetworkSimple(t, ctx, nil, netCfg)
+
+		req := common.NewNormalizedRequest([]byte(
+			`{"jsonrpc":"2.0","id":9,"method":"eth_getBlockByNumber","params":["0x0",false]}`,
+		))
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, jrrErr := resp.JsonRpcResponse()
+		require.NoError(t, jrrErr)
+		require.NotNil(t, jrr.Error)
+		assert.Equal(t, -32000, jrr.Error.Code)
+		assert.Equal(t, "block not found", jrr.Error.Message)
+		assert.Equal(t, float64(9), toJSONNumber(t, jrr.ID()))
+	})
+
+	t.Run("StringRequestIdEchoedOnStaticHit", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		netCfg := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm:          &common.EvmNetworkConfig{ChainId: 123},
+			StaticResponses: []*common.StaticResponseConfig{
+				{
+					Method: "eth_getBlockByNumber",
+					Params: []interface{}{"0x0", false},
+					Response: &common.StaticResponseBodyConfig{
+						Result: map[string]interface{}{"number": "0x0"},
+					},
+				},
+			},
+		}
+		network := setupTestNetworkSimple(t, ctx, nil, netCfg)
+
+		req := common.NewNormalizedRequest([]byte(
+			`{"jsonrpc":"2.0","id":"req-abc-123","method":"eth_getBlockByNumber","params":["0x0",false]}`,
+		))
+
+		resp, err := network.Forward(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, jrrErr := resp.JsonRpcResponse()
+		require.NoError(t, jrrErr)
+		assert.Equal(t, "req-abc-123", jrr.ID())
+	})
+}
+
+// toJSONNumber normalizes a parsed JSON-RPC id value to a float64 for
+// comparison. The request id in tests is always numeric.
+func toJSONNumber(t *testing.T, id interface{}) float64 {
+	t.Helper()
+	switch v := id.(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case json.Number:
+		f, err := v.Float64()
+		require.NoError(t, err)
+		return f
+	}
+	t.Fatalf("unexpected id type %T", id)
+	return 0
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -196,6 +196,12 @@ var (
 		Help:      "Total number of multiplexed requests for a network.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
+	MetricNetworkStaticResponseServedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_static_response_served_total",
+		Help:      "Total number of requests served from a configured static response without contacting any upstream.",
+	}, []string{"project", "network", "category"})
+
 	MetricNetworkHedgedRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_hedged_request_total",
@@ -424,7 +430,6 @@ var (
 		Name:      "x402_payment_total",
 		Help:      "Total number of x402 payments processed (verified, settled, rejected).",
 	}, []string{"project", "network", "facilitator", "outcome"})
-
 )
 
 var DefaultHistogramBuckets = []float64{
@@ -448,15 +453,15 @@ var (
 	MetricNetworkEvmGetLogsRangeRequested     *LabeledHistogram
 	MetricNetworkEvmTraceFilterRangeRequested *LabeledHistogram
 	MetricNetworkHedgeDelaySeconds            *LabeledHistogram
-	MetricConsensusResponsesCollected     *LabeledHistogram
-	MetricConsensusAgreementCount         *LabeledHistogram
-	MetricX402FacilitatorRequestDuration  *LabeledHistogram
-	MetricConsensusDuration               *LabeledHistogram
-	MetricCacheSetSuccessDuration         *LabeledHistogram
-	MetricCacheSetErrorDuration           *LabeledHistogram
-	MetricCacheGetSuccessHitDuration      *LabeledHistogram
-	MetricCacheGetSuccessMissDuration     *LabeledHistogram
-	MetricCacheGetErrorDuration           *LabeledHistogram
+	MetricConsensusResponsesCollected         *LabeledHistogram
+	MetricConsensusAgreementCount             *LabeledHistogram
+	MetricX402FacilitatorRequestDuration      *LabeledHistogram
+	MetricConsensusDuration                   *LabeledHistogram
+	MetricCacheSetSuccessDuration             *LabeledHistogram
+	MetricCacheSetErrorDuration               *LabeledHistogram
+	MetricCacheGetSuccessHitDuration          *LabeledHistogram
+	MetricCacheGetSuccessMissDuration         *LabeledHistogram
+	MetricCacheGetErrorDuration               *LabeledHistogram
 )
 
 // ScoreMetricsMode controls how score metrics are emitted.

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -444,12 +444,6 @@ export interface NetworkDefaults {
   evm?: TsEvmNetworkConfigForDefaults;
   multiplexing?: boolean;
 }
-/**
- * Define a type alias to avoid recursion
- */
-/**
- * If that fails, try the old format with single failsafe object
- */
 export interface CORSConfig {
   allowedOrigins: string[];
   allowedMethods: string[];
@@ -485,12 +479,6 @@ export interface UpstreamConfig {
   routing?: RoutingConfig;
   shadow?: ShadowUpstreamConfig;
 }
-/**
- * Define a type alias to avoid recursion
- */
-/**
- * If that fails, try the old format with single failsafe object
- */
 export interface ShadowUpstreamConfig {
   enabled: boolean;
   sampleRate?: number /* float64 */;
@@ -816,13 +804,37 @@ export interface NetworkConfig {
   alias?: string;
   methods?: MethodsConfig;
   multiplexing?: boolean;
+  staticResponses?: (StaticResponseConfig | undefined)[];
 }
 /**
- * Define a type alias to avoid recursion
+ * StaticResponseConfig declares a canned JSON-RPC response for a specific
+ * (method, params) pair on a network. When an inbound request matches, the
+ * configured response is returned immediately and no upstream is contacted.
+ * Useful for chains that deviate from client assumptions (for example, chains
+ * whose genesis block is not 0) where probing upstreams would yield errors
+ * or inconsistent data.
  */
+export interface StaticResponseConfig {
+  method: string;
+  params?: any[];
+  response?: StaticResponseBodyConfig;
+}
 /**
- * If that fails, try the old format with single failsafe object
+ * StaticResponseBodyConfig holds the JSON-RPC payload to serve. Exactly one
+ * of Result or Error must be set.
  */
+export interface StaticResponseBodyConfig {
+  result?: any;
+  error?: StaticResponseErrorConfig;
+}
+/**
+ * StaticResponseErrorConfig mirrors a JSON-RPC error object.
+ */
+export interface StaticResponseErrorConfig {
+  code: number /* int */;
+  message: string;
+  data?: any;
+}
 export interface DirectiveDefaultsConfig {
   retryEmpty?: boolean;
   retryPending?: boolean;
@@ -1121,6 +1133,20 @@ export interface MetricsConfig {
   port?: number /* int */;
   errorLabelMode?: LabelMode;
   histogramBuckets?: string;
+  /**
+   * HistogramDropLabels removes these labels from every histogram. Counters
+   * and gauges are unaffected. Useful to cap per-instance /metrics response
+   * size when high-cardinality labels (e.g. "user") push a scrape past the
+   * managed scraper's sample/body limits.
+   */
+  histogramDropLabels?: string[];
+  /**
+   * HistogramLabelOverrides re-adds labels for specific histograms even if
+   * they appear in HistogramDropLabels. Key is the metric Name (without the
+   * "erpc_" namespace prefix), e.g. "network_request_duration_seconds".
+   * Value is the list of label names to keep for that metric.
+   */
+  histogramLabelOverrides?: { [key: string]: string[]};
 }
 /**
  * RateLimitStoreConfig defines where rate limit counters are stored


### PR DESCRIPTION
## Summary

Adds a per-network `staticResponses` list that short-circuits inbound requests matching a configured `(method, params)` pair — returning a stubbed JSON-RPC body without contacting any upstream.

## Motivation

Some chains deviate from common client assumptions in ways that make specific RPC requests unanswerable or produce inconsistent responses across upstreams. The motivating case: chains whose genesis block is at height `1` instead of `0` have no valid answer for `eth_getBlockByNumber("0x0", false)`. Clients that probe block 0 (for example, indexers that scan from genesis) see upstream errors or divergent results, and the upstream may be flagged as misbehaving by eRPC's health tracking.

## Design

- New config: `networks[].staticResponses: StaticResponseConfig[]` where each entry has `method`, `params`, and `response` (exactly one of `result` or `error`).
- Match: exact method equality + recursive deep-equality on params. The matcher tolerates numeric-type divergence between YAML config (`int`) and JSON request decoding (`float64`), and compares maps by key regardless of declared order.
- Short-circuit inserted in `Network.Forward` after method extraction and before the multiplexer / cache / upstream-selection path. Matched requests never touch any upstream.
- Inbound request `id` is echoed in the response (the stub's stored id is irrelevant).
- New metric: `erpc_network_static_response_served_total{project,network,category}`.
- Docs: new "Static responses" section in `config/projects/networks.mdx`.

Non-goals: no matcher DSL, no hex normalization, no per-upstream scope, no change to internal state pollers.

## Test plan

- [x] `go test ./common/... ./erpc/...` (new tests pass, existing tests unaffected)
- [x] New matcher unit tests cover numeric equivalence, nested objects with reordered keys, slice length mismatch, hex-string case sensitivity, and validation edge cases.
- [x] New integration tests cover match-hit (no upstream calls observed via gock), non-matching params fall through, error-shaped stub returns proper JSON-RPC error, and inbound id echo.

## Notes

- `telemetry/metrics.go` also carries a few incidental re-alignments surfaced by `gofmt` on pre-existing code; these aren't semantically related to the feature but were picked up by `make fmt`.
- TS types in `typescript/config/src/generated.ts` are regenerated via `tygo`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new request short-circuit path in `Network.Forward` that can bypass cache/multiplexing/upstream selection, so misconfiguration or matcher edge cases could change production request behavior for specific method+params pairs.
> 
> **Overview**
> Adds per-network `staticResponses` configuration to return canned JSON-RPC `result` or `error` bodies for exact `(method, params)` matches, bypassing cache, multiplexing, and upstream selection.
> 
> Implements a deep params matcher (numeric-type tolerant, map key-order independent), validates entries at config load time, serves matched responses while echoing the inbound request `id`, and records a new Prometheus counter `erpc_network_static_response_served_total`. Docs and generated TypeScript config types are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c93ec4b732698f18bd773529cef55289905964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->