### PR TITLE
fix: exclude eth_getBlockReceipts from MarkEmptyAsErrorMethods

### DIFF
--- a/architecture/evm/hooks_test.go
+++ b/architecture/evm/hooks_test.go
@@ -25,8 +25,8 @@ func TestUpstreamPostForward_UnexpectedEmpty_ListedMethods(t *testing.T) {
 	methods := []string{
 		// Blocks (eth_getBlockByHash excluded - subgraphs return empty for it)
 		"eth_getBlockByNumber",
-		"eth_getBlockReceipts",
-		// Transactions (eth_getTransactionReceipt excluded - pending txs return null)
+		// Transactions (eth_getTransactionReceipt and eth_getBlockReceipts excluded -
+		// pending txs return null and 0-tx blocks legitimately return empty arrays)
 		"eth_getTransactionByHash",
 		"eth_getTransactionByBlockHashAndIndex",
 		"eth_getTransactionByBlockNumberAndIndex",
@@ -75,7 +75,6 @@ func TestUpstreamPostForward_UnexpectedEmpty_ListedMethods(t *testing.T) {
 func TestUpstreamPostForward_UnexpectedEmpty_RetryEmptyFalse(t *testing.T) {
 	methods := []string{
 		"eth_getBlockByNumber",
-		"eth_getBlockReceipts",
 		"eth_getTransactionByHash",
 		"debug_traceTransaction",
 		"trace_transaction",
@@ -120,8 +119,11 @@ func TestUpstreamPostForward_UnexpectedEmpty_NonListedMethods(t *testing.T) {
 		"eth_getCode",
 		"eth_getStorageAt",
 		"eth_estimateGas",
-		// eth_getTransactionReceipt intentionally excluded - pending txs correctly return null
+		// Receipts intentionally excluded - empty result is legitimate:
+		// pending txs return null (eth_getTransactionReceipt), 0-tx blocks
+		// return empty arrays (eth_getBlockReceipts).
 		"eth_getTransactionReceipt",
+		"eth_getBlockReceipts",
 	}
 
 	// Create a test network with the default methods configured

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1995,11 +1995,17 @@ func DefaultEmptyResultAccept() []string {
 // upstreams commonly return empty for this method, which is expected behavior.
 // Note: eth_getTransactionReceipt is excluded as a quick remedy. Ideally we'd
 // only allow null for pending txs.
+// Note: eth_getBlockReceipts is excluded for the same reason as
+// eth_getTransactionReceipt — an empty array is the legitimate response for
+// blocks with zero transactions and should not be retried as missing data.
+// Including it here forces the post-forward hook to convert correct empty
+// responses into ErrEndpointMissingData, which bypasses emptyResultAccept and
+// drives retry-with-emptyResultDelay loops that can outrun the network outer
+// timeout (see incident note in the PR description).
 func DefaultMarkEmptyAsErrorMethods() []string {
 	return []string{
 		"eth_blockNumber",
 		"eth_getBlockByNumber",
-		"eth_getBlockReceipts",
 		"eth_getTransactionByHash",
 		"eth_getTransactionByBlockHashAndIndex",
 		"eth_getTransactionByBlockNumberAndIndex",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 42de96537c76606c1efb8cf28747385c61bec4cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->