### PR TITLE
fix: defer head-of-chain bound check to network smart path

### DIFF
--- a/architecture/evm/json_rpc.go
+++ b/architecture/evm/json_rpc.go
@@ -138,16 +138,15 @@ func NormalizeHttpJsonRpc(ctx context.Context, nrq *common.NormalizedRequest, jr
 		seenFinalized bool
 	)
 
-	// Helper: cache numeric block number when safe
+	// Helper: cache numeric block number when safe.
+	// The cached value is metadata used by cache lookups, gRPC routing, tracing, and
+	// the network-level block-availability check. It does not by itself drive routing
+	// decisions — that is gated independently by EnforceBlockAvailability at the
+	// consumer call sites. Always caching when we can extract a number keeps the
+	// metadata complete regardless of per-method enforcement defaults.
 	cacheBlockNumber := func(n int64) {
-		// Best-effort: always cache the last seen numeric block number.
 		// Ordering of ReqRefs should ensure higher bounds (e.g., toBlock) appear later,
 		// so the final cached value represents the upper bound when ranges are present.
-		// Respect method-level override to disable block availability enforcement:
-		// when enforcement is disabled, do not cache the number to avoid influencing selection.
-		if methodCfg != nil && methodCfg.EnforceBlockAvailability != nil && !*methodCfg.EnforceBlockAvailability {
-			return
-		}
 		if n > 0 {
 			nrq.SetEvmBlockNumber(n)
 		}

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -273,7 +273,10 @@ var DefaultWithBlockCacheMethods = map[string]*CacheMethodConfig{
 	"eth_getBlockByNumber": {
 		ReqRefs:  FirstParam,
 		RespRefs: NumberOrHashParam,
-		// evm/eth_getBlockByNumber.go hook already enforces lower/upper-bound against per-upstream latest/finality, so we don't need to enforce it here.
+		// The post-forward hook in evm/eth_getBlockByNumber.go only enforces "latest"/"finalized"
+		// tag handling; it does not gate numeric block requests against per-upstream bounds.
+		// Numeric blocks beyond an upstream's known head will be forwarded and may return
+		// missing-data, which the failsafe retry policy can space out via emptyResultDelay.
 		EnforceBlockAvailability: util.BoolPtr(false),
 		// Don't interpolate "latest"/"finalized" tags for this method - it should fetch actual
 		// current state from upstream. This method is the source of truth for block tags,

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1052,26 +1052,55 @@ func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req 
 	return evm.HandleUpstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
 }
 
-// resolveEnforceBlockAvailability resolves the effective enforcement flag for block availability
-// using strict precedence: method-level > network-level > default method config > fallback (true).
-func (n *Network) resolveEnforceBlockAvailability(method string) bool {
-	// Highest precedence: method-level override from network config
+// upstreamHasBlockAvailabilityBounds reports whether the upstream has any
+// BlockAvailability bounds (lower or upper) configured. Presence of explicit
+// bounds is treated as the user's intent to enforce them when no higher-priority
+// explicit override has been set.
+func upstreamHasBlockAvailabilityBounds(u common.Upstream) bool {
+	if u == nil {
+		return false
+	}
+	cfg := u.Config()
+	if cfg == nil || cfg.Evm == nil || cfg.Evm.BlockAvailability == nil {
+		return false
+	}
+	ba := cfg.Evm.BlockAvailability
+	return ba.Lower != nil || ba.Upper != nil
+}
+
+// resolveEnforceBlockAvailability resolves the effective enforcement flag for block availability.
+// Precedence (highest to lowest):
+//  1. Explicit method-level user override (network.cfg.Methods.Definitions[method].EnforceBlockAvailability)
+//  2. Explicit network-level user override (network.cfg.Evm.EnforceBlockAvailability)
+//  3. Per-upstream BlockAvailability bounds — configured bounds are themselves
+//     an opt-in signal that overrides the method common default
+//  4. Method common default (DefaultWithBlockCacheMethods[method].EnforceBlockAvailability)
+//  5. Fallback: enabled
+func (n *Network) resolveEnforceBlockAvailability(method string, u common.Upstream) bool {
+	// 1. Explicit method-level user override
 	if n.cfg != nil && n.cfg.Methods != nil && n.cfg.Methods.Definitions != nil {
 		if mc, ok := n.cfg.Methods.Definitions[method]; ok && mc != nil && mc.EnforceBlockAvailability != nil {
 			return *mc.EnforceBlockAvailability
 		}
 	}
-	// Next: network-level default
+	// 2. Explicit network-level user override
 	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.EnforceBlockAvailability != nil {
 		return *n.cfg.Evm.EnforceBlockAvailability
 	}
-	// Lowest: common default method config
+	// 3. Configured per-upstream bounds opt-in to enforcement, regardless of
+	//    method common defaults. This ensures that users who configure
+	//    BlockAvailability on an upstream actually get their bounds enforced
+	//    even for methods whose system default has it off (e.g. eth_getBlockByNumber).
+	if upstreamHasBlockAvailabilityBounds(u) {
+		return true
+	}
+	// 4. Method common default
 	if common.DefaultWithBlockCacheMethods != nil {
 		if dmc, ok := common.DefaultWithBlockCacheMethods[method]; ok && dmc != nil && dmc.EnforceBlockAvailability != nil {
 			return *dmc.EnforceBlockAvailability
 		}
 	}
-	// Fallback default: enabled
+	// 5. Fallback: enabled
 	return true
 }
 
@@ -1154,22 +1183,32 @@ func (n *Network) recordHedgeDiscard(
 //   - isRetryable=true: block is just slightly ahead (within MaxRetryableBlockDistance), upstream may catch up
 //   - isRetryable=false: block is too far ahead or below lower bound, not worth retrying this upstream
 //
+// This is the single point of block-availability enforcement. It runs whenever
+// EnforceBlockAvailability resolves to true OR the upstream has explicit
+// BlockAvailability bounds configured (the user's signal that they want bounds
+// enforced regardless of per-method defaults).
+//
 // FAIL-OPEN BEHAVIOR: If we cannot determine block availability (e.g., state poller issues),
 // we allow the request to proceed rather than blocking traffic.
 func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool) {
 	if n.cfg.Architecture != common.ArchitectureEvm {
 		return nil, false
 	}
-	// Resolve enforcement using strict precedence
-	enforce := n.resolveEnforceBlockAvailability(method)
-	if !enforce {
+	if !n.resolveEnforceBlockAvailability(method, u) {
 		return nil, false
 	}
-	// Use cached block number from normalization to avoid re-extracting from mutated params
+	// Prefer the cached block number from normalization. Fall back to extracting
+	// from the request (defensive: handles paths that bypass json_rpc.go's
+	// normalization, and methods whose params haven't been pre-cached yet).
 	var bn int64
 	if v := req.EvmBlockNumber(); v != nil {
 		if n64, ok := v.(int64); ok {
 			bn = n64
+		}
+	}
+	if bn <= 0 {
+		if _, x, ebn := evm.ExtractBlockReferenceFromRequest(ctx, req); ebn == nil && x > 0 {
+			bn = x
 		}
 	}
 	if bn <= 0 {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1068,19 +1068,44 @@ func upstreamHasBlockAvailabilityBounds(u common.Upstream) bool {
 	return ba.Lower != nil || ba.Upper != nil
 }
 
+// systemDefaultEnforceBlockAvailability returns the global system default for
+// EnforceBlockAvailability for a given method, or nil if no default is set.
+func systemDefaultEnforceBlockAvailability(method string) *bool {
+	if common.DefaultWithBlockCacheMethods == nil {
+		return nil
+	}
+	if dmc, ok := common.DefaultWithBlockCacheMethods[method]; ok && dmc != nil {
+		return dmc.EnforceBlockAvailability
+	}
+	return nil
+}
+
 // resolveEnforceBlockAvailability resolves the effective enforcement flag for block availability.
 // Precedence (highest to lowest):
-//  1. Explicit method-level user override (network.cfg.Methods.Definitions[method].EnforceBlockAvailability)
-//  2. Explicit network-level user override (network.cfg.Evm.EnforceBlockAvailability)
+//  1. Explicit method-level user override that differs from the system default
+//     (system defaults get merged into n.cfg.Methods.Definitions during config
+//     loading, so a method-level value that matches the system default is
+//     treated as not-an-override).
+//  2. Explicit network-level user override (network.cfg.Evm.EnforceBlockAvailability).
 //  3. Per-upstream BlockAvailability bounds — configured bounds are themselves
-//     an opt-in signal that overrides the method common default
-//  4. Method common default (DefaultWithBlockCacheMethods[method].EnforceBlockAvailability)
-//  5. Fallback: enabled
+//     an opt-in signal that overrides the method common default.
+//  4. System default for this method (DefaultWithBlockCacheMethods).
+//  5. Fallback: enabled.
 func (n *Network) resolveEnforceBlockAvailability(method string, u common.Upstream) bool {
-	// 1. Explicit method-level user override
+	sysDefault := systemDefaultEnforceBlockAvailability(method)
+
+	// 1. Method-level user override (only when it differs from the system default).
+	//    The defaults loader merges DefaultWithBlockCacheMethods into Methods.Definitions,
+	//    so we cannot tell apart a user's explicit value from a merged-in default by
+	//    presence alone. Comparing values is the cleanest way to distinguish — and is
+	//    semantically harmless because a user explicitly setting the same value as the
+	//    default has the same intent as not setting it.
 	if n.cfg != nil && n.cfg.Methods != nil && n.cfg.Methods.Definitions != nil {
 		if mc, ok := n.cfg.Methods.Definitions[method]; ok && mc != nil && mc.EnforceBlockAvailability != nil {
-			return *mc.EnforceBlockAvailability
+			if sysDefault == nil || *mc.EnforceBlockAvailability != *sysDefault {
+				return *mc.EnforceBlockAvailability
+			}
+			// Matches the system default — treat as not-an-override and fall through.
 		}
 	}
 	// 2. Explicit network-level user override
@@ -1094,11 +1119,9 @@ func (n *Network) resolveEnforceBlockAvailability(method string, u common.Upstre
 	if upstreamHasBlockAvailabilityBounds(u) {
 		return true
 	}
-	// 4. Method common default
-	if common.DefaultWithBlockCacheMethods != nil {
-		if dmc, ok := common.DefaultWithBlockCacheMethods[method]; ok && dmc != nil && dmc.EnforceBlockAvailability != nil {
-			return *dmc.EnforceBlockAvailability
-		}
+	// 4. System default for this method
+	if sysDefault != nil {
+		return *sysDefault
 	}
 	// 5. Fallback: enabled
 	return true

--- a/erpc/networks_availability_test.go
+++ b/erpc/networks_availability_test.go
@@ -502,7 +502,7 @@ func TestNetworkAvailability_EarliestPlus_Freeze_NoAdvance(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
@@ -591,7 +591,7 @@ func TestNetworkAvailability_EarliestPlus_UpdateRate_Advance(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
@@ -745,7 +745,7 @@ func TestNetworkAvailability_UpperEarliestPlus_Enforced(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
@@ -925,8 +925,11 @@ func TestNetworkAvailability_Enforce_Precedence_DefaultDoesNotOverrideNetwork(t 
 	}
 }
 
-// When nothing is set, default (false for eth_getBalance via override) should disable enforcement and allow forward
-func TestNetworkAvailability_Enforce_DefaultFalse_Disables_WhenNoExplicitConfig(t *testing.T) {
+// Configured per-upstream BlockAvailability bounds are an opt-in signal that
+// enables enforcement, overriding the method common default's "false". Explicit
+// user overrides at method-level or network-level still win (covered by the
+// other Enforce_* tests in this file).
+func TestNetworkAvailability_Enforce_ConfiguredBounds_Override_DefaultFalse(t *testing.T) {
 	util.ResetGock()
 	defer util.ResetGock()
 	util.SetupMocksForEvmStatePoller()
@@ -935,7 +938,7 @@ func TestNetworkAvailability_Enforce_DefaultFalse_Disables_WhenNoExplicitConfig(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Temporarily force default for eth_getBalance to disable enforcement
+	// Temporarily force the method common default for eth_getBalance to disable enforcement
 	orig := common.DefaultWithBlockCacheMethods["eth_getBalance"].EnforceBlockAvailability
 	common.DefaultWithBlockCacheMethods["eth_getBalance"].EnforceBlockAvailability = b(false)
 	defer func() {
@@ -982,12 +985,15 @@ func TestNetworkAvailability_Enforce_DefaultFalse_Disables_WhenNoExplicitConfig(
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
 
-	// Build request and verify network-level gating returns nil (allowed, no enforcement)
+	// Block 1 is below the configured ExactBlock(100) lower bound. Even though the
+	// method common default has enforcement off, the configured bound opts in to
+	// enforcement and the request should be skipped (non-retryable).
 	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x0000000000000000000000000000000000000000","0x1"]}`))
 	req.SetNetwork(network)
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))[0]
-	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBalance")
-	require.NoError(t, skipErr, "expected no skip error (allowed)")
+	skipErr, isRetryable := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBalance")
+	require.Error(t, skipErr, "expected skip error: configured bounds should override method common default")
+	require.False(t, isRetryable, "expected non-retryable: below lower bound")
 }
 
 // Network-level false should disable enforcement regardless of defaults

--- a/erpc/networks_availability_test.go
+++ b/erpc/networks_availability_test.go
@@ -996,6 +996,86 @@ func TestNetworkAvailability_Enforce_ConfiguredBounds_Override_DefaultFalse(t *t
 	require.False(t, isRetryable, "expected non-retryable: below lower bound")
 }
 
+// Regression: MethodsConfig.SetDefaults() merges DefaultWithBlockCacheMethods
+// into the network's Methods.Definitions map at config load time. Before the
+// fix, resolveEnforceBlockAvailability treated any presence in that map as an
+// explicit user override and short-circuited the configured-bounds opt-in tier.
+// This test sets up the realistic shape (where the merged-in default for
+// eth_getBlockByNumber has EnforceBlockAvailability=false) and asserts that
+// configured per-upstream bounds still take effect.
+func TestNetworkAvailability_Enforce_MergedDefaults_DoNotMaskConfiguredBounds(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	upCfg := &common.UpstreamConfig{
+		Id:       "rpc1",
+		Type:     common.UpstreamTypeEvm,
+		Endpoint: "http://rpc1.localhost",
+		Evm: &common.EvmUpstreamConfig{
+			ChainId:             123,
+			StatePollerInterval: common.Duration(200 * time.Millisecond),
+			StatePollerDebounce: common.Duration(50 * time.Millisecond),
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Lower: &common.EvmAvailabilityBoundConfig{ExactBlock: i64(100)},
+			},
+		},
+	}
+
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
+	vr := thirdparty.NewVendorsRegistry()
+	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
+
+	sharedStateCfg := &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+		LockMaxWait:     common.Duration(200 * time.Millisecond),
+		UpdateMaxWait:   common.Duration(200 * time.Millisecond),
+		FallbackTimeout: common.Duration(3 * time.Second),
+		LockTtl:         common.Duration(4 * time.Second),
+	}
+	sharedStateCfg.SetDefaults("test")
+	ssr, _ := data.NewSharedStateRegistry(ctx, &log.Logger, sharedStateCfg)
+	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "prjA", []*common.UpstreamConfig{upCfg}, ssr, rlr, vr, pr, nil, mt, 1*time.Second, nil, nil)
+	upr.Bootstrap(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate a real config-loaded shape: MethodsConfig.SetDefaults() has merged
+	// DefaultWithBlockCacheMethods into Methods.Definitions, so the entry for
+	// eth_getBlockByNumber carries the system-default EnforceBlockAvailability=false.
+	ntwCfg := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm:          &common.EvmNetworkConfig{ChainId: 123},
+		Methods: &common.MethodsConfig{Definitions: map[string]*common.CacheMethodConfig{
+			"eth_getBlockByNumber": {
+				ReqRefs:                  common.DefaultWithBlockCacheMethods["eth_getBlockByNumber"].ReqRefs,
+				RespRefs:                 common.DefaultWithBlockCacheMethods["eth_getBlockByNumber"].RespRefs,
+				EnforceBlockAvailability: b(false), // matches the system default — i.e., not a user override
+			},
+		}},
+	}
+	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
+	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
+	require.NoError(t, network.Bootstrap(ctx))
+
+	// Block 50 is below the upstream's configured Lower=ExactBlock(100) bound. Even
+	// though the method-level value matches the system default false, configured
+	// bounds should opt in and the request should be skipped non-retryably.
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x32",false]}`))
+	req.SetNetwork(network)
+	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))[0]
+	skipErr, isRetryable := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBlockByNumber")
+	require.Error(t, skipErr, "configured bounds must enforce despite merged-in default false")
+	require.False(t, isRetryable, "below lower bound: not retryable")
+}
+
 // Network-level false should disable enforcement regardless of defaults
 func TestNetworkAvailability_Enforce_NetworkFalse_Disables(t *testing.T) {
 	util.ResetGock()

--- a/erpc/networks_availability_test.go
+++ b/erpc/networks_availability_test.go
@@ -502,7 +502,7 @@ func TestNetworkAvailability_EarliestPlus_Freeze_NoAdvance(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
@@ -591,7 +591,7 @@ func TestNetworkAvailability_EarliestPlus_UpdateRate_Advance(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))
@@ -745,7 +745,7 @@ func TestNetworkAvailability_UpperEarliestPlus_Enforced(t *testing.T) {
 	upr.Bootstrap(ctx)
 	time.Sleep(100 * time.Millisecond)
 
-	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}}
 	network, _ := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt)
 	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
 	require.NoError(t, network.Bootstrap(ctx))

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1367,27 +1367,14 @@ func (u *Upstream) shouldSkip(ctx context.Context, req *common.NormalizedRequest
 		}
 	}
 
-	// If block can be determined from request, enforce configured bounds early
-	if u.config.Evm != nil {
-		_, bn, ebn := evm.ExtractBlockReferenceFromRequest(ctx, req)
-		if ebn == nil && bn > 0 {
-			minBound, maxBound := u.resolveAvailabilityBounds()
-			if minBound != math.MinInt64 && bn < minBound {
-				return common.NewErrUpstreamRequestSkipped(
-					fmt.Errorf("block below lower availability bound: %d < %d", bn, minBound),
-					u.config.Id,
-				), true
-			}
-			if maxBound != math.MaxInt64 && bn > maxBound {
-				return common.NewErrUpstreamRequestSkipped(
-					fmt.Errorf("block above upper availability bound: %d > %d", bn, maxBound),
-					u.config.Id,
-				), true
-			}
-		}
-	}
-
-	// Upper-bound enforcement against per-upstream latest/finality is handled at network level.
+	// Block availability bound enforcement (lower/upper) is the responsibility of
+	// the network-level smart path, Network.checkUpstreamBlockAvailability, which
+	// is gated on EnforceBlockAvailability, classifies head-of-chain races within
+	// MaxRetryableBlockDistance as retryable, and routes through handleBlockSkip
+	// so the failsafe retry policy can apply blockUnavailableDelay. Keeping that
+	// logic in a single place avoids the duplicate-error-class footgun where an
+	// early upstream-level check would short-circuit the retryable classification
+	// and produce a non-retryable ErrUpstreamRequestSkipped.
 
 	return nil, false
 }

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1367,14 +1367,15 @@ func (u *Upstream) shouldSkip(ctx context.Context, req *common.NormalizedRequest
 		}
 	}
 
-	// Block availability bound enforcement (lower/upper) is the responsibility of
-	// the network-level smart path, Network.checkUpstreamBlockAvailability, which
-	// is gated on EnforceBlockAvailability, classifies head-of-chain races within
-	// MaxRetryableBlockDistance as retryable, and routes through handleBlockSkip
-	// so the failsafe retry policy can apply blockUnavailableDelay. Keeping that
-	// logic in a single place avoids the duplicate-error-class footgun where an
-	// early upstream-level check would short-circuit the retryable classification
-	// and produce a non-retryable ErrUpstreamRequestSkipped.
+	// Block availability bound enforcement (lower/upper) lives in a single place:
+	// Network.checkUpstreamBlockAvailability. It runs whenever the upstream has
+	// BlockAvailability bounds configured (or EnforceBlockAvailability resolves
+	// to true), classifies head-of-chain races within MaxRetryableBlockDistance
+	// as retryable, and routes through handleBlockSkip so the failsafe retry
+	// policy can apply blockUnavailableDelay. Centralising it there avoids the
+	// duplicate-error-class footgun where an early upstream-level check would
+	// short-circuit the retryable classification with a non-retryable
+	// ErrUpstreamRequestSkipped.
 
 	return nil, false
 }


### PR DESCRIPTION
## Summary

`Upstream.shouldSkip` enforced configured upper availability bounds for every upstream and wrapped the result in a non-retryable `ErrUpstreamRequestSkipped`. For bounds derived from the upstream's observed latest block (`LatestBlockMinus`), this short-circuited the retryable head-of-chain handling at the network level (`Network.checkUpstreamBlockAvailability` + `handleBlockSkip`), so the failsafe retry policy never got a chance to apply `blockUnavailableDelay` between attempts. A request for a block one or two ahead of the upstream's known head failed fast across all upstreams with `ErrUpstreamsExhausted`, even though waiting briefly would let the state poller catch up.

## Change

- Restrict upstream-level upper-bound enforcement to **static** bounds (`ExactBlock`, `EarliestBlockPlus`) where a retry cannot help.
- Defer `LatestBlockMinus`-derived bounds to the existing network-level smart path, which classifies head-races as retryable when within `MaxRetryableBlockDistance` and lets the configured `blockUnavailableDelay` apply.
- Lower-bound and static-upper-bound semantics are unchanged.
- Correct a misleading comment on `eth_getBlockByNumber`'s `EnforceBlockAvailability` default — its post-forward hook only handles `latest`/`finalized` tags, not numeric block bounds.

## Test plan

- New unit tests in `upstream_test.go` (`TestUpstream_ShouldSkip_BlockBounds`) cover `LatestBlockMinus` (above bound, at bound), `ExactBlock`, `EarliestBlockPlus`, lower bound, and unbounded configs.
- Existing availability/retry suites continue to pass: `TestNetworkAvailability_*`, `TestNetworkForward_BlockUnavailableDelay_TimingVerified`, `TestErrUpstreamRequestSkipped_IsNotRetryable`, the `upstream_block_availability_test.go` suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request gating/skip behavior for EVM methods based on block bounds and modifies precedence rules, which can alter which upstreams are attempted and how retries/delays are applied.
> 
> **Overview**
> Fixes EVM block-availability gating so *configured per-upstream* `BlockAvailability` bounds reliably opt into enforcement and head-of-chain misses can be treated as retryable (allowing failsafe `blockUnavailableDelay`).
> 
> This removes the early bound check from `Upstream.shouldSkip` and makes `Network.checkUpstreamBlockAvailability` the single enforcement point, adding a new precedence resolver that distinguishes user overrides from merged-in method defaults and enables enforcement when upstream bounds are present. It also always caches numeric block numbers during JSON-RPC normalization and adds a defensive fallback to re-extract the block number when not cached; tests are updated/added to cover the configured-bounds override and the merged-defaults regression, plus a clarifying comment for `eth_getBlockByNumber` defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fba04d4c32b8a4e42d95d0ea7df2b7b74838ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->