### PR TITLE
feat: add Blockdaemon third-party provider

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1405,6 +1405,10 @@ func buildProviderSettings(vendorName string, endpoint *url.URL) (VendorSettings
 		return VendorSettings{
 			"apiKey": endpoint.Host,
 		}, nil
+	case "blockdaemon", "evm+blockdaemon":
+		return VendorSettings{
+			"apiKey": endpoint.Host,
+		}, nil
 	case "erpc", "evm+erpc":
 		settings := VendorSettings{
 			"endpoint": "https://" + endpoint.Host + "/" + strings.TrimPrefix(endpoint.Path, "/"),

--- a/docs/pages/config/projects/providers.mdx
+++ b/docs/pages/config/projects/providers.mdx
@@ -28,6 +28,7 @@ Providers make it easy to add well-known third-parties RPC endpoints quickly. He
 - [`ankr`](#ankr) Accepts ankr.com api key and automatically adds all their EVM chains.
 - [`quicknode`](#quicknode) Accepts quicknode.com api key and automatically adds all their EVM chains.
 - [`routemesh`](#routemesh) Accepts routemesh.io api key and automatically adds all their EVM chains.
+- [`blockdaemon`](#blockdaemon) Accepts blockdaemon.com api key and automatically adds all their EVM chains.
 
 <Callout type='info'>
   eRPC supports **any EVM-compatible** JSON-RPC endpoint when using [`evm` type](/config/projects/upstreams). 
@@ -788,6 +789,48 @@ export default createConfig({
 </Tabs.Tab>
 </Tabs>
 
+#### `blockdaemon`
+
+Built for [Blockdaemon](https://www.blockdaemon.com/) 3rd-party provider to make it easier to import "all supported evm chains" with just an API key.
+
+<Callout type='info'>
+  You can create an API key from your [Blockdaemon dashboard](https://app.blockdaemon.com/). A single key grants access to every EVM chain Blockdaemon's RPC service supports.
+</Callout>
+
+<Tabs items={["yaml", "typescript"]} defaultIndex={0} storageKey="GlobalConfigTypeTabIndex">
+  <Tabs.Tab>
+```yaml filename="erpc.yaml"
+# ...
+projects:
+  - id: main
+    # ...
+    upstreams:
+      - endpoint: blockdaemon://YOUR_BLOCKDAEMON_API_KEY
+        # ...
+```
+</Tabs.Tab>
+  <Tabs.Tab>
+```ts filename="erpc.ts"
+import { createConfig } from "@erpc-cloud/config";
+
+export default createConfig({
+  projects: [
+    {
+      id: "main",
+      // ...
+      upstreams: [
+        {
+          endpoint: "blockdaemon://YOUR_BLOCKDAEMON_API_KEY",
+          // ...
+        },
+      ],
+    },
+  ],
+});
+```
+</Tabs.Tab>
+</Tabs>
+
 #### `quicknode`
 
 Built for [QuickNode](https://www.quicknode.com) 3rd-party provider to make it easier to import "all supported evm chains" with just an API key.
@@ -1061,4 +1104,7 @@ providers:
     settings:
       baseURL: lb.routemes.sh # (optional) Defaults to lb.routemes.sh
       apiKey: xxxxx # Your Routemesh API key
+  - vendor: blockdaemon
+    settings:
+      apiKey: xxxxx # Your Blockdaemon API key
 ```

--- a/thirdparty/blockdaemon.go
+++ b/thirdparty/blockdaemon.go
@@ -1,0 +1,156 @@
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+)
+
+// blockdaemonNetworks maps EVM chain IDs to the path suffix used by Blockdaemon's
+// shared RPC service. Full URL: https://svc.blockdaemon.com/{path}
+//
+// Path suffixes vary per chain — some end in /native, others in /native/http-rpc,
+// Avalanche uses /native/ext/bc/c/eth (C-Chain EVM), and Arbitrum uses
+// /{network}-one/. A single Blockdaemon API key grants access to every chain
+// their RPC product supports.
+//
+// See https://docs.blockdaemon.com/docs/rpc-api
+var blockdaemonNetworks = map[int64]string{
+	// Ethereum
+	1:        "ethereum/mainnet/native",
+	11155111: "ethereum/sepolia/native",
+	560048:   "ethereum/hoodi/native",
+	// Base
+	8453:  "base/mainnet/native/http-rpc",
+	84532: "base/testnet/native/http-rpc",
+	// Optimism
+	10: "optimism/mainnet/native/http-rpc",
+	// Arbitrum One
+	42161:  "arbitrum/mainnet-one/native/http-rpc",
+	421614: "arbitrum/sepolia-one/native/http-rpc",
+	// Avalanche C-Chain (EVM)
+	43114: "avalanche/mainnet/native/ext/bc/c/eth",
+	43113: "avalanche/testnet/native/ext/bc/c/eth",
+	// Ink
+	57073: "ink/mainnet/native",
+	// Monad
+	10143: "monad/testnet/native",
+	// Polygon
+	137:   "polygon/mainnet/native/http-rpc",
+	80002: "polygon/amoy/native/http-rpc",
+	// Tron (TVM is EVM-compatible; path uses /native/jsonrpc)
+	728126428: "tron/mainnet/native/jsonrpc",
+	3448148188: "tron/nile/native/jsonrpc",
+	// X Layer
+	196: "xlayer/mainnet/native",
+	195: "xlayer/testnet/native",
+}
+
+type BlockdaemonVendor struct {
+	common.Vendor
+}
+
+func CreateBlockdaemonVendor() common.Vendor {
+	return &BlockdaemonVendor{}
+}
+
+func (v *BlockdaemonVendor) Name() string {
+	return "blockdaemon"
+}
+
+func (v *BlockdaemonVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger, settings common.VendorSettings, networkId string) (bool, error) {
+	if !strings.HasPrefix(networkId, "evm:") {
+		return false, nil
+	}
+
+	chainID, err := strconv.ParseInt(strings.TrimPrefix(networkId, "evm:"), 10, 64)
+	if err != nil {
+		return false, err
+	}
+	_, ok := blockdaemonNetworks[chainID]
+	return ok, nil
+}
+
+func (v *BlockdaemonVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger, upstream *common.UpstreamConfig, settings common.VendorSettings) ([]*common.UpstreamConfig, error) {
+	if upstream.JsonRpc == nil {
+		upstream.JsonRpc = &common.JsonRpcUpstreamConfig{}
+	}
+
+	apiKey, ok := settings["apiKey"].(string)
+	if !ok || apiKey == "" {
+		return nil, fmt.Errorf("apiKey is required in blockdaemon settings")
+	}
+
+	if upstream.Endpoint == "" {
+		if upstream.Evm == nil {
+			return nil, fmt.Errorf("blockdaemon vendor requires upstream.evm to be defined")
+		}
+		chainID := upstream.Evm.ChainId
+		if chainID == 0 {
+			return nil, fmt.Errorf("blockdaemon vendor requires upstream.evm.chainId to be defined")
+		}
+
+		path, ok := blockdaemonNetworks[chainID]
+		if !ok {
+			return nil, fmt.Errorf("unsupported network chain ID for Blockdaemon: %d", chainID)
+		}
+
+		blockdaemonURL := fmt.Sprintf("https://svc.blockdaemon.com/%s", path)
+		parsedURL, err := url.Parse(blockdaemonURL)
+		if err != nil {
+			return nil, err
+		}
+
+		upstream.Endpoint = parsedURL.String()
+		upstream.Type = common.UpstreamTypeEvm
+	}
+
+	if upstream.JsonRpc.Headers == nil {
+		upstream.JsonRpc.Headers = make(map[string]string)
+	}
+	if _, exists := upstream.JsonRpc.Headers["Authorization"]; !exists {
+		upstream.JsonRpc.Headers["Authorization"] = "Bearer " + apiKey
+	}
+
+	return []*common.UpstreamConfig{upstream}, nil
+}
+
+func (v *BlockdaemonVendor) GetVendorSpecificErrorIfAny(req *common.NormalizedRequest, resp *http.Response, jrr interface{}, details map[string]interface{}) error {
+	bodyMap, ok := jrr.(*common.JsonRpcResponse)
+	if !ok {
+		return nil
+	}
+
+	err := bodyMap.Error
+	if err.Data != "" {
+		details["data"] = err.Data
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		return common.NewErrEndpointUnauthorized(
+			common.NewErrJsonRpcExceptionInternal(
+				int(common.JsonRpcErrorUnauthorized),
+				common.JsonRpcErrorUnauthorized,
+				err.Message,
+				nil,
+				details,
+			),
+		)
+	}
+
+	return nil
+}
+
+func (v *BlockdaemonVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
+	if strings.HasPrefix(ups.Endpoint, "blockdaemon://") || strings.HasPrefix(ups.Endpoint, "evm+blockdaemon://") {
+		return true
+	}
+
+	return strings.Contains(ups.Endpoint, "svc.blockdaemon.com")
+}

--- a/thirdparty/blockdaemon_test.go
+++ b/thirdparty/blockdaemon_test.go
@@ -1,0 +1,117 @@
+package thirdparty
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockdaemonVendor_SupportsNetwork(t *testing.T) {
+	vendor := CreateBlockdaemonVendor()
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	cases := []struct {
+		networkId string
+		expected  bool
+	}{
+		{"evm:1", true},          // Ethereum mainnet
+		{"evm:8453", true},       // Base
+		{"evm:42161", true},      // Arbitrum
+		{"evm:10", true},         // Optimism
+		{"evm:43114", true},      // Avalanche C-Chain
+		{"evm:137", true},        // Polygon
+		{"evm:80002", true},      // Polygon Amoy
+		{"evm:11155111", true},   // Sepolia
+		{"evm:999999999", false}, // unknown
+		{"solana:mainnet", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.networkId, func(t *testing.T) {
+			ok, err := vendor.SupportsNetwork(ctx, &logger, common.VendorSettings{}, c.networkId)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, ok)
+		})
+	}
+}
+
+func TestBlockdaemonVendor_GenerateConfigs(t *testing.T) {
+	vendor := CreateBlockdaemonVendor()
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	t.Run("requires apiKey", func(t *testing.T) {
+		ups := &common.UpstreamConfig{Evm: &common.EvmUpstreamConfig{ChainId: 1}}
+		_, err := vendor.GenerateConfigs(ctx, &logger, ups, common.VendorSettings{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "apiKey is required")
+	})
+
+	t.Run("rejects unsupported chain", func(t *testing.T) {
+		ups := &common.UpstreamConfig{Evm: &common.EvmUpstreamConfig{ChainId: 999999999}}
+		_, err := vendor.GenerateConfigs(ctx, &logger, ups, common.VendorSettings{"apiKey": "key"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported network chain ID")
+	})
+
+	endpointCases := []struct {
+		name     string
+		chainId  int64
+		endpoint string
+	}{
+		{"ethereum", 1, "https://svc.blockdaemon.com/ethereum/mainnet/native"},
+		{"base", 8453, "https://svc.blockdaemon.com/base/mainnet/native/http-rpc"},
+		{"optimism", 10, "https://svc.blockdaemon.com/optimism/mainnet/native/http-rpc"},
+		{"arbitrum", 42161, "https://svc.blockdaemon.com/arbitrum/mainnet-one/native/http-rpc"},
+		{"avalanche", 43114, "https://svc.blockdaemon.com/avalanche/mainnet/native/ext/bc/c/eth"},
+		{"polygon", 137, "https://svc.blockdaemon.com/polygon/mainnet/native/http-rpc"},
+		{"polygon-amoy", 80002, "https://svc.blockdaemon.com/polygon/amoy/native/http-rpc"},
+		{"tron", 728126428, "https://svc.blockdaemon.com/tron/mainnet/native/jsonrpc"},
+		{"tron-nile", 3448148188, "https://svc.blockdaemon.com/tron/nile/native/jsonrpc"},
+	}
+	for _, c := range endpointCases {
+		t.Run("builds "+c.name, func(t *testing.T) {
+			ups := &common.UpstreamConfig{Evm: &common.EvmUpstreamConfig{ChainId: c.chainId}}
+			cfgs, err := vendor.GenerateConfigs(ctx, &logger, ups, common.VendorSettings{"apiKey": "secret-key"})
+			assert.NoError(t, err)
+			assert.Len(t, cfgs, 1)
+			assert.Equal(t, c.endpoint, cfgs[0].Endpoint)
+			assert.Equal(t, common.UpstreamTypeEvm, cfgs[0].Type)
+			assert.Equal(t, "Bearer secret-key", cfgs[0].JsonRpc.Headers["Authorization"])
+		})
+	}
+
+	t.Run("passes through preset endpoint", func(t *testing.T) {
+		ups := &common.UpstreamConfig{
+			Endpoint: "https://svc.blockdaemon.com/base/mainnet/native/http-rpc",
+			Evm:      &common.EvmUpstreamConfig{ChainId: 8453},
+		}
+		cfgs, err := vendor.GenerateConfigs(ctx, &logger, ups, common.VendorSettings{"apiKey": "k"})
+		assert.NoError(t, err)
+		assert.Len(t, cfgs, 1)
+		assert.Equal(t, ups.Endpoint, cfgs[0].Endpoint)
+	})
+}
+
+func TestBlockdaemonVendor_OwnsUpstream(t *testing.T) {
+	vendor := CreateBlockdaemonVendor()
+	cases := []struct {
+		endpoint string
+		owned    bool
+	}{
+		{"blockdaemon://abc", true},
+		{"evm+blockdaemon://abc", true},
+		{"https://svc.blockdaemon.com/ethereum/mainnet/native", true},
+		{"https://rpc.ankr.com/eth/abc", false},
+	}
+	for _, c := range cases {
+		t.Run(c.endpoint, func(t *testing.T) {
+			got := vendor.OwnsUpstream(&common.UpstreamConfig{Endpoint: c.endpoint})
+			assert.Equal(t, c.owned, got)
+		})
+	}
+}

--- a/thirdparty/vendors_registry.go
+++ b/thirdparty/vendors_registry.go
@@ -30,6 +30,7 @@ func NewVendorsRegistry() *VendorsRegistry {
 	r.Register(CreateBlockPiVendor())
 	r.Register(CreateAnkrVendor())
 	r.Register(CreateRoutemeshVendor())
+	r.Register(CreateBlockdaemonVendor())
 	return r
 }
 


### PR DESCRIPTION
## Summary

- Adds `BlockdaemonVendor` to `thirdparty/` — implements `SupportsNetwork`, `GenerateConfigs`, `GetVendorSpecificErrorIfAny`, and `OwnsUpstream`
- Registers the vendor in `thirdparty/vendors_registry.go` and adds `blockdaemon` defaults to `common/defaults.go`
- Adds docs page at `docs/pages/config/projects/providers.mdx` with configuration example
- Supports 16 EVM-compatible networks verified live against the API (see table below)

## Supported networks

| Chain | ID | Endpoint path |
|---|---|---|
| Ethereum mainnet | 1 | `ethereum/mainnet/native` |
| Ethereum Sepolia | 11155111 | `ethereum/sepolia/native` |
| Ethereum Hoodi | 560048 | `ethereum/hoodi/native` |
| Base | 8453 | `base/mainnet/native/http-rpc` |
| Base testnet | 84532 | `base/testnet/native/http-rpc` |
| Optimism | 10 | `optimism/mainnet/native/http-rpc` |
| Arbitrum One | 42161 | `arbitrum/mainnet-one/native/http-rpc` |
| Arbitrum Sepolia | 421614 | `arbitrum/sepolia-one/native/http-rpc` |
| Avalanche C-Chain | 43114 | `avalanche/mainnet/native/ext/bc/c/eth` |
| Avalanche Fuji | 43113 | `avalanche/testnet/native/ext/bc/c/eth` |
| Ink | 57073 | `ink/mainnet/native` |
| Monad testnet | 10143 | `monad/testnet/native` |
| Polygon | 137 | `polygon/mainnet/native/http-rpc` |
| Polygon Amoy | 80002 | `polygon/amoy/native/http-rpc` |
| Tron | 728126428 | `tron/mainnet/native/jsonrpc` |
| Tron Nile | 3448148188 | `tron/nile/native/jsonrpc` |

> **Note:** Blockdaemon does not provide any API to programmatically list supported blockchains or networks. The endpoint map above must be maintained manually by consulting their docs at https://docs.blockdaemon.com/docs/rpc-api. Soneium and Unichain appear in the docs nav but return `404 protocol not supported` with a valid API key — they are excluded until confirmed supported on the shared RPC tier.

## Test plan

- [ ] `go test ./thirdparty/ -run TestBlockdaemon` passes
- [ ] Configure a Blockdaemon upstream in `erpc.yaml` with a real API key and verify requests route correctly