### PR TITLE
fix: synchronize BaseError.Details to prevent consensus panic on concurrent access

### DIFF
--- a/architecture/evm/eth_sendRawTransaction.go
+++ b/architecture/evm/eth_sendRawTransaction.go
@@ -59,8 +59,8 @@ func upstreamPostForward_eth_sendRawTransaction(
 	}
 
 	reason := common.NonceExceptionReason("")
-	if nonceErr.Details != nil {
-		if r, ok := nonceErr.Details["nonceExceptionReason"].(string); ok {
+	if v, ok := nonceErr.GetDetail("nonceExceptionReason"); ok {
+		if r, ok := v.(string); ok {
 			reason = common.NonceExceptionReason(r)
 		}
 	}

--- a/common/errors.go
+++ b/common/errors.go
@@ -188,6 +188,24 @@ type BaseError struct {
 	Message string                 `json:"message,omitempty"`
 	Cause   error                  `json:"cause,omitempty"`
 	Details map[string]interface{} `json:"details,omitempty"`
+
+	// detailsMu guards reads and writes of Details after construction. Errors
+	// flow between goroutines via consensus / failsafe paths: one goroutine
+	// may iterate Details (e.g. fmt formatting → SonicCfg.Marshal) while another
+	// appends keys (e.g. failsafe.TranslateFailsafeError, WithRetryableTowardNetwork).
+	// Without this lock, sonic's map iterator races with the late writers and
+	// triggers the runtime's `concurrent map iteration and map write` fatal.
+	detailsMu sync.RWMutex `json:"-"`
+}
+
+// baseErrorJSON mirrors BaseError's exported fields for JSON serialization
+// without the embedded mutex — converting BaseError to a type-aliased value
+// for marshaling would otherwise copy the lock and trip `go vet`.
+type baseErrorJSON struct {
+	Code    ErrorCode              `json:"code,omitempty"`
+	Message string                 `json:"message,omitempty"`
+	Cause   error                  `json:"cause,omitempty"`
+	Details map[string]interface{} `json:"details,omitempty"`
 }
 
 type StandardError interface {
@@ -208,12 +226,58 @@ type RetryableError interface {
 
 func (e *BaseError) WithRetryableTowardNetwork(r bool) RetryableError {
 	if e != nil {
-		if e.Details == nil {
-			e.Details = map[string]interface{}{}
-		}
-		e.Details["retryableTowardNetwork"] = r
+		e.SetDetail("retryableTowardNetwork", r)
 	}
 	return e
+}
+
+// SetDetail safely writes a key into Details, allocating the map on first use.
+// Use this instead of direct map indexing on any BaseError that may be visible
+// to other goroutines (i.e. anything past the original construction site).
+func (e *BaseError) SetDetail(key string, value interface{}) {
+	if e == nil {
+		return
+	}
+	e.detailsMu.Lock()
+	if e.Details == nil {
+		e.Details = make(map[string]interface{})
+	}
+	e.Details[key] = value
+	e.detailsMu.Unlock()
+}
+
+// GetDetail safely reads a key from Details. The second return is false when
+// the map is nil or the key is absent.
+func (e *BaseError) GetDetail(key string) (interface{}, bool) {
+	if e == nil {
+		return nil, false
+	}
+	e.detailsMu.RLock()
+	defer e.detailsMu.RUnlock()
+	if e.Details == nil {
+		return nil, false
+	}
+	v, ok := e.Details[key]
+	return v, ok
+}
+
+// snapshotDetails returns a defensive shallow copy of Details, taken under
+// RLock so callers can iterate or marshal the result without coordinating
+// with concurrent writers. Returns nil when Details is empty.
+func (e *BaseError) snapshotDetails() map[string]interface{} {
+	if e == nil {
+		return nil
+	}
+	e.detailsMu.RLock()
+	defer e.detailsMu.RUnlock()
+	if len(e.Details) == 0 {
+		return nil
+	}
+	out := make(map[string]interface{}, len(e.Details))
+	for k, v := range e.Details {
+		out[k] = v
+	}
+	return out
 }
 
 func (e *BaseError) GetCode() ErrorCode {
@@ -227,12 +291,15 @@ func (e *BaseError) Unwrap() error {
 func (e *BaseError) Error() string {
 	var detailsStr string
 
-	if len(e.Details) > 0 {
-		s, er := SonicCfg.Marshal(e.Details)
+	// Snapshot Details under RLock so sonic's iterator can't observe a
+	// concurrent write from another goroutine (the consensus tracker calls
+	// fmt.Sprintf("%v", err) while the failsafe stack appends method/upstreamId).
+	if snap := e.snapshotDetails(); len(snap) > 0 {
+		s, er := SonicCfg.Marshal(snap)
 		if er == nil {
 			detailsStr = fmt.Sprintf("(%s)", s)
 		} else {
-			detailsStr = fmt.Sprintf("(%v)", e.Details)
+			detailsStr = fmt.Sprintf("(%v)", snap)
 		}
 	}
 
@@ -272,10 +339,8 @@ func (e *BaseError) DeepestMessage() string {
 	return e.Message
 }
 func (e *BaseError) DeepSearch(key string) interface{} {
-	if e.Details != nil {
-		if v, ok := e.Details[key]; ok {
-			return v
-		}
+	if v, ok := e.GetDetail(key); ok {
+		return v
 	}
 	if e.Cause != nil {
 		if be, ok := e.Cause.(StandardError); ok {
@@ -299,17 +364,27 @@ func (e *BaseError) GetCause() error {
 	return e.Cause
 }
 
-func (e BaseError) MarshalJSON() ([]byte, error) {
-	type Alias BaseError
+// toJSONShape collects BaseError's exported fields into a lock-free shape
+// suitable for embedding in marshalable structs. Details is snapshot-copied
+// under RLock so the returned map is owned by the caller.
+func (e *BaseError) toJSONShape() baseErrorJSON {
+	return baseErrorJSON{
+		Code:    e.Code,
+		Message: e.Message,
+		Cause:   e.Cause,
+		Details: e.snapshotDetails(),
+	}
+}
 
+func (e *BaseError) MarshalJSON() ([]byte, error) {
 	if e.Code == "" || e.Code == "ErrUnknown" || e.Code == "ErrGeneric" {
 		if e.Cause != nil {
 			return SonicCfg.Marshal(&struct {
-				Alias
+				baseErrorJSON
 				Cause interface{} `json:"cause"`
 			}{
-				Alias: (Alias)(e),
-				Cause: e.Cause.Error(),
+				baseErrorJSON: e.toJSONShape(),
+				Cause:         e.Cause.Error(),
 			})
 		}
 		return SonicCfg.Marshal(e.Message)
@@ -327,27 +402,27 @@ func (e BaseError) MarshalJSON() ([]byte, error) {
 			}
 		}
 		return SonicCfg.Marshal(&struct {
-			Alias
+			baseErrorJSON
 			Cause []interface{} `json:"cause"`
 		}{
-			Alias: (Alias)(e),
-			Cause: causes,
+			baseErrorJSON: e.toJSONShape(),
+			Cause:         causes,
 		})
 	} else if cs, ok := cause.(StandardError); ok {
 		return SonicCfg.Marshal(&struct {
-			Alias
+			baseErrorJSON
 			Cause StandardError `json:"cause"`
 		}{
-			Alias: (Alias)(e),
-			Cause: cs,
+			baseErrorJSON: e.toJSONShape(),
+			Cause:         cs,
 		})
 	} else if cause != nil {
 		return SonicCfg.Marshal(&struct {
-			Alias
-			Cause BaseError `json:"cause"`
+			baseErrorJSON
+			Cause baseErrorJSON `json:"cause"`
 		}{
-			Alias: (Alias)(e),
-			Cause: BaseError{
+			baseErrorJSON: e.toJSONShape(),
+			Cause: baseErrorJSON{
 				Code:    "ErrGeneric",
 				Message: cause.Error(),
 			},
@@ -355,10 +430,10 @@ func (e BaseError) MarshalJSON() ([]byte, error) {
 	}
 
 	return SonicCfg.Marshal(&struct {
-		Alias
+		baseErrorJSON
 		Cause interface{} `json:"-"`
 	}{
-		Alias: (Alias)(e),
+		baseErrorJSON: e.toJSONShape(),
 	})
 }
 
@@ -406,8 +481,10 @@ func (e *BaseError) MarshalZerologObject(v *zerolog.Event) {
 			v.Str("cause", e.Cause.Error())
 		}
 	}
-	if e.Details != nil {
-		v.Interface("details", e.Details)
+	if snap := e.snapshotDetails(); snap != nil {
+		// zerolog defers field marshaling, so we hand it our owned snapshot
+		// rather than the live map another goroutine may still be writing to.
+		v.Interface("details", snap)
 	}
 }
 
@@ -811,11 +888,10 @@ func (e *ErrUpstreamRequest) IsObjectNull() bool {
 }
 
 func (e *ErrUpstreamRequest) UpstreamId() string {
-	if e.Details == nil {
-		return ""
-	}
-	if upstreamId, ok := e.Details["upstreamId"].(string); ok {
-		return upstreamId
+	if v, ok := e.GetDetail("upstreamId"); ok {
+		if upstreamId, ok := v.(string); ok {
+			return upstreamId
+		}
 	}
 	return ""
 }
@@ -825,31 +901,28 @@ func (e *ErrUpstreamRequest) FromCache() bool {
 }
 
 func (e *ErrUpstreamRequest) Attempts() int {
-	if e.Details == nil {
-		return 0
-	}
-	if attempts, ok := e.Details["attempts"].(int); ok {
-		return attempts
+	if v, ok := e.GetDetail("attempts"); ok {
+		if attempts, ok := v.(int); ok {
+			return attempts
+		}
 	}
 	return 0
 }
 
 func (e *ErrUpstreamRequest) Retries() int {
-	if e.Details == nil {
-		return 0
-	}
-	if retries, ok := e.Details["retries"].(int); ok {
-		return retries
+	if v, ok := e.GetDetail("retries"); ok {
+		if retries, ok := v.(int); ok {
+			return retries
+		}
 	}
 	return 0
 }
 
 func (e *ErrUpstreamRequest) Hedges() int {
-	if e.Details == nil {
-		return 0
-	}
-	if hedges, ok := e.Details["hedges"].(int); ok {
-		return hedges
+	if v, ok := e.GetDetail("hedges"); ok {
+		if hedges, ok := v.(int); ok {
+			return hedges
+		}
 	}
 	return 0
 }
@@ -1174,31 +1247,28 @@ func (e *ErrUpstreamsExhausted) FromCache() bool {
 }
 
 func (e *ErrUpstreamsExhausted) Attempts() int {
-	if e.Details == nil {
-		return 0
-	}
-	if attempts, ok := e.Details["attempts"].(int); ok {
-		return attempts
+	if v, ok := e.GetDetail("attempts"); ok {
+		if attempts, ok := v.(int); ok {
+			return attempts
+		}
 	}
 	return 0
 }
 
 func (e *ErrUpstreamsExhausted) Retries() int {
-	if e.Details == nil {
-		return 0
-	}
-	if retries, ok := e.Details["retries"].(int); ok {
-		return retries
+	if v, ok := e.GetDetail("retries"); ok {
+		if retries, ok := v.(int); ok {
+			return retries
+		}
 	}
 	return 0
 }
 
 func (e *ErrUpstreamsExhausted) Hedges() int {
-	if e.Details == nil {
-		return 0
-	}
-	if hedges, ok := e.Details["hedges"].(int); ok {
-		return hedges
+	if v, ok := e.GetDetail("hedges"); ok {
+		if hedges, ok := v.(int); ok {
+			return hedges
+		}
 	}
 	return 0
 }
@@ -1577,12 +1647,8 @@ var NewErrJsonRpcRequestPreparation = func(cause error, details map[string]inter
 		},
 	}
 
-	if err.Details == nil {
-		err.Details = make(map[string]interface{})
-	}
-
-	if _, ok := err.Details["retryableTowardNetwork"]; !ok {
-		err.Details["retryableTowardNetwork"] = false
+	if _, ok := err.GetDetail("retryableTowardNetwork"); !ok {
+		err.SetDetail("retryableTowardNetwork", false)
 	}
 
 	return err
@@ -2226,14 +2292,14 @@ func (e *ErrJsonRpcExceptionInternal) CodeChain() string {
 }
 
 func (e *ErrJsonRpcExceptionInternal) NormalizedCode() JsonRpcErrorNumber {
-	if code, ok := e.Details["normalizedCode"]; ok {
+	if code, ok := e.GetDetail("normalizedCode"); ok {
 		return code.(JsonRpcErrorNumber)
 	}
 	return 0
 }
 
 func (e *ErrJsonRpcExceptionInternal) OriginalCode() int {
-	if code, ok := e.Details["originalCode"]; ok {
+	if code, ok := e.GetDetail("originalCode"); ok {
 		if ic, ok := code.(int); ok {
 			return ic
 		} else if fc, ok := code.(float64); ok {
@@ -2442,9 +2508,11 @@ func IsRetryableTowardNetwork(err error) bool {
 		if !ok {
 			break
 		}
-		if base := cse.Base(); base != nil && base.Details != nil {
-			if rt, ok := base.Details["retryableTowardNetwork"].(bool); ok && !rt {
-				return false
+		if base := cse.Base(); base != nil {
+			if v, ok := base.GetDetail("retryableTowardNetwork"); ok {
+				if rt, ok := v.(bool); ok && !rt {
+					return false
+				}
 			}
 		}
 		next := cse.GetCause()
@@ -2649,10 +2717,11 @@ func (e *ErrConsensusLowParticipants) DeepestMessage() string {
 }
 
 func (e *ErrConsensusLowParticipants) SummarizeParticipants() string {
-	if e.Details == nil {
+	v, ok := e.GetDetail("participants")
+	if !ok {
 		return ""
 	}
-	participants, ok := e.Details["participants"].([]ParticipantInfo)
+	participants, ok := v.([]ParticipantInfo)
 	if !ok {
 		return ""
 	}

--- a/common/errors_concurrency_test.go
+++ b/common/errors_concurrency_test.go
@@ -1,0 +1,104 @@
+package common
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestBaseError_DetailsConcurrentReadWriteUnderRace reproduces the
+// `concurrent map iteration and map write` fatal that crashed eRPC when
+// consensus.runAnalyzer formatted an error via fmt.Sprintf("%v", err)
+// while the caller's failsafe stack was still appending method/upstreamId
+// to the same *BaseError's Details map.
+//
+// Run with `-race`: the detector fires on the first unsynchronized access,
+// long before the runtime would otherwise panic. The test passes only when
+// every read/write of Details is locked.
+func TestBaseError_DetailsConcurrentReadWriteUnderRace(t *testing.T) {
+	e := &BaseError{
+		Code:    "ErrTest",
+		Message: "races against late detail writes",
+		Details: map[string]interface{}{"seed": "value"},
+	}
+
+	const duration = 100 * time.Millisecond
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Reader: matches consensus.trackAndPunishMisbehavingUpstreams' fmt.Sprintf path.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = e.Error()
+			}
+		}
+	}()
+
+	// Reader: matches MarshalJSON path (used by zerolog and HTTP responses).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = json.Marshal(e)
+			}
+		}
+	}()
+
+	// Reader: matches DeepSearch / GetDetail call sites.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = e.DeepSearch("upstreamId")
+			}
+		}
+	}()
+
+	// Writer: matches failsafe.TranslateFailsafeError appending late context.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				e.SetDetail("upstreamId", "u1")
+				e.SetDetail("method", "eth_call")
+			}
+		}
+	}()
+
+	// Writer: matches the error normalizer's WithRetryableTowardNetwork classification.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				e.WithRetryableTowardNetwork(i%2 == 0)
+			}
+		}
+	}()
+
+	time.Sleep(duration)
+	close(stop)
+	wg.Wait()
+}

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1310,8 +1310,8 @@ func buildErrorResponseBody(nq *common.NormalizedRequest, err, origErr error, in
 			"message": message,
 		}
 		// Append "data" field, ref: https://www.jsonrpc.org/specification#:~:text=A%20Primitive%20or%20Structured%20value%20that%20contains%20additional%20information%20about%20the%20error.
-		if jre.Details["data"] != nil {
-			errObj["data"] = jre.Details["data"]
+		if data, ok := jre.GetDetail("data"); ok && data != nil {
+			errObj["data"] = data
 		} else if includeErrorDetails != nil && *includeErrorDetails {
 			if method != "eth_call" {
 				// For eth_calls clients expect "data" to be string for revert reason.

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -964,21 +964,16 @@ func TranslateFailsafeError(scope common.Scope, upstreamId string, method string
 
 	if err != nil {
 		if ser, ok := execErr.(common.StandardError); ok {
-			be := ser.Base()
-			if be != nil {
-				var dts map[string]interface{}
-				if be.Details != nil {
-					dts = be.Details
-				} else {
-					dts = make(map[string]interface{})
-				}
+			if be := ser.Base(); be != nil {
+				// Use SetDetail so these late writes coordinate with any
+				// concurrent reader (e.g. consensus.runAnalyzer formatting
+				// the same error via fmt.Sprintf("%v", err)).
 				if method != "" {
-					dts["method"] = method
+					be.SetDetail("method", method)
 				}
 				if upstreamId != "" {
-					dts["upstreamId"] = upstreamId
+					be.SetDetail("upstreamId", upstreamId)
 				}
-				be.Details = dts
 			}
 		}
 		return err

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -639,16 +639,19 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						return nil, ctxErr
 					}
 				}
+				ourTimeoutSet := false
 				if failsafeExecutor.timeout != nil {
 					if td := failsafeExecutor.timeout(ectx, nrq); td != nil {
 						var cancelFn context.CancelFunc
 						ectx, cancelFn = context.WithTimeoutCause(ectx, *td, common.ErrDynamicTimeoutExceeded)
 						defer cancelFn()
+						ourTimeoutSet = true
 					}
 				}
 
 				nr, err := tryForward(ectx, exec)
 				if err != nil {
+					err = injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, ourTimeoutSet)
 					common.SetTraceSpanError(execSpan, err)
 					return nil, err
 				}
@@ -697,6 +700,69 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 		common.SetTraceSpanError(span, err)
 		return nil, err
 	}
+}
+
+// injectDynamicTimeoutSentinelIfDeadlinePassed welds ErrDynamicTimeoutExceeded
+// into err's cause chain when our scope's WithTimeoutCause has elapsed but a
+// race in the batched HTTP client lost the sentinel.
+//
+// Why this is needed: the batched http_json_rpc client builds its own
+// batch-deadline ctx via context.WithDeadline(c.appCtx, batchDeadline) —
+// distinct from the per-request ctx that carries
+// WithTimeoutCause(ErrDynamicTimeoutExceeded). Both contexts share the same
+// deadline, and each has its own time.AfterFunc goroutine. Under heavy
+// contention (e.g. parallel test shards or saturated runtime), batchCtx's
+// AfterFunc may fire microseconds before req.ctx's; the batch processor
+// unblocks from http.Client.Do, reads context.Cause(req.ctx), and observes
+// nil because req.ctx's cause hasn't been recorded yet. It falls back to
+// batchCause which is a bare context.DeadlineExceeded, so the inner error
+// chain loses the sentinel — and TranslateFailsafeError can't classify it
+// as ErrFailsafeTimeoutExceeded.
+//
+// Detection via context.Cause(ectx) at this layer is unreliable for the same
+// scheduling reason. The absolute deadline is a stable signal: when WE set
+// up the WithTimeoutCause and ectx.Deadline() has elapsed at the moment
+// tryForward returned, our scope's timeout is the cause regardless of which
+// goroutine recorded it first.
+//
+// Gated on:
+//   - ourTimeoutSet: this scope owns the WithTimeoutCause that may have fired
+//   - err is timeout-shaped (ErrCodeEndpointRequestTimeout or
+//     context.DeadlineExceeded); non-timeout errors are not touched
+//   - err doesn't already carry the sentinel (idempotent)
+//   - ectx's deadline has elapsed (so our timeout did fire)
+//
+// The mutation is shallow — it edits err.Base().Cause in place. Safe because
+// err is freshly returned by tryForward to a single goroutine and not yet
+// visible to any reader.
+func injectDynamicTimeoutSentinelIfDeadlinePassed(err error, ectx context.Context, ourTimeoutSet bool) error {
+	if !ourTimeoutSet || err == nil {
+		return err
+	}
+	if errors.Is(err, common.ErrDynamicTimeoutExceeded) {
+		return err
+	}
+	if !common.HasErrorCode(err, common.ErrCodeEndpointRequestTimeout) && !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	d, hasDeadline := ectx.Deadline()
+	if !hasDeadline || d.After(time.Now()) {
+		return err
+	}
+	se, ok := err.(common.StandardError)
+	if !ok {
+		return err
+	}
+	base := se.Base()
+	if base == nil {
+		return err
+	}
+	if base.Cause != nil {
+		base.Cause = errors.Join(base.Cause, common.ErrDynamicTimeoutExceeded)
+	} else {
+		base.Cause = common.ErrDynamicTimeoutExceeded
+	}
+	return err
 }
 
 func (u *Upstream) Executor() failsafe.Executor[*common.NormalizedResponse] {

--- a/upstream/upstream_timeout_sentinel_repair_test.go
+++ b/upstream/upstream_timeout_sentinel_repair_test.go
@@ -1,0 +1,124 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// expiredEctx returns a context whose WithTimeoutCause deadline has already
+// elapsed by the time it's returned. cancel must be called by the caller.
+func expiredEctx(cause error) (context.Context, context.CancelFunc) {
+	return context.WithDeadlineCause(context.Background(), time.Now().Add(-time.Millisecond), cause)
+}
+
+func TestInjectDynamicTimeoutSentinelIfDeadlinePassed(t *testing.T) {
+	t.Run("welds sentinel into ErrEndpointRequestTimeout that lost it", func(t *testing.T) {
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		// Inner err that LOST the sentinel — cause is a bare context.DeadlineExceeded.
+		// This mirrors what the batched HTTP client produces under the race.
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, context.DeadlineExceeded)
+		assert.False(t, errors.Is(err, common.ErrDynamicTimeoutExceeded), "precondition: inner err should not yet contain sentinel")
+
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, true)
+
+		assert.True(t, errors.Is(got, common.ErrDynamicTimeoutExceeded),
+			"after welding, errors.Is should locate the sentinel — TranslateFailsafeError relies on this")
+		// The original DeadlineExceeded is still reachable so downstream classification
+		// (e.g. ErrEndpointRequestTimeout code) survives.
+		assert.True(t, errors.Is(got, context.DeadlineExceeded),
+			"original cause must remain in chain alongside the welded sentinel")
+		assert.True(t, common.HasErrorCode(got, common.ErrCodeEndpointRequestTimeout),
+			"original error code must be preserved")
+	})
+
+	t.Run("idempotent when err already carries the sentinel", func(t *testing.T) {
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, common.ErrDynamicTimeoutExceeded)
+		base := err.(common.StandardError).Base()
+		causeBefore := base.Cause
+
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, true)
+
+		assert.Same(t, causeBefore, got.(common.StandardError).Base().Cause,
+			"cause pointer should not be mutated when sentinel already present")
+		assert.True(t, errors.Is(got, common.ErrDynamicTimeoutExceeded))
+	})
+
+	t.Run("no-op when ourTimeoutSet is false", func(t *testing.T) {
+		// When this scope did NOT install a WithTimeoutCause, we must not
+		// claim the timeout — the parent scope (network) owns it.
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, context.DeadlineExceeded)
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, false)
+
+		assert.False(t, errors.Is(got, common.ErrDynamicTimeoutExceeded))
+	})
+
+	t.Run("no-op when deadline has not yet passed", func(t *testing.T) {
+		// ectx is canceled but the cause is something else; deadline far in
+		// the future. A non-deadline cancellation is not our timeout firing.
+		ectx, cancel := context.WithDeadlineCause(context.Background(), time.Now().Add(10*time.Second), common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, context.DeadlineExceeded)
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, true)
+
+		assert.False(t, errors.Is(got, common.ErrDynamicTimeoutExceeded))
+	})
+
+	t.Run("no-op when ectx has no deadline", func(t *testing.T) {
+		// e.g. a plain Background ctx — nothing for us to attribute.
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, context.DeadlineExceeded)
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, context.Background(), true)
+
+		assert.False(t, errors.Is(got, common.ErrDynamicTimeoutExceeded))
+	})
+
+	t.Run("no-op when err is not timeout-shaped", func(t *testing.T) {
+		// Transport failures (connection refused, etc.) must not be reclassified
+		// as upstream-scope timeouts.
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		dummyURL := &url.URL{Scheme: "http", Host: "rpc.example"}
+		err := common.NewErrEndpointTransportFailure(dummyURL, errors.New("connection refused"))
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, true)
+
+		assert.False(t, errors.Is(got, common.ErrDynamicTimeoutExceeded))
+	})
+
+	t.Run("no-op when err is nil", func(t *testing.T) {
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(nil, ectx, true)
+		assert.NoError(t, got)
+	})
+
+	t.Run("preserves a non-sentinel pre-existing cause via errors.Join", func(t *testing.T) {
+		ectx, cancel := expiredEctx(common.ErrDynamicTimeoutExceeded)
+		defer cancel()
+
+		originalCause := errors.New("upstream-specific failure")
+		err := common.NewErrEndpointRequestTimeout(100*time.Millisecond, originalCause)
+
+		got := injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, true)
+
+		// Both the original cause AND the sentinel must remain reachable
+		// so neither downstream classification nor diagnostics regress.
+		assert.True(t, errors.Is(got, originalCause), "original cause must survive welding")
+		assert.True(t, errors.Is(got, common.ErrDynamicTimeoutExceeded), "welded sentinel must be reachable")
+	})
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
Two race fixes uncovered while diagnosing the same production panic. Bundled because the second was found while validating the first; happy to split if you'd prefer.                     
                                                                                                                                                                                                                                                                                                                                                     
### 1. `concurrent map iteration and map write` panic in `BaseError.Error()` (closes #864)                                                                                                
                  
The consensus analyzer's `trackAndPunishMisbehavingUpstreams` formats each failed result via `fmt.Sprintf("<error: %v>", result.Err)`, which routes through `BaseError.Error()` → `SonicCfg.Marshal(e.Details)`. Concurrently the caller's failsafe stack appends `method`/`upstreamId` to the same `*BaseError` via `TranslateFailsafeError`. Both goroutines hit the same map without synchronization.                                                                                                                                                              
                  
The same `*BaseError` pointer flows end-to-end:

- `group.Results[i].Err == group.FirstError` (`analysis.go:101,116`)                                                                                                                      
- `winner.Error = group.FirstError` (`rules.go:212,701,727,760,797`)
- caller passes `winner.Error` → `TranslateFailsafeError` mutates `be.Details` (`failsafe.go:967-981`)                                                                                    
- analyzer keeps reading `result.Err` post-outcome via `fmt.Sprintf %v` (`executor.go:466,716`)                                                                                           
                                                                                                                                                                                            
See #864 for the full pointer-chain analysis.                                                                                                                                             
                                                                                                                                                                                            
### 2. `TestHttpServer_ManualTimeoutScenarios/UpstreamRequestTimeoutBatchingEnabled` flake                                                                                                
   
Surfaced ~10-15% of the time on `main` under load (reproducible without this PR's other changes). The upstream-scope timeout is misclassified as `ErrEndpointRequestTimeout` instead of `ErrFailsafeTimeoutExceeded`.                                                                                                                                                             
   
The batched HTTP client builds its own batch-deadline ctx via `context.WithDeadline(c.appCtx, batchDeadline)` — distinct from the per-request ctx that carries `WithTimeoutCause(ErrDynamicTimeoutExceeded)`. Both contexts share the same deadline, and each has its own `time.AfterFunc` goroutine. Under heavy contention, `batchCtx`'s AfterFunc may fire microseconds before `req.ctx`'s; the batch processor unblocks from `http.Client.Do`, reads `context.Cause(req.ctx)`, observes nil (req.ctx hasn't recorded its cause yet), and falls back to `batchCause` which is a bare `context.DeadlineExceeded`. The inner error chain loses the sentinel — `TranslateFailsafeError` can't satisfy `errors.Is(execErr, ErrDynamicTimeoutExceeded)` and produces the wrong classification.

Detection via `context.Cause(ectx)` at the upstream scope is unreliable for the same reason. Use the absolute deadline as a stable signal: when this scope set up `WithTimeoutCause` and `ectx.Deadline()` has elapsed at the moment `tryForward` returned, our scope's timeout is the cause regardless of which goroutine recorded it first.                                      
   
## Changes                                                                                                                                                                                
                  
### Commit 1 — `common/errors.go` and call sites
- Add `sync.RWMutex` to `BaseError`; new `SetDetail` / `GetDetail` / `snapshotDetails` helpers. `Error()`, `MarshalJSON`, `MarshalZerologObject` snapshot under `RLock` and serialize outside the lock per the project's "grab under lock, use outside" idiom (`.cursor/rules/erpc.md`).                                                                                        
- `MarshalJSON` moves to a pointer receiver and uses a new `baseErrorJSON` shape that excludes the mutex — converting `BaseError` to `Alias` for marshaling would otherwise copy the embedded lock and trip `go vet`.                                                                                                                                                          
- Type-specific accessors (`UpstreamId`, `Attempts`, `Retries`, `Hedges`, `NormalizedCode`, `OriginalCode`, `SummarizeParticipants`) and the cross-error `retryableTowardNetwork` reader go through the locked path.                                                                                                                                                               
- `upstream/failsafe.go`: `TranslateFailsafeError` uses `SetDetail` for late `method`/`upstreamId` writes.
- `architecture/evm/eth_sendRawTransaction.go`, `erpc/http_server.go`: external `Details[k]` readers use `GetDetail`.                                                                     
- Constructor literals (`Details: map[string]interface{}{...}`) are unchanged — the error isn't shared at construction time.                                                              
                                                                                                                                                                                            
### Commit 2 — `upstream/upstream.go`                                                                                                                                                     
- New helper `injectDynamicTimeoutSentinelIfDeadlinePassed(err, ectx, ourTimeoutSet)` welds `ErrDynamicTimeoutExceeded` into the inner error's `Cause` chain (via `errors.Join`) when this scope's `WithTimeoutCause` deadline has elapsed but the sentinel was lost in the batched-client race.                                                                                    
- Gated on: this scope set up `WithTimeoutCause`; err is timeout-shaped (`ErrCodeEndpointRequestTimeout` or `context.DeadlineExceeded`); err doesn't already carry the sentinel; `ectx.Deadline()` has elapsed. Non-timeout errors are not touched; idempotent on already-correct errors.                                                                                  
                  
## Tests                                                                                                                                                                                  
                  
- `common/errors_concurrency_test.go` — regression test for the BaseError race: two readers (`Error`, `json.Marshal`) racing two writers (`SetDetail`, `WithRetryableTowardNetwork`). Trips the race detector reliably on unfixed code at `common/errors.go:230` (and the runtime emits `fatal error: concurrent map writes`); runs clean with the patch.                       
- `upstream/upstream_timeout_sentinel_repair_test.go` — 8 unit tests covering every gate of the new helper plus the welding logic itself, race detector enabled.
- `make fmt` clean.                                                                                                                                                                       
- `make test` (full race-checked suite, all packages) exit 0.
- The previously flaky integration test (`TestHttpServer_ManualTimeoutScenarios/UpstreamRequestTimeoutBatchingEnabled`): 100/100 passes locally with the patch vs ~10/100 fails on main.  
                                                                                                                                                                                            
Closes #864   