### PR TITLE
fix: fall back to in-memory connector when SharedStateConfig is nil

### DIFF
--- a/data/shared_state_registry.go
+++ b/data/shared_state_registry.go
@@ -41,6 +41,24 @@ func NewSharedStateRegistry(
 	cfg *common.SharedStateConfig,
 ) (SharedStateRegistry, error) {
 	lg := logger.With().Str("component", "sharedState").Logger()
+
+	// When cfg is nil (e.g. tests, single-instance deploys, or callers that
+	// forgot to wire shared state) fall back to a local in-memory connector so
+	// the registry is always functional. Log a WARN so operators who intended
+	// a distributed backend notice that state will not propagate across replicas.
+	if cfg == nil {
+		lg.Warn().Msg("shared state config is nil — falling back to in-memory connector; state will NOT be shared across replicas")
+		cfg = &common.SharedStateConfig{
+			Connector: &common.ConnectorConfig{
+				Driver: common.DriverMemory,
+				Memory: &common.MemoryConnectorConfig{
+					MaxItems:     10_000,
+					MaxTotalSize: "100MB",
+				},
+			},
+		}
+	}
+
 	connector, err := NewConnector(appCtx, &lg, cfg.Connector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connector: %w", err)

--- a/data/shared_state_registry_nil_config_test.go
+++ b/data/shared_state_registry_nil_config_test.go
@@ -1,0 +1,57 @@
+package data
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewSharedStateRegistry_NilConfig_FallsBackToMemoryWithWarn verifies that
+// passing a nil SharedStateConfig no longer panics (as it did previously when
+// the constructor dereferenced cfg.Connector). Instead it falls back to an
+// in-memory connector and logs a WARN so operators who intended a distributed
+// backend don't silently lose cross-replica state propagation.
+func TestNewSharedStateRegistry_NilConfig_FallsBackToMemoryWithWarn(t *testing.T) {
+	// Other tests in this package call util.ConfigureTestLogger in init(),
+	// which disables the global level. Re-enable warn-level for this test.
+	prev := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	defer zerolog.SetGlobalLevel(prev)
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
+	reg, err := NewSharedStateRegistry(context.Background(), &logger, nil)
+	require.NoError(t, err, "nil config must no longer return an error / panic")
+	require.NotNil(t, reg, "registry must be non-nil")
+
+	// The registry must still be usable — a trivial counter get should work.
+	counter := reg.GetCounterInt64("test-key", 0)
+	require.NotNil(t, counter)
+	assert.Equal(t, int64(0), counter.GetValue())
+
+	// Verify the WARN log fired with a message operators can grep for.
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["level"] == "warn" && strings.Contains(entry["message"].(string), "in-memory") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"a WARN log must surface the nil-config fallback so operators notice cross-replica state won't propagate; got logs: %s",
+		buf.String())
+}


### PR DESCRIPTION
\`NewSharedStateRegistry\` nil-panicked on \`cfg.Connector\` when \`cfg\` was nil. Fall back to an in-memory connector and log a WARN so operators who intended a distributed backend notice that state won't propagate across replicas.

## Test plan

- [x] New test asserts no panic, registry is usable, and a WARN log with "in-memory" fires.
- [x] Verified the test fails without the fix (nil-panic).
- [x] Full \`./data/\` suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `NewSharedStateRegistry` to silently continue with an in-memory backend when `SharedStateConfig` is nil, which could mask misconfiguration and alter cross-replica behavior; mitigated by emitting a WARN log and adding coverage.
> 
> **Overview**
> Prevents a nil-pointer panic in `NewSharedStateRegistry` by treating a nil `SharedStateConfig` as a supported case and **defaulting to an in-memory connector** (with bounded size limits).
> 
> Adds a regression test that asserts the registry remains usable with nil config and that a **WARN log** is emitted to signal that shared state will not propagate across replicas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc955e8201e432d36c68f3eceda95fda3bf1482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->