### PR TITLE
auth: merge PaymentRequired Accepts across x402 strategies

### DIFF
--- a/auth/registry.go
+++ b/auth/registry.go
@@ -91,17 +91,52 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		return nil, common.NewErrAuthUnauthorized("n/a", "no auth strategy matched make sure correct headers or query strings are provided")
 	}
 
-	// If any strategy returned ErrPaymentRequired (x402), prefer that over a
-	// generic unauthorized error so the 402 response reaches the client.
+	// If multiple strategies returned ErrPaymentRequired (e.g. several x402
+	// strategies advertising different chains/assets), merge their Accepts
+	// arrays into a single 402 response so the challenge advertises every
+	// accepted option. Otherwise SDK clients only ever see the first chain
+	// in the response and signed payments for other chains never get tried.
+	var payErrs []*common.ErrPaymentRequired
 	for _, e := range errs {
 		var payErr *common.ErrPaymentRequired
 		if errors.As(e, &payErr) {
-			return nil, e
+			payErrs = append(payErrs, payErr)
 		}
+	}
+	if len(payErrs) > 0 {
+		return nil, mergePaymentRequired(payErrs)
 	}
 
 	// If no strategy matched or succeeded, consider the request unauthorized
 	return nil, common.NewErrAuthUnauthorized("n/a", errors.Join(errs...).Error())
+}
+
+// mergePaymentRequired combines multiple ErrPaymentRequired errors into a
+// single error whose Accepts list is the concatenation of all inputs. The
+// X402Version, Error, and Resource fields are taken from the first error
+// since they don't vary across x402 strategies for a given request.
+//
+// If any payErr wraps a payload that isn't an X402PaymentRequirementsResponse
+// (some future scheme), we fall back to the first error verbatim rather than
+// dropping foreign entries silently.
+func mergePaymentRequired(errs []*common.ErrPaymentRequired) error {
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	base, ok := errs[0].PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		return errs[0]
+	}
+	merged := append([]X402PaymentRequirement{}, base.Accepts...)
+	for _, e := range errs[1:] {
+		next, ok := e.PaymentRequirements.(X402PaymentRequirementsResponse)
+		if !ok {
+			return errs[0]
+		}
+		merged = append(merged, next.Accepts...)
+	}
+	base.Accepts = merged
+	return common.NewErrPaymentRequired(base)
 }
 
 // FindDatabaseConnector finds a database connector by ID from the strategies

--- a/auth/registry_payment_required_merge_test.go
+++ b/auth/registry_payment_required_merge_test.go
@@ -1,10 +1,16 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/upstream"
+	"github.com/rs/zerolog"
 )
 
 func newPaymentRequired(network, asset string) *common.ErrPaymentRequired {
@@ -69,6 +75,117 @@ func TestMergePaymentRequired_MultipleErrorsConcatAccepts(t *testing.T) {
 		}
 	}
 }
+
+func TestMergePaymentRequired_PreservesFirstResponseHeaderFields(t *testing.T) {
+	first := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "Payment required for this resource",
+		Accepts:     []X402PaymentRequirement{{Scheme: "exact", Network: "eip155:8453"}},
+		Resource:    map[string]string{"url": "https://edge.test/standard/evm/1"},
+	}
+	second := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "different error string that should be ignored",
+		Accepts:     []X402PaymentRequirement{{Scheme: "exact", Network: "eip155:1"}},
+		Resource:    map[string]string{"url": "https://different.example/"},
+	}
+	wrap := func(r X402PaymentRequirementsResponse) *common.ErrPaymentRequired {
+		err := common.NewErrPaymentRequired(r)
+		var pe *common.ErrPaymentRequired
+		errors.As(err, &pe)
+		return pe
+	}
+
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{wrap(first), wrap(second)})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if resp.Error != first.Error {
+		t.Errorf("Error: want %q (from first), got %q", first.Error, resp.Error)
+	}
+	if got, want := resp.Resource.(map[string]string)["url"], "https://edge.test/standard/evm/1"; got != want {
+		t.Errorf("Resource.url: want %q (from first), got %q", want, got)
+	}
+}
+
+// Authenticate-level integration test: configure an AuthRegistry with two real
+// x402 strategies (different chains) and verify an unauthenticated request
+// gets back ONE merged ErrPaymentRequired containing both networks in Accepts.
+func TestAuthRegistry_Authenticate_MergesMultiX402_402(t *testing.T) {
+	logger := zerolog.Nop()
+	rlReg, err := upstream.NewRateLimitersRegistry(context.Background(), nil, &logger)
+	if err != nil {
+		t.Fatalf("NewRateLimitersRegistry: %v", err)
+	}
+
+	// Stub facilitator returns /supported with both chains advertised so each
+	// strategy initializes successfully (it consults /supported at construction).
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/supported" {
+			_ = json.NewEncoder(w).Encode(X402SupportedResponse{
+				Kinds: []X402SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:8453"},
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer facilitator.Close()
+
+	mkStrategy := func(network, asset string) common.AuthStrategyConfig {
+		return common.AuthStrategyConfig{
+			Type: common.AuthTypeX402,
+			X402: &common.X402StrategyConfig{
+				FacilitatorURL:    facilitator.URL,
+				SellerAddress:     "0xSeller",
+				PricePerRequest:   "5",
+				Network:           network,
+				Asset:             asset,
+				Scheme:            "exact",
+				MaxTimeoutSeconds: 604800,
+			},
+		}
+	}
+	cfg := &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{
+			pointer(mkStrategy("eip155:8453", "0xUSDC-base")),
+			pointer(mkStrategy("eip155:1", "0xUSDC-eth")),
+		},
+	}
+	registry, err := NewAuthRegistry(context.Background(), &logger, "test-project", cfg, rlReg)
+	if err != nil {
+		t.Fatalf("NewAuthRegistry: %v", err)
+	}
+
+	ap := &AuthPayload{Type: common.AuthTypeNetwork, Method: "eth_chainId"}
+	_, err = registry.Authenticate(context.Background(), nil, "eth_chainId", ap)
+	if err == nil {
+		t.Fatal("expected ErrPaymentRequired, got nil")
+	}
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T: %v", err, err)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected merged X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 2 {
+		t.Fatalf("Accepts: want 2 networks (merged), got %d: %+v", len(resp.Accepts), resp.Accepts)
+	}
+	if resp.Accepts[0].Network != "eip155:8453" || resp.Accepts[1].Network != "eip155:1" {
+		t.Errorf("Accepts order: want [eip155:8453, eip155:1], got [%s, %s]",
+			resp.Accepts[0].Network, resp.Accepts[1].Network)
+	}
+}
+
+func pointer[T any](v T) *T { return &v }
 
 func TestMergePaymentRequired_NonX402PayloadFallsBackToFirst(t *testing.T) {
 	// First entry is well-formed x402; second carries a foreign payload.

--- a/auth/registry_payment_required_merge_test.go
+++ b/auth/registry_payment_required_merge_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+)
+
+func newPaymentRequired(network, asset string) *common.ErrPaymentRequired {
+	resp := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "Payment required for this resource",
+		Accepts: []X402PaymentRequirement{
+			{Scheme: "exact", Network: network, Asset: asset, Amount: "5", PayTo: "0xSeller"},
+		},
+	}
+	err := common.NewErrPaymentRequired(resp)
+	var pe *common.ErrPaymentRequired
+	if !errors.As(err, &pe) {
+		panic("expected *common.ErrPaymentRequired")
+	}
+	return pe
+}
+
+func TestMergePaymentRequired_SingleErrorPassesThrough(t *testing.T) {
+	in := newPaymentRequired("eip155:8453", "0xUSDC-base")
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{in})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 1 {
+		t.Fatalf("Accepts: want 1, got %d", len(resp.Accepts))
+	}
+	if resp.Accepts[0].Network != "eip155:8453" {
+		t.Errorf("Network: want eip155:8453, got %q", resp.Accepts[0].Network)
+	}
+}
+
+func TestMergePaymentRequired_MultipleErrorsConcatAccepts(t *testing.T) {
+	errs := []*common.ErrPaymentRequired{
+		newPaymentRequired("eip155:8453", "0xUSDC-base"),
+		newPaymentRequired("eip155:1", "0xUSDC-eth"),
+		newPaymentRequired("eip155:42161", "0xUSDC-arb"),
+	}
+	got := mergePaymentRequired(errs)
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 3 {
+		t.Fatalf("Accepts: want 3, got %d", len(resp.Accepts))
+	}
+	wantNetworks := []string{"eip155:8453", "eip155:1", "eip155:42161"}
+	for i, want := range wantNetworks {
+		if resp.Accepts[i].Network != want {
+			t.Errorf("Accepts[%d].Network: want %q, got %q", i, want, resp.Accepts[i].Network)
+		}
+	}
+}
+
+func TestMergePaymentRequired_NonX402PayloadFallsBackToFirst(t *testing.T) {
+	// First entry is well-formed x402; second carries a foreign payload.
+	first := newPaymentRequired("eip155:8453", "0xUSDC-base")
+	foreignErr := common.NewErrPaymentRequired(map[string]string{"scheme": "future-non-x402"})
+	var foreign *common.ErrPaymentRequired
+	if !errors.As(foreignErr, &foreign) {
+		t.Fatalf("expected *common.ErrPaymentRequired")
+	}
+
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{first, foreign})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	// Should be the first error verbatim, not a merged response.
+	if pe != first {
+		t.Errorf("expected first error verbatim on type-assertion failure")
+	}
+}


### PR DESCRIPTION
## Summary

When multiple `x402` strategies are configured (one per accepted chain or asset), `AuthRegistry.Authenticate` currently returns only the **first** strategy's `ErrPaymentRequired` verbatim. The 402 response thus advertises just one chain in its `accepts` array, even though every other strategy would happily accept a signed payment for its own chain. SDK clients (`@circle-fin/x402-batching`, `x402-fetch`, etc.) only ever try the first chain.

This PR collects every `ErrPaymentRequired` from the strategy errors and merges their `Accepts` arrays into one combined response so the 402 challenge advertises every accepted option.

## Behavior

- `len(payErrs) == 1` → unchanged (single x402 strategy → single `accepts`).
- `len(payErrs) > 1` → concatenate `Accepts` in strategy order.
- A `PaymentRequirements` payload that isn't an `X402PaymentRequirementsResponse` falls back to the first error verbatim (no silent dropping of foreign entries).

## Tests

`auth/registry_payment_required_merge_test.go` covers:
- single error pass-through,
- multi-error concatenation + ordering,
- non-x402 payload fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 62feaf9a12e6773a2cdf300e17653c02c1b99b05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->