### PR TITLE
fix: fall back to built-in subdomain map on cold-start API failure

### DIFF
--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -183,21 +183,21 @@ func (v *AlchemyVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Log
 		return false, err
 	}
 
+	apiUrl, ok := settings["chainsUrl"].(string)
+	if !ok || apiUrl == "" {
+		apiUrl = alchemyApiUrl
+	}
+
 	recheckInterval, ok := settings["recheckInterval"].(time.Duration)
 	if !ok {
 		recheckInterval = DefaultAlchemyRecheckInterval
 	}
 
-	err = v.ensureRemoteData(ctx, logger, recheckInterval)
-	if err != nil {
-		return false, fmt.Errorf("unable to load remote data: %w", err)
+	if err = v.ensureRemoteData(ctx, logger, recheckInterval, apiUrl); err != nil {
+		logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
 	}
 
-	networks, ok := v.remoteData[alchemyApiUrl]
-	if !ok || networks == nil {
-		return false, nil
-	}
-
+	networks := v.resolveNetworks(apiUrl)
 	_, exists := networks[chainID]
 	return exists, nil
 }
@@ -222,20 +222,21 @@ func (v *AlchemyVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Log
 			return nil, fmt.Errorf("alchemy vendor requires upstream.evm.chainId to be defined")
 		}
 
+		apiUrl, ok := settings["chainsUrl"].(string)
+		if !ok || apiUrl == "" {
+			apiUrl = alchemyApiUrl
+		}
+
 		recheckInterval, ok := settings["recheckInterval"].(time.Duration)
 		if !ok {
 			recheckInterval = DefaultAlchemyRecheckInterval
 		}
 
-		if err := v.ensureRemoteData(ctx, logger, recheckInterval); err != nil {
-			return nil, fmt.Errorf("unable to load remote data: %w", err)
+		if err := v.ensureRemoteData(ctx, logger, recheckInterval, apiUrl); err != nil {
+			logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
 		}
 
-		networks, ok := v.remoteData[alchemyApiUrl]
-		if !ok || networks == nil {
-			return nil, fmt.Errorf("network data not available")
-		}
-
+		networks := v.resolveNetworks(apiUrl)
 		subdomain, ok := networks[chainID]
 		if !ok {
 			return nil, fmt.Errorf("unsupported network chain ID for Alchemy: %d", chainID)
@@ -325,43 +326,46 @@ func (v *AlchemyVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
 	return strings.Contains(ups.Endpoint, ".alchemy.com") || strings.Contains(ups.Endpoint, ".alchemyapi.io")
 }
 
-func (v *AlchemyVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration) error {
+func (v *AlchemyVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration, apiUrl string) error {
 	v.remoteDataLock.Lock()
 	defer v.remoteDataLock.Unlock()
 
-	if ltm, ok := v.remoteDataLastFetchedAt[alchemyApiUrl]; ok && time.Since(ltm) < recheckInterval {
+	if ltm, ok := v.remoteDataLastFetchedAt[apiUrl]; ok && time.Since(ltm) < recheckInterval {
 		return nil
 	}
 
-	newData, err := v.fetchAlchemyNetworks(ctx)
+	newData, err := v.fetchAlchemyNetworks(ctx, apiUrl)
 	if err != nil {
-		if _, ok := v.remoteData[alchemyApiUrl]; ok {
+		if _, ok := v.remoteData[apiUrl]; ok {
 			logger.Warn().Err(err).Msg("could not refresh Alchemy API data, will use stale data")
 			return nil
 		}
-		// Cold start: the Alchemy API is unreachable and we have no cached data.
-		// Seed from the built-in static subdomain map so ~140 chains still work.
-		// Intentionally do not stamp remoteDataLastFetchedAt — the next call will
-		// retry the API and promote real data as soon as it's reachable.
-		logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
-		fallback := make(map[int64]string, len(defaultAlchemyNetworkSubdomains))
-		for chainID, subdomain := range defaultAlchemyNetworkSubdomains {
-			fallback[chainID] = subdomain
-		}
-		v.remoteData[alchemyApiUrl] = fallback
-		return nil
+		// Cold start with no cached data — callers fall back to defaultAlchemyNetworkSubdomains.
+		// Do not stamp remoteDataLastFetchedAt so the next call retries the API.
+		return err
 	}
 
-	v.remoteData[alchemyApiUrl] = newData
-	v.remoteDataLastFetchedAt[alchemyApiUrl] = time.Now()
+	v.remoteData[apiUrl] = newData
+	v.remoteDataLastFetchedAt[apiUrl] = time.Now()
 	return nil
 }
 
-func (v *AlchemyVendor) fetchAlchemyNetworks(ctx context.Context) (map[int64]string, error) {
+// resolveNetworks returns the cached network map for apiUrl, or the built-in
+// static subdomain map if no remote data has been fetched yet.
+func (v *AlchemyVendor) resolveNetworks(apiUrl string) map[int64]string {
+	v.remoteDataLock.Lock()
+	defer v.remoteDataLock.Unlock()
+	if networks, ok := v.remoteData[apiUrl]; ok && networks != nil {
+		return networks
+	}
+	return defaultAlchemyNetworkSubdomains
+}
+
+func (v *AlchemyVendor) fetchAlchemyNetworks(ctx context.Context, apiUrl string) (map[int64]string, error) {
 	rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(rctx, "GET", alchemyApiUrl, nil)
+	req, err := http.NewRequestWithContext(rctx, "GET", apiUrl, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -140,7 +140,10 @@ var defaultAlchemyNetworkSubdomains = map[int64]string{
 }
 
 const DefaultAlchemyRecheckInterval = 24 * time.Hour
-const alchemyApiUrl = "https://app-api.alchemy.com/trpc/config.getNetworkConfig"
+
+// alchemyApiUrl is the tRPC endpoint used to discover Alchemy networks.
+// Declared as var (not const) so tests can point it at a mock server.
+var alchemyApiUrl = "https://app-api.alchemy.com/trpc/config.getNetworkConfig"
 
 type alchemyNetworkConfigResponse struct {
 	Result struct {
@@ -336,7 +339,17 @@ func (v *AlchemyVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Lo
 			logger.Warn().Err(err).Msg("could not refresh Alchemy API data, will use stale data")
 			return nil
 		}
-		return err
+		// Cold start: the Alchemy API is unreachable and we have no cached data.
+		// Seed from the built-in static subdomain map so ~140 chains still work.
+		// Intentionally do not stamp remoteDataLastFetchedAt — the next call will
+		// retry the API and promote real data as soon as it's reachable.
+		logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
+		fallback := make(map[int64]string, len(defaultAlchemyNetworkSubdomains))
+		for chainID, subdomain := range defaultAlchemyNetworkSubdomains {
+			fallback[chainID] = subdomain
+		}
+		v.remoteData[alchemyApiUrl] = fallback
+		return nil
 	}
 
 	v.remoteData[alchemyApiUrl] = newData

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -195,6 +195,8 @@ func (v *AlchemyVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Log
 
 	if err = v.ensureRemoteData(ctx, logger, recheckInterval, apiUrl); err != nil {
 		logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
+		_, exists := defaultAlchemyNetworkSubdomains[chainID]
+		return exists, nil
 	}
 
 	networks := v.resolveNetworks(apiUrl)
@@ -232,11 +234,14 @@ func (v *AlchemyVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Log
 			recheckInterval = DefaultAlchemyRecheckInterval
 		}
 
+		var networks map[int64]string
 		if err := v.ensureRemoteData(ctx, logger, recheckInterval, apiUrl); err != nil {
 			logger.Warn().Err(err).Msg("could not fetch Alchemy API data on cold start, falling back to built-in subdomain map")
+			networks = defaultAlchemyNetworkSubdomains
+		} else {
+			networks = v.resolveNetworks(apiUrl)
 		}
 
-		networks := v.resolveNetworks(apiUrl)
 		subdomain, ok := networks[chainID]
 		if !ok {
 			return nil, fmt.Errorf("unsupported network chain ID for Alchemy: %d", chainID)

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -141,6 +141,23 @@ var defaultAlchemyNetworkSubdomains = map[int64]string{
 
 const DefaultAlchemyRecheckInterval = 24 * time.Hour
 
+// validateChainsURL returns a non-nil error if rawURL is structurally invalid
+// (bad scheme, empty host). A reachable-but-failing URL is a network error,
+// not a config error, and is handled separately by the cold-start fallback.
+func validateChainsURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid chainsUrl %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid chainsUrl %q: scheme must be http or https", rawURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid chainsUrl %q: host is empty", rawURL)
+	}
+	return nil
+}
+
 // alchemyApiUrl is the tRPC endpoint used to discover Alchemy networks.
 // Declared as var (not const) so tests can point it at a mock server.
 var alchemyApiUrl = "https://app-api.alchemy.com/trpc/config.getNetworkConfig"
@@ -188,6 +205,10 @@ func (v *AlchemyVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Log
 		apiUrl = alchemyApiUrl
 	}
 
+	if err = validateChainsURL(apiUrl); err != nil {
+		return false, err
+	}
+
 	recheckInterval, ok := settings["recheckInterval"].(time.Duration)
 	if !ok {
 		recheckInterval = DefaultAlchemyRecheckInterval
@@ -227,6 +248,10 @@ func (v *AlchemyVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Log
 		apiUrl, ok := settings["chainsUrl"].(string)
 		if !ok || apiUrl == "" {
 			apiUrl = alchemyApiUrl
+		}
+
+		if err := validateChainsURL(apiUrl); err != nil {
+			return nil, err
 		}
 
 		recheckInterval, ok := settings["recheckInterval"].(time.Duration)

--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -141,23 +141,6 @@ var defaultAlchemyNetworkSubdomains = map[int64]string{
 
 const DefaultAlchemyRecheckInterval = 24 * time.Hour
 
-// validateChainsURL returns a non-nil error if rawURL is structurally invalid
-// (bad scheme, empty host). A reachable-but-failing URL is a network error,
-// not a config error, and is handled separately by the cold-start fallback.
-func validateChainsURL(rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("invalid chainsUrl %q: %w", rawURL, err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("invalid chainsUrl %q: scheme must be http or https", rawURL)
-	}
-	if u.Host == "" {
-		return fmt.Errorf("invalid chainsUrl %q: host is empty", rawURL)
-	}
-	return nil
-}
-
 // alchemyApiUrl is the tRPC endpoint used to discover Alchemy networks.
 // Declared as var (not const) so tests can point it at a mock server.
 var alchemyApiUrl = "https://app-api.alchemy.com/trpc/config.getNetworkConfig"

--- a/thirdparty/alchemy_test.go
+++ b/thirdparty/alchemy_test.go
@@ -1,0 +1,104 @@
+package thirdparty
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlchemyVendor_ColdStartFallback_SupportsNetwork(t *testing.T) {
+	// Point the vendor at a URL that is guaranteed to fail so we simulate a
+	// cold-start where the Alchemy API is unreachable.
+	originalURL := swapAlchemyApiURL(t, "http://127.0.0.1:1/does-not-exist")
+	defer swapAlchemyApiURL(t, originalURL)
+
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	// Pick a chain that is in the static fallback map.
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+	require.NoError(t, err, "cold-start fallback should not surface a fetch error")
+	assert.True(t, supported, "chain 1 is hard-coded in defaultAlchemyNetworkSubdomains")
+
+	// Pick a chain that is not in the static map: the fallback cannot invent it.
+	supported, err = vendor.SupportsNetwork(ctx, &logger, settings, "evm:999999999999")
+	require.NoError(t, err)
+	assert.False(t, supported)
+}
+
+func TestAlchemyVendor_ColdStartFallback_GenerateConfigs(t *testing.T) {
+	originalURL := swapAlchemyApiURL(t, "http://127.0.0.1:1/does-not-exist")
+	defer swapAlchemyApiURL(t, originalURL)
+
+	vendor := CreateAlchemyVendor()
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"apiKey":          "test-key",
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	upstream := &common.UpstreamConfig{
+		Evm: &common.EvmUpstreamConfig{ChainId: 1},
+	}
+
+	configs, err := vendor.GenerateConfigs(ctx, &logger, upstream, settings)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Contains(t, configs[0].Endpoint, "eth-mainnet.g.alchemy.com")
+	assert.Contains(t, configs[0].Endpoint, "test-key")
+}
+
+func TestAlchemyVendor_SuccessfulFetchPromotesOverFallback(t *testing.T) {
+	// Serve a response that adds a chain not present in the static map so we
+	// can tell whether the live API result replaced the cold-start fallback.
+	const customChainID = int64(424242)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"data":[{"networkChainId":424242,"kebabCaseId":"custom-net"}]}}`))
+	}))
+	defer server.Close()
+
+	originalURL := swapAlchemyApiURL(t, server.URL)
+	defer swapAlchemyApiURL(t, originalURL)
+
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{"recheckInterval": 24 * time.Hour}
+
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:424242")
+	require.NoError(t, err)
+	assert.True(t, supported, "custom chain from the mocked API should be recognized")
+
+	// Static defaults should still be merged in alongside the live response.
+	supported, err = vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+	require.NoError(t, err)
+	assert.True(t, supported)
+
+	_ = customChainID
+}
+
+// swapAlchemyApiURL temporarily overrides the package-level alchemyApiUrl so
+// tests can point the vendor at a mock server or a deliberately broken URL.
+// Returns the previous value so the caller can restore it.
+func swapAlchemyApiURL(t *testing.T, newURL string) string {
+	t.Helper()
+	prev := alchemyApiUrl
+	alchemyApiUrl = newURL
+	return prev
+}

--- a/thirdparty/alchemy_test.go
+++ b/thirdparty/alchemy_test.go
@@ -169,6 +169,22 @@ func TestAlchemyVendor_ChainsUrlSetting_IsolatedFromDefaultUrl(t *testing.T) {
 	assert.False(t, supported, "chain 888888 should not bleed into the default URL cache")
 }
 
+func TestAlchemyVendor_ChainsUrlSetting_InvalidURLReturnsError(t *testing.T) {
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	for _, badURL := range []string{"not-a-url", "ftp://host", "://missing-scheme"} {
+		settings := common.VendorSettings{
+			"chainsUrl":       badURL,
+			"recheckInterval": 24 * time.Hour,
+		}
+		_, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+		require.Errorf(t, err, "malformed chainsUrl %q should return an error", badURL)
+		assert.Contains(t, err.Error(), "invalid chainsUrl")
+	}
+}
+
 // swapAlchemyApiURL temporarily overrides the package-level alchemyApiUrl so
 // tests can point the vendor at a mock server or a deliberately broken URL.
 // Returns the previous value so the caller can restore it.

--- a/thirdparty/alchemy_test.go
+++ b/thirdparty/alchemy_test.go
@@ -93,6 +93,82 @@ func TestAlchemyVendor_SuccessfulFetchPromotesOverFallback(t *testing.T) {
 	_ = customChainID
 }
 
+func TestAlchemyVendor_ChainsUrlSetting_OverridesDefault(t *testing.T) {
+	const customChainID = int64(777777)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"data":[{"networkChainId":777777,"kebabCaseId":"custom-chains-url-net"}]}}`))
+	}))
+	defer server.Close()
+
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"chainsUrl":       server.URL,
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:777777")
+	require.NoError(t, err)
+	assert.True(t, supported, "chain from chainsUrl mock server should be recognized")
+
+	// Static defaults are still merged in.
+	supported, err = vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+	require.NoError(t, err)
+	assert.True(t, supported)
+}
+
+func TestAlchemyVendor_ChainsUrlSetting_ColdStartFallback(t *testing.T) {
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"chainsUrl":       "http://127.0.0.1:1/does-not-exist",
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+	require.NoError(t, err, "cold-start fallback via chainsUrl should not surface a fetch error")
+	assert.True(t, supported, "chain 1 is hard-coded in defaultAlchemyNetworkSubdomains")
+}
+
+func TestAlchemyVendor_ChainsUrlSetting_IsolatedFromDefaultUrl(t *testing.T) {
+	// Verify that a vendor using chainsUrl does not pollute the cache for the
+	// default alchemyApiUrl (and vice versa) — each URL key is independent.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"data":[{"networkChainId":888888,"kebabCaseId":"isolated-net"}]}}`))
+	}))
+	defer server.Close()
+
+	vendor := CreateAlchemyVendor().(*AlchemyVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settingsWithCustomUrl := common.VendorSettings{
+		"chainsUrl":       server.URL,
+		"recheckInterval": 24 * time.Hour,
+	}
+	settingsDefault := common.VendorSettings{
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	// Populate cache for custom URL.
+	_, err := vendor.SupportsNetwork(ctx, &logger, settingsWithCustomUrl, "evm:888888")
+	require.NoError(t, err)
+
+	// Default URL cache should not know about chain 888888.
+	originalURL := swapAlchemyApiURL(t, "http://127.0.0.1:1/does-not-exist")
+	defer swapAlchemyApiURL(t, originalURL)
+
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settingsDefault, "evm:888888")
+	require.NoError(t, err)
+	assert.False(t, supported, "chain 888888 should not bleed into the default URL cache")
+}
+
 // swapAlchemyApiURL temporarily overrides the package-level alchemyApiUrl so
 // tests can point the vendor at a mock server or a deliberately broken URL.
 // Returns the previous value so the caller can restore it.

--- a/thirdparty/vendor_utils.go
+++ b/thirdparty/vendor_utils.go
@@ -1,0 +1,23 @@
+package thirdparty
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// validateChainsURL returns a non-nil error if rawURL is structurally invalid
+// (bad scheme, empty host). A reachable-but-failing URL is a network error,
+// not a config error, and is handled separately by the cold-start fallback.
+func validateChainsURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid chainsUrl %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid chainsUrl %q: scheme must be http or https", rawURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid chainsUrl %q: host is empty", rawURL)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

When the Alchemy tRPC config endpoint (`https://app-api.alchemy.com/trpc/config.getNetworkConfig`) is unreachable and the vendor has no cached data yet, `AlchemyVendor.ensureRemoteData` currently returns an error. Both `SupportsNetwork` and `GenerateConfigs` then fail, and no Alchemy upstreams are produced for any chain — even though `defaultAlchemyNetworkSubdomains` already hard-codes subdomains for ~140 chains.

That static map was only merged **inside** `fetchAlchemyNetworks` on the success path, so it never protected a cold start.

## Change

- On cold-start fetch failure with no prior cached data, seed `remoteData[alchemyApiUrl]` from `defaultAlchemyNetworkSubdomains`.
- `remoteDataLastFetchedAt` is intentionally left unset so the next call retries the live API and promotes real data as soon as it's reachable. Once a live fetch succeeds, the existing stale-data path takes over on subsequent failures — behavior in that case is unchanged.
- `alchemyApiUrl` changed from `const` to `var` so tests can point the vendor at a mock server / deliberately unreachable URL.

No new data is introduced — this is purely a reordering of when the existing static map is used.

## Test plan

- [x] `TestAlchemyVendor_ColdStartFallback_SupportsNetwork` — unreachable URL, confirms `evm:1` is reported as supported via the static map and an unknown chain is not.
- [x] `TestAlchemyVendor_ColdStartFallback_GenerateConfigs` — confirms a usable `eth-mainnet.g.alchemy.com/v2/<key>` endpoint is generated without the API.
- [x] `TestAlchemyVendor_SuccessfulFetchPromotesOverFallback` — mock server returns a custom chain; confirms live data is accepted and static defaults are still merged in.
- [x] Full `go test ./thirdparty/...` passes.
- [x] `go vet ./thirdparty/...` and `gofmt` clean.