### PR TITLE
fix: map ErrEndpointUnsupported to JSON-RPC -32601

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1493,6 +1493,28 @@ func TranslateToJsonRpcException(err error) error {
 			nil,
 		)
 	}
+	// "Method not found / not supported by upstream" must surface as the
+	// JSON-RPC standard -32601, not the generic -32603 fallthrough below.
+	// This only fires for callers that wrap ErrEndpointUnsupported with a
+	// plain (non-ErrJsonRpcExceptionInternal) cause; the early return at
+	// the top of this function already preserves codes when the chain
+	// already contains an ErrJsonRpcExceptionInternal (the EVM normalizer
+	// path), so EVM behavior is unchanged.
+	if HasErrorCode(err, ErrCodeEndpointUnsupported) {
+		var msg = "method not supported by upstream"
+		if se, ok := err.(StandardError); ok {
+			msg = se.DeepestMessage()
+		} else {
+			msg = err.Error()
+		}
+		return NewErrJsonRpcExceptionInternal(
+			0,
+			JsonRpcErrorUnsupportedException,
+			msg,
+			err,
+			nil,
+		)
+	}
 	if HasErrorCode(err, ErrCodeInvalidRequest, ErrCodeInvalidUrlPath) {
 		return NewErrJsonRpcExceptionInternal(
 			0,

--- a/common/translate_unsupported_method_test.go
+++ b/common/translate_unsupported_method_test.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTranslateToJsonRpcException_UnsupportedMethod_Returns32601 pins that
+// "method not found" upstream errors surface as the JSON-RPC standard -32601
+// rather than the generic -32603 wrap.
+//
+// Discovered via dogfood against a Solana mainnet endpoint: clients calling a
+// method the upstream doesn't implement received -32603 (Internal error) with
+// a "Method not found" string, breaking spec-compliant clients that match on
+// `error.code === -32601`.
+//
+// EVM's normalizer already wraps with ErrJsonRpcExceptionInternal carrying
+// the upstream's original code, so the early-return-on-existing-internal
+// branch in TranslateToJsonRpcException keeps EVM behavior identical. This
+// fix only changes behavior for callers that wrap ErrEndpointUnsupported
+// with a plain cause (e.g. future non-EVM architectures).
+func TestTranslateToJsonRpcException_UnsupportedMethod_Returns32601(t *testing.T) {
+	t.Run("plain_cause_returns_32601", func(t *testing.T) {
+		// Direct ErrEndpointUnsupported with a plain string cause (the case
+		// where no inner ErrJsonRpcExceptionInternal exists in the chain).
+		err := NewErrEndpointUnsupported(errors.New("Method not found"))
+
+		out := TranslateToJsonRpcException(err)
+		require.NotNil(t, out)
+
+		jre := &ErrJsonRpcExceptionInternal{}
+		require.True(t, errors.As(out, &jre), "expected a *ErrJsonRpcExceptionInternal")
+		assert.Equal(t, JsonRpcErrorUnsupportedException, jre.NormalizedCode(),
+			"ErrEndpointUnsupported with plain cause must surface as -32601, not the default -32603")
+	})
+
+	t.Run("wrapped_in_failsafe_returns_32601", func(t *testing.T) {
+		// Real-world chain: ErrFailsafeRetryExceeded → ErrUpstreamRequest →
+		// ErrEndpointUnsupported(plain cause). HasErrorCode walks the chain.
+		base := NewErrEndpointUnsupported(errors.New("Method not found"))
+		now := time.Now()
+		wrapped := NewErrFailsafeRetryExceeded(ScopeUpstream, base, &now)
+
+		out := TranslateToJsonRpcException(wrapped)
+		require.NotNil(t, out)
+
+		jre := &ErrJsonRpcExceptionInternal{}
+		require.True(t, errors.As(out, &jre))
+		assert.Equal(t, JsonRpcErrorUnsupportedException, jre.NormalizedCode(),
+			"ErrEndpointUnsupported deep in the cause chain must still surface as -32601")
+	})
+
+	t.Run("preserves_existing_internal_jsonrpc_code", func(t *testing.T) {
+		// EVM-style chain: the cause is already ErrJsonRpcExceptionInternal
+		// carrying the upstream's original code (e.g. a vendor that returned
+		// a non-standard code with "method not found" semantics). The early
+		// return in TranslateToJsonRpcException must keep that code intact —
+		// the new -32601 case must NOT override it.
+		inner := NewErrJsonRpcExceptionInternal(
+			-32601, // originalCode (vendor-supplied)
+			JsonRpcErrorEvmLargeRange, // normalizedCode used as a sentinel here
+			"vendor-specific message",
+			nil,
+			nil,
+		)
+		base := NewErrEndpointUnsupported(inner)
+
+		out := TranslateToJsonRpcException(base)
+		require.NotNil(t, out)
+
+		jre := &ErrJsonRpcExceptionInternal{}
+		require.True(t, errors.As(out, &jre))
+		assert.Equal(t, JsonRpcErrorEvmLargeRange, jre.NormalizedCode(),
+			"existing ErrJsonRpcExceptionInternal in chain must take precedence over the new -32601 mapping")
+	})
+}


### PR DESCRIPTION
## Summary

Upstreams returning `-32601 "Method not found"` were surfacing to clients as `-32603 "Internal error"` whenever the cause chain didn't already contain an `ErrJsonRpcExceptionInternal`. Spec-compliant clients matching on `error.code === -32601` couldn't detect "method not found" conditions.

Discovered while dogfooding non-EVM architectures — the EVM normalizer happens to wrap upstream errors with `ErrJsonRpcExceptionInternal` carrying the original code, which short-circuits the early-return in `TranslateToJsonRpcException`. Architectures that don't follow that pattern (or extractors that wrap with a plain string cause) hit the `-32603` default.

## Approach

Add one explicit case in `TranslateToJsonRpcException` for `ErrCodeEndpointUnsupported` → `JsonRpcErrorUnsupportedException` (`-32601`), placed before the default `-32603` fallthrough.

## Backward compatibility

- **EVM is unchanged.** The EVM error normalizer wraps with `ErrJsonRpcExceptionInternal(originalCode, …)`, so the early `if HasErrorCode(err, ErrCodeJsonRpcExceptionInternal) { return err }` still wins. The new case never fires for EVM. A regression test pins this.
- **Other architectures and any direct caller of `NewErrEndpointUnsupported(plain-cause)`**: now correctly surface `-32601` instead of `-32603`. This is a correctness fix.

## Test plan

- [x] `TestTranslateToJsonRpcException_UnsupportedMethod_Returns32601/plain_cause_returns_32601` — direct ErrEndpointUnsupported with a string cause produces `-32601`
- [x] `…/wrapped_in_failsafe_returns_32601` — same when buried under `ErrFailsafeRetryExceeded`
- [x] `…/preserves_existing_internal_jsonrpc_code` — when the chain already carries `ErrJsonRpcExceptionInternal` (the EVM path), its `NormalizedCode` is preserved verbatim
- [x] `go test ./common/ ./architecture/evm/` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes externally visible JSON-RPC error code mapping for `ErrEndpointUnsupported`, which can affect client error handling, though scope is limited to unsupported-method paths and includes regression tests to prevent EVM behavior changes.
> 
> **Overview**
> Ensures upstream "method not found/unsupported" failures wrapped as `ErrEndpointUnsupported` translate to the JSON-RPC standard `-32601` (`JsonRpcErrorUnsupportedException`) instead of falling through to `-32603`.
> 
> Adds focused tests covering the direct case, the error being buried in a retry/failsafe chain, and a guard that preserves any pre-existing `ErrJsonRpcExceptionInternal` codes (pinning EVM’s current behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7723f99a84d8dd2f7a569793c0e29b3df20c4617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->