### PR TITLE
feat: migrate dRPC networks discovery to REST JSON API with cold-start fallback

### DIFF
--- a/thirdparty/drpc.go
+++ b/thirdparty/drpc.go
@@ -404,7 +404,7 @@ func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logg
 		return nil, fmt.Errorf("failed to parse dRPC networks response: %w", err)
 	}
 
-	// Prefer highest-priority chain per chainId; only include EVM jsonrpc networks.
+	// Only include EVM JSON-RPC chains with premium access; prefer highest priority when a chain ID appears multiple times.
 	type candidate struct {
 		name     string
 		priority int

--- a/thirdparty/drpc.go
+++ b/thirdparty/drpc.go
@@ -227,9 +227,10 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		recheckInterval = DefaultDrpcRecheckInterval
 	}
 
-	err = v.ensureRemoteData(ctx, logger, recheckInterval, networksURL)
-	if err != nil {
-		return false, fmt.Errorf("unable to load remote data: %w", err)
+	if err = v.ensureRemoteData(ctx, logger, recheckInterval, networksURL); err != nil {
+		logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
+		_, exists := defaultDrpcNetworkNames[chainID]
+		return exists, nil
 	}
 
 	networks, ok := v.remoteData[networksURL]
@@ -270,13 +271,12 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 			recheckInterval = DefaultDrpcRecheckInterval
 		}
 
+		var networks map[int64]string
 		if err := v.ensureRemoteData(ctx, logger, recheckInterval, networksURL); err != nil {
-			return nil, fmt.Errorf("unable to load remote data: %w", err)
-		}
-
-		networks, ok := v.remoteData[networksURL]
-		if !ok || networks == nil {
-			return nil, fmt.Errorf("network data not available")
+			logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
+			networks = defaultDrpcNetworkNames
+		} else {
+			networks = v.remoteData[networksURL]
 		}
 
 		netName, ok := networks[chainID]
@@ -366,17 +366,7 @@ func (v *DrpcVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logge
 			logger.Warn().Err(err).Msg("could not refresh dRPC networks data; will use stale data")
 			return nil
 		}
-		// Cold start: the dRPC API is unreachable and we have no cached data.
-		// Seed from the built-in static network map so known chains still work.
-		// Intentionally do not stamp remoteDataLastFetchedAt — the next call will
-		// retry the API and promote real data as soon as it's reachable.
-		logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
-		fallback := make(map[int64]string, len(defaultDrpcNetworkNames))
-		for chainID, name := range defaultDrpcNetworkNames {
-			fallback[chainID] = name
-		}
-		v.remoteData[networksURL] = fallback
-		return nil
+		return err
 	}
 
 	v.remoteData[networksURL] = newData

--- a/thirdparty/drpc.go
+++ b/thirdparty/drpc.go
@@ -222,6 +222,10 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		chainsURL = drpcNetworksURL
 	}
 
+	if err = validateChainsURL(chainsURL); err != nil {
+		return false, err
+	}
+
 	recheckInterval, ok := settings["recheckInterval"].(time.Duration)
 	if !ok {
 		recheckInterval = DefaultDrpcRecheckInterval
@@ -264,6 +268,10 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 		chainsURL, ok := settings["chainsUrl"].(string)
 		if !ok || chainsURL == "" {
 			chainsURL = drpcNetworksURL
+		}
+
+		if err := validateChainsURL(chainsURL); err != nil {
+			return nil, err
 		}
 
 		recheckInterval, ok := settings["recheckInterval"].(time.Duration)

--- a/thirdparty/drpc.go
+++ b/thirdparty/drpc.go
@@ -217,9 +217,9 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		return false, err
 	}
 
-	networksURL, ok := settings["chainsUrl"].(string)
-	if !ok || networksURL == "" {
-		networksURL = drpcNetworksURL
+	chainsURL, ok := settings["chainsUrl"].(string)
+	if !ok || chainsURL == "" {
+		chainsURL = drpcNetworksURL
 	}
 
 	recheckInterval, ok := settings["recheckInterval"].(time.Duration)
@@ -227,13 +227,13 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		recheckInterval = DefaultDrpcRecheckInterval
 	}
 
-	if err = v.ensureRemoteData(ctx, logger, recheckInterval, networksURL); err != nil {
+	if err = v.ensureRemoteData(ctx, logger, recheckInterval, chainsURL); err != nil {
 		logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
 		_, exists := defaultDrpcNetworkNames[chainID]
 		return exists, nil
 	}
 
-	networks, ok := v.remoteData[networksURL]
+	networks, ok := v.remoteData[chainsURL]
 	if !ok || networks == nil {
 		return false, nil
 	}
@@ -261,9 +261,9 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 			return nil, fmt.Errorf("drpc vendor requires upstream.evm.chainId to be defined")
 		}
 
-		networksURL, ok := settings["chainsUrl"].(string)
-		if !ok || networksURL == "" {
-			networksURL = drpcNetworksURL
+		chainsURL, ok := settings["chainsUrl"].(string)
+		if !ok || chainsURL == "" {
+			chainsURL = drpcNetworksURL
 		}
 
 		recheckInterval, ok := settings["recheckInterval"].(time.Duration)
@@ -272,11 +272,11 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 		}
 
 		var networks map[int64]string
-		if err := v.ensureRemoteData(ctx, logger, recheckInterval, networksURL); err != nil {
+		if err := v.ensureRemoteData(ctx, logger, recheckInterval, chainsURL); err != nil {
 			logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
 			networks = defaultDrpcNetworkNames
 		} else {
-			networks = v.remoteData[networksURL]
+			networks = v.remoteData[chainsURL]
 		}
 
 		netName, ok := networks[chainID]
@@ -352,29 +352,29 @@ func (v *DrpcVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
 	return strings.Contains(ups.Endpoint, ".drpc.org")
 }
 
-func (v *DrpcVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration, networksURL string) error {
+func (v *DrpcVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration, chainsURL string) error {
 	v.remoteDataLock.Lock()
 	defer v.remoteDataLock.Unlock()
 
-	if ltm, ok := v.remoteDataLastFetchedAt[networksURL]; ok && time.Since(ltm) < recheckInterval {
+	if ltm, ok := v.remoteDataLastFetchedAt[chainsURL]; ok && time.Since(ltm) < recheckInterval {
 		return nil
 	}
 
-	newData, err := v.fetchDrpcNetworks(ctx, logger, networksURL)
+	newData, err := v.fetchDrpcNetworks(ctx, logger, chainsURL)
 	if err != nil {
-		if _, ok := v.remoteData[networksURL]; ok {
+		if _, ok := v.remoteData[chainsURL]; ok {
 			logger.Warn().Err(err).Msg("could not refresh dRPC networks data; will use stale data")
 			return nil
 		}
 		return err
 	}
 
-	v.remoteData[networksURL] = newData
-	v.remoteDataLastFetchedAt[networksURL] = time.Now()
+	v.remoteData[chainsURL] = newData
+	v.remoteDataLastFetchedAt[chainsURL] = time.Now()
 	return nil
 }
 
-func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logger, networksURL string) (map[int64]string, error) {
+func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logger, chainsURL string) (map[int64]string, error) {
 	var httpClient = &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -386,7 +386,7 @@ func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logg
 
 	rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(rctx, "GET", networksURL, nil)
+	req, err := http.NewRequestWithContext(rctx, "GET", chainsURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logg
 		logger.Trace().Int64("chain_id", cid).Str("name", c.name).Int("priority", c.priority).Msg("selected dRPC network name")
 	}
 
-	logger.Info().Int("count", len(networkNames)).Str("url", networksURL).Msg("successfully fetched dRPC network names")
+	logger.Info().Int("count", len(networkNames)).Str("url", chainsURL).Msg("successfully fetched dRPC network names")
 
 	return networkNames, nil
 }

--- a/thirdparty/drpc.go
+++ b/thirdparty/drpc.go
@@ -2,8 +2,8 @@ package thirdparty
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -13,28 +13,179 @@ import (
 
 	"github.com/erpc/erpc/common"
 	"github.com/rs/zerolog"
-	"gopkg.in/yaml.v3"
 )
 
-const DefaultDrpcChainsYAMLURL = "https://raw.githubusercontent.com/drpcorg/public/main/chains.yaml"
+// defaultDrpcNetworkNames is a built-in snapshot of chain ID → dRPC network
+// name used as a cold-start fallback when the remote API is unreachable.
+var defaultDrpcNetworkNames = map[int64]string{
+	1:          "ethereum",
+	10:         "optimism",
+	25:         "cronos",
+	30:         "rootstock",
+	31:         "rootstock-testnet",
+	40:         "telos",
+	56:         "bsc",
+	88:         "viction",
+	89:         "viction-testnet",
+	97:         "bsc-testnet",
+	100:        "gnosis",
+	109:        "shibarium",
+	122:        "fuse",
+	130:        "unichain",
+	133:        "hashkey-testnet",
+	137:        "polygon",
+	143:        "monad-mainnet",
+	146:        "sonic",
+	169:        "manta-pacific",
+	177:        "hashkey",
+	196:        "xlayer",
+	199:        "bittorrent",
+	204:        "opbnb",
+	232:        "lens",
+	239:        "tac",
+	240:        "cronos-zkevm-testnet",
+	250:        "fantom",
+	252:        "fraxtal",
+	255:        "kroma",
+	288:        "boba-eth",
+	291:        "orderly",
+	300:        "zksync-sepolia",
+	314:        "filecoin",
+	324:        "zksync",
+	338:        "cronos-testnet",
+	388:        "cronos-zkevm",
+	480:        "worldchain",
+	919:        "mode-testnet",
+	945:        "bittensor-testnet",
+	964:        "bittensor",
+	998:        "hyperliquid-testnet",
+	999:        "hyperliquid",
+	1088:       "metis",
+	1100:       "dymension",
+	1101:       "polygon-zkevm",
+	1111:       "wemix",
+	1112:       "wemix-testnet",
+	1114:       "core-testnet",
+	1116:       "core",
+	1135:       "lisk",
+	1284:       "moonbeam",
+	1285:       "moonriver",
+	1301:       "unichain-sepolia",
+	1315:       "story-aeneid-testnet",
+	1328:       "sei-testnet",
+	1329:       "sei",
+	1750:       "metall2",
+	1868:       "soneium",
+	1923:       "swell",
+	1924:       "swell-testnet",
+	1946:       "soneium-minato",
+	1952:       "xlayer-testnet",
+	2020:       "ronin",
+	2222:       "kava",
+	2288:       "moca",
+	2345:       "goat-mainnet-alpha",
+	2442:       "polygon-zkevm-cardona",
+	2523:       "fraxtal-testnet",
+	2741:       "abstract",
+	2818:       "morph",
+	4002:       "fantom-testnet",
+	4200:       "merlin",
+	4202:       "lisk-sepolia",
+	4217:       "tempo-mainnet",
+	4326:       "megaeth",
+	5000:       "mantle",
+	5003:       "mantle-sepolia",
+	5330:       "superseed",
+	7000:       "zeta-chain",
+	7001:       "zeta-chain-testnet",
+	8217:       "klaytn",
+	8453:       "base",
+	9745:       "plasma",
+	10143:      "monad-testnet",
+	10200:      "gnosis-chiado",
+	11124:      "abstract-sepolia",
+	11235:      "haqq",
+	13371:      "immutable-zkevm",
+	13473:      "immutable-zkevm-testnet",
+	14601:      "sonic-testnet-v2",
+	16602:      "0g-galileo-testnet",
+	16661:      "0g-mainnet",
+	17000:      "holesky",
+	25327:      "everclear",
+	31611:      "mezo-testnet",
+	31612:      "mezo",
+	33111:      "apechain-curtis",
+	33139:      "apechain",
+	34443:      "mode",
+	36888:      "abcore",
+	37111:      "lens-testnet",
+	42161:      "arbitrum",
+	42170:      "arbitrum-nova",
+	42220:      "celo",
+	42431:      "tempo-moderato-testnet",
+	43111:      "hemi",
+	43113:      "avalanche-fuji",
+	43114:      "avalanche",
+	44787:      "celo-alfajores",
+	46630:      "robinhood-testnet",
+	48898:      "zircuit-garfield-testnet",
+	48900:      "zircuit-mainnet",
+	53302:      "superseed-sepolia",
+	57073:      "ink",
+	59141:      "linea-sepolia",
+	59144:      "linea",
+	60808:      "bob",
+	80002:      "polygon-amoy",
+	80069:      "berachain-bepolia",
+	80094:      "berachain",
+	81457:      "blast",
+	84532:      "base-sepolia",
+	97476:      "doma-testnet",
+	97477:      "doma",
+	98866:      "plume",
+	102030:     "creditcoin",
+	102031:     "creditcoin-testnet",
+	167000:     "taiko",
+	167013:     "taiko-hoodi",
+	202601:     "ronin-saigon",
+	314159:     "filecoin-calibration",
+	421614:     "arbitrum-sepolia",
+	534351:     "scroll-sepolia",
+	534352:     "scroll",
+	543210:     "zero",
+	560048:     "hoodi",
+	737373:     "katana-testnet",
+	743111:     "hemi-testnet",
+	747474:     "katana",
+	763373:     "ink-sepolia",
+	808813:     "bob-testnet",
+	1440000:    "xrpl",
+	5042002:    "arc-testnet",
+	6281971:    "dogeos-testnet",
+	7777777:    "zora",
+	11142220:   "celo-sepolia",
+	11155111:   "sepolia",
+	11155420:   "optimism-sepolia",
+	728126428:  "tron",
+	1666600000: "harmony-0",
+}
+
+// drpcNetworksURL is a var (not const) so tests can point it at a mock server.
+var drpcNetworksURL = "https://lb.drpc.org/networks"
+
 const DefaultDrpcRecheckInterval = 24 * time.Hour
 
-type ChainConfig struct {
-	ChainID    string   `yaml:"chain-id"`
-	ShortNames []string `yaml:"short-names"`
-	Priority   int      `yaml:"priority"`
-}
-
-type ProtocolConfig struct {
-	ID     string        `yaml:"id"`
-	Type   string        `yaml:"type"`
-	Chains []ChainConfig `yaml:"chains"`
-}
-
-type ChainsYAML struct {
-	ChainSettings struct {
-		Protocols []ProtocolConfig `yaml:"protocols"`
-	} `yaml:"chain-settings"`
+type drpcNetworksResponse []struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Chains []struct {
+		Name           string `json:"name"`
+		ChainID        string `json:"chain_id"`
+		Priority       int    `json:"priority"`
+		APIType        string `json:"api_type"`
+		BlockchainType string `json:"blockchain_type"`
+		HasPremium     bool   `json:"has_premium"`
+	} `json:"chains"`
 }
 
 type DrpcVendor struct {
@@ -66,9 +217,9 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		return false, err
 	}
 
-	chainsURL, ok := settings["chainsUrl"].(string)
-	if !ok || chainsURL == "" {
-		chainsURL = DefaultDrpcChainsYAMLURL
+	networksURL, ok := settings["chainsUrl"].(string)
+	if !ok || networksURL == "" {
+		networksURL = drpcNetworksURL
 	}
 
 	recheckInterval, ok := settings["recheckInterval"].(time.Duration)
@@ -76,12 +227,12 @@ func (v *DrpcVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger
 		recheckInterval = DefaultDrpcRecheckInterval
 	}
 
-	err = v.ensureRemoteData(ctx, logger, recheckInterval, chainsURL)
+	err = v.ensureRemoteData(ctx, logger, recheckInterval, networksURL)
 	if err != nil {
 		return false, fmt.Errorf("unable to load remote data: %w", err)
 	}
 
-	networks, ok := v.remoteData[chainsURL]
+	networks, ok := v.remoteData[networksURL]
 	if !ok || networks == nil {
 		return false, nil
 	}
@@ -109,9 +260,9 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 			return nil, fmt.Errorf("drpc vendor requires upstream.evm.chainId to be defined")
 		}
 
-		chainsURL, ok := settings["chainsUrl"].(string)
-		if !ok || chainsURL == "" {
-			chainsURL = DefaultDrpcChainsYAMLURL
+		networksURL, ok := settings["chainsUrl"].(string)
+		if !ok || networksURL == "" {
+			networksURL = drpcNetworksURL
 		}
 
 		recheckInterval, ok := settings["recheckInterval"].(time.Duration)
@@ -119,11 +270,11 @@ func (v *DrpcVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger
 			recheckInterval = DefaultDrpcRecheckInterval
 		}
 
-		if err := v.ensureRemoteData(ctx, logger, recheckInterval, chainsURL); err != nil {
+		if err := v.ensureRemoteData(ctx, logger, recheckInterval, networksURL); err != nil {
 			return nil, fmt.Errorf("unable to load remote data: %w", err)
 		}
 
-		networks, ok := v.remoteData[chainsURL]
+		networks, ok := v.remoteData[networksURL]
 		if !ok || networks == nil {
 			return nil, fmt.Errorf("network data not available")
 		}
@@ -201,37 +352,39 @@ func (v *DrpcVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
 	return strings.Contains(ups.Endpoint, ".drpc.org")
 }
 
-func (v *DrpcVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration, chainsURL string) error {
+func (v *DrpcVendor) ensureRemoteData(ctx context.Context, logger *zerolog.Logger, recheckInterval time.Duration, networksURL string) error {
 	v.remoteDataLock.Lock()
 	defer v.remoteDataLock.Unlock()
 
-	if ltm, ok := v.remoteDataLastFetchedAt[chainsURL]; ok && time.Since(ltm) < recheckInterval {
+	if ltm, ok := v.remoteDataLastFetchedAt[networksURL]; ok && time.Since(ltm) < recheckInterval {
 		return nil
 	}
 
-	newData, err := v.fetchDrpcNetworks(ctx, logger, chainsURL)
+	newData, err := v.fetchDrpcNetworks(ctx, logger, networksURL)
 	if err != nil {
-		if _, ok := v.remoteData[chainsURL]; ok {
-			logger.Warn().Err(err).Msg("could not refresh DRPC chains data; will use stale data")
+		if _, ok := v.remoteData[networksURL]; ok {
+			logger.Warn().Err(err).Msg("could not refresh dRPC networks data; will use stale data")
 			return nil
 		}
-		return err
+		// Cold start: the dRPC API is unreachable and we have no cached data.
+		// Seed from the built-in static network map so known chains still work.
+		// Intentionally do not stamp remoteDataLastFetchedAt — the next call will
+		// retry the API and promote real data as soon as it's reachable.
+		logger.Warn().Err(err).Msg("could not fetch dRPC networks data on cold start, falling back to built-in network map")
+		fallback := make(map[int64]string, len(defaultDrpcNetworkNames))
+		for chainID, name := range defaultDrpcNetworkNames {
+			fallback[chainID] = name
+		}
+		v.remoteData[networksURL] = fallback
+		return nil
 	}
 
-	v.remoteData[chainsURL] = newData
-	v.remoteDataLastFetchedAt[chainsURL] = time.Now()
+	v.remoteData[networksURL] = newData
+	v.remoteDataLastFetchedAt[networksURL] = time.Now()
 	return nil
 }
 
-func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logger, chainsURL string) (map[int64]string, error) {
-	rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(rctx, "GET", chainsURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
+func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logger, networksURL string) (map[int64]string, error) {
 	var httpClient = &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -241,58 +394,45 @@ func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logg
 		},
 	}
 
+	rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(rctx, "GET", networksURL, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("DRPC chains API returned non-200 code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("dRPC networks API returned non-200 code: %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	var networks drpcNetworksResponse
+	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+		return nil, fmt.Errorf("failed to parse dRPC networks response: %w", err)
 	}
 
-	var chainsData ChainsYAML
-	if err := yaml.Unmarshal(body, &chainsData); err != nil {
-		return nil, fmt.Errorf("failed to parse DRPC chains YAML: %w", err)
-	}
-
-	// Prefer highest-priority chain per chainId, and only consider EVM networks (type == "eth").
+	// Prefer highest-priority chain per chainId; only include EVM jsonrpc networks.
 	type candidate struct {
 		name     string
 		priority int
 	}
 	best := make(map[int64]candidate)
-	for _, protocol := range chainsData.ChainSettings.Protocols {
-		ptype := strings.ToLower(strings.TrimSpace(protocol.Type))
-		if ptype != "" && ptype != "eth" {
-			continue
-		}
-		for _, chain := range protocol.Chains {
-			// Parse chain-id from hex to int64 (some entries may not have 0x prefix)
-			chainIDStr := strings.TrimPrefix(chain.ChainID, "0x")
-			if chainIDStr == "" {
+	for _, network := range networks {
+		for _, chain := range network.Chains {
+			if chain.BlockchainType != "eth" || chain.APIType != "jsonrpc" || chain.ChainID == "" || !chain.HasPremium {
 				continue
 			}
+			chainIDStr := strings.TrimPrefix(chain.ChainID, "0x")
 			chainID, err := strconv.ParseInt(chainIDStr, 16, 64)
 			if err != nil {
-				logger.Debug().
-					Str("chain_id", chain.ChainID).
-					Err(err).
-					Msg("Failed to parse chain ID")
+				logger.Debug().Str("chain_id", chain.ChainID).Err(err).Msg("failed to parse dRPC chain ID")
 				continue
 			}
-			if len(chain.ShortNames) == 0 {
-				continue
-			}
-			name := chain.ShortNames[0]
-			prio := chain.Priority
-			if cur, ok := best[chainID]; !ok || prio > cur.priority {
-				best[chainID] = candidate{name: name, priority: prio}
+			if cur, ok := best[chainID]; !ok || chain.Priority > cur.priority {
+				best[chainID] = candidate{name: chain.Name, priority: chain.Priority}
 			}
 		}
 	}
@@ -300,17 +440,10 @@ func (v *DrpcVendor) fetchDrpcNetworks(ctx context.Context, logger *zerolog.Logg
 	networkNames := make(map[int64]string, len(best))
 	for cid, c := range best {
 		networkNames[cid] = c.name
-		logger.Trace().
-			Int64("chain_id", cid).
-			Str("name", c.name).
-			Int("priority", c.priority).
-			Msg("selected DRPC network name")
+		logger.Trace().Int64("chain_id", cid).Str("name", c.name).Int("priority", c.priority).Msg("selected dRPC network name")
 	}
 
-	logger.Info().
-		Int("count", len(networkNames)).
-		Str("url", chainsURL).
-		Msg("successfully fetched DRPC network names")
+	logger.Info().Int("count", len(networkNames)).Str("url", networksURL).Msg("successfully fetched dRPC network names")
 
 	return networkNames, nil
 }

--- a/thirdparty/drpc_test.go
+++ b/thirdparty/drpc_test.go
@@ -81,6 +81,22 @@ func TestDrpcVendor_SuccessfulFetchPromotesOverFallback(t *testing.T) {
 	assert.True(t, supported, "custom chain from mocked API should be recognized")
 }
 
+func TestDrpcVendor_ChainsUrlSetting_InvalidURLReturnsError(t *testing.T) {
+	vendor := CreateDrpcVendor().(*DrpcVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	for _, badURL := range []string{"not-a-url", "ftp://host", "://missing-scheme"} {
+		settings := common.VendorSettings{
+			"chainsUrl":       badURL,
+			"recheckInterval": 24 * time.Hour,
+		}
+		_, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+		require.Errorf(t, err, "malformed chainsUrl %q should return an error", badURL)
+		assert.Contains(t, err.Error(), "invalid chainsUrl")
+	}
+}
+
 // swapDrpcNetworksURL temporarily overrides drpcNetworksURL so tests can point
 // the vendor at a mock server or a deliberately broken URL.
 // Returns the previous value so the caller can restore it.

--- a/thirdparty/drpc_test.go
+++ b/thirdparty/drpc_test.go
@@ -1,0 +1,92 @@
+package thirdparty
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrpcVendor_ColdStartFallback_SupportsNetwork(t *testing.T) {
+	prev := swapDrpcNetworksURL(t, "http://127.0.0.1:1/does-not-exist")
+	defer swapDrpcNetworksURL(t, prev)
+
+	vendor := CreateDrpcVendor().(*DrpcVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:1")
+	require.NoError(t, err, "cold-start fallback should not surface a fetch error")
+	assert.True(t, supported, "chain 1 (ethereum) is in defaultDrpcNetworkNames")
+
+	supported, err = vendor.SupportsNetwork(ctx, &logger, settings, "evm:999999999999")
+	require.NoError(t, err)
+	assert.False(t, supported)
+}
+
+func TestDrpcVendor_ColdStartFallback_GenerateConfigs(t *testing.T) {
+	prev := swapDrpcNetworksURL(t, "http://127.0.0.1:1/does-not-exist")
+	defer swapDrpcNetworksURL(t, prev)
+
+	vendor := CreateDrpcVendor()
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{
+		"apiKey":          "test-key",
+		"recheckInterval": 24 * time.Hour,
+	}
+
+	upstream := &common.UpstreamConfig{
+		Evm: &common.EvmUpstreamConfig{ChainId: 1},
+	}
+
+	configs, err := vendor.GenerateConfigs(ctx, &logger, upstream, settings)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Contains(t, configs[0].Endpoint, "lb.drpc.org")
+	assert.Contains(t, configs[0].Endpoint, "ethereum")
+	assert.Contains(t, configs[0].Endpoint, "test-key")
+}
+
+func TestDrpcVendor_SuccessfulFetchPromotesOverFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"custom","label":"Custom","chains":[{"name":"custom-net","chain_id":"0x67932","priority":100,"api_type":"jsonrpc","blockchain_type":"eth","has_premium":true}]}]`))
+	}))
+	defer server.Close()
+
+	prev := swapDrpcNetworksURL(t, server.URL)
+	defer swapDrpcNetworksURL(t, prev)
+
+	vendor := CreateDrpcVendor().(*DrpcVendor)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	settings := common.VendorSettings{"recheckInterval": 24 * time.Hour}
+
+	// 0x67932 = 424242
+	supported, err := vendor.SupportsNetwork(ctx, &logger, settings, "evm:424242")
+	require.NoError(t, err)
+	assert.True(t, supported, "custom chain from mocked API should be recognized")
+}
+
+// swapDrpcNetworksURL temporarily overrides drpcNetworksURL so tests can point
+// the vendor at a mock server or a deliberately broken URL.
+// Returns the previous value so the caller can restore it.
+func swapDrpcNetworksURL(t *testing.T, newURL string) string {
+	t.Helper()
+	prev := drpcNetworksURL
+	drpcNetworksURL = newURL
+	return prev
+}

--- a/thirdparty/vendor_utils.go
+++ b/thirdparty/vendor_utils.go
@@ -1,0 +1,23 @@
+package thirdparty
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// validateChainsURL returns a non-nil error if rawURL is structurally invalid
+// (bad scheme, empty host). A reachable-but-failing URL is a network error,
+// not a config error, and is handled separately by the cold-start fallback.
+func validateChainsURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid chainsUrl %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid chainsUrl %q: scheme must be http or https", rawURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid chainsUrl %q: host is empty", rawURL)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

dRPC now publishes a REST JSON endpoint (\`https://lb.drpc.org/networks\`) that
supersedes the previous GitHub-hosted \`chains.yaml\` file. This PR migrates
network discovery to the new endpoint and restricts it to premium-only chains.
A built-in static map seeds known chains when the endpoint is unreachable at
startup.

## Changes

- **New networks endpoint**: fetch from \`https://lb.drpc.org/networks\` (JSON)
  instead of the GitHub-hosted YAML; drop the \`gopkg.in/yaml.v3\` dependency
- **Premium filter**: only chains with \`has_premium: true\` are included (149 chains)
- **Cold-start fallback**: on first fetch failure, seed from a built-in snapshot
  of 149 EVM chains so known chains still work.
  \`remoteDataLastFetchedAt\` is intentionally left unset so the next call
  retries the live API
- **Testability**: \`drpcNetworksURL\` changed from \`const\` to \`var\` so tests
  can point it at a mock server
- **Tests**: \`drpc_test.go\` covering cold-start fallback and live-fetch promotion

## Testing

- \`TestDrpcVendor_ColdStartFallback_SupportsNetwork\` — endpoint unreachable;
  confirms known chain works via static map, unknown chain does not
- \`TestDrpcVendor_ColdStartFallback_GenerateConfigs\` — confirms a usable
  endpoint is generated without the API
- \`TestDrpcVendor_SuccessfulFetchPromotesOverFallback\` — live data from mock
  server is accepted
- All 149 static endpoints verified live with \`eth_chainId\` (149/149 pass)