### PR TITLE
fix: exclude hedge-cancelled attempts from upstream error rate denominator

### DIFF
--- a/common/upstream.go
+++ b/common/upstream.go
@@ -27,6 +27,7 @@ type HealthTracker interface {
 	RecordUpstreamMisbehavior(up Upstream, method string)
 	RecordUpstreamRequest(up Upstream, method string)
 	RecordUpstreamFailure(up Upstream, method string, err error)
+	RecordUpstreamHedgeCancelled(up Upstream, method string)
 	Cordon(upstream Upstream, method string, reason string)
 	Uncordon(upstream Upstream, method string, reason string)
 }

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -275,6 +275,10 @@ func (t *FakeHealthTracker) RecordUpstreamFailure(up Upstream, method string, er
 	// No-op for testing
 }
 
+func (t *FakeHealthTracker) RecordUpstreamHedgeCancelled(up Upstream, method string) {
+	// No-op for testing
+}
+
 func (t *FakeHealthTracker) Cordon(upstream Upstream, method string, reason string) {
 	// No-op for testing
 }

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1226,6 +1226,7 @@ func (n *Network) recordHedgeDiscard(
 	hedges int,
 ) {
 	ulg.Debug().Err(err).Msgf("discarding hedged request to upstream")
+	u.Tracker().RecordUpstreamHedgeCancelled(u, method)
 	finality := req.Finality(ctx)
 	telemetry.CounterHandle(telemetry.MetricNetworkHedgeDiscardsTotal,
 		n.projectId, n.Label(), u.Id(), method, fmt.Sprintf("%d", attempts),

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -88,6 +88,7 @@ type TrackedMetrics struct {
 	ErrorsTotal            atomic.Int64     `json:"errorsTotal"`
 	RemoteRateLimitedTotal atomic.Int64     `json:"remoteRateLimitedTotal"`
 	RequestsTotal          atomic.Int64     `json:"requestsTotal"`
+	HedgeCancelledTotal    atomic.Int64     `json:"hedgeCancelledTotal"`
 	MisbehaviorsTotal      atomic.Int64     `json:"misbehaviorsTotal"`
 	BlockHeadLag           atomic.Int64     `json:"blockHeadLag"`
 	FinalizationLag        atomic.Int64     `json:"finalizationLag"`
@@ -95,8 +96,19 @@ type TrackedMetrics struct {
 	LastCordonedReason     atomic.Value     `json:"lastCordonedReason"`
 }
 
+// effectiveRequests returns the denominator for rate calculations.
+// Hedge-cancelled attempts are excluded: they were neither successes nor
+// upstream faults, so including them suppresses error/throttle/misbehavior rates.
+func (m *TrackedMetrics) effectiveRequests() int64 {
+	reqs := m.RequestsTotal.Load() - m.HedgeCancelledTotal.Load()
+	if reqs < 0 {
+		return 0
+	}
+	return reqs
+}
+
 func (m *TrackedMetrics) ErrorRate() float64 {
-	reqs := m.RequestsTotal.Load()
+	reqs := m.effectiveRequests()
 	if reqs == 0 {
 		return 0
 	}
@@ -108,16 +120,15 @@ func (m *TrackedMetrics) GetResponseQuantiles() common.QuantileTracker {
 }
 
 func (m *TrackedMetrics) ThrottledRate() float64 {
-	reqs := m.RequestsTotal.Load()
+	reqs := m.effectiveRequests()
 	if reqs == 0 {
 		return 0
 	}
-	throttled := float64(m.RemoteRateLimitedTotal.Load())
-	return throttled / float64(reqs)
+	return float64(m.RemoteRateLimitedTotal.Load()) / float64(reqs)
 }
 
 func (m *TrackedMetrics) MisbehaviorRate() float64 {
-	reqs := m.RequestsTotal.Load()
+	reqs := m.effectiveRequests()
 	if reqs == 0 {
 		return 0
 	}
@@ -130,6 +141,7 @@ func (m *TrackedMetrics) MarshalJSON() ([]byte, error) {
 		"errorsTotal":            m.ErrorsTotal.Load(),
 		"remoteRateLimitedTotal": m.RemoteRateLimitedTotal.Load(),
 		"requestsTotal":          m.RequestsTotal.Load(),
+		"hedgeCancelledTotal":    m.HedgeCancelledTotal.Load(),
 		"misbehaviorsTotal":      m.MisbehaviorsTotal.Load(),
 		"blockHeadLag":           m.BlockHeadLag.Load(),
 		"finalizationLag":        m.FinalizationLag.Load(),
@@ -147,6 +159,7 @@ func (m *TrackedMetrics) MarshalJSON() ([]byte, error) {
 func (m *TrackedMetrics) Reset() {
 	m.ErrorsTotal.Store(0)
 	m.RequestsTotal.Store(0)
+	m.HedgeCancelledTotal.Store(0)
 	m.RemoteRateLimitedTotal.Store(0)
 	m.MisbehaviorsTotal.Store(0)
 	// DO NOT reset m.BlockHeadLag - it's a state metric, not cumulative
@@ -495,6 +508,15 @@ func (t *Tracker) RecordUpstreamRequest(up common.Upstream, method string) {
 	}
 	for _, nk := range t.getNtwKeys(up, method) {
 		t.getNtwMetrics(nk).RequestsTotal.Add(1)
+	}
+}
+
+func (t *Tracker) RecordUpstreamHedgeCancelled(up common.Upstream, method string) {
+	for _, k := range t.getUpsKeys(up, method) {
+		t.getUpsMetrics(k).HedgeCancelledTotal.Add(1)
+	}
+	for _, nk := range t.getNtwKeys(up, method) {
+		t.getNtwMetrics(nk).HedgeCancelledTotal.Add(1)
 	}
 }
 

--- a/health/tracker_test.go
+++ b/health/tracker_test.go
@@ -734,6 +734,44 @@ func TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors(t *testing.T) {
 	})
 }
 
+func TestRecordUpstreamHedgeCancelled_ExcludedFromRateDenominator(t *testing.T) {
+	projectID := "test-hedge"
+	tracker := NewTracker(&log.Logger, projectID, 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+
+	ups := common.NewFakeUpstream("hedge-upstream")
+	method := "eth_call"
+
+	// 10 total attempts: 5 real attempts + 5 that lost the hedge race
+	for i := 0; i < 10; i++ {
+		tracker.RecordUpstreamRequest(ups, method)
+	}
+	// 3 real failures on the 5 real attempts
+	for i := 0; i < 3; i++ {
+		tracker.RecordUpstreamFailure(ups, method, fmt.Errorf("connection refused"))
+	}
+	// 5 hedge-cancelled attempts
+	for i := 0; i < 5; i++ {
+		tracker.RecordUpstreamHedgeCancelled(ups, method)
+	}
+
+	mt := tracker.GetUpstreamMethodMetrics(ups, method)
+	require.NotNil(t, mt)
+	assert.Equal(t, int64(10), mt.RequestsTotal.Load(), "all attempts recorded")
+	assert.Equal(t, int64(5), mt.HedgeCancelledTotal.Load(), "hedge cancellations tracked")
+	assert.Equal(t, int64(3), mt.ErrorsTotal.Load(), "only real errors counted")
+	// denominator is 10-5=5, not 10
+	assert.InDelta(t, 0.6, mt.ErrorRate(), 0.001, "error rate uses effective requests as denominator")
+
+	t.Run("reset_clears_hedge_cancelled", func(t *testing.T) {
+		mt.Reset()
+		assert.Equal(t, int64(0), mt.HedgeCancelledTotal.Load())
+		assert.Equal(t, int64(0), mt.RequestsTotal.Load())
+	})
+}
+
 func TestRecordUpstreamDuration_OnlySuccessInQuantile(t *testing.T) {
 	projectID := "test-latency"
 	tracker := NewTracker(&log.Logger, projectID, 10*time.Second)


### PR DESCRIPTION
## Problem

When a hedged request loses the race, `RecordUpstreamRequest` increments `RequestsTotal` but `RecordUpstreamFailure` is skipped — `ErrCodeUpstreamHedgeCancelled` is correctly not treated as an upstream fault. This creates an asymmetry: hedge-cancelled attempts inflate the denominator of `ErrorRate`, `ThrottledRate`, and `MisbehaviorRate` without contributing to the numerator.

During periods of heavy hedging, a degraded upstream can appear significantly healthier than it is. If 50% of requests to an upstream are hedge-cancelled, its observed error rate is halved — suppressing the signal the selection policy uses to route traffic away from it.

## Solution

Add `HedgeCancelledTotal` to `TrackedMetrics` and call `RecordUpstreamHedgeCancelled` from `recordHedgeDiscard` in `networks.go` — the single unambiguous point where a hedge loss is definitively known (`hedges > 0 && ErrCodeEndpointRequestCanceled`).

Rate calculations subtract `HedgeCancelledTotal` from `RequestsTotal` via a new `effectiveRequests()` helper. `RequestsTotal` is preserved as a true throughput counter so observability is not reduced — `hedgeCancelledTotal` is also exposed in the health JSON endpoint.

## Changes

- `common/upstream.go` — add `RecordUpstreamHedgeCancelled` to `HealthTracker` interface
- `common/upstream_fake.go` — no-op stub
- `health/tracker.go` — `HedgeCancelledTotal` field, `effectiveRequests()` helper, updated rate calculations, `Reset`, `MarshalJSON`, new tracker method
- `erpc/networks.go` — call `u.Tracker().RecordUpstreamHedgeCancelled(u, method)` in `recordHedgeDiscard`
- `health/tracker_test.go` — new test verifying corrected denominator

## Testing

```
make test-fast
```

New test: 10 requests, 5 hedge-cancelled, 3 real failures → `ErrorRate() == 0.6` (3/5), not `0.3` (3/10).