### PR TITLE
feat: cache connector parallel fan-out + transport-only retries

### DIFF
--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -234,9 +234,12 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 
 			jrr, err := c.doGet(policyCtx, connector, req, rpcReq)
 			if err != nil {
-				// Errors caused by peer-cancellation aren't real failures —
-				// they happen because another connector already won.
-				if errors.Is(err, context.Canceled) && fanCtx.Err() != nil {
+				// Errors caused by external cancellation aren't real failures.
+				// fanCtx is done either because a peer connector already won
+				// (cancelFan), or because the caller's context was cancelled,
+				// or because the caller's deadline expired — the latter
+				// surfaces as context.DeadlineExceeded, not context.Canceled.
+				if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && fanCtx.Err() != nil {
 					policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
 					return
 				}

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -213,8 +213,22 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 	fanCtx, cancelFan := context.WithCancel(ctx)
 	defer cancelFan()
 
+	// Defensive backstop: if the caller's context has no deadline and a
+	// connector lacks a failsafe timeout, a hung connector could pin the
+	// fan-out goroutine indefinitely — over time, FDs/connection-pool slots
+	// leak per request. Cap the fan-out at 30s. Properly configured
+	// connectors exit far earlier via their own failsafe timeout.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var bsCancel context.CancelFunc
+		fanCtx, bsCancel = context.WithTimeout(fanCtx, 30*time.Second)
+		defer bsCancel()
+	}
+
+	// Buffer sized to the worst-case spawn count so late peers (after we've
+	// already taken a winner) can post their result without blocking — we
+	// don't drain stragglers; we let them GC with the channel.
 	results := make(chan fanResult, len(policies))
-	var wg sync.WaitGroup
+	spawned := 0
 
 	for _, p := range policies {
 		conn := p.GetConnector()
@@ -222,9 +236,8 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 			c.logger.Debug().Str("connector", conn.Id()).Interface("id", req.ID()).Msg("skipping cache connector due to skip-cache-read directive pattern")
 			continue
 		}
-		wg.Add(1)
+		spawned++
 		go func(policy *data.CachePolicy, connector data.Connector) {
-			defer wg.Done()
 			policyCtx, policySpan := common.StartDetailSpan(fanCtx, "Cache.GetForPolicy", trace.WithAttributes(
 				attribute.String("cache.policy_summary", policy.String()),
 				attribute.String("cache.connector_id", connector.Id()),
@@ -237,9 +250,13 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 				// Errors caused by external cancellation aren't real failures.
 				// fanCtx is done either because a peer connector already won
 				// (cancelFan), or because the caller's context was cancelled,
-				// or because the caller's deadline expired — the latter
-				// surfaces as context.DeadlineExceeded, not context.Canceled.
-				if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && fanCtx.Err() != nil {
+				// or because the caller's deadline expired. The connector's
+				// inner failsafe stack may wrap the context error in a typed
+				// error that errors.Is can't unwind to context.Canceled —
+				// trust fanCtx.Err() as the authoritative signal so wrapped
+				// cancellation doesn't inflate connector_error metrics for
+				// every losing race peer.
+				if fanCtx.Err() != nil {
 					policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
 					return
 				}
@@ -292,6 +309,20 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 				}
 				return
 			}
+			// An emptyish result under EmptyState=Ignore is a miss for THIS
+			// policy — report as miss and let peer connectors keep racing.
+			// Without this, the first emptyish result would win the fan-out,
+			// cancel peers, and only THEN get reclassified as a miss by the
+			// post-fan-out emptyish handling — losing the chance for a peer
+			// with non-empty data or Allow policy to serve a real hit.
+			if jrr.IsResultEmptyish() && policy.EmptyState() == common.CacheEmptyBehaviorIgnore {
+				policySpan.SetAttributes(attribute.String("cache.get_outcome", "empty_ignored"))
+				select {
+				case results <- fanResult{policy: policy, connector: connector, missReason: "empty_result"}:
+				case <-fanCtx.Done():
+				}
+				return
+			}
 			policySpan.SetAttributes(attribute.String("cache.get_outcome", "found"))
 			select {
 			case results <- fanResult{jrr: jrr, policy: policy, connector: connector}:
@@ -301,8 +332,11 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 		}(p, conn)
 	}
 
-	go func() { wg.Wait(); close(results) }()
-
+	// Drain results until we get the first acceptable hit OR every spawned
+	// goroutine has reported back OR the caller's context is cancelled. We
+	// never wait for stragglers after a hit lands — they post into the
+	// buffered channel and exit on their own. Slow peers no longer pin the
+	// user-visible latency of a fast winner.
 	var (
 		jrr        *common.JsonRpcResponse
 		policy     *data.CachePolicy
@@ -311,24 +345,34 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 		lastReject *fanResult
 		lastError  *fanResult
 	)
-	for r := range results {
-		if r.jrr != nil && jrr == nil {
-			rr := r
-			jrr = rr.jrr
-			policy = rr.policy
-			connector = rr.connector
-			continue
-		}
-		switch r.missReason {
-		case "ttl_rejected":
-			rr := r
-			lastReject = &rr
-		case "empty_result":
-			rr := r
-			lastMiss = &rr
-		case "connector_error":
-			rr := r
-			lastError = &rr
+drain:
+	for received := 0; received < spawned && jrr == nil; {
+		select {
+		case r := <-results:
+			received++
+			if r.jrr != nil {
+				rr := r
+				jrr = rr.jrr
+				policy = rr.policy
+				connector = rr.connector
+				continue
+			}
+			switch r.missReason {
+			case "ttl_rejected":
+				rr := r
+				lastReject = &rr
+			case "empty_result":
+				rr := r
+				lastMiss = &rr
+			case "connector_error":
+				rr := r
+				lastError = &rr
+			}
+		case <-ctx.Done():
+			// Caller gave up — stop waiting for in-flight peers. cancelFan
+			// (deferred) propagates the cancel to any still-running
+			// goroutines; the buffered channel and their refs GC together.
+			break drain
 		}
 	}
 

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -260,6 +260,25 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 					policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
 					return
 				}
+				// Semantic-miss errors: the connector is signalling
+				// "no key" / "expired" / "data not available here", not a
+				// real failure. Classify as miss so we don't inflate
+				// connector_error metrics with normal cache misses.
+				//   ErrRecordNotFound  — generic data connector miss
+				//   ErrRecordExpired   — connector miss past TTL
+				//   ErrEndpointMissingData — gRPC connector (e.g. prism)
+				//     translation of "range outside available" / cold
+				//     storage range, see common/grpc_errors.go
+				if common.HasErrorCode(err, common.ErrCodeRecordNotFound) ||
+					common.HasErrorCode(err, common.ErrCodeRecordExpired) ||
+					common.HasErrorCode(err, common.ErrCodeEndpointMissingData) {
+					policySpan.SetAttributes(attribute.String("cache.get_outcome", "miss"))
+					select {
+					case results <- fanResult{policy: policy, connector: connector, missReason: "empty_result"}:
+					case <-fanCtx.Done():
+					}
+					return
+				}
 				common.SetTraceSpanError(policySpan, err)
 				policySpan.SetAttributes(
 					attribute.String("cache.get_outcome", "error"),

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -198,114 +198,178 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 
 	policySpan.End()
 
-	var jrr *common.JsonRpcResponse
-	var connector data.Connector
-	var policy *data.CachePolicy
-	// Track context for correct miss attribution
-	var lastMissConnectorId, lastMissPolicyStr, lastMissTTL string
-	var lastRejectConnectorId, lastRejectPolicyStr, lastRejectTTL string
-	for _, policy = range policies {
-		connector = policy.GetConnector()
-		if req.ShouldSkipCacheRead(connector.Id()) {
-			c.logger.Debug().Str("connector", connector.Id()).Interface("id", req.ID()).Msg("skipping cache connector due to skip-cache-read directive pattern")
+	// Fan out cache reads in parallel across matching connectors. findGetPolicies
+	// already deduped by connector, so each policy here represents a unique
+	// connector. First accepted hit cancels peers; if every connector confirms
+	// a miss (or errors/rejects), the request falls through to the upstream layer.
+	type fanResult struct {
+		jrr        *common.JsonRpcResponse
+		policy     *data.CachePolicy
+		connector  data.Connector
+		err        error
+		missReason string
+	}
+
+	fanCtx, cancelFan := context.WithCancel(ctx)
+	defer cancelFan()
+
+	results := make(chan fanResult, len(policies))
+	var wg sync.WaitGroup
+
+	for _, p := range policies {
+		conn := p.GetConnector()
+		if req.ShouldSkipCacheRead(conn.Id()) {
+			c.logger.Debug().Str("connector", conn.Id()).Interface("id", req.ID()).Msg("skipping cache connector due to skip-cache-read directive pattern")
 			continue
 		}
-		policyCtx, policySpan := common.StartDetailSpan(ctx, "Cache.GetForPolicy", trace.WithAttributes(
-			attribute.String("cache.policy_summary", policy.String()),
-			attribute.String("cache.connector_id", connector.Id()),
-			attribute.String("cache.method", rpcReq.Method),
-		))
-		jrr, err = c.doGet(policyCtx, connector, req, rpcReq)
-		if err != nil {
-			common.SetTraceSpanError(policySpan, err)
-			policySpan.SetAttributes(
-				attribute.String("cache.get_outcome", "error"),
-				attribute.String("cache.error", common.ErrorSummary(err)),
-			)
-			telemetry.MetricCacheGetErrorTotal.WithLabelValues(
-				c.projectId,
-				req.NetworkLabel(),
-				rpcReq.Method,
-				connector.Id(),
-				policy.String(),
-				policy.GetTTL().String(),
-				common.ErrorSummary(err),
-			).Inc()
-			telemetry.MetricCacheGetErrorDuration.WithLabelValues(
-				c.projectId,
-				req.NetworkLabel(),
-				rpcReq.Method,
-				connector.Id(),
-				policy.String(),
-				policy.GetTTL().String(),
-				common.ErrorSummary(err),
-			).Observe(time.Since(start).Seconds())
-		} else if jrr == nil {
-			policySpan.SetAttributes(attribute.String("cache.get_outcome", "miss"))
-		} else {
-			policySpan.SetAttributes(attribute.String("cache.get_outcome", "found"))
-		}
-		if c.logger.GetLevel() == zerolog.TraceLevel {
-			c.logger.Trace().Interface("policy", policy).Str("connector", connector.Id()).Interface("id", req.ID()).Err(err).Msg("skipping cache policy during GET because it returned nil or error")
-		} else {
-			c.logger.Debug().Str("connector", connector.Id()).Interface("id", req.ID()).Err(err).Msg("skipping cache policy during GET because it returned nil or error")
-		}
+		wg.Add(1)
+		go func(policy *data.CachePolicy, connector data.Connector) {
+			defer wg.Done()
+			policyCtx, policySpan := common.StartDetailSpan(fanCtx, "Cache.GetForPolicy", trace.WithAttributes(
+				attribute.String("cache.policy_summary", policy.String()),
+				attribute.String("cache.connector_id", connector.Id()),
+				attribute.String("cache.method", rpcReq.Method),
+			))
+			defer policySpan.End()
 
-		// Record a miss attribution for this attempt if it returned nil without error
-		if err == nil && jrr == nil && policy != nil {
-			lastMissConnectorId = connector.Id()
-			lastMissPolicyStr = policy.String()
-			lastMissTTL = policy.GetTTL().String()
-		}
-
-		policySpan.End()
-		if jrr != nil {
-			// Validate the cached result's age against the policy's TTL
-			if c.shouldAcceptCachedResult(ctx, req, jrr, policy) {
-				// Result is acceptable, use it
-				break
-			} else {
-				// Result is too old, reject it and try the next policy
-				c.logger.Debug().Str("connector", connector.Id()).Interface("id", req.ID()).Msg("cached result rejected due to age exceeding TTL")
-				// Record last rejection context to attribute miss correctly
-				lastRejectConnectorId = connector.Id()
-				lastRejectPolicyStr = policy.String()
-				lastRejectTTL = policy.GetTTL().String()
-				jrr = nil
-				continue
+			jrr, err := c.doGet(policyCtx, connector, req, rpcReq)
+			if err != nil {
+				// Errors caused by peer-cancellation aren't real failures —
+				// they happen because another connector already won.
+				if errors.Is(err, context.Canceled) && fanCtx.Err() != nil {
+					policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
+					return
+				}
+				common.SetTraceSpanError(policySpan, err)
+				policySpan.SetAttributes(
+					attribute.String("cache.get_outcome", "error"),
+					attribute.String("cache.error", common.ErrorSummary(err)),
+				)
+				telemetry.MetricCacheGetErrorTotal.WithLabelValues(
+					c.projectId,
+					req.NetworkLabel(),
+					rpcReq.Method,
+					connector.Id(),
+					policy.String(),
+					policy.GetTTL().String(),
+					common.ErrorSummary(err),
+				).Inc()
+				telemetry.MetricCacheGetErrorDuration.WithLabelValues(
+					c.projectId,
+					req.NetworkLabel(),
+					rpcReq.Method,
+					connector.Id(),
+					policy.String(),
+					policy.GetTTL().String(),
+					common.ErrorSummary(err),
+				).Observe(time.Since(start).Seconds())
+				if c.logger.GetLevel() <= zerolog.DebugLevel {
+					c.logger.Debug().Str("connector", connector.Id()).Interface("id", req.ID()).Err(err).Msg("cache connector errored during GET")
+				}
+				select {
+				case results <- fanResult{policy: policy, connector: connector, err: err, missReason: "connector_error"}:
+				case <-fanCtx.Done():
+				}
+				return
 			}
+			if jrr == nil {
+				policySpan.SetAttributes(attribute.String("cache.get_outcome", "miss"))
+				select {
+				case results <- fanResult{policy: policy, connector: connector, missReason: "empty_result"}:
+				case <-fanCtx.Done():
+				}
+				return
+			}
+			if !c.shouldAcceptCachedResult(ctx, req, jrr, policy) {
+				c.logger.Debug().Str("connector", connector.Id()).Interface("id", req.ID()).Msg("cached result rejected due to age exceeding TTL")
+				policySpan.SetAttributes(attribute.String("cache.get_outcome", "ttl_rejected"))
+				select {
+				case results <- fanResult{policy: policy, connector: connector, missReason: "ttl_rejected"}:
+				case <-fanCtx.Done():
+				}
+				return
+			}
+			policySpan.SetAttributes(attribute.String("cache.get_outcome", "found"))
+			select {
+			case results <- fanResult{jrr: jrr, policy: policy, connector: connector}:
+				cancelFan()
+			case <-fanCtx.Done():
+			}
+		}(p, conn)
+	}
+
+	go func() { wg.Wait(); close(results) }()
+
+	var (
+		jrr        *common.JsonRpcResponse
+		policy     *data.CachePolicy
+		connector  data.Connector
+		lastMiss   *fanResult
+		lastReject *fanResult
+		lastError  *fanResult
+	)
+	for r := range results {
+		if r.jrr != nil && jrr == nil {
+			rr := r
+			jrr = rr.jrr
+			policy = rr.policy
+			connector = rr.connector
+			continue
+		}
+		switch r.missReason {
+		case "ttl_rejected":
+			rr := r
+			lastReject = &rr
+		case "empty_result":
+			rr := r
+			lastMiss = &rr
+		case "connector_error":
+			rr := r
+			lastError = &rr
 		}
 	}
 
 	if jrr == nil {
-		// Prefer attributing miss to age-guard rejection if any, otherwise the last miss
-		labelConnectorId := connector.Id()
-		labelPolicyStr := policy.String()
-		labelTTL := policy.GetTTL().String()
+		// All connectors confirmed miss / errored / age-rejected. Attribute the
+		// fall-through metric to the most informative outcome we observed,
+		// preferring rejections over plain misses over errors.
+		var labelConnector data.Connector
+		var labelPolicy *data.CachePolicy
 		missReason := "empty_result"
-		if lastRejectConnectorId != "" {
-			labelConnectorId = lastRejectConnectorId
-			labelPolicyStr = lastRejectPolicyStr
-			labelTTL = lastRejectTTL
+		switch {
+		case lastReject != nil:
+			labelConnector = lastReject.connector
+			labelPolicy = lastReject.policy
 			missReason = "ttl_rejected"
-		} else if lastMissConnectorId != "" {
-			labelConnectorId = lastMissConnectorId
-			labelPolicyStr = lastMissPolicyStr
-			labelTTL = lastMissTTL
+		case lastMiss != nil:
+			labelConnector = lastMiss.connector
+			labelPolicy = lastMiss.policy
 			missReason = "connector_miss"
-		}
-		if err != nil {
+		case lastError != nil:
+			labelConnector = lastError.connector
+			labelPolicy = lastError.policy
 			missReason = "connector_error"
-			labelConnectorId = connector.Id()
-			labelPolicyStr = policy.String()
-			labelTTL = policy.GetTTL().String()
+		default:
+			if len(policies) > 0 {
+				labelPolicy = policies[0]
+				labelConnector = labelPolicy.GetConnector()
+			}
 		}
+
+		if labelConnector == nil || labelPolicy == nil {
+			span.SetAttributes(attribute.Bool("cache.hit", false))
+			return nil, nil
+		}
+
+		labelConnectorId := labelConnector.Id()
+		labelPolicyStr := labelPolicy.String()
+		labelTTL := labelPolicy.GetTTL().String()
+
 		span.SetAttributes(
 			attribute.String("cache.miss_reason", missReason),
 			attribute.String("cache.miss_connector_id", labelConnectorId),
 			attribute.String("cache.miss_policy", labelPolicyStr),
 		)
-
 		telemetry.MetricCacheGetSuccessMissTotal.WithLabelValues(
 			c.projectId,
 			req.NetworkLabel(),

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -246,20 +246,27 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 			defer policySpan.End()
 
 			jrr, err := c.doGet(policyCtx, connector, req, rpcReq)
+			// Unconditional cancellation guard — runs regardless of whether
+			// doGet returned an error. fanCtx is done either because a peer
+			// connector already won (cancelFan), the caller's context was
+			// cancelled, or the 30s defensive backstop expired. We treat any
+			// outcome that arrives once fanCtx is done as "cancelled":
+			//   - (err != nil): the inner failsafe may wrap the context error
+			//     in a typed error that errors.Is can't unwind to
+			//     context.Canceled — fanCtx.Err() is the authoritative signal
+			//     so wrapped cancellation doesn't inflate connector_error.
+			//   - (nil, nil): a buggy connector that swallows ctx cancellation
+			//     internally and returns a silent miss — we shouldn't credit
+			//     it as a genuine miss against this connector's policy.
+			//   - (jrr, nil): a late-arriving hit after the winner already
+			//     sent. The consumer will discard it anyway (jrr already set);
+			//     marking cancelled avoids running shouldAcceptCachedResult /
+			//     emptyish checks for a result that won't be used.
+			if fanCtx.Err() != nil {
+				policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
+				return
+			}
 			if err != nil {
-				// Errors caused by external cancellation aren't real failures.
-				// fanCtx is done either because a peer connector already won
-				// (cancelFan), or because the caller's context was cancelled,
-				// or because the caller's deadline expired. The connector's
-				// inner failsafe stack may wrap the context error in a typed
-				// error that errors.Is can't unwind to context.Canceled —
-				// trust fanCtx.Err() as the authoritative signal so wrapped
-				// cancellation doesn't inflate connector_error metrics for
-				// every losing race peer.
-				if fanCtx.Err() != nil {
-					policySpan.SetAttributes(attribute.String("cache.get_outcome", "cancelled"))
-					return
-				}
 				// Semantic-miss errors: the connector is signalling
 				// "no key" / "expired" / "data not available here", not a
 				// real failure. Classify as miss so we don't inflate

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -368,10 +368,47 @@ drain:
 				rr := r
 				lastError = &rr
 			}
-		case <-ctx.Done():
-			// Caller gave up — stop waiting for in-flight peers. cancelFan
-			// (deferred) propagates the cancel to any still-running
-			// goroutines; the buffered channel and their refs GC together.
+		case <-fanCtx.Done():
+			// fanCtx fires from any of: (a) caller cancelled the parent
+			// ctx, (b) the 30s defensive backstop fired, (c) a winner
+			// called cancelFan() AFTER sending its hit into the buffer.
+			// Listening on fanCtx (not ctx) is required: if we only
+			// watched ctx, the backstop timeout in case (b) would cancel
+			// goroutines (so they return without sending) while leaving
+			// this loop blocked forever on a parent that never deadlines.
+			//
+			// Before bailing, drain any results already in the buffer.
+			// In case (c) the winner's send happened-before its cancelFan,
+			// so the hit IS in the channel — Go's select just happened to
+			// pick the Done branch over the receive branch. Picking up
+			// that hit here avoids a phantom miss under the race.
+		drainBuffer:
+			for {
+				select {
+				case r := <-results:
+					received++
+					if r.jrr != nil && jrr == nil {
+						rr := r
+						jrr = rr.jrr
+						policy = rr.policy
+						connector = rr.connector
+					} else {
+						switch r.missReason {
+						case "ttl_rejected":
+							rr := r
+							lastReject = &rr
+						case "empty_result":
+							rr := r
+							lastMiss = &rr
+						case "connector_error":
+							rr := r
+							lastError = &rr
+						}
+					}
+				default:
+					break drainBuffer
+				}
+			}
 			break drain
 		}
 	}

--- a/data/failsafe.go
+++ b/data/failsafe.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"slices"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/erpc/erpc/common"
@@ -16,7 +20,61 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// isTransportError reports whether err originates from the network/transport
+// layer. Retries are reserved for these — application-level errors (server-side
+// failures, malformed responses, validation issues) are not retriable, since
+// retrying them just burns budget without changing the outcome.
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if common.HasErrorCode(err, common.ErrCodeEndpointTransportFailure) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Aborted:
+			return true
+		}
+	}
+
+	// Fallback: opaque errors whose string clearly indicates transport-layer
+	// failure. This covers connectors that surface bare errors.New(...) for
+	// common transport faults without typing them.
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "network is unreachable"),
+		strings.Contains(msg, "tls handshake"),
+		strings.Contains(msg, "i/o timeout"):
+		return true
+	}
+
+	return false
+}
 
 var scopeConnector = common.Scope("connector")
 
@@ -530,10 +588,21 @@ func createCacheRetryPolicy(logger *zerolog.Logger, connectorId string, cfg *com
 			return false
 		}
 
-		// Retry all other errors (connection failures, server errors, etc.)
+		// Retry only on transport-layer errors. Application-level failures
+		// (server errors, malformed responses, etc.) burn retry budget without
+		// changing the outcome, so they fall through to the caller.
+		if !isTransportError(err) {
+			span.SetAttributes(
+				attribute.Bool("retry", false),
+				attribute.String("reason", "non_retriable_application_error"),
+				attribute.String("error.summary", common.ErrorSummary(err)),
+			)
+			return false
+		}
+
 		span.SetAttributes(
 			attribute.Bool("retry", true),
-			attribute.String("reason", "retriable_error"),
+			attribute.String("reason", "transport_error"),
 			attribute.String("error.summary", common.ErrorSummary(err)),
 		)
 		return true

--- a/data/failsafe.go
+++ b/data/failsafe.go
@@ -59,17 +59,36 @@ func isTransportError(err error) bool {
 	}
 
 	// Fallback: opaque errors whose string clearly indicates transport-layer
-	// failure. This covers connectors that surface bare errors.New(...) for
-	// common transport faults without typing them.
+	// failure or a known-transient server condition that retry can resolve.
+	// Covers connectors that surface bare errors.New(...) and well-known
+	// server-transient signals (redis cluster recovery, http/2 GOAWAY,
+	// closed-conn reuse) that the typed checks miss.
 	msg := strings.ToLower(err.Error())
 	switch {
+	// Connection-level transport faults
 	case strings.Contains(msg, "connection refused"),
 		strings.Contains(msg, "connection reset"),
 		strings.Contains(msg, "broken pipe"),
 		strings.Contains(msg, "no such host"),
 		strings.Contains(msg, "network is unreachable"),
 		strings.Contains(msg, "tls handshake"),
-		strings.Contains(msg, "i/o timeout"):
+		strings.Contains(msg, "i/o timeout"),
+		strings.Contains(msg, "operation timed out"),
+		// Connection-pool / reused-conn state (Go runtime + common clients)
+		strings.Contains(msg, "use of closed network connection"),
+		strings.Contains(msg, "client is closed"),
+		strings.Contains(msg, "unexpectedly closed"),
+		// HTTP/2 transport-level retryable signal
+		strings.Contains(msg, "goaway"),
+		// Redis cluster transients (recoverable on retry):
+		//   "LOADING Redis is loading the dataset in memory"
+		//   "CLUSTERDOWN The cluster is down"
+		//   "MASTERDOWN Link with MASTER is down"
+		//   "TRYAGAIN Multiple keys request during rehashing"
+		strings.Contains(msg, "clusterdown"),
+		strings.Contains(msg, "masterdown"),
+		strings.Contains(msg, "tryagain"),
+		strings.Contains(msg, "redis is loading"):
 		return true
 	}
 

--- a/data/failsafe_transport_test.go
+++ b/data/failsafe_transport_test.go
@@ -1,0 +1,232 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsTransportError(t *testing.T) {
+	u, err := url.Parse("https://example.com/rpc")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain stringy error", errors.New("something went wrong"), false},
+		{"app exception", fmt.Errorf("invalid argument: bad request"), false},
+		{"connection refused string", errors.New("dial tcp: connection refused"), true},
+		{"connection reset string", errors.New("read: connection reset by peer"), true},
+		{"broken pipe string", errors.New("write: broken pipe"), true},
+		{"no such host string", errors.New("dial tcp: lookup foo.invalid: no such host"), true},
+		{"i/o timeout string", errors.New("read tcp 1.2.3.4:443: i/o timeout"), true},
+		{"tls handshake string", errors.New("net/http: TLS handshake timeout"), true},
+		{"network unreachable string", errors.New("dial: network is unreachable"), true},
+		{"syscall ECONNREFUSED", syscall.ECONNREFUSED, true},
+		{"syscall ECONNRESET", syscall.ECONNRESET, true},
+		{"syscall EPIPE", syscall.EPIPE, true},
+		{"syscall ETIMEDOUT", syscall.ETIMEDOUT, true},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"net.OpError timeout", &net.OpError{Op: "read", Err: timeoutErr{}}, true},
+		{"grpc Unavailable", status.Error(codes.Unavailable, "service down"), true},
+		{"grpc DeadlineExceeded", status.Error(codes.DeadlineExceeded, "took too long"), true},
+		{"grpc Aborted", status.Error(codes.Aborted, "aborted by transport"), true},
+		{"grpc InvalidArgument", status.Error(codes.InvalidArgument, "bad params"), false},
+		{"grpc PermissionDenied", status.Error(codes.PermissionDenied, "no"), false},
+		{"common transport failure", common.NewErrEndpointTransportFailure(u, errors.New("dial fail")), true},
+		{"wrapped grpc unavailable", fmt.Errorf("rpc: %w", status.Error(codes.Unavailable, "x")), true},
+		{"wrapped io.EOF", fmt.Errorf("read: %w", io.EOF), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransportError(tc.err))
+		})
+	}
+}
+
+// timeoutErr satisfies net.Error with Timeout() == true so we can construct
+// a synthetic net.OpError without doing real I/O.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "synthetic timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestCacheFailsafe_RetryPolicy_RetriesTypedTransportFailure(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("test")
+
+	u, _ := url.Parse("https://example.com/rpc")
+	transportErr := common.NewErrEndpointTransportFailure(u, errors.New("dial fail"))
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, transportErr).Times(2)
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("data"), nil).Once()
+
+	fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+		{
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 5,
+				Delay:       common.Duration(5 * time.Millisecond),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	result, err := fc.Get(context.Background(), "", "pk", "rk", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), result)
+	mc.AssertNumberOfCalls(t, "Get", 3)
+}
+
+func TestCacheFailsafe_RetryPolicy_RetriesGrpcUnavailable(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("test")
+
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, status.Error(codes.Unavailable, "no service")).Times(2)
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("data"), nil).Once()
+
+	fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+		{
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 5,
+				Delay:       common.Duration(5 * time.Millisecond),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	result, err := fc.Get(context.Background(), "", "pk", "rk", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), result)
+	mc.AssertNumberOfCalls(t, "Get", 3)
+}
+
+func TestCacheFailsafe_RetryPolicy_RetriesNetTimeout(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("test")
+
+	netErr := &net.OpError{Op: "read", Err: timeoutErr{}}
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, netErr).Times(2)
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("data"), nil).Once()
+
+	fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+		{
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 5,
+				Delay:       common.Duration(5 * time.Millisecond),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	result, err := fc.Get(context.Background(), "", "pk", "rk", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), result)
+	mc.AssertNumberOfCalls(t, "Get", 3)
+}
+
+func TestCacheFailsafe_RetryPolicy_DoesNotRetryApplicationError(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("test")
+
+	appErr := errors.New("malformed response payload")
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, appErr)
+
+	fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+		{
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 5,
+				Delay:       common.Duration(5 * time.Millisecond),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fc.Get(context.Background(), "", "pk", "rk", nil)
+	require.Error(t, err)
+	mc.AssertNumberOfCalls(t, "Get", 1)
+}
+
+func TestCacheFailsafe_RetryPolicy_DoesNotRetryGrpcInvalidArgument(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("test")
+
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, status.Error(codes.InvalidArgument, "bad params"))
+
+	fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+		{
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 5,
+				Delay:       common.Duration(5 * time.Millisecond),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fc.Get(context.Background(), "", "pk", "rk", nil)
+	require.Error(t, err)
+	mc.AssertNumberOfCalls(t, "Get", 1)
+}
+
+// Sanity check: the existing well-known transient errors (record_not_found,
+// record_expired, context cancellation) still don't retry under the narrowed
+// predicate.
+func TestCacheFailsafe_RetryPolicy_StillExcludesKnownNonRetriable(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"record not found", common.NewErrRecordNotFound("pk", "rk", "memory")},
+		{"context canceled", context.Canceled},
+		{"context deadline exceeded", context.DeadlineExceeded},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := NewMockConnector("test")
+			mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return(nil, tc.err)
+
+			fc, err := NewFailsafeConnector(&logger, mc, []*common.FailsafeConfig{
+				{
+					Retry: &common.RetryPolicyConfig{
+						MaxAttempts: 3,
+						Delay:       common.Duration(5 * time.Millisecond),
+					},
+				},
+			}, nil)
+			require.NoError(t, err)
+
+			_, _ = fc.Get(context.Background(), "", "pk", "rk", nil)
+			mc.AssertNumberOfCalls(t, "Get", 1)
+		})
+	}
+}

--- a/data/failsafe_transport_test.go
+++ b/data/failsafe_transport_test.go
@@ -54,6 +54,21 @@ func TestIsTransportError(t *testing.T) {
 		{"common transport failure", common.NewErrEndpointTransportFailure(u, errors.New("dial fail")), true},
 		{"wrapped grpc unavailable", fmt.Errorf("rpc: %w", status.Error(codes.Unavailable, "x")), true},
 		{"wrapped io.EOF", fmt.Errorf("read: %w", io.EOF), true},
+		// Connection-pool / reused-conn state
+		{"use of closed network connection", errors.New("write tcp 1.2.3.4:443->5.6.7.8:443: use of closed network connection"), true},
+		{"go-redis client is closed", errors.New("redis: client is closed"), true},
+		{"unexpectedly closed", errors.New("EOF: stream unexpectedly closed"), true},
+		// HTTP/2 GOAWAY
+		{"http2 goaway", errors.New("http2: server sent GOAWAY and closed the connection"), true},
+		// Redis cluster transients
+		{"redis CLUSTERDOWN", errors.New("CLUSTERDOWN The cluster is down"), true},
+		{"redis MASTERDOWN", errors.New("MASTERDOWN Link with MASTER is down and slave-serve-stale-data is set to 'no'."), true},
+		{"redis TRYAGAIN", errors.New("TRYAGAIN Multiple keys request during rehashing of slot"), true},
+		{"redis LOADING", errors.New("LOADING Redis is loading the dataset in memory"), true},
+		// "operation timed out" variant
+		{"operation timed out", errors.New("dial: operation timed out"), true},
+		// Negative case: application errors that look textually close but aren't transient
+		{"redis nil reply not retriable", errors.New("redis: nil"), false},
 	}
 
 	for _, tc := range cases {

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/telemetry"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -255,6 +257,46 @@ func TestEvmJsonRpcCache_FanOut_ParentContextCancellationStopsAll(t *testing.T) 
 	elapsed := time.Since(t0)
 	assert.Less(t, elapsed, 500*time.Millisecond,
 		"caller-cancelled context should unwind all goroutines promptly (took %v)", elapsed)
+}
+
+// ParentContextDeadlineStopsAll covers the deadline path: the parent context
+// expires (rather than being explicitly cancelled), which propagates to peer
+// connectors as context.DeadlineExceeded — distinct from context.Canceled.
+// The cancellation guard must treat both alike, otherwise spurious connector
+// error metrics get emitted and the goroutine takes the noisy error path.
+func TestEvmJsonRpcCache_FanOut_ParentContextDeadlineStopsAll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	for _, c := range conns {
+		c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				callCtx := args.Get(0).(context.Context)
+				<-callCtx.Done()
+			}).
+			Return(nil, context.DeadlineExceeded).Maybe()
+	}
+
+	beforeErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+
+	getCtx, cancelGet := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelGet()
+	t0 := time.Now()
+	_, _ = cache.Get(getCtx, newGetBlockByNumberRequest(t, network, cache))
+	elapsed := time.Since(t0)
+
+	// Allow goroutines a brief moment to drain any (incorrect) metric emission.
+	time.Sleep(50 * time.Millisecond)
+	afterErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"deadline-expired parent context should unwind all goroutines promptly (took %v)", elapsed)
+	assert.Equal(t, beforeErr, afterErr,
+		"deadline-cancelled connector calls must not emit cache_get_error_total — they are external cancellations, not connector failures")
 }
 
 func TestEvmJsonRpcCache_FanOut_RespectsSkipCacheReadDirective(t *testing.T) {

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -325,6 +325,38 @@ func TestEvmJsonRpcCache_FanOut_RespectsSkipCacheReadDirective(t *testing.T) {
 		mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything)
 }
 
+// MissAsErrorIsNotEmittedAsConnectorError is the regression for the
+// shadow-deployment finding: cache connectors return ErrRecordNotFound /
+// ErrEndpointMissingData to signal "this connector doesn't have the key" —
+// semantic misses, not transport failures. Before the fix the fan-out
+// goroutine classified them as connector_error and incremented
+// MetricCacheGetErrorTotal on every cache miss, polluting dashboards
+// (shadow logged 36k+ "errors" per 15min that were just normal misses).
+func TestEvmJsonRpcCache_FanOut_MissAsErrorIsClassifiedAsMiss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	for _, c := range conns {
+		c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+			Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", c.Id()))
+	}
+
+	beforeErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.Nil(t, resp, "all connectors returning ErrRecordNotFound is a miss, not an error")
+
+	afterErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+	assert.Equal(t, beforeErr, afterErr,
+		"ErrRecordNotFound from connectors is a semantic miss — must not increment cache_get_error_total")
+}
+
 // WrappedCancellationDoesNotInflateErrorMetric is the regression for the
 // inner-failsafe wrapping issue: when a losing peer's `doGet` returns
 // through an inner failsafe stack, the underlying context error can be

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -324,3 +324,94 @@ func TestEvmJsonRpcCache_FanOut_RespectsSkipCacheReadDirective(t *testing.T) {
 	conns[0].AssertNotCalled(t, "Get",
 		mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything)
 }
+
+// WrappedCancellationDoesNotInflateErrorMetric is the regression for the
+// inner-failsafe wrapping issue: when a losing peer's `doGet` returns
+// through an inner failsafe stack, the underlying context error can be
+// wrapped in a typed error that `errors.Is(err, context.Canceled)` fails
+// to unwind. The cancellation guard must trust `fanCtx.Err() != nil` as
+// the authoritative signal, not the error type, so wrapped cancellation
+// from a losing peer does not increment cache_get_error_total.
+func TestEvmJsonRpcCache_FanOut_WrappedCancellationDoesNotInflateError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	cached := `{"number":"0x1","hash":"0xfast"}`
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil) // immediate hit
+
+	// Loser observes cancellation but surfaces a typed, opaque error that
+	// does NOT unwrap to context.Canceled — simulates an inner failsafe
+	// wrapper. Pre-fix guard (errors.Is on context.Canceled) would miss
+	// this and increment connector_error metric for every fan-out loser.
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			callCtx := args.Get(0).(context.Context)
+			<-callCtx.Done()
+		}).
+		Return(nil, errors.New("opaque-inner-failsafe-wrap")).Maybe()
+
+	beforeErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+
+	// Allow the cancelled peer goroutine a moment to drain.
+	time.Sleep(50 * time.Millisecond)
+	afterErr := promUtil.CollectAndCount(telemetry.MetricCacheGetErrorTotal)
+	assert.Equal(t, beforeErr, afterErr,
+		"wrapped cancellation from a losing peer must not increment cache_get_error_total")
+}
+
+// SlowPeerDoesNotBlockFastWinner is the regression for the consumer-drain
+// bug: previously `for r := range results` waited for the channel to close,
+// which only happened after wg.Wait — so any peer slow to observe
+// cancellation (buffered TCP write, inner failsafe state, misbehaving
+// stack) pinned the user-visible latency to MAX(connector latency). The
+// fix breaks out of the drain loop on first acceptable hit; stragglers
+// drain into the buffered channel on their own.
+func TestEvmJsonRpcCache_FanOut_SlowPeerDoesNotBlockFastWinner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	cached := `{"number":"0x1","hash":"0xfast"}`
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil) // immediate hit
+
+	// Peer that intentionally ignores ctx.Done — simulates a connector with
+	// buffered work or a stack that doesn't honor cancellation promptly. If
+	// the consumer waited for this peer, Get() would block for the full
+	// slowDelay before returning.
+	const slowDelay = 800 * time.Millisecond
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			time.Sleep(slowDelay)
+		}).
+		Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", "slow")).Maybe()
+
+	t0 := time.Now()
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+	elapsed := time.Since(t0)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"fast hit should not wait for unresponsive peer (took %v); slow peer would have taken %v",
+		elapsed, slowDelay)
+}

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -1,0 +1,284 @@
+package erpc
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fanOutPolicies wires both mock connectors as cache policies for the same
+// network+method so the cache layer fans out across them.
+func fanOutPolicies(t *testing.T, conns []*data.MockConnector) []*data.CachePolicy {
+	t.Helper()
+	policies := make([]*data.CachePolicy, 0, len(conns))
+	for _, c := range conns {
+		p, err := data.NewCachePolicy(&common.CachePolicyConfig{
+			Network:   "evm:123",
+			Method:    "eth_getBlockByNumber",
+			Connector: c.Id(),
+		}, c)
+		require.NoError(t, err)
+		policies = append(policies, p)
+	}
+	return policies
+}
+
+func newGetBlockByNumberRequest(t *testing.T, network *Network, cache common.CacheDAL) *common.NormalizedRequest {
+	t.Helper()
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1",false],"id":1}`))
+	req.SetNetwork(network)
+	req.SetCacheDal(cache)
+	return req
+}
+
+func TestEvmJsonRpcCache_FanOut_FirstHitWins(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	expected := `{"number":"0x1","hash":"0xfromA"}`
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(expected), nil)
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(`{"number":"0x1","hash":"0xfromB"}`), nil).Maybe()
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	// We don't assert which connector wins — only that we got one of the hits.
+	got := jrr.GetResultString()
+	require.Truef(t,
+		got == expected || got == `{"number":"0x1","hash":"0xfromB"}`,
+		"unexpected response: %s", got,
+	)
+	require.True(t, resp.FromCache())
+}
+
+func TestEvmJsonRpcCache_FanOut_AllMissReturnsNil(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	notFound := common.NewErrRecordNotFound("evm:123:1", "k", "mock")
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, notFound)
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, notFound)
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.Nil(t, resp, "all-miss should fall through to upstream layer")
+	conns[0].AssertCalled(t, "Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything)
+	conns[1].AssertCalled(t, "Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything)
+}
+
+func TestEvmJsonRpcCache_FanOut_OneMissOneHit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	notFound := common.NewErrRecordNotFound("evm:123:1", "k", "mock1")
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, notFound)
+
+	cached := `{"number":"0x1","hash":"0xabc"}`
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil)
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+}
+
+func TestEvmJsonRpcCache_FanOut_OneErrorOneHit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, errors.New("connection refused"))
+
+	cached := `{"number":"0x1","hash":"0xabc"}`
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil)
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp, "errors on one connector must not block hits from peers")
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+}
+
+func TestEvmJsonRpcCache_FanOut_AllErrorsFallThrough(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, errors.New("connection refused"))
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return(nil, errors.New("i/o timeout"))
+
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+
+	require.NoError(t, err, "Get must not surface connector errors — caller falls through to upstream")
+	require.Nil(t, resp)
+}
+
+func TestEvmJsonRpcCache_FanOut_RunsConcurrently(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	// Both connectors take 100ms; if run sequentially the call would take ≥200ms.
+	// Parallel fan-out keeps it under ~150ms.
+	const delay = 100 * time.Millisecond
+	for _, c := range conns {
+		c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+			After(delay).
+			Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", c.Id()))
+	}
+
+	t0 := time.Now()
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+	elapsed := time.Since(t0)
+
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	assert.Less(t, elapsed, 180*time.Millisecond,
+		"fan-out should run connectors concurrently (took %v)", elapsed)
+}
+
+// FirstHitCancelsPeer verifies that once one connector returns a hit, peer
+// connectors observe context cancellation. The slow connector here would take
+// 1s if not cancelled — the assertion is that the call returns much earlier.
+func TestEvmJsonRpcCache_FanOut_FirstHitCancelsPeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	cached := `{"number":"0x1","hash":"0xfast"}`
+	conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil) // immediate hit
+
+	var slowSawCancel atomic.Bool
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			callCtx := args.Get(0).(context.Context)
+			select {
+			case <-callCtx.Done():
+				slowSawCancel.Store(true)
+			case <-time.After(time.Second):
+			}
+		}).
+		Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", "mock2")).Maybe()
+
+	t0 := time.Now()
+	resp, err := cache.Get(context.Background(), newGetBlockByNumberRequest(t, network, cache))
+	elapsed := time.Since(t0)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"slow peer should be cancelled once fast peer wins (took %v)", elapsed)
+	// Allow up to 200ms for the slow goroutine to observe cancellation.
+	assert.Eventually(t, slowSawCancel.Load, 200*time.Millisecond, 5*time.Millisecond,
+		"slow peer goroutine should observe context cancellation after first hit wins")
+}
+
+func TestEvmJsonRpcCache_FanOut_ParentContextCancellationStopsAll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	for _, c := range conns {
+		c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				callCtx := args.Get(0).(context.Context)
+				<-callCtx.Done()
+			}).
+			Return(nil, context.Canceled).Maybe()
+	}
+
+	getCtx, cancelGet := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancelGet()
+	}()
+	t0 := time.Now()
+	_, _ = cache.Get(getCtx, newGetBlockByNumberRequest(t, network, cache))
+	elapsed := time.Since(t0)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"caller-cancelled context should unwind all goroutines promptly (took %v)", elapsed)
+}
+
+func TestEvmJsonRpcCache_FanOut_RespectsSkipCacheReadDirective(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	cached := `{"number":"0x1","hash":"0xfromB"}`
+	conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+		Return([]byte(cached), nil)
+
+	req := newGetBlockByNumberRequest(t, network, cache)
+	req.SetDirectives(&common.RequestDirectives{SkipCacheRead: conns[0].Id()})
+
+	resp, err := cache.Get(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, err := resp.JsonRpcResponse()
+	require.NoError(t, err)
+	assert.Equal(t, cached, jrr.GetResultString())
+	conns[0].AssertNotCalled(t, "Get",
+		mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
Two related changes to the cache read path.

**Parallel fan-out across cache connectors.** `EvmJsonRpcCache.Get` previously walked matching cache connectors sequentially, returning on the first hit. With multiple cache connectors configured, slow misses on the first connector forced legitimate hits on later connectors to wait. The new path fires connectors in parallel; first accepted hit wins and cancels in-flight peers; all-miss falls through to upstreams. Age-guard validation runs per-result so a stale entry on one connector cannot block a fresh hit on another.

**Transport-only retries.** The `HandleIf` predicate retried every error that wasn't an explicit cache miss / context cancellation. Application-level failures (server-side errors, malformed responses) burn retry budget without changing the outcome. Retries are now reserved for typed transport errors: `ErrCodeEndpointTransportFailure`, `net.Error.Timeout()`, common `syscall` errnos, `io.EOF` / `io.ErrUnexpectedEOF`, gRPC `Unavailable` / `DeadlineExceeded` / `Aborted`, with a string fallback for opaque errors surfacing well-known transport phrases.

## Test plan
- [x] `data` package: `TestIsTransportError` (table-driven), `TestCacheFailsafe_RetryPolicy_*`
- [x] `erpc` package: `TestEvmJsonRpcCache_FanOut_*` (first-hit-wins, all-miss fall through, one-error-one-hit, all-errors fall through, concurrent execution, peer cancellation on first hit, parent context cancellation, skip-cache-read directive)
- [x] No regressions in existing `TestEvmJsonRpcCache_*` suite
- [x] `go vet ./...` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cache read and connector retry paths, adding new concurrency/cancellation behavior and changing which errors trigger retries; mistakes could impact latency, cache hit attribution, or resilience under failure.
> 
> **Overview**
> **Cache reads now fan out in parallel across matching connectors** in `EvmJsonRpcCache.Get`: the first acceptable hit wins and cancels peers, while misses/TTL rejections/semantic-miss errors fall through without blocking on slow connectors, with a 30s defensive timeout and improved miss attribution/metrics.
> 
> **Connector retry policy is tightened to transport-only errors** via new `isTransportError` checks (typed and string fallbacks), preventing retries on application-level failures; adds targeted test coverage for fan-out behavior, cancellation/metrics regressions, and transport-only retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd6c2a50d04e8565fbf03fe578ceec14c4d681a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->