### PR TITLE
chore: bump manifesto schema version to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DataDog/sketches-go v1.4.8
 	github.com/IGLOU-EU/go-wildcard/v2 v2.1.0
 	github.com/aws/aws-sdk-go v1.55.8
-	github.com/blockchain-data-standards/manifesto v0.0.0
+	github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650
 	github.com/bytedance/sonic v1.15.0
 	github.com/dgraph-io/ristretto/v2 v2.4.0
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260417185455-377cced2b921 h1:bz29Uc7RNXJ6FNPsflbU0mqz2s9qoqaw8+L4ODiaQVM=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260417185455-377cced2b921/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650 h1:1x8E2huS+AGPFxVj2Zt57JygwpBSOKnScsDHp/pqgIo=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency-only change limited to `go.mod`/`go.sum`, with no application logic modifications.
> 
> **Overview**
> Bumps `github.com/blockchain-data-standards/manifesto` to a newer pseudo-version (latest schema) and updates `go.sum` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4887eacacc3c582593452fd5261225bee20d362f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->