### PR TITLE
fix(common/json_rpc): reject NaN/Inf/oversized/fractional float ids

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -207,7 +208,14 @@ func (r *JsonRpcResponse) parseIDLocked() error {
 	}
 	switch v := rawID.(type) {
 	case float64:
-		r.id = int64(v)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("id must be a finite number")
+		}
+		id := int64(v)
+		if float64(id) != v {
+			return fmt.Errorf("id must be an integer in int64 range")
+		}
+		r.id = id
 		return nil
 	case string:
 		r.id = v
@@ -1300,7 +1308,14 @@ func (r *JsonRpcRequest) UnmarshalJSON(data []byte) error {
 		}
 		switch v := id.(type) {
 		case float64:
-			r.ID = int64(v)
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return fmt.Errorf("id must be a finite number")
+			}
+			idInt := int64(v)
+			if float64(idInt) != v {
+				return fmt.Errorf("id must be an integer in int64 range")
+			}
+			r.ID = idInt
 		case string:
 			r.ID = v
 		}

--- a/common/json_rpc_test.go
+++ b/common/json_rpc_test.go
@@ -738,3 +738,35 @@ func TestJsonRpcRequest_CloneDeepCopy(t *testing.T) {
 		assert.Equal(t, "0x2", originalMap["toBlock"])
 	})
 }
+
+func TestJsonRpcRequest_UnmarshalJSON_FloatIDValidation(t *testing.T) {
+    cases := []struct {
+        name    string
+        body    string
+        wantErr bool
+        wantID  interface{}
+    }{
+        {"normal int", `{"id":42,"method":"x","jsonrpc":"2.0"}`, false, int64(42)},
+        {"normal string", `{"id":"abc","method":"x","jsonrpc":"2.0"}`, false, "abc"},
+        {"oversized 26 digit", `{"id":99999999999999999999999999,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"1e20", `{"id":1e20,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"1e308", `{"id":1e308,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"9.3e18 just over 2^63", `{"id":9.3e18,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"-1e20", `{"id":-1e20,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"exact 2^63 boundary", `{"id":9223372036854775808,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"2^64-1", `{"id":18446744073709551615,"method":"x","jsonrpc":"2.0"}`, true, nil},
+        {"fractional 1.5", `{"id":1.5,"method":"x","jsonrpc":"2.0"}`, true, nil},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            req := &JsonRpcRequest{}
+            err := req.UnmarshalJSON([]byte(tc.body))
+            if (err != nil) != tc.wantErr {
+                t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+            }
+            if !tc.wantErr && !reflect.DeepEqual(req.ID, tc.wantID) {
+                t.Fatalf("got id=%v (%T), want %v (%T)", req.ID, req.ID, tc.wantID, tc.wantID)
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Summary

`(*JsonRpcRequest).UnmarshalJSON` and `(*JsonRpcResponse).parseIDLocked` previously cast an `interface{}` `float64` id straight to `int64` with `r.ID = int64(v)`. On x86_64 this lowers to `cvttsd2si`, which silently saturates `NaN`, `±Inf`, and any `|v| >= 2^63` to `MinInt64`. Sonic filters `NaN`/`Inf` literals at parse time, but it still accepts every large finite
double JSON allows (`1e20`, `1e308`, `9.3e18`, `9223372036854775808`, ...), so attacker-controlled ids silently collapse to `MinInt64`. Fractional ids (`1.5`) likewise truncate to `1` with no error. This creates collision risk for any layer keyed on `r.ID` after the cast (cache, dedup, response routing) and may violate JSON RPC 2.0 §4 round-tripping for internal id consumers. 

This PR round-trips the cast (`if float64(id) != v { error }`) and explicitly rejects `NaN`/`Inf` for defense in depth, in both call sites.

Closes #869

## Test plan

- New table-driven tests in `common/json_rpc_test.go` covering the verified attacker payloads (`99999999999999999999999999`, `1e20`,  `1e308`, `9.3e18`, `-1e20`, `9223372036854775808`, `18446744073709551615`,  `1.5`) plus `42` and a string id as positive cases.
- `go test ./common/...` passes locally.
- `go vet ./common/...` passes locally.
- Manual `curl` against a local `erpc` build with the payloads from the linked issue confirms each rejected payload now returns a JSON RPC error rather than a corrupted `r.ID`.