### PR TITLE
feat: latest-block guarantee via per-network method list

### DIFF
--- a/architecture/evm/eth_getBlockByNumber.go
+++ b/architecture/evm/eth_getBlockByNumber.go
@@ -152,7 +152,10 @@ func enforceHighestBlock(ctx context.Context, network common.Network, nq *common
 
 	switch bnp {
 	case "latest":
-		highestBlockNumber := network.EvmHighestLatestBlockNumber(ctx)
+		// Self-reference: when picking a higher "latest" block, ensure that block
+		// is actually servable by an upstream supporting eth_getBlockByNumber. This
+		// composes with any LatestBlockGuaranteedMethods configured on the network.
+		highestBlockNumber := network.EvmHighestLatestBlockNumber(ctx, "eth_getBlockByNumber")
 		_, respBlockNumber, err := ExtractBlockReferenceFromResponse(ctx, nr)
 		if err != nil {
 			return nil, err
@@ -213,7 +216,8 @@ func enforceHighestBlock(ctx context.Context, network common.Network, nq *common
 			return nr, re
 		}
 	case "finalized":
-		highestBlockNumber := network.EvmHighestFinalizedBlockNumber(ctx)
+		// Same self-reference rationale as the "latest" branch above.
+		highestBlockNumber := network.EvmHighestFinalizedBlockNumber(ctx, "eth_getBlockByNumber")
 		_, respBlockNumber, err := ExtractBlockReferenceFromResponse(ctx, nr)
 		if err != nil {
 			return nil, err

--- a/architecture/evm/eth_getBlockByNumber_test.go
+++ b/architecture/evm/eth_getBlockByNumber_test.go
@@ -50,11 +50,11 @@ func (t *testNetwork) Logger() *zerolog.Logger {
 	return &logger
 }
 
-func (t *testNetwork) EvmHighestLatestBlockNumber(ctx context.Context) int64 {
+func (t *testNetwork) EvmHighestLatestBlockNumber(ctx context.Context, extraMethods ...string) int64 {
 	return 0
 }
 
-func (t *testNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
+func (t *testNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context, extraMethods ...string) int64 {
 	return 0
 }
 

--- a/architecture/evm/eth_getLogs_test.go
+++ b/architecture/evm/eth_getLogs_test.go
@@ -97,12 +97,12 @@ func (m *mockNetwork) EvmStatePoller() common.EvmStatePoller {
 	return args.Get(0).(common.EvmStatePoller)
 }
 
-func (m *mockNetwork) EvmHighestLatestBlockNumber(ctx context.Context) int64 {
+func (m *mockNetwork) EvmHighestLatestBlockNumber(ctx context.Context, extraMethods ...string) int64 {
 	args := m.Called(ctx)
 	return args.Get(0).(int64)
 }
 
-func (m *mockNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
+func (m *mockNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context, extraMethods ...string) int64 {
 	args := m.Called(ctx)
 	return args.Get(0).(int64)
 }

--- a/architecture/evm/eth_query_test.go
+++ b/architecture/evm/eth_query_test.go
@@ -36,8 +36,10 @@ func (n *queryTestNetwork) Forward(ctx context.Context, req *common.NormalizedRe
 func (n *queryTestNetwork) GetFinality(ctx context.Context, req *common.NormalizedRequest, resp *common.NormalizedResponse) common.DataFinalityState {
 	return common.DataFinalityStateFinalized
 }
-func (n *queryTestNetwork) EvmHighestLatestBlockNumber(ctx context.Context) int64 { return n.latest }
-func (n *queryTestNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
+func (n *queryTestNetwork) EvmHighestLatestBlockNumber(ctx context.Context, extraMethods ...string) int64 {
+	return n.latest
+}
+func (n *queryTestNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context, extraMethods ...string) int64 {
 	return n.finalized
 }
 func (n *queryTestNetwork) EvmLeaderUpstream(ctx context.Context) common.Upstream { return nil }

--- a/common/config.go
+++ b/common/config.go
@@ -1789,6 +1789,26 @@ type EvmNetworkConfig struct {
 	// to work safely with transaction broadcasting.
 	// Set to false to disable this behavior and return raw upstream errors.
 	IdempotentTransactionBroadcast *bool `yaml:"idempotentTransactionBroadcast,omitempty" json:"idempotentTransactionBroadcast,omitempty"`
+
+	// LatestBlockGuaranteedMethods constrains the network's reported "latest" and
+	// "finalized" block numbers to ones for which every listed method is actually
+	// servable by at least one non-syncing upstream.
+	//
+	// Algorithm: for each listed method, find the highest block among upstreams
+	// that can serve that method (via ShouldHandleMethod, which honors
+	// allow/ignoreMethods plus dynamic autoIgnoreUnsupportedMethods); the network's
+	// effective latest/finalized is the minimum across those per-method maxima. If
+	// any method has no supporting upstream, the result is 0 (treated as "unknown")
+	// so callers fall through to their existing fallbacks.
+	//
+	// Use this when an upstream may be ahead of the chain head it can fully serve
+	// (e.g. one provider reports latest=N but cannot serve eth_getBlockReceipts(N)
+	// while another provider that can is one block behind). Without this, clients
+	// see "block not found" on the follow-up call.
+	//
+	// Empty/nil disables the constraint and the raw highest block across upstreams
+	// is returned (current behavior).
+	LatestBlockGuaranteedMethods []string `yaml:"latestBlockGuaranteedMethods,omitempty" json:"latestBlockGuaranteedMethods,omitempty"`
 }
 
 // EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1889,6 +1889,9 @@ func (n *NetworkConfig) SetDefaults(upstreams []*UpstreamConfig, defaults *Netwo
 			if n.Evm.TraceFilterSplitConcurrency == 0 && defaults.Evm.TraceFilterSplitConcurrency != 0 {
 				n.Evm.TraceFilterSplitConcurrency = defaults.Evm.TraceFilterSplitConcurrency
 			}
+			if len(n.Evm.LatestBlockGuaranteedMethods) == 0 && len(defaults.Evm.LatestBlockGuaranteedMethods) > 0 {
+				n.Evm.LatestBlockGuaranteedMethods = append([]string(nil), defaults.Evm.LatestBlockGuaranteedMethods...)
+			}
 		} else if n.Evm == nil && defaults.Evm != nil {
 			n.Evm = &EvmNetworkConfig{}
 			*n.Evm = *defaults.Evm

--- a/common/network.go
+++ b/common/network.go
@@ -27,8 +27,14 @@ type Network interface {
 	GetFinality(ctx context.Context, req *NormalizedRequest, resp *NormalizedResponse) DataFinalityState
 
 	// TODO Move to EvmNetwork interface?
-	EvmHighestLatestBlockNumber(ctx context.Context) int64
-	EvmHighestFinalizedBlockNumber(ctx context.Context) int64
+	// EvmHighestLatestBlockNumber returns the highest "latest" block number across
+	// upstreams. Optional extraMethods are unioned with the network's configured
+	// LatestBlockGuaranteedMethods; the resulting set constrains which upstream
+	// blocks count (see EvmNetworkConfig.LatestBlockGuaranteedMethods).
+	EvmHighestLatestBlockNumber(ctx context.Context, extraMethods ...string) int64
+	// EvmHighestFinalizedBlockNumber mirrors EvmHighestLatestBlockNumber for the
+	// "finalized" tag.
+	EvmHighestFinalizedBlockNumber(ctx context.Context, extraMethods ...string) int64
 	EvmLeaderUpstream(ctx context.Context) Upstream
 }
 

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -108,81 +108,187 @@ func (n *Network) Logger() *zerolog.Logger {
 	return n.logger
 }
 
-func (n *Network) EvmHighestLatestBlockNumber(ctx context.Context) int64 {
-	ctx, span := common.StartDetailSpan(ctx, "Network.EvmHighestLatestBlockNumber")
-	defer span.End()
-
-	upstreams := n.upstreamsRegistry.GetNetworkUpstreams(ctx, n.networkId)
-	var maxBlock int64 = 0
-	for _, u := range upstreams {
-		statePoller := u.EvmStatePoller()
-		if statePoller == nil {
-			continue
-		}
-
-		// Check if the node is syncing - skip syncing nodes as their block numbers may be unreliable
-		if u.EvmSyncingState() == common.EvmSyncingStateSyncing {
-			n.logger.Debug().Str("upstreamId", u.Id()).Msg("skipping syncing upstream for highest latest block calculation")
-			continue
-		}
-
-		// Check if upstream is excluded by selection policy
-		if n.selectionPolicyEvaluator != nil {
-			// We use "eth_blockNumber" as it's a common method that would be used to get latest block
-			if err := n.selectionPolicyEvaluator.AcquirePermit(n.logger, u, "eth_blockNumber"); err != nil {
-				n.logger.Debug().Str("upstreamId", u.Id()).Err(err).Msg("skipping upstream excluded by selection policy for highest latest block calculation")
-				continue
-			}
-		}
-
-		// Use effective latest block which considers blockAvailability.upper config
-		// (e.g., if upstream has latestBlockMinus: 5, use latest-5 instead of latest)
-		upBlock := u.EvmEffectiveLatestBlock()
-		if upBlock > maxBlock {
-			maxBlock = upBlock
-		}
-	}
-	span.SetAttributes(attribute.Int64("highest_latest_block", maxBlock))
-	return maxBlock
+func (n *Network) EvmHighestLatestBlockNumber(ctx context.Context, extraMethods ...string) int64 {
+	return n.evmHighestBlock(
+		ctx,
+		"latest",
+		"eth_blockNumber",
+		n.guaranteedMethodsUnion(extraMethods),
+		(*upstream.Upstream).EvmEffectiveLatestBlock,
+	)
 }
 
-func (n *Network) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
-	ctx, span := common.StartDetailSpan(ctx, "Network.EvmHighestFinalizedBlockNumber", trace.WithAttributes(
+func (n *Network) EvmHighestFinalizedBlockNumber(ctx context.Context, extraMethods ...string) int64 {
+	return n.evmHighestBlock(
+		ctx,
+		"finalized",
+		"eth_getBlockByNumber",
+		n.guaranteedMethodsUnion(extraMethods),
+		(*upstream.Upstream).EvmEffectiveFinalizedBlock,
+	)
+}
+
+// guaranteedMethodsUnion returns the deduplicated union of the network's configured
+// LatestBlockGuaranteedMethods and the caller-supplied extras. Order is preserved
+// in (configured-first, extras-second) order; empty entries are dropped. Returns
+// nil when the result is empty so the caller can branch on len()==0.
+func (n *Network) guaranteedMethodsUnion(extras []string) []string {
+	var configured []string
+	if n.cfg != nil && n.cfg.Evm != nil {
+		configured = n.cfg.Evm.LatestBlockGuaranteedMethods
+	}
+	if len(configured) == 0 && len(extras) == 0 {
+		return nil
+	}
+	merged := make([]string, 0, len(configured)+len(extras))
+	seen := make(map[string]struct{}, len(configured)+len(extras))
+	for _, m := range configured {
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		merged = append(merged, m)
+	}
+	for _, m := range extras {
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		merged = append(merged, m)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// evmHighestBlock computes the highest block reported by the network's upstreams,
+// optionally constrained to a set of methods that must each be servable by at least
+// one non-syncing, non-policy-excluded upstream.
+//
+// When requiredMethods is empty, returns max(blockGetter(u)) across eligible
+// upstreams (the historical, unconstrained behavior).
+//
+// When requiredMethods is non-empty, computes
+//
+//	min over m in requiredMethods of max(blockGetter(u)) where u.ShouldHandleMethod(m)
+//
+// and returns 0 when any required method has no supporting eligible upstream — in
+// that case the network is treated as "unable to guarantee a block height" and
+// callers fall through to whatever fallback they had for the unconstrained case.
+//
+// Method support is read via Upstream.ShouldHandleMethod, which honors statically
+// configured allow/ignoreMethods AND the dynamically populated ignore list from
+// autoIgnoreUnsupportedMethods. This means once an upstream returns
+// "method not supported" once, it is automatically excluded from future guarantee
+// calculations for that method without operator intervention.
+func (n *Network) evmHighestBlock(
+	ctx context.Context,
+	blockKind string,
+	permitMethod string,
+	requiredMethods []string,
+	blockGetter func(*upstream.Upstream) int64,
+) int64 {
+	spanName := "Network.EvmHighestLatestBlockNumber"
+	if blockKind == "finalized" {
+		spanName = "Network.EvmHighestFinalizedBlockNumber"
+	}
+	ctx, span := common.StartDetailSpan(ctx, spanName, trace.WithAttributes(
 		attribute.String("network.id", n.networkId),
+		attribute.String("block.kind", blockKind),
 	))
 	defer span.End()
 
 	upstreams := n.upstreamsRegistry.GetNetworkUpstreams(ctx, n.networkId)
+
+	// Per-method maxima are only allocated when the guarantee constraint is active.
+	var perMethodMax map[string]int64
+	if len(requiredMethods) > 0 {
+		perMethodMax = make(map[string]int64, len(requiredMethods))
+		for _, m := range requiredMethods {
+			perMethodMax[m] = 0
+		}
+	}
+
 	var maxBlock int64 = 0
 	for _, u := range upstreams {
 		statePoller := u.EvmStatePoller()
 		if statePoller == nil {
 			continue
 		}
-
-		// Check if the node is syncing - skip syncing nodes as their block numbers may be unreliable
 		if u.EvmSyncingState() == common.EvmSyncingStateSyncing {
-			n.logger.Debug().Str("upstreamId", u.Id()).Msg("skipping syncing upstream for highest finalized block calculation")
+			n.logger.Debug().Str("upstreamId", u.Id()).Str("blockKind", blockKind).Msg("skipping syncing upstream for highest block calculation")
 			continue
 		}
-
-		// Check if upstream is excluded by selection policy
 		if n.selectionPolicyEvaluator != nil {
-			// We use "eth_getBlockByNumber" as it's a common method that would be used to get finalized block
-			if err := n.selectionPolicyEvaluator.AcquirePermit(n.logger, u, "eth_getBlockByNumber"); err != nil {
-				n.logger.Debug().Str("upstreamId", u.Id()).Err(err).Msg("skipping upstream excluded by selection policy for highest finalized block calculation")
+			if err := n.selectionPolicyEvaluator.AcquirePermit(n.logger, u, permitMethod); err != nil {
+				n.logger.Debug().Str("upstreamId", u.Id()).Str("blockKind", blockKind).Err(err).Msg("skipping upstream excluded by selection policy for highest block calculation")
 				continue
 			}
 		}
 
-		// Use effective finalized block which considers blockAvailability.upper config
-		upBlock := u.EvmEffectiveFinalizedBlock()
-		if upBlock > maxBlock {
-			maxBlock = upBlock
+		upBlock := blockGetter(u)
+		if upBlock <= 0 {
+			continue
+		}
+
+		if perMethodMax == nil {
+			if upBlock > maxBlock {
+				maxBlock = upBlock
+			}
+			continue
+		}
+
+		// Constrained path: only attribute this upstream's block to methods it can serve.
+		for _, m := range requiredMethods {
+			allowed, err := u.ShouldHandleMethod(m)
+			if err != nil {
+				n.logger.Debug().Str("upstreamId", u.Id()).Str("method", m).Err(err).Msg("error checking method support; treating as unsupported")
+				continue
+			}
+			if !allowed {
+				continue
+			}
+			if upBlock > perMethodMax[m] {
+				perMethodMax[m] = upBlock
+			}
 		}
 	}
-	span.SetAttributes(attribute.Int64("highest_finalized_block", maxBlock))
-	return maxBlock
+
+	if perMethodMax == nil {
+		span.SetAttributes(attribute.Int64("highest_"+blockKind+"_block", maxBlock))
+		return maxBlock
+	}
+
+	// Take min across the per-method maxima. Any unsatisfied method (max == 0)
+	// short-circuits to 0 so callers fall through to their existing fallbacks.
+	result := int64(math.MaxInt64)
+	for _, m := range requiredMethods {
+		mb := perMethodMax[m]
+		if mb == 0 {
+			n.logger.Debug().Str("method", m).Str("blockKind", blockKind).Msg("no upstream can serve guaranteed method; treating highest block as 0")
+			span.SetAttributes(attribute.String("unsatisfied_method", m))
+			return 0
+		}
+		if mb < result {
+			result = mb
+		}
+	}
+	if result == math.MaxInt64 {
+		// All methods returned 0 simultaneously — defensive; the loop above already returns.
+		result = 0
+	}
+	span.SetAttributes(
+		attribute.Int64("highest_"+blockKind+"_block", result),
+		attribute.StringSlice("guaranteed_methods", requiredMethods),
+	)
+	return result
 }
 
 func (n *Network) EvmLowestFinalizedBlockNumber(ctx context.Context) int64 {

--- a/erpc/networks_latest_block_guarantee_test.go
+++ b/erpc/networks_latest_block_guarantee_test.go
@@ -1,0 +1,484 @@
+package erpc
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/thirdparty"
+	"github.com/erpc/erpc/upstream"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// guaranteeFixture wires up a Network plus N Upstreams, mocks chainId, and exposes
+// the bootstrapped objects so individual tests can manipulate state pollers and
+// then call EvmHighestLatestBlockNumber/EvmHighestFinalizedBlockNumber.
+//
+// Why a helper: every existing TestNetwork_HighestLatestBlockNumber subtest
+// repeats ~70 lines of boilerplate. Extracting the boilerplate keeps each new
+// subtest focused on the property under test.
+type guaranteeFixture struct {
+	t       *testing.T
+	ctx     context.Context
+	cancel  context.CancelFunc
+	network *Network
+	// upstreams is keyed by upstream Id for easy lookup.
+	upstreams map[string]*upstream.Upstream
+}
+
+func newGuaranteeFixture(
+	t *testing.T,
+	upstreamCfgs []*common.UpstreamConfig,
+	guaranteedMethods []string,
+) *guaranteeFixture {
+	t.Helper()
+
+	util.ResetGock()
+	t.Cleanup(util.ResetGock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Mock eth_chainId for every upstream so detectFeatures succeeds. Persist so
+	// any in-flight bootstrap retries don't run out of mocks.
+	for _, ucfg := range upstreamCfgs {
+		gock.New(ucfg.Endpoint).
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), `eth_chainId`)
+			}).
+			Reply(200).
+			JSON([]byte(`{"result":"0x7b"}`)) // 123
+	}
+
+	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	require.NoError(t, err)
+	metricsTracker := health.NewTracker(&log.Logger, "test", time.Minute)
+
+	vr := thirdparty.NewVendorsRegistry()
+	pr, err := thirdparty.NewProvidersRegistry(&log.Logger, vr, []*common.ProviderConfig{}, nil)
+	require.NoError(t, err)
+
+	ssr, err := data.NewSharedStateRegistry(ctx, &log.Logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: "memory",
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+	})
+	require.NoError(t, err)
+
+	upstreamsRegistry := upstream.NewUpstreamsRegistry(
+		ctx,
+		&log.Logger,
+		"test",
+		upstreamCfgs,
+		ssr,
+		rateLimitersRegistry,
+		vr,
+		pr,
+		nil,
+		metricsTracker,
+		1*time.Second,
+		nil,
+		nil,
+	)
+
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm: &common.EvmNetworkConfig{
+			ChainId:                      123,
+			LatestBlockGuaranteedMethods: guaranteedMethods,
+		},
+	}
+
+	network, err := NewNetwork(
+		ctx,
+		&log.Logger,
+		"test",
+		networkConfig,
+		rateLimitersRegistry,
+		upstreamsRegistry,
+		metricsTracker,
+	)
+	require.NoError(t, err)
+
+	upstreamsRegistry.Bootstrap(ctx)
+	time.Sleep(150 * time.Millisecond)
+	require.NoError(t, upstreamsRegistry.GetInitializer().WaitForTasks(ctx))
+	require.NoError(t, network.Bootstrap(ctx))
+	time.Sleep(150 * time.Millisecond)
+
+	upsList := upstreamsRegistry.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
+	require.Len(t, upsList, len(upstreamCfgs))
+
+	upstreams := make(map[string]*upstream.Upstream, len(upsList))
+	for _, u := range upsList {
+		upstreams[u.Id()] = u
+	}
+	for _, cfg := range upstreamCfgs {
+		require.Contains(t, upstreams, cfg.Id, "missing upstream %q after bootstrap", cfg.Id)
+	}
+
+	return &guaranteeFixture{
+		t:         t,
+		ctx:       ctx,
+		cancel:    cancel,
+		network:   network,
+		upstreams: upstreams,
+	}
+}
+
+// withSyncedLatest sets a not-syncing state and a latest block on the upstream.
+func (f *guaranteeFixture) withSyncedLatest(id string, block int64) {
+	u := f.upstreams[id]
+	u.EvmStatePoller().SetSyncingState(common.EvmSyncingStateNotSyncing)
+	u.EvmStatePoller().SuggestLatestBlock(block)
+}
+
+// withSyncedFinalized sets a not-syncing state and a finalized block on the
+// upstream. SuggestFinalizedBlock applies asynchronously, so this helper polls
+// until the value is observable (or fails the test).
+func (f *guaranteeFixture) withSyncedFinalized(id string, block int64) {
+	u := f.upstreams[id]
+	u.EvmStatePoller().SetSyncingState(common.EvmSyncingStateNotSyncing)
+	u.EvmStatePoller().SuggestFinalizedBlock(block)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if u.EvmStatePoller().FinalizedBlock() >= block {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.GreaterOrEqualf(f.t, u.EvmStatePoller().FinalizedBlock(), block,
+		"finalized block did not settle for upstream %q", id)
+}
+
+func (f *guaranteeFixture) withSyncing(id string) {
+	f.upstreams[id].EvmStatePoller().SetSyncingState(common.EvmSyncingStateSyncing)
+}
+
+// makeEvmUpstream returns an UpstreamConfig with the given Id, allow/ignore method
+// rules, and autoIgnoreUnsupportedMethods enabled by default (so dynamic
+// IgnoreMethod() calls actually take effect).
+func makeEvmUpstream(id string, allow, ignore []string) *common.UpstreamConfig {
+	return &common.UpstreamConfig{
+		Type:                         common.UpstreamTypeEvm,
+		Id:                           id,
+		Endpoint:                     "http://" + id + ".localhost",
+		AllowMethods:                 allow,
+		IgnoreMethods:                ignore,
+		AutoIgnoreUnsupportedMethods: util.BoolPtr(true),
+		Evm: &common.EvmUpstreamConfig{
+			ChainId: 123,
+		},
+	}
+}
+
+// TestLatestBlockGuarantee_NoMethodsConfigured verifies the historical
+// (unconstrained) behavior is preserved when LatestBlockGuaranteedMethods is empty.
+func TestLatestBlockGuarantee_NoMethodsConfigured(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, nil),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		nil, // no guarantee
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	assert.Equal(t, int64(100), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_AllSupportSingleMethod is the trivial guarantee case:
+// every upstream supports the single guaranteed method, so the result equals the
+// raw max.
+func TestLatestBlockGuarantee_AllSupportSingleMethod(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, nil),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	assert.Equal(t, int64(100), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_CapabilityGapCapsLatest is the headline scenario:
+// the upstream with the highest latest block does NOT support a guaranteed method,
+// while a lower-block upstream does. The guarantee floor is the lower block.
+func TestLatestBlockGuarantee_CapabilityGapCapsLatest(t *testing.T) {
+	// alice is ahead but ignores trace_block. bob is behind but supports it.
+	// Expected: latest = min(maxOver(eth_getBlockByNumber)=100, maxOver(trace_block)=95) = 95.
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"trace_block"}),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber", "trace_block"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	assert.Equal(t, int64(95), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_NoUpstreamSupportsMethod returns 0 when any guaranteed
+// method has no supporting upstream. 0 is the sentinel "unknown" used elsewhere
+// in the codebase so callers fall through to existing fallbacks.
+func TestLatestBlockGuarantee_NoUpstreamSupportsMethod(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"trace_block"}),
+			makeEvmUpstream("bob", nil, []string{"trace_block"}),
+		},
+		[]string{"trace_block"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	assert.Equal(t, int64(0), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_SyncingUpstreamIsExcludedEvenWhenItSupports verifies
+// that the existing "ignore syncing nodes" filter applies before method-support
+// is considered. A syncing node with the highest block must not contribute.
+func TestLatestBlockGuarantee_SyncingUpstreamIsExcludedEvenWhenItSupports(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, nil), // would be the leader but is syncing
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber"},
+	)
+	f.withSyncedLatest("alice", 999)
+	f.withSyncedLatest("bob", 95)
+	f.withSyncing("alice")
+
+	assert.Equal(t, int64(95), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_IgnoreAllExceptIdiom verifies the canonical
+// "this upstream only serves a narrow set of methods" idiom (ignoreMethods="*"
+// rescued by allowMethods) is honored by the guarantee algorithm.
+//
+// Note: AllowMethods on its own does NOT act as a strict whitelist in this
+// codebase — by design, it only "rescues" methods from IgnoreMethods. To
+// express "only serve eth_getBlockByNumber" you must combine the two.
+func TestLatestBlockGuarantee_IgnoreAllExceptIdiom(t *testing.T) {
+	// alice declares she only supports eth_getBlockByNumber. bob supports all.
+	// Even though alice has the higher block, the trace_block maximum across
+	// supporting upstreams is bound by bob's 95.
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", []string{"eth_getBlockByNumber"}, []string{"*"}),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber", "trace_block"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	assert.Equal(t, int64(95), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_DynamicIgnoreSelfHealing exercises the
+// autoIgnoreUnsupportedMethods feedback loop: once an upstream is taught
+// dynamically that it doesn't support a method, the guarantee algorithm must
+// stop counting its blocks toward that method's max — without operator
+// intervention.
+func TestLatestBlockGuarantee_DynamicIgnoreSelfHealing(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			// Both initially declare full support; alice will be taught dynamically.
+			makeEvmUpstream("alice", nil, nil),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"trace_block"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	// Before any feedback, alice (the leader) supports everything -> max = 100.
+	assert.Equal(t, int64(100), f.network.EvmHighestLatestBlockNumber(f.ctx))
+
+	// Simulate alice returning "method not supported" -> autoIgnore registers it.
+	f.upstreams["alice"].IgnoreMethod("trace_block")
+
+	// Now alice should be excluded from the trace_block calculation, so max = 95.
+	assert.Equal(t, int64(95), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_ExtraMethodsUnionWithConfigured verifies the variadic
+// extras compose with the configured set: the per-call `eth_getBlockByNumber`
+// auto-injection in the eth_getBlockByNumber post-forward should compose with,
+// not replace, any configured guaranteed methods.
+func TestLatestBlockGuarantee_ExtraMethodsUnionWithConfigured(t *testing.T) {
+	// Configured: trace_block. Extra (passed at call site): eth_getBlockByNumber.
+	// alice supports eth_getBlockByNumber but not trace_block; carol supports both
+	// but is behind. The min-of-max should be carol's block.
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"trace_block"}),
+			makeEvmUpstream("carol", nil, nil),
+		},
+		[]string{"trace_block"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("carol", 90)
+
+	// Without the extra, the min-of-max is bound by carol's trace_block contribution
+	// (alice ignores trace_block) -> 90.
+	assert.Equal(t, int64(90), f.network.EvmHighestLatestBlockNumber(f.ctx))
+
+	// Extras don't lower the floor below what configured methods already give.
+	assert.Equal(t, int64(90), f.network.EvmHighestLatestBlockNumber(f.ctx, "eth_getBlockByNumber"))
+}
+
+// TestLatestBlockGuarantee_ExtraMethodOnlyConstrainsWithoutConfig verifies the
+// "self-reference" piece: even with no configured methods, passing
+// "eth_getBlockByNumber" as an extra correctly excludes upstreams that ignore it.
+func TestLatestBlockGuarantee_ExtraMethodOnlyConstrainsWithoutConfig(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"eth_getBlockByNumber"}),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		nil, // no configured methods
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	// Unconstrained: alice still wins (her ignore of eth_getBlockByNumber doesn't
+	// matter when no methods are required).
+	assert.Equal(t, int64(100), f.network.EvmHighestLatestBlockNumber(f.ctx))
+
+	// With the self-reference extra, alice must be excluded for that method.
+	assert.Equal(t, int64(95), f.network.EvmHighestLatestBlockNumber(f.ctx, "eth_getBlockByNumber"))
+}
+
+// TestLatestBlockGuarantee_DuplicateExtraMethodIsDeduplicated guards against the
+// trivial bug where passing the same method as an extra inflates the required-set.
+func TestLatestBlockGuarantee_DuplicateExtraMethodIsDeduplicated(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"eth_getBlockByNumber"}),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber"},
+	)
+	f.withSyncedLatest("alice", 100)
+	f.withSyncedLatest("bob", 95)
+
+	// Result should be the same whether we pass "eth_getBlockByNumber" as extra
+	// or not, because it's already configured.
+	withoutExtra := f.network.EvmHighestLatestBlockNumber(f.ctx)
+	withExtra := f.network.EvmHighestLatestBlockNumber(f.ctx, "eth_getBlockByNumber")
+	assert.Equal(t, withoutExtra, withExtra)
+	assert.Equal(t, int64(95), withExtra)
+}
+
+// TestLatestBlockGuarantee_FinalizedBlock mirrors the latest-block tests for the
+// finalized path so we know both code paths share the algorithm correctly.
+func TestLatestBlockGuarantee_FinalizedBlock(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, []string{"trace_block"}),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"trace_block"},
+	)
+	f.withSyncedFinalized("alice", 90)
+	f.withSyncedFinalized("bob", 80)
+
+	// alice is excluded for trace_block, bob is the only contributor.
+	assert.Equal(t, int64(80), f.network.EvmHighestFinalizedBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_ZeroBlocksAreIgnored guards a small bug class: an
+// upstream that hasn't reported a block yet (effective block == 0) must not be
+// counted as "supporting" the method at block 0 (which would then make any
+// guarantee effectively zero).
+func TestLatestBlockGuarantee_ZeroBlocksAreIgnored(t *testing.T) {
+	f := newGuaranteeFixture(t,
+		[]*common.UpstreamConfig{
+			makeEvmUpstream("alice", nil, nil),
+			makeEvmUpstream("bob", nil, nil),
+		},
+		[]string{"eth_getBlockByNumber"},
+	)
+	f.withSyncedLatest("alice", 100)
+	// bob deliberately not given a latest block (stays at 0)
+	f.upstreams["bob"].EvmStatePoller().SetSyncingState(common.EvmSyncingStateNotSyncing)
+
+	// bob's 0 must not pull max down; alice carries the method.
+	assert.Equal(t, int64(100), f.network.EvmHighestLatestBlockNumber(f.ctx))
+}
+
+// TestLatestBlockGuarantee_DefaultsPropagation verifies that
+// networkDefaults.evm.latestBlockGuaranteedMethods flows into per-network
+// EvmNetworkConfig when the network does not set its own.
+func TestLatestBlockGuarantee_DefaultsPropagation(t *testing.T) {
+	t.Run("default applies when network has no own list", func(t *testing.T) {
+		network := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm: &common.EvmNetworkConfig{
+				ChainId: 123,
+			},
+		}
+		defaults := &common.NetworkDefaults{
+			Evm: &common.EvmNetworkConfig{
+				LatestBlockGuaranteedMethods: []string{"eth_getBlockReceipts", "trace_block"},
+			},
+		}
+		require.NoError(t, network.SetDefaults(nil, defaults))
+		assert.Equal(t, []string{"eth_getBlockReceipts", "trace_block"}, network.Evm.LatestBlockGuaranteedMethods)
+	})
+
+	t.Run("network-level setting wins over defaults", func(t *testing.T) {
+		network := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm: &common.EvmNetworkConfig{
+				ChainId:                      123,
+				LatestBlockGuaranteedMethods: []string{"eth_getLogs"},
+			},
+		}
+		defaults := &common.NetworkDefaults{
+			Evm: &common.EvmNetworkConfig{
+				LatestBlockGuaranteedMethods: []string{"eth_getBlockReceipts"},
+			},
+		}
+		require.NoError(t, network.SetDefaults(nil, defaults))
+		assert.Equal(t, []string{"eth_getLogs"}, network.Evm.LatestBlockGuaranteedMethods)
+	})
+
+	t.Run("defaults copy is independent from source", func(t *testing.T) {
+		// Mutating the propagated list must not bleed back into the defaults
+		// (which are shared across networks).
+		defaultsList := []string{"eth_getBlockReceipts"}
+		network := &common.NetworkConfig{
+			Architecture: common.ArchitectureEvm,
+			Evm:          &common.EvmNetworkConfig{ChainId: 123},
+		}
+		defaults := &common.NetworkDefaults{
+			Evm: &common.EvmNetworkConfig{LatestBlockGuaranteedMethods: defaultsList},
+		}
+		require.NoError(t, network.SetDefaults(nil, defaults))
+		network.Evm.LatestBlockGuaranteedMethods[0] = "MUTATED"
+		assert.Equal(t, "eth_getBlockReceipts", defaultsList[0], "default list must not be mutated through network ref")
+	})
+}

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -963,6 +963,24 @@ export interface EvmNetworkConfig {
    * Set to false to disable this behavior and return raw upstream errors.
    */
   idempotentTransactionBroadcast?: boolean;
+  /**
+   * LatestBlockGuaranteedMethods constrains the network's reported "latest" and
+   * "finalized" block numbers to ones for which every listed method is actually
+   * servable by at least one non-syncing upstream.
+   * Algorithm: for each listed method, find the highest block among upstreams
+   * that can serve that method (via ShouldHandleMethod, which honors
+   * allow/ignoreMethods plus dynamic autoIgnoreUnsupportedMethods); the network's
+   * effective latest/finalized is the minimum across those per-method maxima. If
+   * any method has no supporting upstream, the result is 0 (treated as "unknown")
+   * so callers fall through to their existing fallbacks.
+   * Use this when an upstream may be ahead of the chain head it can fully serve
+   * (e.g. one provider reports latest=N but cannot serve eth_getBlockReceipts(N)
+   * while another provider that can is one block behind). Without this, clients
+   * see "block not found" on the follow-up call.
+   * Empty/nil disables the constraint and the raw highest block across upstreams
+   * is returned (current behavior).
+   */
+  latestBlockGuaranteedMethods?: string[];
 }
 /**
  * EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.


### PR DESCRIPTION
```yaml
evm:
  latestBlockGuaranteedMethods:
    - eth_getBlockByNumber
    - eth_getBlockReceipts
    - eth_getLogs
```

For each listed method we take the max block among supporting upstreams; the network's effective `latest` / `finalized` is the min across those per-method maxima. Returns 0 when any method has no supporting upstream so callers fall through to existing fallbacks.

Method support comes from `Upstream.ShouldHandleMethod`, so the `autoIgnoreUnsupportedMethods` feedback loop already excludes upstreams that returned "method not supported" — no extra wiring.

Closes the same gap as #806 without the profile registry, built-in presets, directive header, wildcard parser, or `ShouldHandleMethod` refactor.