### PR TITLE
fix: wrap permanent init failures with NewTaskFatal

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -750,6 +750,14 @@ type ErrUpstreamClientInitialization struct {
 	BaseError
 }
 
+// Note: ErrUpstreamClientInitialization deliberately does not implement
+// IsTaskFatal — the same constructor is used for both permanent
+// (chainId-mismatch, parse-error, unsupported-type) and transient (RPC/network
+// failure during chainId detection) causes. Call sites that know the cause is
+// permanent wrap with common.NewTaskFatal() so the Initializer stops retrying.
+// Leaving this unimplemented keeps transient failures retryable — a provider
+// outage during startup should be recoverable once the provider returns.
+
 var NewErrUpstreamClientInitialization = func(cause error, upstream Upstream) error {
 	return &ErrUpstreamClientInitialization{
 		UpstreamAwareError: UpstreamAwareError{

--- a/common/errors_task_fatal_test.go
+++ b/common/errors_task_fatal_test.go
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/util"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildUpstreamInitErr constructs a bare ErrUpstreamClientInitialization with
+// the given cause — the shape produced by upstream.go for the RPC-failure path.
+func buildUpstreamInitErr(cause error) error {
+	return &ErrUpstreamClientInitialization{
+		BaseError: BaseError{
+			Code:    "ErrUpstreamClientInitialization",
+			Message: "could not initialize upstream client",
+			Cause:   cause,
+		},
+	}
+}
+
+// TestErrUpstreamClientInitialization_NotFatalByDefault pins the contract that
+// the base error type does NOT implement IsTaskFatal. Call sites that know the
+// cause is permanent (chainId mismatch, parse error, unsupported type) wrap
+// with common.NewTaskFatal(). Call sites that carry a potentially transient
+// cause (RPC failure during chainId detection) leave the error unwrapped so
+// the Initializer's auto-retry loop keeps trying.
+func TestErrUpstreamClientInitialization_NotFatalByDefault(t *testing.T) {
+	err := buildUpstreamInitErr(errors.New("connection refused during startup"))
+
+	var fatal interface{ IsTaskFatal() bool }
+	assert.False(t, errors.As(err, &fatal),
+		"bare ErrUpstreamClientInitialization must NOT satisfy IsTaskFatal so transient failures stay retryable")
+}
+
+// TestErrUpstreamClientInitialization_WrappedWithTaskFatal_IsFatal verifies
+// that call sites with permanently-broken causes (chainId mismatch, parse
+// error) produce an error that the Initializer treats as fatal.
+func TestErrUpstreamClientInitialization_WrappedWithTaskFatal_IsFatal(t *testing.T) {
+	inner := buildUpstreamInitErr(errors.New("chainId mismatch: configured 1, detected 137"))
+	wrapped := NewTaskFatal(inner)
+
+	var fatal interface{ IsTaskFatal() bool }
+	require.True(t, errors.As(wrapped, &fatal),
+		"NewTaskFatal-wrapped ErrUpstreamClientInitialization must satisfy IsTaskFatal")
+	assert.True(t, fatal.IsTaskFatal())
+
+	// Sanity: the underlying error type is still reachable via errors.As.
+	var uErr *ErrUpstreamClientInitialization
+	assert.True(t, errors.As(wrapped, &uErr),
+		"the underlying ErrUpstreamClientInitialization must still be retrievable via errors.As")
+}
+
+// TestErrUpstreamClientInitialization_WrappedStopsInitializerRetryLoop
+// exercises the real util.Initializer: a task that returns a
+// NewTaskFatal-wrapped ErrUpstreamClientInitialization transitions to
+// TaskFatal after a single attempt. This covers the "permanent failure"
+// call sites (chainId mismatch, parse error, unsupported client type).
+func TestErrUpstreamClientInitialization_WrappedStopsInitializerRetryLoop(t *testing.T) {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	init := util.NewInitializer(appCtx, &logger, &util.InitializerConfig{
+		TaskTimeout:   time.Second,
+		AutoRetry:     true,
+		RetryMinDelay: time.Millisecond,
+		RetryMaxDelay: time.Millisecond * 10,
+		RetryFactor:   1.1,
+	})
+	require.NotNil(t, init)
+
+	var attempts int32
+	task := util.NewBootstrapTask("chainid-mismatch", func(ctx context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return NewTaskFatal(buildUpstreamInitErr(
+			errors.New("chainId mismatch: configured 1, detected 137"),
+		))
+	})
+
+	runCtx, runCancel := context.WithTimeout(appCtx, 200*time.Millisecond)
+	defer runCancel()
+	_ = init.ExecuteTasks(runCtx, task)
+
+	time.Sleep(150 * time.Millisecond)
+	init.Stop(nil)
+
+	got := atomic.LoadInt32(&attempts)
+	assert.Equal(t, int32(1), got,
+		"NewTaskFatal-wrapped ErrUpstreamClientInitialization must stop retries (attempted %d times)", got)
+	assert.Equal(t, util.StateFatal, init.State(),
+		"initializer must be in StateFatal after a permanent init failure")
+}
+
+// TestErrUpstreamClientInitialization_TransientCauseIsRetried verifies the
+// other direction: an RPC-failure-path error (unwrapped) keeps the task
+// retryable, so the upstream can self-heal when the provider recovers.
+func TestErrUpstreamClientInitialization_TransientCauseIsRetried(t *testing.T) {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	init := util.NewInitializer(appCtx, &logger, &util.InitializerConfig{
+		TaskTimeout:   time.Second,
+		AutoRetry:     true,
+		RetryMinDelay: time.Millisecond,
+		RetryMaxDelay: time.Millisecond * 10,
+		RetryFactor:   1.1,
+	})
+	require.NotNil(t, init)
+
+	var attempts int32
+	task := util.NewBootstrapTask("transient-network", func(ctx context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return buildUpstreamInitErr(errors.New("connection refused during startup"))
+	})
+
+	runCtx, runCancel := context.WithTimeout(appCtx, 200*time.Millisecond)
+	defer runCancel()
+	_ = init.ExecuteTasks(runCtx, task)
+
+	time.Sleep(150 * time.Millisecond)
+	init.Stop(nil)
+
+	got := atomic.LoadInt32(&attempts)
+	assert.Greater(t, got, int32(5),
+		"bare ErrUpstreamClientInitialization (transient cause) must keep retrying; observed only %d attempts", got)
+	assert.NotEqual(t, util.StateFatal, init.State(),
+		"initializer must NOT enter StateFatal for transient init failures")
+}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1251,6 +1251,10 @@ func (u *Upstream) detectFeatures(ctx context.Context) error {
 		}
 		nid, err := u.EvmGetChainId(ctx)
 		if err != nil {
+			// RPC / network failure — potentially transient (provider outage,
+			// rate limit during startup, DNS blip). Leave the init error
+			// unwrapped so the Initializer's auto-retry loop can keep trying;
+			// the upstream will self-heal if the provider recovers.
 			return common.NewErrUpstreamClientInitialization(
 				&common.BaseError{
 					Code:  "ErrUpstreamChainIdDetectionFailed",
@@ -1261,22 +1265,26 @@ func (u *Upstream) detectFeatures(ctx context.Context) error {
 		}
 		realChainID, err := strconv.ParseInt(nid, 0, 64)
 		if err != nil {
-			return common.NewErrUpstreamClientInitialization(
+			// Upstream returned a non-numeric chainId — won't self-heal on
+			// retry. Wrap with NewTaskFatal so the Initializer stops retrying.
+			return common.NewTaskFatal(common.NewErrUpstreamClientInitialization(
 				&common.BaseError{
 					Code:  "ErrUpstreamChainIdDetectionFailed",
 					Cause: err,
 				},
 				u,
-			)
+			))
 		}
 		if cfg.Evm.ChainId > 0 && cfg.Evm.ChainId != realChainID {
-			return common.NewErrUpstreamClientInitialization(
+			// Misconfiguration (wrong upstream for this network) — permanent.
+			// Wrap with NewTaskFatal so the Initializer stops retrying.
+			return common.NewTaskFatal(common.NewErrUpstreamClientInitialization(
 				&common.BaseError{
 					Code:  "ErrUpstreamChainIdMismatch",
 					Cause: fmt.Errorf("chainId mismatch: configured %d, detected %d", cfg.Evm.ChainId, realChainID),
 				},
 				u,
-			)
+			))
 		}
 		cfg.Evm.ChainId = realChainID
 		u.networkId.Store(util.EvmNetworkId(cfg.Evm.ChainId))


### PR DESCRIPTION
## Summary

Bootstrap initialization can fail for two kinds of reasons, and the Initializer (\`util/initializer.go\`) should treat them differently:

**Permanent** (deterministically won't self-heal on retry):
- chainId mismatch (configured != detected) — misconfiguration
- chainId parse error — upstream returned a non-numeric value

**Transient** (may self-heal when the provider recovers):
- \`EvmGetChainId\` RPC failure — network blip, provider outage, rate limit during startup, TLS handshake race

Previously all four shared a single error type without \`IsTaskFatal\`, so every failure (permanent or not) was retried indefinitely — a misconfigured upstream hung dependent requests for ~30s per retry cycle.

## Why not a blanket fix on the error type

The first iteration of this PR added \`IsTaskFatal()\` returning true on \`ErrUpstreamClientInitialization\` directly. That was too aggressive: it would have made transient RPC failures during chainId detection permanently fatal, so a provider outage at startup would have silently killed an upstream until the process restarted. Thanks to the review feedback on that — caught before merge.

## What this PR does instead

Keep \`ErrUpstreamClientInitialization\` semantically neutral. Wrap only the two permanently-broken call sites in \`upstream/upstream.go\` with the existing \`common.NewTaskFatal()\` helper:
- chainId parse error
- chainId mismatch

Leave the RPC-failure path unwrapped so the auto-retry loop can recover once the provider returns.

## Test plan

- [x] Bare \`ErrUpstreamClientInitialization\` must NOT satisfy \`IsTaskFatal\` (transient-friendly).
- [x] \`NewTaskFatal\`-wrapped version must satisfy \`IsTaskFatal\` AND stay reachable via \`errors.As(&ErrUpstreamClientInitialization)\`.
- [x] Integration: wrapped form stops retries after 1 attempt, initializer enters \`StateFatal\`.
- [x] Integration: unwrapped form keeps retrying (>5 attempts in a 150ms window), initializer does NOT enter \`StateFatal\` — the negative-control test that would have caught the over-aggressive v1.
- [x] \`./common/...\`, \`./util/...\`, \`./upstream/...\` suites pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootstrap retry/fatal behavior for upstream initialization, which can affect service startup and error surfacing if call sites misclassify errors as fatal or transient.
> 
> **Overview**
> Adjusts upstream feature detection to distinguish *transient* vs *permanent* upstream initialization failures: RPC/network chainId detection errors remain retryable, while non-numeric chainId responses and configured/detected chainId mismatches are now wrapped with `common.NewTaskFatal()` so `util.Initializer` stops retrying and enters a fatal state.
> 
> Adds tests that pin this contract: `ErrUpstreamClientInitialization` is not fatal by default, becomes fatal when wrapped, and the real initializer retries transient causes but stops immediately on fatal-wrapped ones. Also documents in `common/errors.go` why `ErrUpstreamClientInitialization` intentionally does not implement `IsTaskFatal` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1793265287fa7ee5d283d012daf50a6ddda588d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->