### PR TITLE
fix: normalize emptyish trace_filter/arbtrace_filter upstream responses to []

### DIFF
--- a/architecture/evm/common.go
+++ b/architecture/evm/common.go
@@ -43,3 +43,29 @@ func upstreamPostForward_markUnexpectedEmpty(
 		u,
 	)
 }
+
+// normalizeEmptyArrayResponse returns a new NormalizedResponse with result `[]`,
+// inheriting metadata from rs. Takes ownership of rs (calls Release()).
+func normalizeEmptyArrayResponse(
+	ctx context.Context,
+	u common.Upstream,
+	rq *common.NormalizedRequest,
+	rs *common.NormalizedResponse,
+) (*common.NormalizedResponse, error) {
+	jrr, err := common.NewJsonRpcResponse(rq.ID(), []interface{}{}, nil)
+	if err != nil {
+		return nil, err
+	}
+	nnr := common.NewNormalizedResponse().WithRequest(rq).WithJsonRpcResponse(jrr)
+	nnr.SetFromCache(rs.FromCache())
+	nnr.SetEvmBlockRef(rs.EvmBlockRef())
+	nnr.SetEvmBlockNumber(rs.EvmBlockNumber())
+	nnr.SetDuration(rs.Duration())
+	nnr.SetAttempts(rs.Attempts())
+	nnr.SetRetries(rs.Retries())
+	nnr.SetHedges(rs.Hedges())
+	nnr.SetUpstream(u)
+	rq.SetLastValidResponse(ctx, nnr)
+	rs.Release()
+	return nnr, nil
+}

--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -355,23 +355,7 @@ func upstreamPostForward_eth_getLogs(ctx context.Context, n common.Network, u co
 	defer span.End()
 
 	if re == nil && rs != nil && rs.IsResultEmptyish(ctx) {
-		// This is to normalize empty logs responses (e.g. instead of returning "null")
-		jrr, err := common.NewJsonRpcResponse(rq.ID(), []interface{}{}, nil)
-		if err != nil {
-			return nil, err
-		}
-		nnr := common.NewNormalizedResponse().WithRequest(rq).WithJsonRpcResponse(jrr)
-		nnr.SetFromCache(rs.FromCache())
-		nnr.SetEvmBlockRef(rs.EvmBlockRef())
-		nnr.SetEvmBlockNumber(rs.EvmBlockNumber())
-		nnr.SetAttempts(rs.Attempts())
-		nnr.SetRetries(rs.Retries())
-		nnr.SetHedges(rs.Hedges())
-		nnr.SetUpstream(u)
-		rq.SetLastValidResponse(ctx, nnr)
-		// We replaced the original response with a normalized one; release the old instance
-		rs.Release()
-		return nnr, nil
+		return normalizeEmptyArrayResponse(ctx, u, rq, rs)
 	}
 
 	return rs, re

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -157,6 +157,9 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 		// Then apply directive-based validation
 		rs, validationErr = upstreamPostForward_eth_getBlockByNumber(ctx, n, u, rq, rs, re)
 
+	case "trace_filter", "arbtrace_filter":
+		rs, validationErr = upstreamPostForward_trace_filter(ctx, n, u, rq, rs, re)
+
 	default:
 		// For other methods, only apply the mark empty check if configured
 		if shouldMarkEmpty {

--- a/architecture/evm/trace_filter.go
+++ b/architecture/evm/trace_filter.go
@@ -355,6 +355,24 @@ func upstreamPreForward_trace_filter(ctx context.Context, n common.Network, u co
 	return false, nil, nil
 }
 
+// upstreamPostForward_trace_filter normalizes emptyish results (e.g. `null`)
+// into `[]`. Some upstreams return `null` when no traces match, which breaks
+// consumers that decode the result as an array.
+func upstreamPostForward_trace_filter(ctx context.Context, n common.Network, u common.Upstream, rq *common.NormalizedRequest, rs *common.NormalizedResponse, re error) (*common.NormalizedResponse, error) {
+	ctx, span := common.StartDetailSpan(ctx, "Upstream.PostForwardHook.trace_filter", trace.WithAttributes(
+		attribute.String("request.id", fmt.Sprintf("%v", rq.ID())),
+		attribute.String("network.id", n.Id()),
+		attribute.String("upstream.id", u.Id()),
+	))
+	defer span.End()
+
+	if re == nil && rs != nil && rs.IsResultEmptyish(ctx) {
+		return normalizeEmptyArrayResponse(ctx, u, rq, rs)
+	}
+
+	return rs, re
+}
+
 // traceFilterSubRequest captures the parameters needed to construct a split
 // trace_filter/arbtrace_filter sub-request.
 type traceFilterSubRequest struct {

--- a/architecture/evm/trace_filter_normalize_test.go
+++ b/architecture/evm/trace_filter_normalize_test.go
@@ -1,0 +1,93 @@
+package evm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockEvmUpstream(id string) *mockEvmUpstream {
+	m := &mockEvmUpstream{}
+	m.On("Id").Return(id).Maybe()
+	return m
+}
+
+func TestUpstreamPostForward_TraceFilter_NormalizesNullToEmptyArray(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		rawBody []byte
+	}{
+		{"trace_filter null", "trace_filter", []byte("null")},
+		{"trace_filter empty string", "trace_filter", []byte(`""`)},
+		{"trace_filter empty object", "trace_filter", []byte("{}")},
+		{"arbtrace_filter null", "arbtrace_filter", []byte("null")},
+	}
+
+	network := &testNetwork{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := common.NewNormalizedRequest([]byte(
+				`{"jsonrpc":"2.0","id":1,"method":"` + tc.method + `","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
+			))
+			jrr, err := common.NewJsonRpcResponseFromBytes([]byte(`1`), tc.rawBody, nil)
+			assert.NoError(t, err)
+			resp := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+
+			out, outErr := HandleUpstreamPostForward(
+				context.Background(), network, newMockEvmUpstream("mock-up"), req, resp, nil, false,
+			)
+			assert.NoError(t, outErr)
+			assert.NotNil(t, out)
+
+			outJrr, err := out.JsonRpcResponse(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "[]", outJrr.GetResultString(),
+				"expected emptyish result to be normalized to []")
+		})
+	}
+}
+
+func TestUpstreamPostForward_TraceFilter_PreservesNonEmptyResult(t *testing.T) {
+	network := &testNetwork{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}
+
+	original := `[{"type":"call","subtraces":0,"traceAddress":[],"blockNumber":1}]`
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"trace_filter","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
+	))
+	jrr, err := common.NewJsonRpcResponseFromBytes([]byte(`1`), []byte(original), nil)
+	assert.NoError(t, err)
+	resp := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+
+	out, outErr := HandleUpstreamPostForward(
+		context.Background(), network, newMockEvmUpstream("mock-up"), req, resp, nil, false,
+	)
+	assert.NoError(t, outErr)
+
+	outJrr, err := out.JsonRpcResponse(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, original, outJrr.GetResultString(),
+		"non-empty result must be passed through unchanged")
+}
+
+func TestUpstreamPostForward_TraceFilter_PassThroughOnError(t *testing.T) {
+	network := &testNetwork{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}
+
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"trace_filter","params":[{"fromBlock":"0x1","toBlock":"0x1"}]}`,
+	))
+	jrr, err := common.NewJsonRpcResponseFromBytes([]byte(`1`), []byte("null"), nil)
+	assert.NoError(t, err)
+	resp := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+
+	upstreamErr := errors.New("upstream transport failure")
+	out, outErr := HandleUpstreamPostForward(
+		context.Background(), network, newMockEvmUpstream("mock-up"), req, resp, upstreamErr, false,
+	)
+	assert.Same(t, upstreamErr, outErr, "hook must propagate the upstream error unchanged")
+	assert.Same(t, resp, out, "response should be returned unchanged when an error is present")
+}


### PR DESCRIPTION
## Motivation

Some upstreams return JSON `null` for `trace_filter` / `arbtrace_filter` requests that match no traces. Consumers that decode the result as an array error on `null` (`"invalid type: null, expected a sequence"`), stranding indexers at the first no-match block.

## Change

Add an upstream post-forward hook for `trace_filter` / `arbtrace_filter` that rewrites emptyish results to `[]`, mirroring the existing `eth_getLogs` behaviour. Extract the shared logic into `normalizeEmptyArrayResponse` so both hooks share one code path (and pick up `Duration()` metadata that the inline `eth_getLogs` version was dropping).

## Interactions considered

- **Cache**: hook runs inside `doForward` before the async `cacheDal.Set`, so the cache stores the normalized `[]`.
- **Auto-split**: split sub-requests go through `n.Forward` → `doForward` → this hook, so each sub-response is normalized before merging. `GetLogsMultiResponseWriter` already skipped `IsResultEmptyish` inputs, so merge output is unchanged.
- **`MarkEmptyAsErrorMethods`**: `trace_filter` / `arbtrace_filter` aren't in the default list (empty is a legitimate "no match" result), so normalization doesn't compete with the mark-empty path.
- **Errors**: `HandleUpstreamPostForward` short-circuits on `re != nil` before the method switch, so this hook only runs for successful upstream responses.

## Tests

`trace_filter_normalize_test.go` covers `null` / `""` / `{}` normalization for both methods, non-empty passthrough, and error-path passthrough.