### PR TITLE
fix: short-circuit on agreed empty results when no competing group

### DIFF
--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -719,3 +719,58 @@ func TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic(t *testing.T) {
 		e.recordMetricsAndTracing(req, time.Now(), result, nil /* analysis */, labels, span)
 	})
 }
+
+// emptyResponse returns an empty JSON-RPC array result, the canonical shape for
+// eth_getLogs on a block with no matching events. Used to exercise the empty-
+// result branch of the unassailable_lead short-circuit rule.
+func emptyResponse() *common.NormalizedResponse {
+	jrpc, _ := common.NewJsonRpcResponse(1, []interface{}{}, nil)
+	return common.NewNormalizedResponse().WithJsonRpcResponse(jrpc)
+}
+
+// TestConsensus_ShortCircuit_EmptyResponses_StuckParticipant verifies that when
+// the agreement threshold is met by empty responses (e.g. eth_getLogs on a
+// block with no matching events) and no competing non-empty group exists,
+// consensus short-circuits without waiting for the slow/stuck remaining
+// participants. Without this, consensus blocks on responseChan until the outer
+// failsafe timeout fires — the production pattern observed on Monad eth_getLogs.
+func TestConsensus_ShortCircuit_EmptyResponses_StuckParticipant(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := NewConsensusPolicyBuilder().
+		WithMaxParticipants(3).
+		WithAgreementThreshold(1).
+		WithLogger(&logger).
+		Build()
+
+	req := newTestRequest()
+
+	var callCount atomic.Int32
+	slowRelease := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, common.RequestContextKey, req)
+
+	fsExec := failsafe.NewExecutor(pol).WithContext(ctx)
+
+	start := time.Now()
+	resp, err := fsExec.GetWithExecution(func(exec failsafe.Execution[*common.NormalizedResponse]) (*common.NormalizedResponse, error) {
+		n := callCount.Add(1)
+		if n <= 2 {
+			return emptyResponse(), nil // two fast participants with matching empty responses
+		}
+		<-slowRelease // third participant blocks indefinitely
+		return emptyResponse(), nil
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"short-circuit on agreed empty result must not wait for stuck participant")
+
+	// Unblock the slow participant so the analyzer can finish in the background
+	// and the test doesn't leak a goroutine.
+	close(slowRelease)
+}

--- a/consensus/rules.go
+++ b/consensus/rules.go
@@ -895,7 +895,7 @@ var shortCircuitRules = []shortCircuitRule{
 		},
 	},
 	{
-		Description: "winner meets agreement threshold, is non-empty, and lead is unassailable (no possible tie with remaining)",
+		Description: "winner meets agreement threshold (empty or non-empty) and lead is unassailable (no possible tie with remaining)",
 		Reason:      "unassailable_lead",
 		Condition: func(w *failsafeCommon.PolicyResult[*common.NormalizedResponse], a *consensusAnalysis) bool {
 			// With remaining participants, avoid short-circuiting when a preference could still
@@ -922,7 +922,26 @@ var shortCircuitRules = []shortCircuitRule{
 					return false
 				}
 			}
-			if best == nil || best.ResponseType != ResponseTypeNonEmpty || best.Count < a.config.agreementThreshold {
+			if best == nil || best.Count < a.config.agreementThreshold {
+				return false
+			}
+			if best.ResponseType == ResponseTypeEmpty {
+				// Allow short-circuit for empty results only when no other valid group
+				// exists that could catch up or create a tie. This handles the common
+				// case where all responding upstreams agree on an empty result (e.g.,
+				// eth_getLogs for a block with no matching events) while a stuck
+				// participant blocks the collect loop.
+				hasCompetingGroup := false
+				for _, g := range a.getValidGroups() {
+					if g.Hash != best.Hash {
+						hasCompetingGroup = true
+						break
+					}
+				}
+				if hasCompetingGroup {
+					return false
+				}
+			} else if best.ResponseType != ResponseTypeNonEmpty {
 				return false
 			}
 			// Compute second best among valid groups (non-infrastructure)


### PR DESCRIPTION
## Problem

The `unassailable_lead` short-circuit rule only fires when the winning group is `ResponseTypeNonEmpty`. When the agreement threshold is met by empty responses (e.g. `eth_getLogs` on a block with no matching events), consensus blocks on `responseChan` waiting for all `maxParticipants` to return — even when one of them is slow or stuck on a degraded upstream. The wait runs to the outer network-level failsafe timeout, turning a sub-second request into a tens-of-seconds user-facing failure.

Reproduces consistently in production: a single chain configured with `consensusConfig(threshold=1, max=3, preferNonEmpty=true)` for `eth_getLogs` produces 2,000+ such hangs per hour. Trace shows all `Upstream.Forward` spans completing in <200ms while `Consensus.CollectResponses` runs for the full network timeout floor. Independent of any specific upstream slowness — it's the consensus aggregator itself blocking.

## Fix

Allow short-circuit when the winning group is empty **AND** no other valid group could catch up or create a tie. When a competing non-empty group is present, still wait for all participants — that preserves `preferNonEmpty` semantics (don't prematurely pick empty over a potential non-empty winner).
```

## Tests

- New: `TestConsensus_ShortCircuit_EmptyResponses_StuckParticipant` — two participants return matching empty responses fast, third blocks indefinitely; asserts caller is released in <500ms. Fails without the fix.
- All existing `consensus/...` tests pass unchanged. The existing `TestConsensus_ShortCircuit_CallerGetsWinnerBeforeSlowParticipants` covers the analogous non-empty case.

## Test plan

- [x] `go test ./consensus/...` (passes locally)
- [x] Build all packages clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts consensus short-circuiting behavior, which can change request completion timing and winner selection in edge cases involving empty results and slow participants. Guardrails and a targeted regression test reduce risk, but it impacts core consensus flow.
> 
> **Overview**
> Fixes `unassailable_lead` short-circuiting to allow **agreed empty results** (e.g. `eth_getLogs` returning `[]`) to return early when the agreement threshold is met and **no other valid response group exists** that could catch up or tie.
> 
> Updates the rule’s condition to treat empty winners differently: it now blocks short-circuiting if any competing valid group is present (preserving preference semantics), and adds a regression test (`TestConsensus_ShortCircuit_EmptyResponses_StuckParticipant`) that ensures consensus doesn’t wait on a stuck participant once empty agreement is reached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9ea5adb2f3388215ad8ad79568bd831a6c3b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->