### PR TITLE
chore: bump manifesto schema version to latest (add daFootprintGasScalar to json-rpc golang schema)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DataDog/sketches-go v1.4.8
 	github.com/IGLOU-EU/go-wildcard/v2 v2.1.0
 	github.com/aws/aws-sdk-go v1.55.8
-	github.com/blockchain-data-standards/manifesto v0.0.0-20260427160234-741431397c20
+	github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650
 	github.com/bytedance/sonic v1.15.0
 	github.com/dgraph-io/ristretto/v2 v2.4.0
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/blockchain-data-standards/manifesto v0.0.0-20260417185455-377cced2b92
 github.com/blockchain-data-standards/manifesto v0.0.0-20260417185455-377cced2b921/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260427160234-741431397c20 h1:EoiilWx+Rh0svyI894Z8rqHwRrkVhX3KmtbEPRFhE5M=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260427160234-741431397c20/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650 h1:1x8E2huS+AGPFxVj2Zt57JygwpBSOKnScsDHp/pqgIo=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; the main impact is any downstream compile/runtime behavior changes introduced by the updated `manifesto` module.
> 
> **Overview**
> Updates the `github.com/blockchain-data-standards/manifesto` Go module to a newer pseudo-version in `go.mod`, with corresponding checksum additions in `go.sum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885f35db309c8cd75f4389d2c614c32b4f0406ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->