### PR TITLE
feat: state-readiness probe to detect head-vs-trie race

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -92,6 +92,23 @@ type EvmStatePoller struct {
 	earliestSchedulerStarted     map[common.EvmAvailabilityProbeType]bool
 	earliestInitialDetectionDone map[common.EvmAvailabilityProbeType]bool // tracks if THIS instance did initial detection
 	earliestMu                   sync.RWMutex
+
+	// State-readiness probe tracking. stateReadyBlock is updated only when the
+	// configured strategy (EvmNetworkConfig.StateProbe) passes its assertions
+	// at the upstream's current latest block. When no probe is configured,
+	// StateReadyBlock() falls through to LatestBlock(). Protected by stateMu
+	// alongside the other detection-state fields.
+	//
+	// lastStateProbeResult holds the JSON-RPC result string from the most
+	// recent successful probe. It's the "prev" the changingStorage strategy
+	// compares against to detect silent-stale-prev-block staleness.
+	stateReadyBlock          int64
+	stateProbeFailureCount   int
+	stateProbeSuccessfulOnce bool
+	skipStateProbeCheck      bool
+	stateProbeDetectionIssue string
+	lastStateProbeResult     string
+	stateProbeInProgress     sync.Mutex
 }
 
 func NewEvmStatePoller(
@@ -343,6 +360,20 @@ func (e *EvmStatePoller) Poll(ctx context.Context) error {
 		e.initializeEarliestBlockDetectionAndStartScheduler(ctx)
 	}()
 
+	// State-readiness probe (only when configured on the network). Runs
+	// concurrently with latest/finalized poll — but reads latestBlockShared,
+	// so the first cycle may see block=0 and no-op. The next cycle will catch up.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if e.networkStateProbeConfig() == nil {
+			return
+		}
+		if _, err := e.PollStateReady(ctx); err != nil {
+			e.logger.Debug().Err(err).Msg("state-readiness probe returned error")
+		}
+	}()
+
 	wg.Wait()
 
 	if len(errs) > 0 {
@@ -482,6 +513,214 @@ func (e *EvmStatePoller) SuggestLatestBlock(blockNumber int64) {
 
 func (e *EvmStatePoller) LatestBlock() int64 {
 	return e.latestBlockShared.GetValue()
+}
+
+// StateReadyBlock returns the most recent block at which a state-readiness probe
+// confirmed the upstream's state DB is consistent.
+//
+// When no StateProbe is configured (or the probe has been skipped after repeated
+// failures), this falls back to LatestBlock() — preserving legacy behavior so
+// upstreams without a configured probe are NOT mistakenly excluded.
+func (e *EvmStatePoller) StateReadyBlock() int64 {
+	cfg := e.networkStateProbeConfig()
+	if cfg == nil {
+		return e.LatestBlock()
+	}
+	e.stateMu.RLock()
+	skip := e.skipStateProbeCheck
+	successOnce := e.stateProbeSuccessfulOnce
+	val := e.stateReadyBlock
+	e.stateMu.RUnlock()
+	if skip || !successOnce {
+		// Degraded fallback: probe has never succeeded (or was disabled) — be
+		// permissive rather than blocking all traffic on a missing signal.
+		return e.LatestBlock()
+	}
+	return val
+}
+
+// networkStateProbeConfig returns the per-network StateProbe config or nil.
+func (e *EvmStatePoller) networkStateProbeConfig() *common.EvmStateProbeConfig {
+	e.stateMu.RLock()
+	defer e.stateMu.RUnlock()
+	if e.cfg == nil {
+		return nil
+	}
+	return e.cfg.StateProbe
+}
+
+// PollStateReady runs the configured state-readiness probe at the upstream's
+// current latest block. On success advances stateReadyBlock to that block; on
+// failure leaves the previous value intact.
+//
+// Returns (block-at-which-probe-was-attempted, error). When no probe is
+// configured returns (0, nil) and StateReadyBlock falls back to LatestBlock.
+func (e *EvmStatePoller) PollStateReady(ctx context.Context) (int64, error) {
+	probeCfg := e.networkStateProbeConfig()
+	if probeCfg == nil || probeCfg.Strategy == "" {
+		return 0, nil
+	}
+
+	e.stateMu.RLock()
+	if e.skipStateProbeCheck {
+		e.stateMu.RUnlock()
+		return 0, nil
+	}
+	failureThreshold := probeCfg.FailureThreshold
+	if failureThreshold <= 0 {
+		failureThreshold = 10
+	}
+	e.stateMu.RUnlock()
+
+	// Coalesce concurrent probes — there's no value in running multiple at once
+	// against the same upstream/block.
+	if !e.stateProbeInProgress.TryLock() {
+		return 0, nil
+	}
+	defer e.stateProbeInProgress.Unlock()
+
+	block := e.LatestBlock()
+	if block <= 0 {
+		return 0, nil
+	}
+
+	// If we've already verified state at >= this block, skip.
+	e.stateMu.RLock()
+	already := e.stateReadyBlock
+	prevResult := e.lastStateProbeResult
+	e.stateMu.RUnlock()
+	if already >= block {
+		return block, nil
+	}
+
+	ctx, span := common.StartDetailSpan(ctx, "EvmStatePoller.PollStateReady",
+		trace.WithAttributes(
+			attribute.String("upstream.id", e.upstream.Id()),
+			attribute.String("network.id", e.upstream.NetworkId()),
+			attribute.Int64("block.number", block),
+			attribute.String("probe.strategy", string(probeCfg.Strategy)),
+		),
+	)
+	defer span.End()
+
+	result, ready, err := e.runStateProbe(ctx, probeCfg, block, prevResult)
+	if err != nil {
+		e.recordStateProbeFailure(err.Error(), failureThreshold)
+		span.SetAttributes(attribute.Bool("probe.ready", false), attribute.String("probe.error", err.Error()))
+		return block, err
+	}
+	if !ready {
+		e.recordStateProbeFailure("probe assertions failed", failureThreshold)
+		span.SetAttributes(attribute.Bool("probe.ready", false))
+		return block, nil
+	}
+
+	e.stateMu.Lock()
+	if block > e.stateReadyBlock {
+		e.stateReadyBlock = block
+	}
+	e.stateProbeFailureCount = 0
+	e.stateProbeSuccessfulOnce = true
+	e.stateProbeDetectionIssue = ""
+	e.lastStateProbeResult = result
+	e.stateMu.Unlock()
+
+	span.SetAttributes(attribute.Bool("probe.ready", true))
+	return block, nil
+}
+
+func (e *EvmStatePoller) recordStateProbeFailure(detail string, threshold int) {
+	e.stateMu.Lock()
+	defer e.stateMu.Unlock()
+	if e.stateProbeSuccessfulOnce {
+		// Once we've seen success, transient probe failures don't disable the
+		// poller — they just leave stateReadyBlock at its prior value, which
+		// naturally caps freshness until the next successful probe.
+		e.stateProbeDetectionIssue = detail
+		return
+	}
+	e.stateProbeFailureCount++
+	if e.stateProbeFailureCount >= threshold {
+		e.skipStateProbeCheck = true
+		e.stateProbeDetectionIssue = fmt.Sprintf("disabled after %d consecutive failures: %s", e.stateProbeFailureCount, detail)
+		e.logger.Warn().
+			Int("failures", e.stateProbeFailureCount).
+			Str("detail", detail).
+			Msg("disabling state-readiness probe after consecutive failures; StateReadyBlock will fall through to LatestBlock")
+		return
+	}
+	e.stateProbeDetectionIssue = detail
+}
+
+// runStateProbe dispatches to the configured strategy. Returns
+// (resultBytes, ready, error). When ready=true the caller stores resultBytes
+// as the next "prev" for differs-against-prev assertions.
+func (e *EvmStatePoller) runStateProbe(
+	ctx context.Context,
+	probeCfg *common.EvmStateProbeConfig,
+	block int64,
+	prevResult string,
+) (string, bool, error) {
+	switch probeCfg.Strategy {
+	case common.StateProbeChangingStorage:
+		return e.runChangingStorageProbe(ctx, probeCfg, block, prevResult)
+	default:
+		return "", false, fmt.Errorf("state probe: unknown strategy %q", probeCfg.Strategy)
+	}
+}
+
+// runChangingStorageProbe reads eth_getStorageAt(address, slot, block) and
+// passes iff the result is non-empty AND differs from the previous successful
+// probe. Catches both "0x0 at head" and silent-stale-prev-block staleness in
+// one check.
+//
+// First-cycle semantics: when prevResult is empty (no successful probe yet),
+// the differs-against-prev check is bypassed so a healthy upstream can advance
+// stateReadyBlock on cold start without waiting for a second cycle.
+func (e *EvmStatePoller) runChangingStorageProbe(
+	ctx context.Context,
+	probeCfg *common.EvmStateProbeConfig,
+	block int64,
+	prevResult string,
+) (string, bool, error) {
+	hexBlock := fmt.Sprintf("0x%x", uint64(block))
+	body, err := common.SonicCfg.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      util.RandomID(),
+		"method":  "eth_getStorageAt",
+		"params":  []interface{}{probeCfg.Address, probeCfg.Slot, hexBlock},
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("state probe (changingStorage): marshal request: %w", err)
+	}
+
+	pr := common.NewNormalizedRequest(body)
+	resp, err := e.upstream.Forward(ctx, pr, true)
+	if resp != nil {
+		defer resp.Release()
+	}
+	if err != nil {
+		if common.HasErrorCode(err,
+			common.ErrCodeUpstreamRequestSkipped,
+			common.ErrCodeUpstreamMethodIgnored,
+			common.ErrCodeEndpointUnsupported,
+		) {
+			// Upstream can't run this probe at all (e.g. method not allowed).
+			// Treat as no-signal: don't advance, don't penalize.
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	jrr, err := resp.JsonRpcResponse()
+	if err != nil || jrr == nil {
+		return "", false, fmt.Errorf("state probe (changingStorage): parse response: %w", err)
+	}
+	if jrr.Error != nil {
+		return "", false, fmt.Errorf("state probe (changingStorage): rpc error: %s", jrr.Error.Error())
+	}
+
+	result, ready := classifyChangingStorageResult(jrr.GetResultBytes(), prevResult)
+	return result, ready, nil
 }
 
 func (e *EvmStatePoller) PollFinalizedBlockNumber(ctx context.Context) (int64, error) {
@@ -903,6 +1142,7 @@ func (e *EvmStatePoller) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	// Collect state under stateMu first, then release before acquiring earliestMu
 	// to avoid nested lock ordering issues (always acquire locks in consistent order).
 	e.stateMu.RLock()
+	stateProbeConfigured := e.cfg != nil && e.cfg.StateProbe != nil && e.cfg.StateProbe.Strategy != ""
 	diag := &common.EvmStatePollerDiagnostics{
 		Enabled:        e.Enabled,
 		LatestBlock:    e.latestBlockShared.GetValue(),
@@ -921,6 +1161,13 @@ func (e *EvmStatePoller) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 		SkipFinalizedCheck:           e.skipFinalizedCheck,
 		FinalizedBlockFailureCount:   e.finalizedBlockFailureCount,
 		FinalizedBlockSuccessfulOnce: e.finalizedBlockSuccessfulOnce,
+
+		// State-readiness probe status
+		StateReadyBlock:          e.stateReadyBlock,
+		StateProbeConfigured:     stateProbeConfigured,
+		StateProbeFailureCount:   e.stateProbeFailureCount,
+		StateProbeSuccessfulOnce: e.stateProbeSuccessfulOnce,
+		StateProbeDetectionIssue: e.stateProbeDetectionIssue,
 	}
 
 	// Build detection issue messages
@@ -931,6 +1178,13 @@ func (e *EvmStatePoller) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	skipFinalizedCheck := e.skipFinalizedCheck
 	finalizedBlockSuccessfulOnce := e.finalizedBlockSuccessfulOnce
 	e.stateMu.RUnlock()
+
+	// When the probe isn't configured the StateReadyBlock falls through to
+	// LatestBlock — surface that so diagnostics readers aren't confused by a
+	// zero stateReadyBlock value.
+	if !stateProbeConfigured {
+		diag.StateReadyBlock = diag.LatestBlock
+	}
 
 	if skipSyncingCheck && !syncingSuccessfulOnce {
 		diag.SyncingCheckError = "syncing check disabled after consecutive failures (method may not be supported)"

--- a/architecture/evm/state_probe.go
+++ b/architecture/evm/state_probe.go
@@ -1,0 +1,31 @@
+package evm
+
+import (
+	"github.com/erpc/erpc/util"
+)
+
+// classifyChangingStorageResult applies the two assertions of the
+// "changingStorage" probe strategy:
+//
+//  1. non-empty result (catches "0x0 at head" — the literal failure mode from
+//     the captured trace a96e11c29cdf5be9e26b05c7c15773b8 on Polygon).
+//  2. result differs from the previous successful probe (catches the silent-
+//     stale-prev-block failure mode where a node serves the value from block
+//     N-1 while claiming to be at block N).
+//
+// First-cycle semantics: when prevResult is empty, assertion (2) is bypassed
+// so a healthy upstream can advance stateReadyBlock on cold start without
+// waiting for a second cycle.
+//
+// Returns (resultToStoreAsPrev, ready). When ready=false the caller should
+// leave stateReadyBlock unchanged.
+func classifyChangingStorageResult(resultBytes []byte, prevResult string) (string, bool) {
+	if util.IsBytesEmptyish(resultBytes) {
+		return "", false
+	}
+	result := string(resultBytes)
+	if prevResult != "" && result == prevResult {
+		return "", false
+	}
+	return result, true
+}

--- a/architecture/evm/state_probe_dispatch_test.go
+++ b/architecture/evm/state_probe_dispatch_test.go
@@ -1,0 +1,51 @@
+package evm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+)
+
+// TestRunStateProbe_UnknownStrategy confirms the dispatch returns an error
+// without touching the upstream when an unknown strategy slips past config
+// validation (defense-in-depth — Validate() should catch this earlier, but
+// the runtime must also refuse).
+func TestRunStateProbe_UnknownStrategy(t *testing.T) {
+	e := &EvmStatePoller{}
+	probeCfg := &common.EvmStateProbeConfig{
+		Strategy: "nonEmptyCode", // valid name but not implemented in v1
+		Address:  "0xdead",
+	}
+
+	stored, ready, err := e.runStateProbe(context.Background(), probeCfg, 100, "prev")
+	if err == nil {
+		t.Fatalf("expected error for unknown strategy, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown strategy") {
+		t.Fatalf("error %q does not mention unknown strategy", err.Error())
+	}
+	if ready {
+		t.Fatalf("unknown strategy must not be ready")
+	}
+	if stored != "" {
+		t.Fatalf("unknown strategy must not return a stored value")
+	}
+}
+
+// TestRunStateProbe_EmptyStrategy confirms empty Strategy also routes to the
+// default branch and errors (callers should be gated by Validate() but the
+// runtime defends).
+func TestRunStateProbe_EmptyStrategy(t *testing.T) {
+	e := &EvmStatePoller{}
+	probeCfg := &common.EvmStateProbeConfig{}
+
+	_, ready, err := e.runStateProbe(context.Background(), probeCfg, 100, "")
+	if err == nil {
+		t.Fatalf("expected error for empty strategy")
+	}
+	if ready {
+		t.Fatalf("empty strategy must not be ready")
+	}
+}

--- a/architecture/evm/state_probe_test.go
+++ b/architecture/evm/state_probe_test.go
@@ -1,0 +1,337 @@
+package evm
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyChangingStorageResult walks the full assertion truth table for
+// the "changingStorage" strategy: both empty-variants the upstream might
+// return for "0x0 at head" and the same-as-prev variants the upstream might
+// return for "stale prev-block value".
+//
+// Inputs are JSON-encoded result bytes — the same shape jrr.GetResultBytes()
+// produces — so quoted hex strings are the production-realistic form.
+func TestClassifyChangingStorageResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     string
+		prev       string
+		wantReady  bool
+		wantStored string
+	}{
+		// =====================================================================
+		// Empty-variant rejection (assertion 1: non-empty)
+		// =====================================================================
+		{name: "Empty_QuotedZero", result: `"0x0"`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_QuotedBareHex", result: `"0x"`, prev: `"0xabc"`, wantReady: false},
+		// Quoted uppercase-X variants of length >4 are classified as empty by
+		// util.IsBytesEmptyish; the 4-byte "0X" exact form is an existing
+		// asymmetric quirk of that helper and is not exercised here.
+		{name: "Empty_QuotedUppercaseX_Zero", result: `"0X0"`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_NullLiteral", result: `null`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_QuotedEmptyString", result: `""`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_JsonEmptyArray", result: `[]`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_JsonEmptyObject", result: `{}`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_ZeroByte", result: `0`, prev: `"0xabc"`, wantReady: false},
+		{name: "Empty_ZeroBytesInput", result: ``, prev: `"0xabc"`, wantReady: false},
+		{
+			name:      "Empty_32ByteZeroPadded",
+			result:    `"0x0000000000000000000000000000000000000000000000000000000000000000"`,
+			prev:      `"0xabc"`,
+			wantReady: false,
+		},
+		{
+			name:      "Empty_32ByteZeroPadded_UppercaseX",
+			result:    `"0X0000000000000000000000000000000000000000000000000000000000000000"`,
+			prev:      `"0xabc"`,
+			wantReady: false,
+		},
+
+		// =====================================================================
+		// Same-as-prev rejection (assertion 2: differs)
+		// =====================================================================
+		{
+			name:      "SameAsPrev_Short",
+			result:    `"0xde0b6b3a7640000"`,
+			prev:      `"0xde0b6b3a7640000"`,
+			wantReady: false,
+		},
+		{
+			name:      "SameAsPrev_32ByteWord",
+			result:    `"0x000000000000000000000000000000000000000000000a968163f0a57b400000"`,
+			prev:      `"0x000000000000000000000000000000000000000000000a968163f0a57b400000"`,
+			wantReady: false,
+		},
+
+		// =====================================================================
+		// Healthy path: non-empty AND changed
+		// =====================================================================
+		{
+			name:       "Changed_Short",
+			result:     `"0xde0b6b3a7640001"`,
+			prev:       `"0xde0b6b3a7640000"`,
+			wantReady:  true,
+			wantStored: `"0xde0b6b3a7640001"`,
+		},
+		{
+			name:       "Changed_32ByteWord",
+			result:     `"0x000000000000000000000000000000000000000000000a968163f0a57b400001"`,
+			prev:       `"0x000000000000000000000000000000000000000000000a968163f0a57b400000"`,
+			wantReady:  true,
+			wantStored: `"0x000000000000000000000000000000000000000000000a968163f0a57b400001"`,
+		},
+		{
+			// Crucially: a zero-padded SMALL non-zero value should be ready —
+			// IsBytesEmptyish must trim leading zeros and see the remainder.
+			name:       "Changed_ZeroPaddedTinyValue",
+			result:     `"0x0000000000000000000000000000000000000000000000000000000000000001"`,
+			prev:       `"0x0000000000000000000000000000000000000000000000000000000000000002"`,
+			wantReady:  true,
+			wantStored: `"0x0000000000000000000000000000000000000000000000000000000000000001"`,
+		},
+		{
+			name:       "Changed_CaseSensitiveStringDiffers",
+			result:     `"0xABC"`,
+			prev:       `"0xabc"`,
+			wantReady:  true, // byte-equal check; differs because A != a
+			wantStored: `"0xABC"`,
+		},
+
+		// =====================================================================
+		// Cold start (prev == "")
+		// =====================================================================
+		{
+			name:       "ColdStart_AcceptsNonEmpty",
+			result:     `"0xde0b6b3a7640000"`,
+			prev:       ``,
+			wantReady:  true,
+			wantStored: `"0xde0b6b3a7640000"`,
+		},
+		{
+			// Even on cold start, an empty result is rejected by assertion 1.
+			name:      "ColdStart_RejectsEmpty",
+			result:    `"0x0"`,
+			prev:      ``,
+			wantReady: false,
+		},
+		{
+			name:       "ColdStart_AcceptsLongHex",
+			result:     `"0x000000000000000000000000000000000000000000000a968163f0a57b400000"`,
+			prev:       ``,
+			wantReady:  true,
+			wantStored: `"0x000000000000000000000000000000000000000000000a968163f0a57b400000"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored, ready := classifyChangingStorageResult([]byte(tt.result), tt.prev)
+			if ready != tt.wantReady {
+				t.Fatalf("ready = %v, want %v (result=%s prev=%s)", ready, tt.wantReady, tt.result, tt.prev)
+			}
+			if ready && stored != tt.wantStored {
+				t.Fatalf("stored = %q, want %q", stored, tt.wantStored)
+			}
+			if !ready && stored != "" {
+				t.Fatalf("stored should be empty when not ready, got %q", stored)
+			}
+		})
+	}
+}
+
+// TestClassifyChangingStorageResult_NilBytes documents nil-bytes handling
+// explicitly so callers can rely on it (len(nil) == 0, treated as empty).
+func TestClassifyChangingStorageResult_NilBytes(t *testing.T) {
+	stored, ready := classifyChangingStorageResult(nil, "")
+	if ready {
+		t.Fatalf("nil bytes must not be ready")
+	}
+	if stored != "" {
+		t.Fatalf("nil bytes must produce empty stored, got %q", stored)
+	}
+}
+
+// TestClassifyChangingStorageResult_ReturnToPriorValue confirms that the
+// strategy doesn't penalize legitimate value oscillation. If a slot reads
+// A → B → A across cycles (e.g. a per-block pendingNonce that rotates),
+// each transition is "ready" because each result differs from the immediately
+// previous one.
+func TestClassifyChangingStorageResult_ReturnToPriorValue(t *testing.T) {
+	prev := ""
+
+	// Cycle 1: cold start with value A → ready, prev = A.
+	stored, ready := classifyChangingStorageResult([]byte(`"0xa"`), prev)
+	if !ready {
+		t.Fatalf("cycle 1 must be ready")
+	}
+	prev = stored
+
+	// Cycle 2: value B → ready, prev = B.
+	stored, ready = classifyChangingStorageResult([]byte(`"0xb"`), prev)
+	if !ready {
+		t.Fatalf("cycle 2 must be ready (A → B)")
+	}
+	prev = stored
+
+	// Cycle 3: back to value A → ready (differs from prev=B).
+	stored, ready = classifyChangingStorageResult([]byte(`"0xa"`), prev)
+	if !ready {
+		t.Fatalf("cycle 3 must be ready (B → A is a change vs prev=B)")
+	}
+	prev = stored
+
+	// Cycle 4: A again → NOT ready (same as prev=A).
+	_, ready = classifyChangingStorageResult([]byte(`"0xa"`), prev)
+	if ready {
+		t.Fatalf("cycle 4 must NOT be ready (A → A same as prev)")
+	}
+}
+
+// TestClassifyChangingStorageResult_StuckUpstream confirms that an upstream
+// returning the same non-empty value across many cycles is rejected after
+// the first one (only the initial cycle advances, subsequent ones don't).
+func TestClassifyChangingStorageResult_StuckUpstream(t *testing.T) {
+	const stuck = `"0xde0b6b3a7640000"`
+	prev := ""
+
+	// Cycle 1: cold start, value accepted.
+	stored, ready := classifyChangingStorageResult([]byte(stuck), prev)
+	if !ready {
+		t.Fatalf("cycle 1 (cold start) must be ready")
+	}
+	prev = stored
+
+	// Cycles 2-10: same value repeatedly → all rejected, prev unchanged.
+	for i := 2; i <= 10; i++ {
+		_, ready = classifyChangingStorageResult([]byte(stuck), prev)
+		if ready {
+			t.Fatalf("cycle %d returning same value must NOT be ready", i)
+		}
+	}
+}
+
+// TestClassifyChangingStorageResult_RecoveryAfterStall confirms that an
+// upstream can recover: after a stretch of same-as-prev responses, the first
+// response that finally differs is accepted.
+func TestClassifyChangingStorageResult_RecoveryAfterStall(t *testing.T) {
+	prev := ""
+
+	// Cold start, accept value A.
+	stored, ready := classifyChangingStorageResult([]byte(`"0xa"`), prev)
+	if !ready {
+		t.Fatalf("cold start must be ready")
+	}
+	prev = stored
+
+	// Five cycles of A → all rejected.
+	for i := 0; i < 5; i++ {
+		_, ready = classifyChangingStorageResult([]byte(`"0xa"`), prev)
+		if ready {
+			t.Fatalf("stuck cycle %d must not be ready", i)
+		}
+	}
+	// prev unchanged across all of those — caller's invariant.
+	if prev != `"0xa"` {
+		t.Fatalf("prev must remain unchanged across rejected cycles, got %q", prev)
+	}
+
+	// Sixth cycle: upstream recovers, returns B → accepted, prev advances.
+	stored, ready = classifyChangingStorageResult([]byte(`"0xb"`), prev)
+	if !ready {
+		t.Fatalf("recovery cycle must be ready")
+	}
+	if stored != `"0xb"` {
+		t.Fatalf("recovery cycle stored = %q, want %q", stored, `"0xb"`)
+	}
+}
+
+// TestClassifyChangingStorageResult_TenderlyTraceScenario reconstructs the
+// exact 3-cycle value sequence from the captured trace. Cycle 3 simulates the
+// misbehaving upstream returning either 0x0 (literal trie miss) or the
+// prev-block value (silent snapshot fallback) — both must be rejected.
+func TestClassifyChangingStorageResult_TenderlyTraceScenario(t *testing.T) {
+	// Cycle 1 — cold start, totalSupply has some value at block N.
+	stored, ready := classifyChangingStorageResult([]byte(`"0xde0b6b3a7640000"`), "")
+	if !ready {
+		t.Fatalf("cold-start non-empty must be ready")
+	}
+	prev := stored
+
+	// Cycle 2 — healthy upstream advances; totalSupply changes at block N+1.
+	stored, ready = classifyChangingStorageResult([]byte(`"0xde0b6b3a7640001"`), prev)
+	if !ready {
+		t.Fatalf("healthy upstream with changed value must be ready")
+	}
+	prev = stored
+
+	// Cycle 3a — misbehaving upstream returns 0x0 (trie node not committed).
+	_, readyA := classifyChangingStorageResult([]byte(`"0x0"`), prev)
+	if readyA {
+		t.Fatalf("0x0 at advertised head must NOT advance stateReadyBlock")
+	}
+
+	// Cycle 3b — misbehaving upstream returns the prev-block value silently.
+	_, readyB := classifyChangingStorageResult([]byte(`"0xde0b6b3a7640001"`), prev)
+	if readyB {
+		t.Fatalf("same-as-prev result must NOT advance stateReadyBlock")
+	}
+
+	// Cycle 3c — misbehaving upstream returns 32-byte zero-padded zero.
+	_, readyC := classifyChangingStorageResult(
+		[]byte(`"0x0000000000000000000000000000000000000000000000000000000000000000"`),
+		prev,
+	)
+	if readyC {
+		t.Fatalf("32-byte zero-padded result must NOT advance stateReadyBlock")
+	}
+}
+
+// TestClassifyChangingStorageResult_PrevPersistsAcrossRejections confirms that
+// the caller's stored-prev contract works: when an assertion fails, the
+// returned stored value is empty so the caller leaves prev unchanged.
+func TestClassifyChangingStorageResult_PrevPersistsAcrossRejections(t *testing.T) {
+	prev := `"0xa"`
+
+	for _, badResult := range []string{`"0x0"`, `null`, `"0xa"`, ``} {
+		stored, ready := classifyChangingStorageResult([]byte(badResult), prev)
+		if ready {
+			t.Fatalf("bad result %q should not be ready", badResult)
+		}
+		if stored != "" {
+			t.Fatalf("bad result %q should produce empty stored, got %q", badResult, stored)
+		}
+		// Caller would leave prev as-is — assertion is on this function's contract.
+	}
+}
+
+// TestClassifyChangingStorageResult_LongValuesDoNotAlias confirms that two
+// long hex values that share a long zero prefix but differ in the last byte
+// are correctly classified as "differs". (Defensive against accidental
+// prefix-comparison bugs.)
+func TestClassifyChangingStorageResult_LongValuesDoNotAlias(t *testing.T) {
+	a := `"0x000000000000000000000000000000000000000000000000000000000000000a"`
+	b := `"0x000000000000000000000000000000000000000000000000000000000000000b"`
+
+	stored, ready := classifyChangingStorageResult([]byte(b), a)
+	if !ready {
+		t.Fatalf("differing in last byte must be ready")
+	}
+	if stored != b {
+		t.Fatalf("stored mismatch")
+	}
+}
+
+// TestClassifyChangingStorageResult_QuoteSensitivity confirms the function
+// treats quoted and unquoted forms as distinct (production-realistic inputs
+// are quoted; this documents that the function isn't normalizing).
+func TestClassifyChangingStorageResult_QuoteSensitivity(t *testing.T) {
+	// Quoted "0xa" vs unquoted 0xa — strict string equality.
+	stored, ready := classifyChangingStorageResult([]byte(`"0xa"`), `0xa`)
+	if !ready {
+		t.Fatalf(`"0xa" should differ from unquoted 0xa under strict equality`)
+	}
+	if !strings.Contains(stored, "0xa") {
+		t.Fatalf("stored should contain 0xa")
+	}
+}

--- a/architecture/evm/util.go
+++ b/architecture/evm/util.go
@@ -16,6 +16,30 @@ func IsNonRetryableWriteMethod(method string) bool {
 		method == "eth_newPendingTransactionFilter"
 }
 
+// IsStateReadMethod returns true for JSON-RPC methods whose result depends on
+// the state trie at a specific block. These methods are vulnerable to the
+// head-vs-trie race — an upstream may advance its head pointer to block N
+// before its state DB is consistent at N, causing a silent zero-valued response.
+//
+// State-read methods can opt into the StateReady availability confidence so
+// the upstream-selection and retry layers consult the state-readiness probe
+// instead of trusting the upstream's head pointer alone.
+func IsStateReadMethod(method string) bool {
+	switch method {
+	case "eth_getBalance",
+		"eth_getCode",
+		"eth_getStorageAt",
+		"eth_getTransactionCount",
+		"eth_getProof",
+		"eth_call",
+		"eth_estimateGas",
+		"eth_simulateV1",
+		"eth_createAccessList":
+		return true
+	}
+	return false
+}
+
 func IsMissingDataError(err error) bool {
 	txt := err.Error()
 	return strings.Contains(txt, "missing trie node") ||

--- a/architecture/evm/util_state_read_test.go
+++ b/architecture/evm/util_state_read_test.go
@@ -1,0 +1,94 @@
+package evm
+
+import "testing"
+
+func TestIsStateReadMethod(t *testing.T) {
+	stateReads := []string{
+		"eth_getBalance",
+		"eth_getCode",
+		"eth_getStorageAt",
+		"eth_getTransactionCount",
+		"eth_getProof",
+		"eth_call",
+		"eth_estimateGas",
+		"eth_simulateV1",
+		"eth_createAccessList",
+	}
+	for _, m := range stateReads {
+		if !IsStateReadMethod(m) {
+			t.Errorf("IsStateReadMethod(%q) = false, want true", m)
+		}
+	}
+
+	notStateReads := []string{
+		"eth_blockNumber",
+		"eth_getBlockByNumber",
+		"eth_getBlockByHash",
+		"eth_getBlockTransactionCountByHash",
+		"eth_getBlockTransactionCountByNumber",
+		"eth_getLogs",
+		"eth_getTransactionByHash",
+		"eth_getTransactionByBlockNumberAndIndex",
+		"eth_getTransactionReceipt",
+		"eth_getBlockReceipts",
+		"eth_chainId",
+		"eth_syncing",
+		"eth_sendRawTransaction",
+		"eth_sendTransaction",
+		"eth_newFilter",
+		"net_version",
+		"web3_clientVersion",
+		"trace_call",
+		"trace_block",
+		"trace_filter",
+		"trace_transaction",
+		"debug_traceTransaction",
+		"debug_traceCall",
+		"debug_traceBlockByHash",
+		"arbtrace_call",
+		"",
+	}
+	for _, m := range notStateReads {
+		if IsStateReadMethod(m) {
+			t.Errorf("IsStateReadMethod(%q) = true, want false", m)
+		}
+	}
+}
+
+// TestIsStateReadMethod_CaseSensitive confirms exact-string match — alternate
+// casings like "eth_getbalance" or "ETH_GETBALANCE" must NOT classify as
+// state-read, because JSON-RPC method names are case-sensitive on the wire
+// and the upstream-selection / retry logic must mirror that.
+func TestIsStateReadMethod_CaseSensitive(t *testing.T) {
+	casings := []string{
+		"eth_getbalance",   // lowercase b
+		"ETH_GETBALANCE",   // uppercase
+		"Eth_GetBalance",   // mixed
+		"eth_GetBalance",   // PascalCase
+		" eth_getBalance",  // leading whitespace
+		"eth_getBalance ",  // trailing whitespace
+		"eth_getBalance\t", // trailing tab
+	}
+	for _, m := range casings {
+		if IsStateReadMethod(m) {
+			t.Errorf("IsStateReadMethod(%q) = true, want false (must be exact match)", m)
+		}
+	}
+}
+
+// TestIsStateReadMethod_NotPrefixMatch confirms that method names that are
+// prefixed by a state-read method but aren't equal don't match. Defensive
+// against accidental strings.HasPrefix-style logic.
+func TestIsStateReadMethod_NotPrefixMatch(t *testing.T) {
+	prefixed := []string{
+		"eth_getBalanceAt",     // hypothetical method with state-read name as prefix
+		"eth_getCodeHash",      // ditto
+		"eth_call_internal",    // ditto
+		"eth_estimateGasPrice", // ditto
+	}
+	for _, m := range prefixed {
+		if IsStateReadMethod(m) {
+			t.Errorf("IsStateReadMethod(%q) = true, want false (not exact match)", m)
+		}
+	}
+}

--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -35,6 +35,15 @@ type AvailbilityConfidence int
 const (
 	AvailbilityConfidenceBlockHead AvailbilityConfidence = 1
 	AvailbilityConfidenceFinalized AvailbilityConfidence = 2
+	// AvailbilityConfidenceStateReady requires that the upstream has not only
+	// observed a given block at its head, but that its state DB is consistent
+	// at that block. Distinguishes head-vs-trie races where a node's block
+	// header pointer has advanced but state slots for that block are not yet
+	// committed (returns 0x0 / "0x" / null silently).
+	//
+	// Requires EvmNetworkConfig.StateProbe to be configured. Without a probe
+	// config this confidence falls back to BlockHead semantics.
+	AvailbilityConfidenceStateReady AvailbilityConfidence = 3
 )
 
 func (c AvailbilityConfidence) String() string {
@@ -43,6 +52,8 @@ func (c AvailbilityConfidence) String() string {
 		return "blockHead"
 	case AvailbilityConfidenceFinalized:
 		return "finalizedBlock"
+	case AvailbilityConfidenceStateReady:
+		return "stateReady"
 	default:
 		return fmt.Sprintf("unknown(%d)", c)
 	}
@@ -68,6 +79,9 @@ func (c *AvailbilityConfidence) UnmarshalYAML(unmarshal func(interface{}) error)
 		return nil
 	case "finalizedblock", "2":
 		*c = AvailbilityConfidenceFinalized
+		return nil
+	case "stateready", "3":
+		*c = AvailbilityConfidenceStateReady
 		return nil
 	}
 
@@ -107,10 +121,20 @@ type EvmStatePoller interface {
 	PollLatestBlockNumber(ctx context.Context) (int64, error)
 	PollFinalizedBlockNumber(ctx context.Context) (int64, error)
 	PollEarliestBlockNumber(ctx context.Context, probe EvmAvailabilityProbeType, staleness time.Duration) (int64, error)
+	// PollStateReady runs the configured StateProbe at the current latest block.
+	// On success advances StateReadyBlock to the probed block; on failure leaves
+	// it unchanged. Returns (block at which probe was attempted, error).
+	// When no StateProbe is configured, returns (0, nil) and StateReadyBlock
+	// will report LatestBlock as a backward-compatible fallback.
+	PollStateReady(ctx context.Context) (int64, error)
 	SyncingState() EvmSyncingState
 	SetSyncingState(state EvmSyncingState)
 	LatestBlock() int64
 	FinalizedBlock() int64
+	// StateReadyBlock returns the most recent block at which the state probe
+	// confirmed the upstream's state DB is consistent. When no StateProbe is
+	// configured, falls back to LatestBlock.
+	StateReadyBlock() int64
 	IsBlockFinalized(blockNumber int64) (bool, error)
 	SuggestFinalizedBlock(blockNumber int64)
 	SuggestLatestBlock(blockNumber int64)
@@ -128,6 +152,13 @@ type EvmStatePollerDiagnostics struct {
 	// Block head information
 	LatestBlock    int64 `json:"latestBlock"`
 	FinalizedBlock int64 `json:"finalizedBlock"`
+
+	// State-readiness probe diagnostics.
+	StateReadyBlock           int64  `json:"stateReadyBlock,omitempty"`
+	StateProbeConfigured      bool   `json:"stateProbeConfigured,omitempty"`
+	StateProbeFailureCount    int    `json:"stateProbeFailureCount,omitempty"`
+	StateProbeSuccessfulOnce  bool   `json:"stateProbeSuccessfulOnce,omitempty"`
+	StateProbeDetectionIssue  string `json:"stateProbeDetectionIssue,omitempty"`
 
 	// Syncing state
 	SyncingState      string `json:"syncingState"`

--- a/common/config.go
+++ b/common/config.go
@@ -1789,6 +1789,110 @@ type EvmNetworkConfig struct {
 	// to work safely with transaction broadcasting.
 	// Set to false to disable this behavior and return raw upstream errors.
 	IdempotentTransactionBroadcast *bool `yaml:"idempotentTransactionBroadcast,omitempty" json:"idempotentTransactionBroadcast,omitempty"`
+
+	// StateProbe configures a per-network state-readiness probe used by the
+	// state poller to detect the head-vs-trie race: a node's block-header
+	// pointer can advance to block N before its state DB is consistent at
+	// block N, causing state reads (eth_getBalance, eth_getCode,
+	// eth_getStorageAt, etc.) to silently return zero-valued or stale results.
+	//
+	// The probe is a single named strategy plus its typed inputs (see
+	// EvmStateProbeConfig). Each poller cycle runs the strategy at the
+	// upstream's current latest block; StateReadyBlock advances only when the
+	// strategy passes. State-read methods can then opt into the StateReady
+	// availability confidence to be routed away from upstreams whose state DB
+	// has not yet caught up to their advertised head.
+	//
+	// When not configured, StateReadyBlock falls back to LatestBlock and the
+	// new confidence behaves identically to BlockHead (no behavior change).
+	StateProbe *EvmStateProbeConfig `yaml:"stateProbe,omitempty" json:"stateProbe,omitempty"`
+}
+
+// EvmStateProbeStrategy names the algorithm an EvmStateProbeConfig invokes.
+// The set is intentionally small and curated; each strategy is a typed,
+// self-contained check rather than a user-composed expression. New strategies
+// land as code, not as config syntax.
+type EvmStateProbeStrategy string
+
+const (
+	// StateProbeChangingStorage reads eth_getStorageAt(address, slot, latestBlock)
+	// and passes iff the result is non-empty AND differs from the previous
+	// successful probe. Catches both "0x0 at head" (the literal failure mode
+	// from trace a96e11c29cdf5be9e26b05c7c15773b8 on Polygon, 2026-05-13) and
+	// the silent-stale-prev-block failure mode where a node serves the value
+	// from block N-1 while claiming to be at block N.
+	//
+	// Requires a slot that legitimately changes on most blocks (e.g. a
+	// high-activity ERC-20 totalSupply, a Uniswap V3 pool slot0). On chains
+	// where no such slot exists, prefer one of the simpler strategies that
+	// will land as follow-ups.
+	StateProbeChangingStorage EvmStateProbeStrategy = "changingStorage"
+)
+
+// EvmStateProbeConfig declares which named strategy the state poller runs
+// each cycle to verify an upstream's state DB is consistent at its advertised
+// head block.
+//
+// Example (Polygon, USDC.e totalSupply slot — changes on most blocks):
+//
+//	stateProbe:
+//	  strategy: changingStorage
+//	  address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+//	  slot:    "0x3"
+//
+// When stateProbe is nil, StateReadyBlock falls back to LatestBlock and
+// AvailbilityConfidenceStateReady behaves identically to BlockHead. Existing
+// networks are unaffected until they opt in.
+type EvmStateProbeConfig struct {
+	// Strategy selects the probe implementation. Currently only
+	// "changingStorage" is supported.
+	Strategy EvmStateProbeStrategy `yaml:"strategy" json:"strategy"`
+
+	// Address is the contract or account address the probe targets.
+	// Required for "changingStorage".
+	Address string `yaml:"address,omitempty" json:"address,omitempty"`
+
+	// Slot is the storage slot the probe reads.
+	// Required for "changingStorage".
+	Slot string `yaml:"slot,omitempty" json:"slot,omitempty"`
+
+	// FailureThreshold caps consecutive probe failures before the state poller
+	// disables the probe and StateReadyBlock falls back to LatestBlock
+	// (degraded permissive mode). Default 10.
+	FailureThreshold int `yaml:"failureThreshold,omitempty" json:"failureThreshold,omitempty"`
+}
+
+func (c *EvmStateProbeConfig) Copy() *EvmStateProbeConfig {
+	if c == nil {
+		return nil
+	}
+	return &EvmStateProbeConfig{
+		Strategy:         c.Strategy,
+		Address:          c.Address,
+		Slot:             c.Slot,
+		FailureThreshold: c.FailureThreshold,
+	}
+}
+
+// Validate returns nil iff the config is internally consistent for its strategy.
+func (c *EvmStateProbeConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	switch c.Strategy {
+	case "":
+		return fmt.Errorf("stateProbe.strategy is required")
+	case StateProbeChangingStorage:
+		if c.Address == "" {
+			return fmt.Errorf("stateProbe.address is required for strategy %q", c.Strategy)
+		}
+		if c.Slot == "" {
+			return fmt.Errorf("stateProbe.slot is required for strategy %q", c.Strategy)
+		}
+	default:
+		return fmt.Errorf("stateProbe.strategy %q is not a known strategy (supported: %q)", c.Strategy, StateProbeChangingStorage)
+	}
+	return nil
 }
 
 // EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.

--- a/common/config_state_probe_test.go
+++ b/common/config_state_probe_test.go
@@ -1,0 +1,235 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvmStateProbeConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *EvmStateProbeConfig
+		wantErr string // substring; "" means no error expected
+	}{
+		// =====================================================================
+		// Nil + empty cases
+		// =====================================================================
+		{
+			name:    "Nil_NoError",
+			cfg:     nil,
+			wantErr: "",
+		},
+		{
+			name:    "AllFieldsZero_FailsOnStrategy",
+			cfg:     &EvmStateProbeConfig{},
+			wantErr: "stateProbe.strategy is required",
+		},
+
+		// =====================================================================
+		// Strategy validation
+		// =====================================================================
+		{
+			name: "UnknownStrategy_Errors",
+			cfg: &EvmStateProbeConfig{
+				Strategy: "nonEmptyCode", // valid future name, not in v1
+				Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:     "0x3",
+			},
+			wantErr: `stateProbe.strategy "nonEmptyCode" is not a known strategy`,
+		},
+		{
+			// Case sensitivity matters — strategy names are exact strings.
+			name: "Strategy_CaseSensitive",
+			cfg: &EvmStateProbeConfig{
+				Strategy: "ChangingStorage", // capital C, wrong case
+				Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:     "0x3",
+			},
+			wantErr: "is not a known strategy",
+		},
+		{
+			name: "Strategy_WhitespacePadded_TreatedAsUnknown",
+			cfg: &EvmStateProbeConfig{
+				Strategy: " changingStorage ",
+				Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:     "0x3",
+			},
+			wantErr: "is not a known strategy",
+		},
+
+		// =====================================================================
+		// changingStorage — input requirements
+		// =====================================================================
+		{
+			name: "ChangingStorage_MissingAddress",
+			cfg: &EvmStateProbeConfig{
+				Strategy: StateProbeChangingStorage,
+				Slot:     "0x3",
+			},
+			wantErr: "stateProbe.address is required",
+		},
+		{
+			name: "ChangingStorage_MissingSlot",
+			cfg: &EvmStateProbeConfig{
+				Strategy: StateProbeChangingStorage,
+				Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+			},
+			wantErr: "stateProbe.slot is required",
+		},
+		{
+			// Order: strategy is checked first, then per-strategy inputs.
+			// Missing both inputs — error should mention address (the first one).
+			name: "ChangingStorage_BothMissing_ReportsAddressFirst",
+			cfg: &EvmStateProbeConfig{
+				Strategy: StateProbeChangingStorage,
+			},
+			wantErr: "stateProbe.address is required",
+		},
+		{
+			name: "ChangingStorage_Complete_NoError",
+			cfg: &EvmStateProbeConfig{
+				Strategy: StateProbeChangingStorage,
+				Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:     "0x3",
+			},
+			wantErr: "",
+		},
+		{
+			name: "ChangingStorage_WithFailureThreshold",
+			cfg: &EvmStateProbeConfig{
+				Strategy:         StateProbeChangingStorage,
+				Address:          "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:             "0x3",
+				FailureThreshold: 25,
+			},
+			wantErr: "",
+		},
+		{
+			// Negative FailureThreshold is accepted at validate-time (the poller
+			// treats anything <=0 as "use default 10"). Documenting that contract.
+			name: "ChangingStorage_NegativeFailureThreshold_Accepted",
+			cfg: &EvmStateProbeConfig{
+				Strategy:         StateProbeChangingStorage,
+				Address:          "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+				Slot:             "0x3",
+				FailureThreshold: -5,
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvmStateProbeConfig_Copy(t *testing.T) {
+	t.Run("NilCopy_ReturnsNil", func(t *testing.T) {
+		var c *EvmStateProbeConfig
+		if got := c.Copy(); got != nil {
+			t.Fatalf("nil copy should return nil, got %+v", got)
+		}
+	})
+
+	t.Run("DeepCopy_Independent", func(t *testing.T) {
+		orig := &EvmStateProbeConfig{
+			Strategy:         StateProbeChangingStorage,
+			Address:          "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+			Slot:             "0x3",
+			FailureThreshold: 5,
+		}
+		dup := orig.Copy()
+
+		if dup == orig {
+			t.Fatalf("Copy must return a new pointer")
+		}
+		if dup.Strategy != orig.Strategy || dup.Address != orig.Address ||
+			dup.Slot != orig.Slot || dup.FailureThreshold != orig.FailureThreshold {
+			t.Fatalf("fields not copied faithfully: %+v vs %+v", dup, orig)
+		}
+
+		// Mutate dup; orig must be unaffected.
+		dup.Address = "0xdead"
+		if orig.Address == "0xdead" {
+			t.Fatalf("mutation of copy leaked back to original")
+		}
+	})
+
+	t.Run("Copy_PreservesZeroFailureThreshold", func(t *testing.T) {
+		orig := &EvmStateProbeConfig{
+			Strategy: StateProbeChangingStorage,
+			Address:  "0xabc",
+			Slot:     "0x1",
+			// FailureThreshold left at zero (its zero value)
+		}
+		dup := orig.Copy()
+		if dup.FailureThreshold != 0 {
+			t.Fatalf("zero FailureThreshold should be preserved, got %d", dup.FailureThreshold)
+		}
+	})
+
+	t.Run("Copy_PreservesEmptyStringFields", func(t *testing.T) {
+		// Even with empty Address/Slot (config is invalid but Copy should be
+		// byte-faithful) — Copy doesn't validate, it duplicates.
+		orig := &EvmStateProbeConfig{Strategy: StateProbeChangingStorage}
+		dup := orig.Copy()
+		if dup.Address != "" || dup.Slot != "" {
+			t.Fatalf("empty fields should be preserved as empty, got %+v", dup)
+		}
+	})
+
+	t.Run("Copy_RoundTripStillValidates", func(t *testing.T) {
+		orig := &EvmStateProbeConfig{
+			Strategy:         StateProbeChangingStorage,
+			Address:          "0xabc",
+			Slot:             "0x1",
+			FailureThreshold: 7,
+		}
+		if err := orig.Validate(); err != nil {
+			t.Fatalf("orig should be valid: %v", err)
+		}
+		dup := orig.Copy()
+		if err := dup.Validate(); err != nil {
+			t.Fatalf("copy should also be valid: %v", err)
+		}
+	})
+
+	t.Run("Copy_LongAddressPreserved", func(t *testing.T) {
+		// Address is a string — Copy must preserve byte-exact value (no
+		// case-normalization, no whitespace trimming).
+		const oddAddr = "  0xMixedCaseAddressWithSpaces  "
+		orig := &EvmStateProbeConfig{
+			Strategy: StateProbeChangingStorage,
+			Address:  oddAddr,
+			Slot:     "0x3",
+		}
+		dup := orig.Copy()
+		if dup.Address != oddAddr {
+			t.Fatalf("Copy must preserve address byte-exact, got %q", dup.Address)
+		}
+	})
+}
+
+// TestEvmStateProbeStrategy_StringContract documents that the strategy
+// constant's underlying string value is the wire format (used as-is in YAML
+// configs). Changing this is a breaking config change.
+func TestEvmStateProbeStrategy_StringContract(t *testing.T) {
+	if got := string(StateProbeChangingStorage); got != "changingStorage" {
+		t.Fatalf("StateProbeChangingStorage wire value drifted: got %q, want %q",
+			got, "changingStorage")
+	}
+}

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -169,14 +169,27 @@ func (u *FakeUpstream) EvmBlockAvailabilityBounds() (int64, int64) {
 }
 
 type FakeEvmStatePoller struct {
-	latestBlockNumber    int64
-	finalizedBlockNumber int64
+	latestBlockNumber     int64
+	finalizedBlockNumber  int64
+	stateReadyBlockNumber int64
+	stateProbeConfigured  bool
 }
 
 func NewFakeEvmStatePoller(latestBlockNumber int64, finalizedBlockNumber int64) EvmStatePoller {
 	return &FakeEvmStatePoller{
 		latestBlockNumber:    latestBlockNumber,
 		finalizedBlockNumber: finalizedBlockNumber,
+	}
+}
+
+// NewFakeEvmStatePollerWithStateReady constructs a fake whose StateReadyBlock is
+// decoupled from LatestBlock. Use for tests that exercise head-vs-trie races.
+func NewFakeEvmStatePollerWithStateReady(latestBlockNumber, finalizedBlockNumber, stateReadyBlockNumber int64) EvmStatePoller {
+	return &FakeEvmStatePoller{
+		latestBlockNumber:     latestBlockNumber,
+		finalizedBlockNumber:  finalizedBlockNumber,
+		stateReadyBlockNumber: stateReadyBlockNumber,
+		stateProbeConfigured:  true,
 	}
 }
 
@@ -224,6 +237,26 @@ func (p *FakeEvmStatePoller) PollLatestBlockNumber(ctx context.Context) (int64, 
 	return p.latestBlockNumber, nil
 }
 
+func (p *FakeEvmStatePoller) PollStateReady(ctx context.Context) (int64, error) {
+	if !p.stateProbeConfigured {
+		return 0, nil
+	}
+	return p.stateReadyBlockNumber, nil
+}
+
+func (p *FakeEvmStatePoller) StateReadyBlock() int64 {
+	if !p.stateProbeConfigured {
+		return p.latestBlockNumber
+	}
+	return p.stateReadyBlockNumber
+}
+
+// SetStateReadyBlock overrides the state-ready block for fake testing.
+func (p *FakeEvmStatePoller) SetStateReadyBlock(blockNumber int64) {
+	p.stateReadyBlockNumber = blockNumber
+	p.stateProbeConfigured = true
+}
+
 func (p *FakeEvmStatePoller) SetNetworkConfig(config *NetworkConfig) {
 	// No-op for testing
 }
@@ -246,10 +279,12 @@ func (p *FakeEvmStatePoller) SyncingState() EvmSyncingState {
 
 func (p *FakeEvmStatePoller) GetDiagnostics() *EvmStatePollerDiagnostics {
 	return &EvmStatePollerDiagnostics{
-		Enabled:        true,
-		LatestBlock:    p.latestBlockNumber,
-		FinalizedBlock: p.finalizedBlockNumber,
-		SyncingState:   EvmSyncingStateUnknown.String(),
+		Enabled:              true,
+		LatestBlock:          p.latestBlockNumber,
+		FinalizedBlock:       p.finalizedBlockNumber,
+		StateReadyBlock:      p.StateReadyBlock(),
+		StateProbeConfigured: p.stateProbeConfigured,
+		SyncingState:         EvmSyncingStateUnknown.String(),
 	}
 }
 

--- a/common/upstream_fake_state_ready_test.go
+++ b/common/upstream_fake_state_ready_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"context"
+	"testing"
+)
+
+// TestFakeEvmStatePoller_StateReadyBlock_FallsBackToLatest verifies the
+// backward-compat contract: a fake constructed without a state-readiness
+// override returns LatestBlock from StateReadyBlock(), so tests using the
+// "no probe configured" code path see expected behavior.
+func TestFakeEvmStatePoller_StateReadyBlock_FallsBackToLatest(t *testing.T) {
+	p := NewFakeEvmStatePoller(100, 50)
+	if got := p.StateReadyBlock(); got != 100 {
+		t.Fatalf("StateReadyBlock() = %d, want LatestBlock fallback = 100", got)
+	}
+}
+
+// TestFakeEvmStatePoller_StateReadyBlock_RespectsOverride verifies the
+// constructor that decouples StateReadyBlock from LatestBlock — used by
+// tests that exercise head-vs-trie races.
+func TestFakeEvmStatePoller_StateReadyBlock_RespectsOverride(t *testing.T) {
+	p := NewFakeEvmStatePollerWithStateReady(100, 50, 95)
+	if got := p.LatestBlock(); got != 100 {
+		t.Fatalf("LatestBlock() = %d, want 100", got)
+	}
+	if got := p.FinalizedBlock(); got != 50 {
+		t.Fatalf("FinalizedBlock() = %d, want 50", got)
+	}
+	if got := p.StateReadyBlock(); got != 95 {
+		t.Fatalf("StateReadyBlock() = %d, want override 95", got)
+	}
+}
+
+// TestFakeEvmStatePoller_PollStateReady documents the two behaviors of
+// PollStateReady on the fake: zero-result when no probe is configured (so
+// the upstream-side flow doesn't accidentally rely on a poll happening),
+// and the override value when one is set.
+func TestFakeEvmStatePoller_PollStateReady(t *testing.T) {
+	t.Run("NoProbeConfigured_ReturnsZero", func(t *testing.T) {
+		p := NewFakeEvmStatePoller(100, 50)
+		got, err := p.PollStateReady(context.Background())
+		if err != nil {
+			t.Fatalf("PollStateReady() error: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("PollStateReady() = %d, want 0 (no probe)", got)
+		}
+	})
+
+	t.Run("ProbeConfigured_ReturnsOverride", func(t *testing.T) {
+		p := NewFakeEvmStatePollerWithStateReady(100, 50, 95)
+		got, err := p.PollStateReady(context.Background())
+		if err != nil {
+			t.Fatalf("PollStateReady() error: %v", err)
+		}
+		if got != 95 {
+			t.Fatalf("PollStateReady() = %d, want 95", got)
+		}
+	})
+}
+
+// TestFakeEvmStatePoller_Diagnostics confirms the new diagnostic fields are
+// populated correctly by the fake (used in /healthcheck integration tests).
+func TestFakeEvmStatePoller_Diagnostics(t *testing.T) {
+	t.Run("WithoutProbe_FallsBack", func(t *testing.T) {
+		p := NewFakeEvmStatePoller(100, 50)
+		d := p.GetDiagnostics()
+		if d.StateProbeConfigured {
+			t.Fatalf("StateProbeConfigured should be false without probe")
+		}
+		if d.StateReadyBlock != 100 {
+			t.Fatalf("StateReadyBlock in diagnostics = %d, want 100 fallback", d.StateReadyBlock)
+		}
+	})
+
+	t.Run("WithProbe_ReportsOverride", func(t *testing.T) {
+		p := NewFakeEvmStatePollerWithStateReady(100, 50, 95)
+		d := p.GetDiagnostics()
+		if !d.StateProbeConfigured {
+			t.Fatalf("StateProbeConfigured should be true with probe")
+		}
+		if d.StateReadyBlock != 95 {
+			t.Fatalf("StateReadyBlock in diagnostics = %d, want 95", d.StateReadyBlock)
+		}
+	})
+}

--- a/upstream/failsafe.go
+++ b/upstream/failsafe.go
@@ -699,8 +699,25 @@ func createRetryPolicy(scope common.Scope, cfg *common.RetryPolicyConfig, dynami
 										attribute.String("extracted_block_error", fmt.Sprintf("%v", ebn)),
 									)
 									if ebn == nil && bn > 0 {
+										// For state-read methods (eth_getBalance, eth_getCode, etc.) the
+										// upstream's reported head pointer is NOT a sufficient signal that
+										// an empty result is legitimate — the state DB may not yet be
+										// consistent at this block even though the header is. Consult the
+										// state-readiness probe via StateReady confidence so the shortcut
+										// only fires when the state trie has been verified.
+										//
+										// When no StateProbe is configured, StateReadyBlock falls through
+										// to LatestBlock, preserving prior behavior.
+										effectiveConfidence := emptyResultConfidence
+										if evm.IsStateReadMethod(method) {
+											effectiveConfidence = common.AvailbilityConfidenceStateReady
+										}
+										span.SetAttributes(
+											attribute.String("availability.confidence", effectiveConfidence.String()),
+											attribute.Bool("method.is_state_read", evm.IsStateReadMethod(method)),
+										)
 										// Use EvmAssertBlockAvailability to check if the upstream can handle the block
-										if avail, err := ups.EvmAssertBlockAvailability(ctx, method, emptyResultConfidence, false, bn); err == nil && avail {
+										if avail, err := ups.EvmAssertBlockAvailability(ctx, method, effectiveConfidence, false, bn); err == nil && avail {
 											// If the upstream can handle the block and returned empty, don't retry
 											span.SetAttributes(
 												attribute.Bool("block_available", true),

--- a/upstream/failsafe_test.go
+++ b/upstream/failsafe_test.go
@@ -260,7 +260,14 @@ func TestRetryPolicy_EmptyResultWithIgnore(t *testing.T) {
 				}
 			}
 			if shouldCheckAvailability {
-				mockUpstream.On("EvmAssertBlockAvailability", mock.Anything, tt.method, common.AvailbilityConfidenceBlockHead, false, int64(100)).Return(true, nil).Maybe()
+				// State-read methods now request StateReady confidence so the
+				// retry shortcut consults the readiness probe instead of the raw
+				// head pointer. Non-state-read methods still use BlockHead.
+				expectedConfidence := common.AvailbilityConfidenceBlockHead
+				if evm.IsStateReadMethod(tt.method) {
+					expectedConfidence = common.AvailbilityConfidenceStateReady
+				}
+				mockUpstream.On("EvmAssertBlockAvailability", mock.Anything, tt.method, expectedConfidence, false, int64(100)).Return(true, nil).Maybe()
 			}
 
 			// Create mock response

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -962,6 +962,53 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 
 		// If MaxAvailableRecentBlocks is not configured, assume the node can handle the block if it's <= latest
 		return blockNumber <= latestBlock, nil
+	case common.AvailbilityConfidenceStateReady:
+		//
+		// StateReady: the upstream must have not only observed the block at its head
+		// but also confirmed (via the configured state probe) that its state DB is
+		// consistent at that block. Defends against the head-vs-trie race where a
+		// fast-ingesting node advances its head pointer before state slots are
+		// committed for that block, causing silent zero-valued state reads.
+		//
+		// When no StateProbe is configured for the network, StateReadyBlock falls
+		// back to LatestBlock — i.e. this behaves identically to BlockHead. This
+		// preserves backward compatibility for chains that haven't opted into the
+		// readiness probe yet.
+		//
+		stateReady := statePoller.StateReadyBlock()
+		// Same force-fresh semantics as BlockHead — if the requested block is
+		// beyond what we know is state-ready, give the poller one shot to catch
+		// up before rejecting.
+		if blockNumber > stateReady && forceFreshIfStale {
+			if _, err := statePoller.PollLatestBlockNumber(ctx); err != nil {
+				return false, fmt.Errorf("failed to poll latest block number: %w", err)
+			}
+			if _, err := statePoller.PollStateReady(ctx); err != nil {
+				return false, fmt.Errorf("failed to poll state-readiness probe: %w", err)
+			}
+			stateReady = statePoller.StateReadyBlock()
+		}
+		if blockNumber > stateReady {
+			telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
+				u.ProjectId,
+				u.VendorName(),
+				u.NetworkLabel(),
+				u.Id(),
+				forMethod,
+				confidence.String(),
+			).Inc()
+			return false, nil
+		}
+		if cfg.Evm.MaxAvailableRecentBlocks > 0 {
+			available, err := u.assertUpstreamLowerBound(ctx, statePoller, blockNumber, cfg.Evm.MaxAvailableRecentBlocks, forMethod, confidence)
+			if err != nil {
+				return false, err
+			}
+			if !available {
+				return false, nil
+			}
+		}
+		return true, nil
 	default:
 		return false, fmt.Errorf("unsupported block availability confidence: %s", confidence)
 	}

--- a/upstream/upstream_block_availability_test.go
+++ b/upstream/upstream_block_availability_test.go
@@ -22,6 +22,11 @@ type mockEvmStatePollerEnhanced struct {
 	pollCount      int
 	// For simulating block progression
 	blockProgression []int64
+	// When non-zero, decouples StateReadyBlock from latestBlock so tests can
+	// exercise the head-vs-trie race. When zero, StateReadyBlock returns
+	// latestBlock as before.
+	stateReadyBlockOverride int64
+	pollStateReadyCallCount int
 }
 
 func (m *mockEvmStatePollerEnhanced) Bootstrap(ctx context.Context) error { return nil }
@@ -64,13 +69,27 @@ func (m *mockEvmStatePollerEnhanced) IsBlockFinalized(blockNumber int64) (bool, 
 func (m *mockEvmStatePollerEnhanced) SuggestFinalizedBlock(blockNumber int64)    {}
 func (m *mockEvmStatePollerEnhanced) SuggestLatestBlock(blockNumber int64)       {}
 func (m *mockEvmStatePollerEnhanced) SetNetworkConfig(cfg *common.NetworkConfig) {}
-func (m *mockEvmStatePollerEnhanced) IsObjectNull() bool                         { return m.isNull }
+func (m *mockEvmStatePollerEnhanced) IsObjectNull() bool { return m.isNull }
+func (m *mockEvmStatePollerEnhanced) StateReadyBlock() int64 {
+	if m.stateReadyBlockOverride != 0 {
+		return m.stateReadyBlockOverride
+	}
+	return m.latestBlock
+}
+func (m *mockEvmStatePollerEnhanced) PollStateReady(ctx context.Context) (int64, error) {
+	m.pollStateReadyCallCount++
+	if m.pollError != nil {
+		return 0, m.pollError
+	}
+	return m.StateReadyBlock(), nil
+}
 func (m *mockEvmStatePollerEnhanced) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	return &common.EvmStatePollerDiagnostics{
-		Enabled:        true,
-		LatestBlock:    m.latestBlock,
-		FinalizedBlock: m.finalizedBlock,
-		SyncingState:   common.EvmSyncingStateNotSyncing.String(),
+		Enabled:         true,
+		LatestBlock:     m.latestBlock,
+		FinalizedBlock:  m.finalizedBlock,
+		StateReadyBlock: m.latestBlock,
+		SyncingState:    common.EvmSyncingStateNotSyncing.String(),
 	}
 }
 
@@ -626,13 +645,20 @@ func (m *mockEvmStatePollerWithCustomBehavior) IsBlockFinalized(blockNumber int6
 func (m *mockEvmStatePollerWithCustomBehavior) SuggestFinalizedBlock(blockNumber int64)    {}
 func (m *mockEvmStatePollerWithCustomBehavior) SuggestLatestBlock(blockNumber int64)       {}
 func (m *mockEvmStatePollerWithCustomBehavior) SetNetworkConfig(cfg *common.NetworkConfig) {}
-func (m *mockEvmStatePollerWithCustomBehavior) IsObjectNull() bool                         { return false }
+func (m *mockEvmStatePollerWithCustomBehavior) IsObjectNull() bool { return false }
+func (m *mockEvmStatePollerWithCustomBehavior) StateReadyBlock() int64 {
+	return m.getLatestBlock()
+}
+func (m *mockEvmStatePollerWithCustomBehavior) PollStateReady(ctx context.Context) (int64, error) {
+	return 0, nil
+}
 func (m *mockEvmStatePollerWithCustomBehavior) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	return &common.EvmStatePollerDiagnostics{
-		Enabled:        true,
-		LatestBlock:    m.getLatestBlock(),
-		FinalizedBlock: m.finalizedBlock,
-		SyncingState:   common.EvmSyncingStateNotSyncing.String(),
+		Enabled:         true,
+		LatestBlock:     m.getLatestBlock(),
+		FinalizedBlock:  m.finalizedBlock,
+		StateReadyBlock: m.getLatestBlock(),
+		SyncingState:    common.EvmSyncingStateNotSyncing.String(),
 	}
 }
 

--- a/upstream/upstream_state_ready_test.go
+++ b/upstream/upstream_state_ready_test.go
@@ -1,0 +1,331 @@
+package upstream
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+// makeUpstream constructs a minimal Upstream for EvmAssertBlockAvailability
+// tests. Each test supplies its own state poller.
+func makeUpstream(poller common.EvmStatePoller) *Upstream {
+	logger := zerolog.Nop()
+	return &Upstream{
+		config: &common.UpstreamConfig{
+			Id:   "test-upstream",
+			Type: common.UpstreamTypeEvm,
+			Evm:  &common.EvmUpstreamConfig{},
+		},
+		logger:         &logger,
+		evmStatePoller: poller,
+		networkId:      util.AtomicValue("evm:137"),
+	}
+}
+
+// TestEvmAssertBlockAvailability_StateReady_HeadVsTrieRace mirrors the
+// production trace a96e11c29cdf5be9e26b05c7c15773b8: an upstream advanced its
+// head pointer to block N (claiming availability) while its state DB had not
+// committed slots for block N, causing eth_getBalance to silently return 0x0.
+//
+// With AvailbilityConfidenceStateReady, the upstream's state-readiness probe
+// keeps StateReadyBlock at N-1, so EvmAssertBlockAvailability rejects N and
+// the retry shortcut in upstream/failsafe.go is no longer fooled by a fresh
+// head pointer when the state is stale.
+func TestEvmAssertBlockAvailability_StateReady_HeadVsTrieRace(t *testing.T) {
+	t.Run("HeadAheadOfStateReady_StateReadyConfidence_Rejects", func(t *testing.T) {
+		// Simulates the moment of the captured trace: head pointer advanced
+		// to 86811349 but state DB only consistent through 86811348.
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811348,
+		}
+		up := makeUpstream(poller)
+
+		// BlockHead confidence accepts the request because the head pointer
+		// is at the requested block — legacy behavior, must NOT regress.
+		canHead, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceBlockHead, false, 86811349)
+		assert.NoError(t, err)
+		assert.True(t, canHead,
+			"BlockHead confidence trusts the head pointer alone — legacy behavior")
+
+		// StateReady confidence consults the probe and rejects.
+		canReady, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 86811349)
+		assert.NoError(t, err)
+		assert.False(t, canReady,
+			"StateReady rejects when stateReadyBlock < requested block")
+	})
+
+	t.Run("StateReadyConfidence_AcceptsAtExactBoundary", func(t *testing.T) {
+		// Block exactly equal to stateReadyBlock — must accept (boundary).
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811349,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 86811349)
+		assert.NoError(t, err)
+		assert.True(t, can, "block == stateReadyBlock must be accepted")
+	})
+
+	t.Run("StateReadyConfidence_AcceptsAtEarlierBlock", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811348,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 86811348)
+		assert.NoError(t, err)
+		assert.True(t, can, "earlier block must be accepted")
+	})
+
+	t.Run("StateReadyConfidence_AcceptsZeroBlock", func(t *testing.T) {
+		// blockNumber=0 (genesis) should be accepted under StateReady the same
+		// way it is under BlockHead — boundary parity.
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811349,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 0)
+		assert.NoError(t, err)
+		assert.True(t, can, "block=0 must be accepted (genesis)")
+	})
+
+	t.Run("StateReadyConfidence_AcceptsNegativeBlock", func(t *testing.T) {
+		// Negative block numbers shouldn't crash and should follow the same
+		// permissive semantics as BlockHead (mirrors existing edge-case test).
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811349,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, -1)
+		assert.NoError(t, err)
+		assert.True(t, can, "negative block must follow BlockHead semantics")
+	})
+
+	t.Run("StateReadyConfidence_NoProbeOverride_FallsThroughToHead", func(t *testing.T) {
+		// Without a probe override (mock's stateReadyBlockOverride=0), the
+		// fake's StateReadyBlock() falls back to latestBlock. StateReady
+		// confidence behaves identically to BlockHead — backward-compat.
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:    86811349,
+			finalizedBlock: 86811000,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 86811349)
+		assert.NoError(t, err)
+		assert.True(t, can,
+			"without configured probe, StateReady must be no-op equivalent to BlockHead")
+	})
+
+	t.Run("StateReadyConfidence_RejectsBlocksAheadOfStateReady_NoForceFresh", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811348,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 86811350)
+		assert.NoError(t, err)
+		assert.False(t, can)
+		assert.Equal(t, 0, poller.pollStateReadyCallCount,
+			"must not poll when forceFreshIfStale=false")
+	})
+
+	t.Run("StateReadyConfidence_ForcePollsWhenStale", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811348,
+		}
+		up := makeUpstream(poller)
+
+		// stateReadyBlockOverride is sticky — PollStateReady returns the same
+		// override. The request stays rejected but the poll fires.
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, true, 86811349)
+		assert.NoError(t, err)
+		assert.False(t, can)
+		assert.GreaterOrEqual(t, poller.pollStateReadyCallCount, 1,
+			"must poll state-readiness probe at least once when forceFreshIfStale=true")
+	})
+
+	t.Run("StateReadyConfidence_ForceFresh_NoOpWhenNotStale", func(t *testing.T) {
+		// When block <= stateReadyBlock from the start, force-fresh is unnecessary
+		// and should NOT trigger a poll.
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:             86811349,
+			finalizedBlock:          86811000,
+			stateReadyBlockOverride: 86811349,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, true, 86811348)
+		assert.NoError(t, err)
+		assert.True(t, can)
+		assert.Equal(t, 0, poller.pollStateReadyCallCount,
+			"must not poll when block is already within stateReadyBlock")
+	})
+}
+
+// TestEvmAssertBlockAvailability_StateReady_RegressionGuards confirms that
+// adding the new confidence didn't break the existing confidences.
+func TestEvmAssertBlockAvailability_StateReady_RegressionGuards(t *testing.T) {
+	t.Run("BlockHead_StillWorks", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:    1000,
+			finalizedBlock: 900,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceBlockHead, false, 1000)
+		assert.NoError(t, err)
+		assert.True(t, can)
+
+		can, err = up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceBlockHead, false, 1001)
+		assert.NoError(t, err)
+		assert.False(t, can, "block beyond latestBlock must be rejected")
+	})
+
+	t.Run("Finalized_StillWorks", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:    1000,
+			finalizedBlock: 900,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceFinalized, false, 900)
+		assert.NoError(t, err)
+		assert.True(t, can, "Finalized accepts block <= finalizedBlock")
+
+		can, err = up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceFinalized, false, 950)
+		assert.NoError(t, err)
+		assert.False(t, can, "Finalized rejects unfinalized block")
+	})
+
+	t.Run("UnknownConfidence_StillErrors", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:    1000,
+			finalizedBlock: 900,
+		}
+		up := makeUpstream(poller)
+
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidence(999), false, 500)
+		assert.False(t, can)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported block availability confidence")
+	})
+}
+
+// TestEvmAssertBlockAvailability_StateReady_NilGuards confirms the new
+// confidence's nil-guard paths match the existing confidences'.
+func TestEvmAssertBlockAvailability_StateReady_NilGuards(t *testing.T) {
+	t.Run("NilUpstream", func(t *testing.T) {
+		var up *Upstream
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 100)
+		assert.False(t, can)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "upstream or config is nil")
+	})
+
+	t.Run("NilConfig", func(t *testing.T) {
+		up := &Upstream{}
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 100)
+		assert.False(t, can)
+		assert.Error(t, err)
+	})
+
+	t.Run("NonEvmUpstream", func(t *testing.T) {
+		logger := zerolog.Nop()
+		up := &Upstream{
+			config: &common.UpstreamConfig{
+				Id:   "non-evm",
+				Type: "solana", // not EvmType
+			},
+			logger:         &logger,
+			evmStatePoller: &mockEvmStatePollerEnhanced{latestBlock: 100},
+			networkId:      util.AtomicValue("solana"),
+		}
+		can, err := up.EvmAssertBlockAvailability(context.Background(),
+			"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 50)
+		assert.False(t, can)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not an EVM type")
+	})
+}
+
+// TestEvmAssertBlockAvailability_StateReady_LowerBound_Disabled exercises the
+// interaction between the new confidence and the legacy MaxAvailableRecentBlocks
+// lower-bound check.
+func TestEvmAssertBlockAvailability_StateReady_LowerBound_Disabled(t *testing.T) {
+	logger := zerolog.Nop()
+	up := &Upstream{
+		config: &common.UpstreamConfig{
+			Id:   "test-upstream",
+			Type: common.UpstreamTypeEvm,
+			Evm: &common.EvmUpstreamConfig{
+				MaxAvailableRecentBlocks: 0, // no lower bound
+			},
+		},
+		logger: &logger,
+		evmStatePoller: &mockEvmStatePollerEnhanced{
+			latestBlock:             1000,
+			finalizedBlock:          900,
+			stateReadyBlockOverride: 1000,
+		},
+		networkId: util.AtomicValue("evm:1"),
+	}
+
+	can, err := up.EvmAssertBlockAvailability(context.Background(),
+		"eth_getBalance", common.AvailbilityConfidenceStateReady, false, 1)
+	assert.NoError(t, err)
+	assert.True(t, can, "with no MaxAvailableRecentBlocks, any block <= stateReady is accepted")
+}
+
+// TestEvmAssertBlockAvailability_StateReady_MaxInt64 is a boundary smoke
+// test — passing a max int64 block must reject without overflowing.
+func TestEvmAssertBlockAvailability_StateReady_MaxInt64(t *testing.T) {
+	up := makeUpstream(&mockEvmStatePollerEnhanced{
+		latestBlock:             1000,
+		finalizedBlock:          900,
+		stateReadyBlockOverride: 1000,
+	})
+
+	can, err := up.EvmAssertBlockAvailability(context.Background(),
+		"eth_getBalance", common.AvailbilityConfidenceStateReady, false, math.MaxInt64)
+	assert.NoError(t, err)
+	assert.False(t, can, "max int64 must be rejected, not overflow")
+}

--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -308,12 +308,19 @@ func (m *mockEvmStatePoller) PollEarliestBlockNumber(ctx context.Context, probe 
 	return 0, nil
 }
 
+func (m *mockEvmStatePoller) StateReadyBlock() int64 { return m.latestBlock }
+
+func (m *mockEvmStatePoller) PollStateReady(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockEvmStatePoller) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	return &common.EvmStatePollerDiagnostics{
-		Enabled:        true,
-		LatestBlock:    m.latestBlock,
-		FinalizedBlock: m.finalizedBlock,
-		SyncingState:   common.EvmSyncingStateNotSyncing.String(),
+		Enabled:         true,
+		LatestBlock:     m.latestBlock,
+		FinalizedBlock:  m.finalizedBlock,
+		StateReadyBlock: m.latestBlock,
+		SyncingState:    common.EvmSyncingStateNotSyncing.String(),
 	}
 }
 
@@ -623,12 +630,21 @@ func (m *mockEvmStatePollerWithUpdate) EarliestBlock(probe common.EvmAvailabilit
 	return 0
 }
 
+func (m *mockEvmStatePollerWithUpdate) StateReadyBlock() int64 {
+	return m.LatestBlock()
+}
+
+func (m *mockEvmStatePollerWithUpdate) PollStateReady(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockEvmStatePollerWithUpdate) GetDiagnostics() *common.EvmStatePollerDiagnostics {
 	return &common.EvmStatePollerDiagnostics{
-		Enabled:        true,
-		LatestBlock:    m.LatestBlock(),
-		FinalizedBlock: m.FinalizedBlock(),
-		SyncingState:   common.EvmSyncingStateNotSyncing.String(),
+		Enabled:         true,
+		LatestBlock:     m.LatestBlock(),
+		FinalizedBlock:  m.FinalizedBlock(),
+		StateReadyBlock: m.LatestBlock(),
+		SyncingState:    common.EvmSyncingStateNotSyncing.String(),
 	}
 }
 func (m *mockEvmStatePollerWithUpdate) PollEarliestBlockNumber(ctx context.Context, probe common.EvmAvailabilityProbeType, staleness time.Duration) (int64, error) {


### PR DESCRIPTION
## Problem

For state-read methods (`eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`, …), an upstream's reported head block isn't a sufficient proof that its state DB is consistent at that block. Fast-ingesting nodes — especially load-balanced ones — can advance their head pointer to block N before their state trie has committed slots for N, and silently return zero-valued or stale-prev-block results.

The retry shortcut at [`upstream/failsafe.go:703`](upstream/failsafe.go) trusted the head pointer (`reason="block_available_but_empty"` → `retry=false`), so a wrong-empty result for a state read was returned to the client without any retry against other upstreams.

## What this PR adds

A new availability primitive — `AvailbilityConfidenceStateReady` — that requires the upstream's state DB to be **verifiably consistent** at the requested block, not just observed at its head. Backed by a per-network state-readiness probe that the state poller runs alongside its existing cycle.

The probe is a single named strategy with typed inputs (no expression DSL):

```yaml
network:
  evm:
    chainId: 137
    stateProbe:
      strategy: changingStorage
      address: "0x..."   # contract with a high-activity slot
      slot:    "0x..."   # slot that changes on most blocks
```

`changingStorage` reads `eth_getStorageAt(address, slot, latestBlock)` each cycle and advances `stateReadyBlock` iff the result is **non-empty** AND **differs from the previous successful probe**. The first check catches `0x0`/`"0x"`/`null` returned at the advertised head; the second catches the silent-stale-prev-block case where a node serves the value from block N-1 while claiming to be at block N. Both assertions live in the strategy implementation, not in user config.

Future strategies can land as code (same shape, no config-language churn).

## Behavior

- **No behavior change without opt-in.** When `EvmNetworkConfig.StateProbe` is nil, `StateReadyBlock()` returns `LatestBlock()`, the new confidence behaves identically to `BlockHead`, and the retry shortcut decides the same outcome as before.
- **Wired at the leak site.** [`upstream/failsafe.go:703`](upstream/failsafe.go) — the `block_available_but_empty` shortcut now requests `StateReady` confidence when `evm.IsStateReadMethod(method)`. Other methods keep using `emptyResultConfidence`.
- **Cold-start permissive.** First probe with a non-empty result advances `stateReadyBlock` without waiting for a second cycle.
- **Failure threshold (default 10).** Consecutive probe failures disable the probe for that upstream and fall back to `LatestBlock` semantics, so a misconfigured probe can't black-hole an upstream.

## What this PR does NOT change

- The upstream-selection gate at [`erpc/networks.go:1281`](erpc/networks.go) stays on `BlockHead`. Promoting it to `StateReady` for state-read methods is a follow-up — the tolerance policy needs its own design discussion.

## Tests

- `architecture/evm/state_probe_test.go` — full assertion truth table for `changingStorage` plus a 3-cycle scenario test.
- `upstream/upstream_state_ready_test.go` — `EvmAssertBlockAvailability` rejects under `StateReady` when state-readiness lags head, accepts under `BlockHead` (legacy parity), and the no-probe-configured fallback.
- `common/config_state_probe_test.go` — load-time config validation.
- `architecture/evm/util_state_read_test.go` — `IsStateReadMethod` coverage.

`go test ./common/... ./architecture/evm/... ./upstream/...` passes; `go vet ./...` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new block-availability confidence used in retry/availability decisions for state-read JSON-RPC calls; mistakes could incorrectly suppress retries or mark upstreams stale despite backward-compatible fallbacks when the probe is unconfigured/disabled.
> 
> **Overview**
> Adds an opt-in *state-readiness* signal to detect head-vs-trie races where an upstream reports block N at its head but cannot yet serve consistent state at N.
> 
> The EVM state poller now optionally runs a per-network `stateProbe` (initial `changingStorage` strategy) to advance a new `StateReadyBlock`, exposes probe diagnostics, and disables the probe after a configurable consecutive-failure threshold.
> 
> Upstream block availability and the retry shortcut for empty state-read responses now consult the new `AvailbilityConfidenceStateReady` for methods classified by `evm.IsStateReadMethod`, with explicit fallback to legacy `LatestBlock`/`BlockHead` semantics when no probe is configured. Extensive unit tests cover config validation, probe classification/dispatch, and `EvmAssertBlockAvailability` behavior under head-vs-state divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f76ee6f6566c66d6fb805fd110b98f20c1ec5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->