### PR TITLE
feat: expose blockHeadLagSeconds and finalizationLagSeconds in selection policy

### DIFF
--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -254,9 +254,19 @@ export type UpstreamMetrics = {
     // (e.g. 10 blocks ≈ 120s on Ethereum, ≈ 2.5s on Arbitrum).
     blockHeadLag: number;
 
+    // Seconds this upstream is behind the network's highest known block head,
+    // derived from blockHeadLag × the EMA-estimated block time.
+    // Zero until the block-time EMA has collected at least 3 samples.
+    blockHeadLagSeconds: number;
+
     // Number of finalized blocks this upstream is behind the network's highest known
     // finalized block. Block-number delta, not seconds.
     finalizationLag: number;
+
+    // Seconds this upstream is behind the network's highest known finalized block,
+    // derived from finalizationLag × the EMA-estimated block time.
+    // Zero until the block-time EMA has collected at least 3 samples.
+    finalizationLagSeconds: number;
 };
 
 // Method is either `*` (all methods) or a specific method name.

--- a/erpc/policy_evaluator.go
+++ b/erpc/policy_evaluator.go
@@ -105,6 +105,8 @@ func (p *PolicyEvaluator) evaluateUpstreams() error {
 		return fmt.Errorf("no upstreams found for network: %s", p.networkId)
 	}
 
+	blockTime := p.metricsTracker.GetNetworkBlockTime(p.networkId)
+
 	if p.config.EvalPerMethod {
 		// Handle method-specific evaluations
 		// Get all metrics to find unique methods
@@ -118,13 +120,13 @@ func (p *PolicyEvaluator) evaluateUpstreams() error {
 
 		// Evaluate each method separately
 		for method := range allMetrics {
-			if err := p.evaluateMethod(method, upsList); err != nil {
+			if err := p.evaluateMethod(method, upsList, blockTime); err != nil {
 				p.logger.Error().Err(err).Str("method", method).Msg("failed to evaluate user-defined selectionPolicy for method")
 			}
 		}
 	} else {
 		// Handle network-level evaluation
-		if err := p.evaluateMethod("*", upsList); err != nil {
+		if err := p.evaluateMethod("*", upsList, blockTime); err != nil {
 			p.logger.Error().Err(err).Msg("failed to evaluate user-defined selectionPolicy for network")
 		}
 	}
@@ -132,23 +134,36 @@ func (p *PolicyEvaluator) evaluateUpstreams() error {
 	return nil
 }
 
-func (p *PolicyEvaluator) evaluateMethod(method string, upsList []*upstream.Upstream) error {
+func (p *PolicyEvaluator) evaluateMethod(method string, upsList []*upstream.Upstream, blockTime time.Duration) error {
 	metricsData := make([]metricData, len(upsList))
 	for i, ups := range upsList {
 		metrics := p.metricsTracker.GetUpstreamMethodMetrics(ups, method)
+
+		blockHeadLag := metrics.BlockHeadLag.Load()
+		finalizationLag := metrics.FinalizationLag.Load()
+
+		blockHeadLagSeconds := 0.0
+		finalizationLagSeconds := 0.0
+		if blockTime > 0 {
+			blockHeadLagSeconds = float64(blockHeadLag) * blockTime.Seconds()
+			finalizationLagSeconds = float64(finalizationLag) * blockTime.Seconds()
+		}
+
 		metricsData[i] = metricData{
 			"id":     ups.Id(),
 			"config": ups.Config(),
 			"metrics": map[string]interface{}{
-				"errorRate":          metrics.ErrorRate(),
-				"errorsTotal":        metrics.ErrorsTotal.Load(),
-				"requestsTotal":      metrics.RequestsTotal.Load(),
-				"throttledRate":      metrics.ThrottledRate(),
-				"p90ResponseSeconds": metrics.ResponseQuantiles.GetQuantile(0.90).Seconds(),
-				"p95ResponseSeconds": metrics.ResponseQuantiles.GetQuantile(0.95).Seconds(),
-				"p99ResponseSeconds": metrics.ResponseQuantiles.GetQuantile(0.99).Seconds(),
-				"blockHeadLag":       metrics.BlockHeadLag.Load(),
-				"finalizationLag":    metrics.FinalizationLag.Load(),
+				"errorRate":              metrics.ErrorRate(),
+				"errorsTotal":            metrics.ErrorsTotal.Load(),
+				"requestsTotal":          metrics.RequestsTotal.Load(),
+				"throttledRate":          metrics.ThrottledRate(),
+				"p90ResponseSeconds":     metrics.ResponseQuantiles.GetQuantile(0.90).Seconds(),
+				"p95ResponseSeconds":     metrics.ResponseQuantiles.GetQuantile(0.95).Seconds(),
+				"p99ResponseSeconds":     metrics.ResponseQuantiles.GetQuantile(0.99).Seconds(),
+				"blockHeadLag":           blockHeadLag,
+				"finalizationLag":        finalizationLag,
+				"blockHeadLagSeconds":    blockHeadLagSeconds,
+				"finalizationLagSeconds": finalizationLagSeconds,
 
 				// @deprecated
 				"p90LatencySecs": metrics.ResponseQuantiles.GetQuantile(0.90).Seconds(),

--- a/erpc/policy_evaluator_test.go
+++ b/erpc/policy_evaluator_test.go
@@ -2164,3 +2164,182 @@ func TestPolicyEvaluatorBlockHeadLagFlow(t *testing.T) {
 		}
 	})
 }
+
+func TestPolicyEvaluatorLagSeconds(t *testing.T) {
+	logger := log.Logger
+
+	// warmEMA feeds 4 observations into the tracker with a fixed 2-second block
+	// time so that GetNetworkBlockTime returns ~2s for the test network.
+	warmEMA := func(mt *health.Tracker, ups *upstream.Upstream) {
+		base := int64(1700000000)
+		mt.SetLatestBlockNumber(ups, 100, base)
+		mt.SetLatestBlockNumber(ups, 101, base+2)
+		mt.SetLatestBlockNumber(ups, 102, base+4)
+		mt.SetLatestBlockNumber(ups, 103, base+6)
+	}
+
+	t.Run("BlockHeadLagSecondsZeroBeforeEMAWarm", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ntw, ups1, ups2, _ := createTestNetwork(t, ctx)
+
+		// Policy filters on blockHeadLagSeconds; with a cold EMA all seconds
+		// values are 0 so every upstream passes the threshold.
+		evalFn, err := common.CompileFunction(`
+			(upstreams, method) => {
+				const defaults = upstreams.filter(u => u.config.group === 'main');
+				return defaults.filter(u => u.metrics.blockHeadLagSeconds < 5);
+			}
+		`)
+		require.NoError(t, err)
+
+		config := &common.SelectionPolicyConfig{
+			EvalPerMethod: false,
+			EvalFunction:  evalFn,
+		}
+
+		mt := ntw.metricsTracker
+		evaluator, err := NewPolicyEvaluator("evm:123", &logger, config, ntw.upstreamsRegistry, mt)
+		require.NoError(t, err)
+		evaluator.appCtx = ctx
+
+		// Precondition: EMA must be cold so blockHeadLagSeconds is 0 regardless of lag.
+		require.Zero(t, mt.GetNetworkBlockTime("evm:123"), "EMA must be cold before this test")
+
+		// Give ups2 a large block lag but pass no timestamps, so EMA stays cold.
+		mt.SetLatestBlockNumber(ups1, 120, 0)
+		mt.SetLatestBlockNumber(ups2, 100, 0) // 20-block lag, but lagSeconds = 0
+
+		require.NoError(t, evaluator.evaluateUpstreams())
+
+		// Both should be active because blockHeadLagSeconds == 0 when EMA is cold.
+		err = evaluator.AcquirePermit(&logger, ups1, "eth_getBalance")
+		assert.NoError(t, err, "ups1 should be active")
+		err = evaluator.AcquirePermit(&logger, ups2, "eth_getBalance")
+		assert.NoError(t, err, "ups2 should be active: lagSeconds is 0 when EMA not warm")
+	})
+
+	t.Run("BlockHeadLagSecondsFiltering", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ntw, ups1, ups2, _ := createTestNetwork(t, ctx)
+
+		evalFn, err := common.CompileFunction(`
+			(upstreams, method) => {
+				const defaults = upstreams.filter(u => u.config.group === 'main');
+				return defaults.filter(u => u.metrics.blockHeadLagSeconds < 10);
+			}
+		`)
+		require.NoError(t, err)
+
+		config := &common.SelectionPolicyConfig{
+			EvalPerMethod: false,
+			EvalFunction:  evalFn,
+		}
+
+		mt := ntw.metricsTracker
+		evaluator, err := NewPolicyEvaluator("evm:123", &logger, config, ntw.upstreamsRegistry, mt)
+		require.NoError(t, err)
+		evaluator.appCtx = ctx
+
+		// Pre-create metric rows so upstreamsByNetwork is populated before lag
+		// values are written; without this, SetLatestBlockNumber finds an empty
+		// index and the lag is never stored.
+		mt.RecordUpstreamRequest(ups1, "*")
+		mt.RecordUpstreamRequest(ups2, "*")
+
+		// Warm up the EMA to ~2s block time using ups1 as the advancing upstream.
+		warmEMA(mt, ups1)
+		// ups1 is now at block 103 (network head); ups2 at block 97 → lag = 6 blocks → ~12s.
+		mt.SetLatestBlockNumber(ups2, 97, 0)
+
+		require.NoError(t, evaluator.evaluateUpstreams())
+
+		// ups1: 0s lag → passes. ups2: ~12s lag → cordoned.
+		err = evaluator.AcquirePermit(&logger, ups1, "eth_getBalance")
+		assert.NoError(t, err, "ups1 should be active with 0s lag")
+		err = evaluator.AcquirePermit(&logger, ups2, "eth_getBalance")
+		assert.Error(t, err, "ups2 should be cordoned: ~12s lag exceeds 10s threshold")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamExcludedByPolicy))
+
+		// ups2 catches up: lag = 1 block → ~2s, which is under the 10s threshold.
+		mt.SetLatestBlockNumber(ups2, 102, 0)
+
+		require.NoError(t, evaluator.evaluateUpstreams())
+
+		err = evaluator.AcquirePermit(&logger, ups1, "eth_getBalance")
+		assert.NoError(t, err, "ups1 should remain active")
+		err = evaluator.AcquirePermit(&logger, ups2, "eth_getBalance")
+		assert.NoError(t, err, "ups2 should be uncordoned: ~2s lag is under threshold")
+	})
+
+	t.Run("FinalizationLagSecondsFiltering", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+		defer util.AssertNoPendingMocks(t, 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ntw, ups1, ups2, _ := createTestNetwork(t, ctx)
+
+		evalFn, err := common.CompileFunction(`
+			(upstreams, method) => {
+				const defaults = upstreams.filter(u => u.config.group === 'main');
+				return defaults.filter(u => u.metrics.finalizationLagSeconds < 30);
+			}
+		`)
+		require.NoError(t, err)
+
+		config := &common.SelectionPolicyConfig{
+			EvalPerMethod: false,
+			EvalFunction:  evalFn,
+		}
+
+		mt := ntw.metricsTracker
+		evaluator, err := NewPolicyEvaluator("evm:123", &logger, config, ntw.upstreamsRegistry, mt)
+		require.NoError(t, err)
+		evaluator.appCtx = ctx
+
+		// Pre-create metric rows so upstreamsByNetwork is populated before lag
+		// values are written; without this, SetLatestBlockNumber finds an empty
+		// index and the lag is never stored.
+		mt.RecordUpstreamRequest(ups1, "*")
+		mt.RecordUpstreamRequest(ups2, "*")
+
+		// Warm up the EMA to ~2s block time.
+		warmEMA(mt, ups1)
+
+		// ups1 finalized at 100 (network head); ups2 finalized at 80 → lag = 20 → ~40s.
+		mt.SetFinalizedBlockNumber(ups1, 100)
+		mt.SetFinalizedBlockNumber(ups2, 80)
+
+		require.NoError(t, evaluator.evaluateUpstreams())
+
+		err = evaluator.AcquirePermit(&logger, ups1, "eth_getBalance")
+		assert.NoError(t, err, "ups1 should be active with 0s finalization lag")
+		err = evaluator.AcquirePermit(&logger, ups2, "eth_getBalance")
+		assert.Error(t, err, "ups2 should be cordoned: ~40s finalization lag exceeds 30s threshold")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamExcludedByPolicy))
+
+		// ups2 catches up: lag = 4 blocks → ~8s, under the 30s threshold.
+		mt.SetFinalizedBlockNumber(ups2, 96)
+
+		require.NoError(t, evaluator.evaluateUpstreams())
+
+		err = evaluator.AcquirePermit(&logger, ups1, "eth_getBalance")
+		assert.NoError(t, err, "ups1 should remain active")
+		err = evaluator.AcquirePermit(&logger, ups2, "eth_getBalance")
+		assert.NoError(t, err, "ups2 should be uncordoned: ~8s finalization lag is under threshold")
+	})
+}


### PR DESCRIPTION
## Summary

`blockHeadLag` and `finalizationLag` in the selection policy eval function are
raw block-count deltas. Policy authors who want to reason in time units must
independently know the chain's block time — which varies by network and changes
post-merge/upgrade.

This adds `blockHeadLagSeconds` and `finalizationLagSeconds` to the upstream
metrics object passed to `evalFunction`, derived from the existing EMA-based
block time estimate (`GetNetworkBlockTime`). The two new fields make time-based
lag thresholds expressible directly in policy scripts without any chain-specific
knowledge in the config.

## Changes

- In `evaluateMethod`, call `GetNetworkBlockTime(networkId)` once per evaluation
  tick (network-level EMA, shared across all upstreams).
- Derive `blockHeadLagSeconds = blockHeadLag * blockTime.Seconds()` and
  `finalizationLagSeconds = finalizationLag * blockTime.Seconds()` per upstream.
- Both fields are `0.0` when the block time EMA is not yet warm (fewer than 3
  samples), matching the existing behaviour of `GetNetworkBlockTime` returning 0.
- Existing `blockHeadLag` and `finalizationLag` fields are unchanged.

## Example policy usage

```js
// exclude upstreams more than 120 seconds behind head
upstreams.filter(u => u.metrics.blockHeadLagSeconds <= 120)
```

## Tests

`TestPolicyEvaluatorLagSeconds` covers three cases:

- **BlockHeadLagSecondsZeroBeforeEMAWarm**: with a cold EMA, `blockHeadLagSeconds`
  is 0 regardless of block lag, so all upstreams pass any threshold.
- **BlockHeadLagSecondsFiltering**: after warming the EMA to ~2s block time, an
  upstream 6 blocks behind (~12s) is cordoned by a `< 10s` threshold, then
  uncordoned once it catches up.
- **FinalizationLagSecondsFiltering**: same pattern for `finalizationLagSeconds`.

Note: `RecordUpstreamRequest` is called for both upstreams before seeding lag
values. `SetLatestBlockNumber` writes into `upstreamsByNetwork`, which is only
populated once `getUpsMetrics` has been called for an upstream — without this,
lag writes are dropped and the assertions would not hold.

## Notes

- No new `TrackedMetrics` fields — the seconds values are derived at eval time,
  not stored. The block time is a network-level quantity; embedding it in the
  per-upstream struct would be a layering violation and could go stale between
  lag updates and block-time EMA ticks.
- Prometheus users can already compute this via
  `erpc_upstream_block_head_lag * on(network) group_left() (erpc_network_dynamic_block_time_milliseconds / 1000)`.
