### PR TITLE
fix: rewrite response ID for all JSON-RPC architectures

### DIFF
--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1494,19 +1494,20 @@ func (n *Network) normalizeResponse(ctx context.Context, req *common.NormalizedR
 	ctx, span := common.StartDetailSpan(ctx, "Network.NormalizeResponse")
 	defer span.End()
 
-	switch n.Architecture() {
-	case common.ArchitectureEvm:
-		if resp != nil {
-			// This ensures that even if upstream gives us wrong/missing ID we'll
-			// use correct one from original incoming request.
-			if jrr, err := resp.JsonRpcResponse(ctx); err == nil && jrr != nil {
-				jrq, err := req.JsonRpcRequest(ctx)
-				if err != nil {
-					return err
-				}
-				if err := jrr.SetID(jrq.ID); err != nil {
-					return err
-				}
+	// For any JSON-RPC architecture: ensure the response ID always reflects the
+	// client's original request ID, regardless of what the upstream echoed back.
+	// This is especially important for proxies that normalize or multiplex IDs
+	// toward upstreams, and must apply to every JSON-RPC architecture — not just
+	// EVM — so non-EVM clients (Solana and future architectures) aren't left with
+	// mismatched response IDs.
+	if resp != nil {
+		if jrr, err := resp.JsonRpcResponse(ctx); err == nil && jrr != nil {
+			jrq, err := req.JsonRpcRequest(ctx)
+			if err != nil {
+				return err
+			}
+			if err := jrr.SetID(jrq.ID); err != nil {
+				return err
 			}
 		}
 	}

--- a/erpc/networks_normalize_response_test.go
+++ b/erpc/networks_normalize_response_test.go
@@ -1,0 +1,75 @@
+package erpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeResponse_IDRewrite_AppliesToAllArchitectures pins the contract
+// that the response ID always reflects the client's original request ID, for
+// every JSON-RPC architecture. Prior to the fix, the rewrite was guarded by
+// `switch n.Architecture() { case common.ArchitectureEvm: ... }`, so any
+// non-EVM JSON-RPC architecture would leak whatever ID the upstream echoed.
+func TestNormalizeResponse_IDRewrite_AppliesToAllArchitectures(t *testing.T) {
+	ctx := context.Background()
+
+	// Upstream responded with ID 99 (what an upstream might echo after its
+	// own multiplexing/renumbering); client sent ID 1 and expects 1 back.
+	buildResp := func(t *testing.T) *common.NormalizedResponse {
+		t.Helper()
+		jrr := common.MustNewJsonRpcResponseFromBytes(
+			[]byte(`99`),      // id bytes the upstream returned
+			[]byte(`"0xabc"`), // some result
+			nil,
+		)
+		return common.NewNormalizedResponse().WithJsonRpcResponse(jrr)
+	}
+
+	buildReq := func() *common.NormalizedRequest {
+		return common.NewNormalizedRequest([]byte(`{"method":"eth_chainId","params":[],"id":1,"jsonrpc":"2.0"}`))
+	}
+
+	// Asserts the response's ID matches the request's parsed ID (both should
+	// end up as float64(1) after JSON decode).
+	assertResponseMatchesRequest := func(t *testing.T, req *common.NormalizedRequest, resp *common.NormalizedResponse) {
+		t.Helper()
+		jrr, err := resp.JsonRpcResponse(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, jrr)
+		jrq, err := req.JsonRpcRequest(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, jrq)
+		assert.Equal(t, jrq.ID, jrr.ID(),
+			"response ID should be rewritten to match the client's original request ID")
+	}
+
+	t.Run("EVM", func(t *testing.T) {
+		network := &Network{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}
+		req := buildReq()
+		resp := buildResp(t)
+		require.NoError(t, network.normalizeResponse(ctx, req, resp))
+		assertResponseMatchesRequest(t, req, resp)
+	})
+
+	t.Run("NonEvmJsonRpcArchitecture", func(t *testing.T) {
+		// Regression: pre-fix this returned the upstream's echoed ID (99)
+		// because the switch only handled EVM. Post-fix: rewrite applies to
+		// any JSON-RPC architecture. We use a placeholder architecture name
+		// so the test exercises the non-EVM branch without depending on a
+		// specific architecture being merged to main.
+		network := &Network{cfg: &common.NetworkConfig{Architecture: common.NetworkArchitecture("jsonrpc-test")}}
+		req := buildReq()
+		resp := buildResp(t)
+		require.NoError(t, network.normalizeResponse(ctx, req, resp))
+		assertResponseMatchesRequest(t, req, resp)
+	})
+
+	t.Run("NilResponse_NoError", func(t *testing.T) {
+		network := &Network{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}
+		assert.NoError(t, network.normalizeResponse(ctx, buildReq(), nil))
+	})
+}


### PR DESCRIPTION
## Summary

The response-ID normalization that preserves the client's original request ID was gated by `switch n.Architecture() { case common.ArchitectureEvm: ... }`. Any non-EVM JSON-RPC architecture silently leaked whatever ID the upstream echoed back — including upstreams that renumber or multiplex IDs toward themselves. Clients submitting \`id=1\` could receive a response with \`id=99\` for any non-EVM architecture, violating the JSON-RPC 2.0 expectation that the response id matches the request id.

Drop the architecture gate. EVM behavior is unchanged; non-EVM architectures now get the correct behavior they were silently missing.

## Test plan

- [x] New \`TestNormalizeResponse_IDRewrite_AppliesToAllArchitectures\` asserts the rewrite fires for EVM and a non-EVM JSON-RPC architecture, and that a nil response is a no-op.
- [x] Verified the test fails without the fix (non-EVM returns upstream's echoed ID 99 instead of request's 1) and passes with the fix.
- [x] EVM subtest confirms no regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change confined to response normalization that now rewrites JSON-RPC `id` for non-EVM architectures; EVM behavior is preserved and covered by a regression test.
> 
> **Overview**
> Ensures `Network.normalizeResponse` always rewrites the JSON-RPC response `id` to match the client’s original request `id`, removing the prior EVM-only gate so non-EVM JSON-RPC architectures don’t leak upstream-renumbered IDs.
> 
> Adds `TestNormalizeResponse_IDRewrite_AppliesToAllArchitectures` to cover EVM, a non-EVM JSON-RPC architecture, and the nil-response no-op behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72de0191884486c1ec44177239327b1c23ee4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->