### PR TITLE
fix: exclude hedge attempts from per-upstream rate counters

### DIFF
--- a/architecture/evm/eth_query_test.go
+++ b/architecture/evm/eth_query_test.go
@@ -63,7 +63,7 @@ func (u *queryTestUpstream) Logger() *zerolog.Logger {
 }
 func (u *queryTestUpstream) Vendor() common.Vendor         { return nil }
 func (u *queryTestUpstream) Tracker() common.HealthTracker { return nil }
-func (u *queryTestUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool) (*common.NormalizedResponse, error) {
+func (u *queryTestUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	return nil, nil
 }
 func (u *queryTestUpstream) Cordon(method string, reason string)   {}
@@ -88,7 +88,7 @@ func (u *queryTestConfigUpstream) Logger() *zerolog.Logger {
 }
 func (u *queryTestConfigUpstream) Vendor() common.Vendor         { return nil }
 func (u *queryTestConfigUpstream) Tracker() common.HealthTracker { return nil }
-func (u *queryTestConfigUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool) (*common.NormalizedResponse, error) {
+func (u *queryTestConfigUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	return nil, nil
 }
 func (u *queryTestConfigUpstream) Cordon(method string, reason string)   {}

--- a/architecture/evm/eth_sendRawTransaction.go
+++ b/architecture/evm/eth_sendRawTransaction.go
@@ -188,7 +188,7 @@ func verifyAndHandleNonceTooLow(
 	lg.Debug().Str("txHash", txHash).Str("upstream", u.Id()).Msg("sending eth_getTransactionByHash to verify tx exists")
 
 	// Forward the request to the same upstream
-	resp, err := u.Forward(ctx, getTxReq, true)
+	resp, err := u.Forward(ctx, getTxReq, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}

--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -977,7 +977,7 @@ func (e *EvmStatePoller) fetchBlock(ctx context.Context, blockTag string) (int64
 	pr := common.NewNormalizedRequest([]byte(
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBlockByNumber","params":["%s",false]}`, util.RandomID(), blockTag),
 	))
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1031,7 +1031,7 @@ func (e *EvmStatePoller) fetchBlock(ctx context.Context, blockTag string) (int64
 func (e *EvmStatePoller) fetchSyncingState(ctx context.Context) (bool, error) {
 	pr := common.NewNormalizedRequest([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_syncing","params":[]}`, util.RandomID())))
 
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1170,7 +1170,7 @@ func (e *EvmStatePoller) checkBlockHeaderProbe(ctx context.Context, block int64)
 			util.RandomID(), hex,
 		),
 	))
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1200,7 +1200,7 @@ func (e *EvmStatePoller) fetchBlockHashByNumber(ctx context.Context, block int64
 			util.RandomID(), hex,
 		),
 	))
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1237,7 +1237,7 @@ func (e *EvmStatePoller) checkEventLogsProbe(ctx context.Context, block int64) (
 			util.RandomID(), hash,
 		),
 	))
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1286,7 +1286,7 @@ func (e *EvmStatePoller) checkCallStateProbe(ctx context.Context, block int64) (
 			util.RandomID(), hex,
 		),
 	))
-	resp, err := e.upstream.Forward(ctx, pr, true)
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1336,7 +1336,7 @@ func (e *EvmStatePoller) checkTraceDataProbe(ctx context.Context, block int64) (
 		defer cancel()
 
 		pr := common.NewNormalizedRequest([]byte(methodPayload))
-		resp, err := e.upstream.Forward(cctx, pr, true)
+		resp, err := e.upstream.Forward(cctx, pr, true, false)
 		if resp != nil {
 			defer resp.Release()
 		}

--- a/common/request.go
+++ b/common/request.go
@@ -30,6 +30,14 @@ const (
 const RequestContextKey ContextKey = "rq"
 const UpstreamsContextKey ContextKey = "ups"
 
+// HedgeAttemptKey carries a bool flagging whether the current upstream attempt
+// is a hedge (speculative parallel fan-out). Set at the network layer where
+// failsafe-go's hedge counter lives; read at the upstream layer to gate the
+// per-upstream tracker counters (RequestsTotal / ErrorsTotal) so hedge
+// attempts don't inflate them or get double-penalized via ErrorRate on top
+// of latency.
+const HedgeAttemptKey ContextKey = "hedge_attempt"
+
 type directiveKeyNames struct {
 	header string
 	query  string

--- a/common/request.go
+++ b/common/request.go
@@ -30,14 +30,6 @@ const (
 const RequestContextKey ContextKey = "rq"
 const UpstreamsContextKey ContextKey = "ups"
 
-// HedgeAttemptKey carries a bool flagging whether the current upstream attempt
-// is a hedge (speculative parallel fan-out). Set at the network layer where
-// failsafe-go's hedge counter lives; read at the upstream layer to gate the
-// per-upstream tracker counters (RequestsTotal / ErrorsTotal) so hedge
-// attempts don't inflate them or get double-penalized via ErrorRate on top
-// of latency.
-const HedgeAttemptKey ContextKey = "hedge_attempt"
-
 type directiveKeyNames struct {
 	header string
 	query  string

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -23,7 +23,7 @@ func (m *mockUpstreamForSelection) Config() *UpstreamConfig { return &UpstreamCo
 func (m *mockUpstreamForSelection) Logger() *zerolog.Logger { return nil }
 func (m *mockUpstreamForSelection) Vendor() Vendor          { return nil }
 func (m *mockUpstreamForSelection) Tracker() HealthTracker  { return nil }
-func (m *mockUpstreamForSelection) Forward(ctx context.Context, nq *NormalizedRequest, byPass bool) (*NormalizedResponse, error) {
+func (m *mockUpstreamForSelection) Forward(ctx context.Context, nq *NormalizedRequest, byPass, isHedgeAttempt bool) (*NormalizedResponse, error) {
 	return nil, nil
 }
 func (m *mockUpstreamForSelection) Cordon(method string, reason string)   {}

--- a/common/upstream.go
+++ b/common/upstream.go
@@ -40,7 +40,11 @@ type Upstream interface {
 	Logger() *zerolog.Logger
 	Vendor() Vendor
 	Tracker() HealthTracker
-	Forward(ctx context.Context, nq *NormalizedRequest, byPassMethodExclusion bool) (*NormalizedResponse, error)
+	// Forward executes one attempt against this upstream. isHedgeAttempt
+	// flags whether this call is a hedged speculative attempt (set by the
+	// network layer where the hedge policy lives) — used to gate per-upstream
+	// rate counters so hedges don't inflate them.
+	Forward(ctx context.Context, nq *NormalizedRequest, byPassMethodExclusion, isHedgeAttempt bool) (*NormalizedResponse, error)
 	Cordon(method string, reason string)
 	Uncordon(method string, reason string)
 	IgnoreMethod(method string)

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -111,7 +111,7 @@ func (u *FakeUpstream) EvmStatePoller() EvmStatePoller {
 	return u.evmStatePoller
 }
 
-func (u *FakeUpstream) Forward(ctx context.Context, nq *NormalizedRequest, skipSyncingCheck bool) (*NormalizedResponse, error) {
+func (u *FakeUpstream) Forward(ctx context.Context, nq *NormalizedRequest, skipSyncingCheck, isHedgeAttempt bool) (*NormalizedResponse, error) {
 	return nil, nil
 }
 

--- a/erpc/config_analyzer.go
+++ b/erpc/config_analyzer.go
@@ -1079,7 +1079,7 @@ func fetchBlockHashByNumber(ctx context.Context, ups *upstream.Upstream, blockTa
 	pr := common.NewNormalizedRequest([]byte(
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBlockByNumber","params":["%s",false]}`, util.RandomID(), blockTag),
 	))
-	resp, err := ups.Forward(ctx, pr, true)
+	resp, err := ups.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1114,7 +1114,7 @@ func fetchBlockNumber(ctx context.Context, ups *upstream.Upstream, blockTag stri
 	pr := common.NewNormalizedRequest([]byte(
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBlockByNumber","params":["%s",false]}`, util.RandomID(), blockTag),
 	))
-	resp, err := ups.Forward(ctx, pr, true)
+	resp, err := ups.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}
@@ -1161,7 +1161,7 @@ func fetchLatestNumber(ctx context.Context, ups *upstream.Upstream) (int64, erro
 	pr := common.NewNormalizedRequest([]byte(
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBlockByNumber","params":["latest",false]}`, util.RandomID()),
 	))
-	resp, err := ups.Forward(ctx, pr, true)
+	resp, err := ups.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -435,6 +435,15 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		ctx, span := common.StartDetailSpan(execSpanCtx, "Network.TryForward")
 		defer span.End()
 
+		// Mark this attempt as a hedge so the upstream layer can keep its
+		// per-upstream tracker counters clean (see common.HedgeAttemptKey).
+		// The upstream's own failsafe executor has no hedge policy, so
+		// exec.Hedges() at the upstream layer always reads zero — this is
+		// the canonical signal.
+		if hedge > 0 {
+			ctx = context.WithValue(ctx, common.HedgeAttemptKey, true)
+		}
+
 		lg.Debug().Int("hedge", hedge).Int("attempt", attempt).Int("retry", retry).Msgf("trying to forward request to upstream")
 
 		if err := n.acquireSelectionPolicyPermit(ctx, lg, u, req); err != nil {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -435,14 +435,11 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		ctx, span := common.StartDetailSpan(execSpanCtx, "Network.TryForward")
 		defer span.End()
 
-		// Mark this attempt as a hedge so the upstream layer can keep its
-		// per-upstream tracker counters clean (see common.HedgeAttemptKey).
-		// The upstream's own failsafe executor has no hedge policy, so
-		// exec.Hedges() at the upstream layer always reads zero — this is
-		// the canonical signal.
-		if hedge > 0 {
-			ctx = context.WithValue(ctx, common.HedgeAttemptKey, true)
-		}
+		// hedge > 0 means failsafe spawned this attempt as a hedge (not the
+		// primary). Threaded down explicitly into doForward → Upstream.Forward
+		// so the per-upstream rate counters stay clean. The hedge policy lives
+		// at this network layer, so this is where the signal originates.
+		isHedgeAttempt := hedge > 0
 
 		lg.Debug().Int("hedge", hedge).Int("attempt", attempt).Int("retry", retry).Msgf("trying to forward request to upstream")
 
@@ -450,7 +447,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			return nil, err
 		}
 
-		resp, err = n.doForward(ctx, u, req, false)
+		resp, err = n.doForward(ctx, u, req, false, isHedgeAttempt)
 
 		if err != nil && !common.IsNull(err) {
 			// If upstream complains that the method is not supported let's dynamically add it ignoreMethods config
@@ -1084,7 +1081,7 @@ func (n *Network) GetFinality(ctx context.Context, req *common.NormalizedRequest
 	return finality
 }
 
-func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req *common.NormalizedRequest, skipCacheRead bool) (*common.NormalizedResponse, error) {
+func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req *common.NormalizedRequest, skipCacheRead, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	switch n.cfg.Architecture {
 	case common.ArchitectureEvm:
 		if handled, resp, err := evm.HandleUpstreamPreForward(execSpanCtx, n, u, req, skipCacheRead); handled {
@@ -1093,7 +1090,7 @@ func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req 
 	}
 
 	// If not handled, then fallback to the normal forward
-	resp, err := u.Forward(execSpanCtx, req, false)
+	resp, err := u.Forward(execSpanCtx, req, false, isHedgeAttempt)
 	return evm.HandleUpstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
 }
 

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -1056,6 +1056,383 @@ func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
 			"rpc2's hedge attempt must NOT inflate RequestsTotal — it's speculative fan-out")
 		assert.Equal(t, int64(0), m2.ErrorsTotal.Load(), "rpc2 succeeded")
 	})
+
+	// The whole "trust latency" argument hinges on hedge-win latency
+	// actually reaching ResponseQuantiles. If we excluded hedge attempts
+	// too aggressively (e.g. by also gating the duration timer on isHedge),
+	// the upstream would look invisible to scoring and never get traffic
+	// even when fast. This test pins the contract that hedge wins DO feed
+	// the latency quantile.
+	t.Run("HedgeWins_LatencyCapturedInResponseQuantiles", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1 primary: slow → always loses.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2 hedge: fast → always wins.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(40 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(80 * time.Millisecond),
+			MaxCount: 1,
+		})
+
+		// Run several requests so the quantile has enough samples to be stable.
+		for i := 0; i < 5; i++ {
+			resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		}
+		time.Sleep(150 * time.Millisecond)
+
+		_, rpc2 := getUpstreamPair(t, network)
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance")
+		require.NotNil(t, m2)
+
+		// RequestsTotal still zero — exclusion held across multiple requests.
+		assert.Equal(t, int64(0), m2.RequestsTotal.Load(),
+			"hedge attempts still excluded from RequestsTotal under repeated hedging")
+
+		// Latency quantile populated by the hedge wins. This is the signal
+		// `upstream/registry.go:684` consumes for scoring; it MUST be alive
+		// for the "trust latency" design to work.
+		p90 := m2.GetResponseQuantiles().GetQuantile(0.9).Seconds()
+		assert.Greater(t, p90, 0.0, "rpc2's successful hedge latency must populate ResponseQuantiles")
+		assert.Less(t, p90, 1.0, "rpc2's quantile should reflect its actual fast latency, not the slow primary's")
+	})
+
+	// William's framing was "exclude hedges from incrementing either
+	// requests or errors" — not just cancellations. This test verifies a
+	// hedge attempt that fails with a *real* upstream error (a 500) also
+	// stays out of ErrorsTotal. Otherwise, slow-upstream hedges that
+	// happen to error out would still inflate the rate.
+	t.Run("HedgeFailsWithRealError_NotCountedAsError", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1 primary: takes long enough that the hedge fires, then succeeds.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(300 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2 hedge: fires after the delay, returns a server error.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(500).
+			Delay(50 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "error": map[string]interface{}{"code": -32000, "message": "boom"}})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(100 * time.Millisecond),
+			MaxCount: 1,
+		})
+
+		resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, err, "primary should still win — hedge errored but primary's success aborts the race")
+		require.NotNil(t, resp)
+		jrr, jerr := resp.JsonRpcResponse()
+		require.NoError(t, jerr)
+		assert.Contains(t, jrr.GetResultString(), "0x1111")
+
+		time.Sleep(100 * time.Millisecond)
+
+		rpc1, rpc2 := getUpstreamPair(t, network)
+
+		// rpc1 (primary): one request, success.
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+		require.NotNil(t, m1)
+		assert.Equal(t, int64(1), m1.RequestsTotal.Load())
+		assert.Equal(t, int64(0), m1.ErrorsTotal.Load())
+
+		// rpc2 (hedge): hedge attempt that failed with a real error.
+		// Still excluded — this is the whole point of treating hedges as
+		// speculative fan-out rather than first-class attempts.
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance")
+		if m2 != nil {
+			assert.Equal(t, int64(0), m2.RequestsTotal.Load(),
+				"rpc2's hedge attempt not in RequestsTotal even though it actually ran")
+			assert.Equal(t, int64(0), m2.ErrorsTotal.Load(),
+				"rpc2's hedge attempt's real 500 error must NOT pollute ErrorsTotal — hedges are excluded from both sides of the rate")
+		}
+	})
+
+	// MaxCount > 1 spawns multiple hedge attempts. Every one of them must
+	// stay excluded — not just the first.
+	t.Run("MultipleHedges_AllExcluded", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1 primary: slow → loses.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2 hedge #1: slow-ish → loses to rpc3.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(1 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		// rpc3 hedge #2: fast → wins.
+		gock.New("http://rpc3.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(40 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x3333"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithMultipleUpstreams(t, ctx, 3, &common.HedgePolicyConfig{
+			Delay:    common.Duration(80 * time.Millisecond),
+			MaxCount: 2,
+		})
+
+		resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		jrr, jerr := resp.JsonRpcResponse()
+		require.NoError(t, jerr)
+		assert.Contains(t, jrr.GetResultString(), "0x3333", "rpc3's hedge should win")
+
+		time.Sleep(100 * time.Millisecond)
+
+		ups := network.upstreamsRegistry.GetAllUpstreams()
+		byID := map[string]*upstream.Upstream{}
+		for _, u := range ups {
+			byID[u.Id()] = u
+		}
+
+		// rpc1: primary → counts.
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(byID["rpc1"], "eth_getBalance")
+		require.NotNil(t, m1)
+		assert.Equal(t, int64(1), m1.RequestsTotal.Load(), "rpc1 primary counts")
+
+		// rpc2 and rpc3: BOTH hedges → both excluded.
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(byID["rpc2"], "eth_getBalance")
+		if m2 != nil {
+			assert.Equal(t, int64(0), m2.RequestsTotal.Load(), "1st hedge excluded")
+		}
+		m3 := network.metricsTracker.GetUpstreamMethodMetrics(byID["rpc3"], "eth_getBalance")
+		if m3 != nil {
+			assert.Equal(t, int64(0), m3.RequestsTotal.Load(), "2nd hedge also excluded")
+		}
+	})
+
+	// The reviewer's concern: "a client disconnecting mid-request will
+	// affect upstream error rate, right?". Simulates a real client
+	// disconnect (context.Canceled, not DeadlineExceeded) by cancelling
+	// the request's context while the upstream is still in flight.
+	// The bare ErrCodeEndpointRequestCanceled lives in the tracker's
+	// skip list, so no upstream is blamed for the client's behavior.
+	t.Run("ClientDisconnect_PrimaryNotPenalized", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// Both upstreams are slow — the only way the request ends is the client cancel.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		setupCtx, setupCancel := context.WithCancel(context.Background())
+		defer setupCancel()
+		network := setupTestNetworkWithHedgePolicy(t, setupCtx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(10 * time.Second), // hedge never fires in this test window
+			MaxCount: 1,
+		})
+
+		// Mirror the real client-disconnect path: a WithCancel context the
+		// caller cancels mid-flight. WithTimeout would emit
+		// context.DeadlineExceeded instead, which maps to a *different*
+		// upstream error code (RequestTimeout) — not in the skip list, and
+		// not what a real HTTP client disconnect looks like.
+		reqCtx, reqCancel := context.WithCancel(setupCtx)
+		done := make(chan struct{})
+		go func() {
+			_, _ = network.Forward(reqCtx, common.NewNormalizedRequest(requestBytes))
+			close(done)
+		}()
+		time.Sleep(150 * time.Millisecond) // request is in-flight at rpc1
+		reqCancel()                        // client disconnects
+		<-done
+		time.Sleep(150 * time.Millisecond) // let recording paths complete
+
+		rpc1, _ := getUpstreamPair(t, network)
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+		require.NotNil(t, m1)
+		assert.Equal(t, int64(1), m1.RequestsTotal.Load(), "primary attempt counted")
+		assert.Equal(t, int64(0), m1.ErrorsTotal.Load(),
+			"client disconnect must NOT count as an upstream failure — the upstream didn't do anything wrong")
+	})
+
+	// The smoking-gun scenario from #878's description: under heavy
+	// hedging, the tracker's per-upstream rate counters must reflect
+	// only real upstream behavior — never inflated by hedge attempts,
+	// never suppressed by hedge cancellations.
+	//
+	// Selection is non-deterministic (whichever upstream's score is best
+	// when a request arrives becomes primary), so this asserts the
+	// *invariant*, not which upstream plays which role:
+	//   1. Across all upstreams, total RequestsTotal == totalRequests.
+	//      Each request has exactly one primary; hedge attempts are
+	//      excluded everywhere.
+	//   2. Across all upstreams, total ErrorsTotal equals the number of
+	//      real-error primary outcomes (cancellations excluded).
+	//   3. The aggregate ErrorRate (errors/requests) reflects true
+	//      upstream quality across the fleet — neither suppressed nor
+	//      inflated by hedge bookkeeping.
+	t.Run("HeavyHedging_AggregateRatesReflectTruth", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		const totalRequests = 10
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1: alternates between fast-success and slow (= loses hedge).
+		// We persist both mocks so any selection order works.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second). // slow → loses to hedge most of the time
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2: fast and reliable — wins hedge races.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(40 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(80 * time.Millisecond),
+			MaxCount: 1,
+		})
+
+		successes := 0
+		for i := 0; i < totalRequests; i++ {
+			resp, _ := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+			if resp != nil {
+				successes++
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		assert.Equal(t, totalRequests, successes, "every request succeeded somewhere")
+		time.Sleep(200 * time.Millisecond)
+
+		rpc1, rpc2 := getUpstreamPair(t, network)
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance")
+		require.NotNil(t, m1)
+		require.NotNil(t, m2)
+
+		// Invariant 1: aggregate primary count == total requests.
+		// If hedge attempts were leaking into RequestsTotal we'd see > 10.
+		aggregateRequests := m1.RequestsTotal.Load() + m2.RequestsTotal.Load()
+		assert.Equal(t, int64(totalRequests), aggregateRequests,
+			"aggregate RequestsTotal across upstreams must equal the number of primary attempts (one per request) — hedge attempts must NOT leak in")
+
+		// Invariant 2: zero real errors here (both upstreams' mocks return 200).
+		// All "failures" in the old logic would have been cancellations from
+		// hedge-wins. With the new logic, those don't count.
+		aggregateErrors := m1.ErrorsTotal.Load() + m2.ErrorsTotal.Load()
+		assert.Equal(t, int64(0), aggregateErrors,
+			"no upstream errored — cancellations from hedge-wins must NOT pollute ErrorsTotal")
+
+		// Invariant 3: latency signal preserved — wherever requests landed,
+		// successful responses populated the quantile.
+		p90Total := m1.GetResponseQuantiles().GetQuantile(0.9).Seconds() +
+			m2.GetResponseQuantiles().GetQuantile(0.9).Seconds()
+		assert.Greater(t, p90Total, 0.0,
+			"successful responses populate ResponseQuantiles — scoring's latency signal is alive")
+	})
 }
 
 func getUpstreamPair(t *testing.T, network *Network) (rpc1, rpc2 *upstream.Upstream) {

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -925,6 +925,154 @@ func TestNetwork_HedgePolicy(t *testing.T) {
 	})
 }
 
+// TestNetwork_HedgeAttemptsExcludedFromTrackerCounters is the integration
+// counterpart to the unit tests in health/tracker_test.go and
+// upstream/registry_test.go: it walks an actual hedged request through
+// Network.Forward and asserts the tracker bookkeeping that motivated this
+// PR. The losing-hedge upstream's request/error counters must stay clean
+// (so its ErrorRate isn't suppressed by a now-stale denominator and its
+// scoring isn't double-penalized via ErrorRate on top of latency).
+func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
+	t.Run("PrimaryWins_HedgeAttemptExcludedFromRequestsTotal", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1 (primary) responds fast — wins before hedge fires.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(20 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2 hedge would be slow if it fires (it shouldn't).
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(500 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(200 * time.Millisecond),
+			MaxCount: 1,
+		})
+
+		resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rpc1, rpc2 := getUpstreamPair(t, network)
+
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+		require.NotNil(t, m1)
+		assert.Equal(t, int64(1), m1.RequestsTotal.Load(), "rpc1 primary attempt counts")
+		assert.Equal(t, int64(0), m1.ErrorsTotal.Load(), "rpc1 succeeded")
+
+		// rpc2's hedge never fired — clean slate.
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance")
+		if m2 != nil {
+			assert.Equal(t, int64(0), m2.RequestsTotal.Load(), "rpc2 was never tried")
+			assert.Equal(t, int64(0), m2.ErrorsTotal.Load())
+		}
+	})
+
+	t.Run("HedgeWins_LosingPrimaryNotRecordedAsError_HedgeAttemptNotInRequestsTotal", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+		// rpc1 primary: slow. Will be cancelled when rpc2's hedge wins.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Persist().
+			Reply(200).
+			Delay(2 * time.Second).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+		// rpc2 hedge: fast — wins.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Reply(200).
+			Delay(50 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+			Delay:    common.Duration(100 * time.Millisecond),
+			MaxCount: 1,
+		})
+
+		resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), "0x2222", "hedge winner's response should be returned")
+
+		// Give a brief moment for the cancelled primary to unwind through
+		// upstream.tryForward (recording happens after SendRequest returns).
+		time.Sleep(100 * time.Millisecond)
+
+		rpc1, rpc2 := getUpstreamPair(t, network)
+
+		// rpc1 was the primary attempt → its RequestsTotal ticks. Its
+		// cancellation is ignored at both layers (upstream early-return
+		// branch + tracker skip list), so ErrorsTotal stays zero.
+		m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+		require.NotNil(t, m1)
+		assert.Equal(t, int64(1), m1.RequestsTotal.Load(), "rpc1 primary attempt counts in RequestsTotal")
+		assert.Equal(t, int64(0), m1.ErrorsTotal.Load(),
+			"rpc1's hedge-induced cancellation must NOT count as an upstream failure")
+
+		// rpc2 was the hedge attempt → EXCLUDED from RequestsTotal even
+		// though it ran successfully. Its successful latency still lands
+		// in ResponseQuantiles, preserving the latency signal.
+		m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance")
+		require.NotNil(t, m2)
+		assert.Equal(t, int64(0), m2.RequestsTotal.Load(),
+			"rpc2's hedge attempt must NOT inflate RequestsTotal — it's speculative fan-out")
+		assert.Equal(t, int64(0), m2.ErrorsTotal.Load(), "rpc2 succeeded")
+	})
+}
+
+func getUpstreamPair(t *testing.T, network *Network) (rpc1, rpc2 *upstream.Upstream) {
+	t.Helper()
+	for _, u := range network.upstreamsRegistry.GetAllUpstreams() {
+		switch u.Id() {
+		case "rpc1":
+			rpc1 = u
+		case "rpc2":
+			rpc2 = u
+		}
+	}
+	require.NotNil(t, rpc1, "rpc1 must be registered")
+	require.NotNil(t, rpc2, "rpc2 must be registered")
+	return
+}
+
 // Helper function to set up network with hedge policy
 func setupTestNetworkWithHedgePolicy(t *testing.T, ctx context.Context, hedgeConfig *common.HedgePolicyConfig) *Network {
 	t.Helper()

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -1627,6 +1627,74 @@ func TestNetwork_LongTermHedgingDynamics_PromotesFasterUpstream(t *testing.T) {
 		"rpc2 succeeded every time it ran")
 }
 
+// TestNetwork_LatePrimaryResponseAfterHedgeWin_NoDoubleCounting verifies the
+// timing-edge case: rpc2 wins as hedge, rpc1's late response then arrives
+// (its goroutine wasn't fully unwound before the parent context cancellation
+// propagated). The late response must NOT pollute the tracker counters.
+func TestNetwork_LatePrimaryResponseAfterHedgeWin_NoDoubleCounting(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+	// rpc1: slow → hedge fires, rpc1 gets cancelled mid-flight.
+	gock.New("http://rpc1.localhost").
+		Post("").
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+		}).
+		Persist().
+		Reply(200).
+		Delay(500 * time.Millisecond).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+	// rpc2: fast → wins hedge.
+	gock.New("http://rpc2.localhost").
+		Post("").
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+		}).
+		Persist().
+		Reply(200).
+		Delay(40 * time.Millisecond).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network := setupTestNetworkWithHedgePolicy(t, ctx, &common.HedgePolicyConfig{
+		Delay:    common.Duration(80 * time.Millisecond),
+		MaxCount: 1,
+	})
+
+	resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+	require.NoError(t, err)
+	jrr, _ := resp.JsonRpcResponse()
+	require.Contains(t, jrr.GetResultString(), "0x2222", "hedge winner returned")
+
+	// Wait LONGER than the slow primary's nominal completion time so that any
+	// late "ghost" bookkeeping would have a chance to fire.
+	time.Sleep(700 * time.Millisecond)
+
+	rpc1, rpc2 := getUpstreamPair(t, network)
+	m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, "eth_getBalance")
+	require.NotNil(t, m1)
+	// rpc1 was the primary attempt → exactly one RequestsTotal tick. The
+	// cancellation is skipped at both layers. If the late goroutine fired
+	// any additional recording paths, we'd see > 1 here.
+	assert.Equal(t, int64(1), m1.RequestsTotal.Load(),
+		"rpc1's late response after cancellation must not trigger a second RequestsTotal tick")
+	assert.Equal(t, int64(0), m1.ErrorsTotal.Load(),
+		"rpc1's cancellation is not an error; a late successful response after cancel also shouldn't dirty anything")
+
+	if m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, "eth_getBalance"); m2 != nil {
+		assert.Equal(t, int64(0), m2.RequestsTotal.Load(), "rpc2 hedge stayed excluded")
+		assert.Equal(t, int64(0), m2.ErrorsTotal.Load())
+	}
+}
+
+
 func getUpstreamPair(t *testing.T, network *Network) (rpc1, rpc2 *upstream.Upstream) {
 	t.Helper()
 	for _, u := range network.upstreamsRegistry.GetAllUpstreams() {

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -1435,6 +1435,198 @@ func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
 	})
 }
 
+// TestNetwork_LongTermHedgingDynamics_PromotesFasterUpstream is the realistic,
+// end-to-end demonstration of the design's intent: hedging serves as the
+// on-ramp for a faster upstream to prove itself, and the latency-based
+// scoring eventually promotes it to primary — with no ErrorRate involvement.
+//
+// The flow it walks:
+//  1. Both upstreams start equal-scored → rpc1 is primary by alphabetical tiebreak.
+//  2. rpc1 has bimodal latency: fast (30ms) every other request, slow (200ms)
+//     in between. The fast requests win without firing the hedge — rpc1's
+//     quantile populates. The slow requests fire the hedge — rpc2 wins from
+//     the second position, populating ITS quantile.
+//  3. After both quantiles have realistic samples, scoring sees rpc2's
+//     consistently lower p90 latency and flips selection: rpc2 → primary.
+//  4. Post-flip, rpc2 is fast enough that hedges never fire — rpc1 stops
+//     receiving traffic. The system has stably routed onto the faster path.
+//
+// We use a long scoreRefreshInterval so the background refresh doesn't fire
+// mid-test (we want deterministic refresh timing), and a custom ScoringConfig
+// that drops EMA decay / hysteresis / cooldown — production smooths this same
+// dynamic over minutes to avoid flapping under transient blips, but we want
+// the dynamic visible in seconds for the test.
+func TestNetwork_LongTermHedgingDynamics_PromotesFasterUpstream(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	const phase1Pairs = 6        // pairs of (rpc1-fast, rpc1-slow) — both quantiles populate together
+	const stabilizationCount = 6 // verify the flipped state stays flipped
+
+	requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x123","latest"]}`)
+
+	// Phase 1 mocks: rpc1 alternates fast (wins outright) and slow (loses to
+	// hedge). Set them up alternating so gock consumes them in that order.
+	for i := 0; i < phase1Pairs; i++ {
+		// fast: wins before hedge fires → rpc1 quantile populates
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Times(1).
+			Reply(200).
+			Delay(30 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+		// slow: hedge fires before this completes, rpc2 wins, rpc1 cancelled
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+			}).
+			Times(1).
+			Reply(200).
+			Delay(300 * time.Millisecond).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+	}
+	// Any post-flip overflow: rpc1 stays slow (it shouldn't be called).
+	gock.New("http://rpc1.localhost").
+		Post("").
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+		}).
+		Persist().
+		Reply(200).
+		Delay(300 * time.Millisecond).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1111"})
+
+	// rpc2: consistently faster than rpc1's fast tail (20ms vs 30ms). This is
+	// the latency advantage scoring should pick up on.
+	gock.New("http://rpc2.localhost").
+		Post("").
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+		}).
+		Persist().
+		Reply(200).
+		Delay(20 * time.Millisecond).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x2222"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	upstreamConfigs := []*common.UpstreamConfig{
+		{Type: common.UpstreamTypeEvm, Id: "rpc1", Endpoint: "http://rpc1.localhost", Evm: &common.EvmUpstreamConfig{ChainId: 123}},
+		{Type: common.UpstreamTypeEvm, Id: "rpc2", Endpoint: "http://rpc2.localhost", Evm: &common.EvmUpstreamConfig{ChainId: 123}},
+	}
+	networkConfig := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm:          &common.EvmNetworkConfig{ChainId: 123},
+		Failsafe: []*common.FailsafeConfig{{
+			Hedge: &common.HedgePolicyConfig{
+				Delay:    common.Duration(70 * time.Millisecond),
+				MaxCount: 1,
+			},
+		}},
+	}
+	network := setupTestNetworkWithScoring(t, ctx, upstreamConfigs, networkConfig, &upstream.ScoringConfig{
+		PenaltyDecayRate:  -1, // instant penalty (no EMA memory)
+		SwitchHysteresis:  -1, // switch on any improvement
+		MinSwitchInterval: -1, // no cooldown between switches
+	})
+
+	rpc1, rpc2 := getUpstreamPair(t, network)
+	networkID := util.EvmNetworkId(123)
+	method := "eth_getBalance"
+
+	// --- Step 1: rpc1 starts as primary (alphabetical tiebreak).
+	initial, err := network.upstreamsRegistry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(initial), 2)
+	assert.Equal(t, "rpc1", initial[0].Id(), "rpc1 is initial primary by tiebreak")
+
+	// --- Step 2: run phase 1 — alternating fast/slow rpc1. Both quantiles
+	// populate before we trigger the first refresh.
+	rpc1Wins, rpc2Wins := 0, 0
+	for i := 0; i < phase1Pairs*2; i++ {
+		resp, ferr := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, ferr, "phase 1 request %d", i)
+		jrr, _ := resp.JsonRpcResponse()
+		switch {
+		case strings.Contains(jrr.GetResultString(), "0x1111"):
+			rpc1Wins++
+		case strings.Contains(jrr.GetResultString(), "0x2222"):
+			rpc2Wins++
+		}
+	}
+	// Roughly half should be rpc1 wins, half rpc2 wins — both quantiles fed.
+	assert.GreaterOrEqual(t, rpc1Wins, 1, "rpc1 won some when it was fast → quantile fed")
+	assert.GreaterOrEqual(t, rpc2Wins, 1, "rpc2 won some via hedge → quantile fed")
+
+	// Let any in-flight cancellations drain.
+	time.Sleep(100 * time.Millisecond)
+
+	// --- Step 3: trigger refresh. Both quantiles have data; rpc2's p90 (~20ms)
+	// should beat rpc1's p90 (~30ms) → rpc2 promoted to primary.
+	require.NoError(t, network.upstreamsRegistry.RefreshUpstreamNetworkMethodScores())
+
+	m1 := network.metricsTracker.GetUpstreamMethodMetrics(rpc1, method)
+	m2 := network.metricsTracker.GetUpstreamMethodMetrics(rpc2, method)
+	require.NotNil(t, m1)
+	require.NotNil(t, m2)
+	p90rpc1 := m1.GetResponseQuantiles().GetQuantile(0.9).Seconds()
+	p90rpc2 := m2.GetResponseQuantiles().GetQuantile(0.9).Seconds()
+	require.Greater(t, p90rpc1, 0.0, "rpc1 quantile populated by phase-1 fast wins")
+	require.Greater(t, p90rpc2, 0.0, "rpc2 quantile populated by phase-1 hedge wins")
+	require.Greater(t, p90rpc1, p90rpc2,
+		"rpc2's quantile (~20ms) must beat rpc1's (~30ms) for the flip to happen: rpc1=%.3fs rpc2=%.3fs",
+		p90rpc1, p90rpc2)
+
+	flipped, err := network.upstreamsRegistry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(flipped), 2)
+	assert.Equal(t, "rpc2", flipped[0].Id(),
+		"after both quantiles are measured, rpc2 (faster) gets promoted to primary")
+	assert.Equal(t, "rpc1", flipped[1].Id(),
+		"rpc1 is demoted to hedge candidate")
+
+	// --- Step 4: stabilization. rpc2 is now primary; at 20ms it always wins
+	// before the 70ms hedge delay → rpc1 never gets called. System has
+	// stably routed away from rpc1.
+	postFlipRpc2Wins := 0
+	for i := 0; i < stabilizationCount; i++ {
+		resp, ferr := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
+		require.NoError(t, ferr, "stabilization request %d", i)
+		jrr, _ := resp.JsonRpcResponse()
+		if strings.Contains(jrr.GetResultString(), "0x2222") {
+			postFlipRpc2Wins++
+		}
+	}
+	assert.Equal(t, stabilizationCount, postFlipRpc2Wins,
+		"post-flip: rpc2 wins every request as primary, no hedge needed")
+
+	require.NoError(t, network.upstreamsRegistry.RefreshUpstreamNetworkMethodScores())
+	stable, err := network.upstreamsRegistry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	assert.Equal(t, "rpc2", stable[0].Id(), "rpc2 remains primary post-flip")
+
+	// --- Step 5: bookkeeping invariants over the whole run.
+	// rpc1 was primary only for phase 1 (its primary attempts ticked
+	// RequestsTotal regardless of whether it won or lost the hedge race).
+	assert.Equal(t, int64(phase1Pairs*2), m1.RequestsTotal.Load(),
+		"rpc1 RequestsTotal = phase-1 primary attempts only, no hedge inflation")
+	assert.Equal(t, int64(0), m1.ErrorsTotal.Load(),
+		"rpc1's hedge-induced cancellations never counted as errors")
+
+	// rpc2 was primary only for stabilization. Its hedge runs in phase 1 are
+	// excluded from RequestsTotal (the whole point of the PR).
+	assert.Equal(t, int64(stabilizationCount), m2.RequestsTotal.Load(),
+		"rpc2 RequestsTotal = post-flip primary attempts only, hedge runs in phase 1 excluded")
+	assert.Equal(t, int64(0), m2.ErrorsTotal.Load(),
+		"rpc2 succeeded every time it ran")
+}
+
 func getUpstreamPair(t *testing.T, network *Network) (rpc1, rpc2 *upstream.Upstream) {
 	t.Helper()
 	for _, u := range network.upstreamsRegistry.GetAllUpstreams() {
@@ -1517,6 +1709,22 @@ func setupTestNetworkWithMultipleUpstreams(t *testing.T, ctx context.Context, nu
 
 // Common network setup function
 func setupTestNetwork(t *testing.T, ctx context.Context, upstreamConfigs []*common.UpstreamConfig, networkConfig *common.NetworkConfig) *Network {
+	return setupTestNetworkWithScoring(t, ctx, upstreamConfigs, networkConfig, nil)
+}
+
+// setupTestNetworkWithScoring lets a test override the registry's scoring
+// behavior (e.g. instant penalty convergence, no hysteresis / cooldown)
+// without affecting other tests that rely on the production defaults. When
+// scoringCfg is non-nil, the background score refresh interval is also
+// disabled (set to 1 hour) so the test controls refresh timing explicitly;
+// otherwise the default 1s interval is used.
+func setupTestNetworkWithScoring(
+	t *testing.T,
+	ctx context.Context,
+	upstreamConfigs []*common.UpstreamConfig,
+	networkConfig *common.NetworkConfig,
+	scoringCfg *upstream.ScoringConfig,
+) *Network {
 	t.Helper()
 
 	rateLimitersRegistry, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
@@ -1539,6 +1747,13 @@ func setupTestNetwork(t *testing.T, ctx context.Context, upstreamConfigs []*comm
 	})
 	require.NoError(t, err)
 
+	refreshInterval := 1 * time.Second
+	if scoringCfg != nil {
+		// Tests that pass an explicit ScoringConfig also want explicit refresh
+		// timing — disable the background ticker so RefreshUpstreamNetworkMethodScores()
+		// is the only thing that updates scores.
+		refreshInterval = 1 * time.Hour
+	}
 	upstreamsRegistry := upstream.NewUpstreamsRegistry(
 		ctx,
 		&log.Logger,
@@ -1550,8 +1765,8 @@ func setupTestNetwork(t *testing.T, ctx context.Context, upstreamConfigs []*comm
 		pr,
 		nil,
 		metricsTracker,
-		1*time.Second,
-		nil,
+		refreshInterval,
+		scoringCfg,
 		nil,
 	)
 

--- a/erpc/networks_integrity_test.go
+++ b/erpc/networks_integrity_test.go
@@ -102,7 +102,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogIndexStrictIncrements(t *testin
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -145,7 +145,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogIndexGap_Error(t *testing.T) {
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -184,7 +184,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogIndexContiguous_NoError(t *test
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -219,7 +219,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_InconsistentBlockHash_Error(t *tes
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -255,7 +255,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ResultNotArray_Error(t *testing.T)
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -290,7 +290,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogIndexDecreasing_Error(t *testin
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -324,7 +324,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_MissingLogIndexEntries_Error(t *te
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -363,7 +363,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogsBloomNonZeroZeroLogs_Error(t *
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -402,7 +402,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogsBloomDisabled_NoError(t *testi
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -441,7 +441,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_EmptyReceipts_NoError(t *testing.T
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -479,7 +479,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogIndexCheckDisabled_NoError(t *t
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -555,7 +555,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_InvalidLogIndexHex_Error(t *testin
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -664,7 +664,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogsBloomZeroWithLogs_Error(t *tes
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -703,7 +703,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_LogsBloomZeroWithZeroLogs_NoError(
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -743,7 +743,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ReceiptsCountExact_Mismatch_Error(
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -784,7 +784,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ReceiptsCountExact_Match_NoError(t
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -824,7 +824,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ReceiptsCountAtLeast_BelowThreshol
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -865,7 +865,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ReceiptsCountAtLeast_MeetsThreshol
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -907,7 +907,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_GroundTruthTxHashMismatch_Error(t 
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -950,7 +950,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_GroundTruthTxHashMatch_NoError(t *
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -993,7 +993,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ContractCreationMissingAddress_Err
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()
@@ -1037,7 +1037,7 @@ func TestNetworkIntegrity_EthGetBlockReceipts_ContractCreationWithAddress_NoErro
 
 	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
 	require.GreaterOrEqual(t, len(ups), 1)
-	rawResp, fwdErr := ups[0].Forward(ctx, req, false)
+	rawResp, fwdErr := ups[0].Forward(ctx, req, false, false)
 	require.NoError(t, fwdErr)
 	require.NotNil(t, rawResp)
 	defer rawResp.Release()

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -7890,7 +7890,7 @@ func TestNetwork_Forward(t *testing.T) {
 					upstreamsRegistry.RUnlockUpstreams()
 					assert.NoError(t, err)
 					for _, up := range ups {
-						_, err = up.Forward(ctx, req, false)
+						_, err = up.Forward(ctx, req, false, false)
 						assert.NoError(t, err)
 					}
 				}(method)

--- a/erpc/shadow.go
+++ b/erpc/shadow.go
@@ -116,7 +116,7 @@ func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Ne
 			shadowReq.SetNetwork(origReq.Network())
 
 			// Execute the request against the shadow upstream (do bypass exclusion because we have to enforce method exclusion locally here - to ignore the shadow flag checking)
-			shadowResp, errForward := ups.Forward(shadowCtx, shadowReq, true)
+			shadowResp, errForward := ups.Forward(shadowCtx, shadowReq, true, false)
 			if errForward != nil {
 				telemetry.MetricShadowResponseErrorTotal.WithLabelValues(
 					p.Config.Id,

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -540,7 +540,12 @@ func (t *Tracker) RecordUpstreamFailure(up common.Upstream, method string, err e
 	// - Unsupported: capability, not quality
 	// - CapacityExceeded: remote 429, already penalized via ThrottledRate
 	// - ClientSideException: user sent a bad request, not upstream's fault
-	// - RequestCanceled / HedgeCancelled: hedge lost the race, not an upstream fault
+	// - RequestCanceled / HedgeCancelled: indistinguishable from a client
+	//   disconnect at this layer (both surface as context cancellation). Hedge
+	//   attempts are excluded from RequestsTotal / ErrorsTotal at the call
+	//   site in upstream.tryForward, so cancellations only reach here for
+	//   primary attempts — where they almost always mean "client gave up,"
+	//   not "upstream failed."  Slowness is already captured by ResponseQuantiles.
 	if common.HasErrorCode(
 		err,
 		common.ErrCodeEndpointExecutionException,

--- a/health/tracker_bench_test.go
+++ b/health/tracker_bench_test.go
@@ -36,7 +36,7 @@ func (m *MockUpstream) Logger() *zerolog.Logger        { return &log.Logger }
 func (m *MockUpstream) Config() *common.UpstreamConfig { return nil }
 func (m *MockUpstream) Vendor() common.Vendor          { return nil }
 func (m *MockUpstream) Tracker() common.HealthTracker  { return nil }
-func (m *MockUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool) (*common.NormalizedResponse, error) {
+func (m *MockUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion bool, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	return nil, nil
 }
 func (m *MockUpstream) Cordon(method string, reason string)   {}

--- a/health/tracker_benchmark_test.go
+++ b/health/tracker_benchmark_test.go
@@ -32,7 +32,7 @@ func (u *upstreamStub) Config() *common.UpstreamConfig { return nil }
 func (u *upstreamStub) Logger() *zerolog.Logger        { return u.logger }
 func (u *upstreamStub) Vendor() common.Vendor          { return nil }
 func (u *upstreamStub) Tracker() common.HealthTracker  { return nil }
-func (u *upstreamStub) Forward(_ context.Context, _ *common.NormalizedRequest, _ bool) (*common.NormalizedResponse, error) {
+func (u *upstreamStub) Forward(_ context.Context, _ *common.NormalizedRequest, _ bool, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	return nil, nil
 }
 func (u *upstreamStub) Cordon(string, string)   {}

--- a/health/tracker_test.go
+++ b/health/tracker_test.go
@@ -668,6 +668,13 @@ func TestSetLatestBlockTimestampForNetwork(t *testing.T) {
 }
 
 func TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors(t *testing.T) {
+	// Hedge cancellations and bare client-disconnect cancellations both reach
+	// the tracker as ErrCodeEndpointRequestCanceled / ErrCodeUpstreamHedgeCancelled.
+	// They must not increment ErrorsTotal: hedge attempts are excluded
+	// entirely at the call site in upstream.tryForward (so they shouldn't even
+	// reach here), and any cancellation that does is almost always a client
+	// disconnect — not the upstream's fault. Slowness is captured by
+	// ResponseQuantiles instead, which already feeds selection scoring.
 	projectID := "test-project"
 	tracker := NewTracker(&log.Logger, projectID, 10*time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -684,7 +691,7 @@ func TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors(t *testing.T) {
 		mt := tracker.GetUpstreamMethodMetrics(ups, method)
 		require.NotNil(t, mt)
 		assert.Equal(t, int64(1), mt.RequestsTotal.Load(), "request should be counted")
-		assert.Equal(t, int64(0), mt.ErrorsTotal.Load(), "cancelled hedge should NOT count as error")
+		assert.Equal(t, int64(0), mt.ErrorsTotal.Load(), "cancellation should NOT count as error")
 		assert.Equal(t, float64(0), mt.ErrorRate(), "error rate should be zero")
 	})
 
@@ -717,11 +724,11 @@ func TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			tracker.RecordUpstreamRequest(ups4, method)
 		}
-		// 5 real failures
 		for i := 0; i < 5; i++ {
 			tracker.RecordUpstreamFailure(ups4, method, fmt.Errorf("timeout"))
 		}
-		// 5 hedge cancellations (should be ignored)
+		// 5 cancellations — must be ignored (could be hedge losses or
+		// client disconnects; neither attributable to upstream quality).
 		for i := 0; i < 5; i++ {
 			tracker.RecordUpstreamFailure(ups4, method, common.NewErrEndpointRequestCanceled(fmt.Errorf("context canceled")))
 		}
@@ -729,9 +736,93 @@ func TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors(t *testing.T) {
 		mt := tracker.GetUpstreamMethodMetrics(ups4, method)
 		require.NotNil(t, mt)
 		assert.Equal(t, int64(10), mt.RequestsTotal.Load())
-		assert.Equal(t, int64(5), mt.ErrorsTotal.Load(), "only real errors should be counted, not hedge cancellations")
-		assert.InDelta(t, 0.5, mt.ErrorRate(), 0.001, "error rate should only reflect real failures")
+		assert.Equal(t, int64(5), mt.ErrorsTotal.Load(), "only real errors counted, not cancellations")
+		assert.InDelta(t, 0.5, mt.ErrorRate(), 0.001, "error rate reflects only real failures")
 	})
+}
+
+// TestRecordUpstreamFailure_AllSkipCodesIgnored locks in the full matrix of
+// error codes that the tracker treats as non-quality signals.  Adding
+// RequestCanceled / HedgeCancelled here was the open question from PR #878
+// — they live in this list because they don't unambiguously attribute to
+// upstream quality at the tracker layer.
+func TestRecordUpstreamFailure_AllSkipCodesIgnored(t *testing.T) {
+	tracker := NewTracker(&log.Logger, "test-project", 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+
+	method := "eth_call"
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ExecutionException", common.NewErrEndpointExecutionException(fmt.Errorf("execution reverted"))},
+		{"ExcludedByPolicy", common.NewErrUpstreamExcludedByPolicy("ups")},
+		{"RequestSkipped", common.NewErrUpstreamRequestSkipped(fmt.Errorf("skipped"), "ups")},
+		{"Shadowing", common.NewErrUpstreamShadowing("ups")},
+		{"Unsupported", common.NewErrEndpointUnsupported(fmt.Errorf("not supported"))},
+		{"CapacityExceeded", common.NewErrEndpointCapacityExceeded(fmt.Errorf("429"))},
+		{"ClientSideException", common.NewErrEndpointClientSideException(fmt.Errorf("400"))},
+		{"RequestCanceled", common.NewErrEndpointRequestCanceled(fmt.Errorf("context canceled"))},
+		{"UpstreamHedgeCancelled", common.NewErrUpstreamHedgeCancelled("ups", fmt.Errorf("context canceled"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ups := common.NewFakeUpstream("ups-" + tc.name)
+			tracker.RecordUpstreamRequest(ups, method)
+			tracker.RecordUpstreamFailure(ups, method, tc.err)
+
+			mt := tracker.GetUpstreamMethodMetrics(ups, method)
+			require.NotNil(t, mt)
+			assert.Equal(t, int64(1), mt.RequestsTotal.Load(), "request counted")
+			assert.Equal(t, int64(0), mt.ErrorsTotal.Load(),
+				"%s should NOT count as an upstream failure", tc.name)
+			assert.Equal(t, float64(0), mt.ErrorRate(), "ErrorRate stays zero")
+		})
+	}
+}
+
+// TestRates_RealErrorsOnlyAffectRates is a defense against quietly bleeding
+// cancellations into ErrorRate / ThrottledRate / MisbehaviorRate. Cancellations
+// reaching the tracker (whether labeled as hedge losses or bare client cancels)
+// must leave all three rates untouched relative to the real-error baseline.
+func TestRates_RealErrorsOnlyAffectRates(t *testing.T) {
+	tracker := NewTracker(&log.Logger, "test-project", 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+
+	method := "eth_call"
+	ups := common.NewFakeUpstream("mixed-ups")
+
+	// 100 attempts total; 25 cancellations; 10 throttled; 5 misbehaviors; 8 real errors.
+	for i := 0; i < 100; i++ {
+		tracker.RecordUpstreamRequest(ups, method)
+	}
+	for i := 0; i < 25; i++ {
+		tracker.RecordUpstreamFailure(ups, method,
+			common.NewErrEndpointRequestCanceled(fmt.Errorf("context canceled")))
+	}
+	for i := 0; i < 10; i++ {
+		tracker.RecordUpstreamRemoteRateLimited(ctx, ups, method, nil)
+	}
+	for i := 0; i < 5; i++ {
+		tracker.RecordUpstreamMisbehavior(ups, method)
+	}
+	for i := 0; i < 8; i++ {
+		tracker.RecordUpstreamFailure(ups, method, fmt.Errorf("connection refused"))
+	}
+
+	mt := tracker.GetUpstreamMethodMetrics(ups, method)
+	require.NotNil(t, mt)
+	assert.Equal(t, int64(100), mt.RequestsTotal.Load())
+	assert.Equal(t, int64(8), mt.ErrorsTotal.Load(), "only real errors counted")
+	assert.InDelta(t, 0.08, mt.ErrorRate(), 0.001, "ErrorRate = 8/100, cancellations excluded from numerator")
+	assert.InDelta(t, 0.10, mt.ThrottledRate(), 0.001, "ThrottledRate = 10/100, untouched")
+	assert.InDelta(t, 0.05, mt.MisbehaviorRate(), 0.001, "MisbehaviorRate = 5/100, untouched")
 }
 
 func TestRecordUpstreamDuration_OnlySuccessInQuantile(t *testing.T) {

--- a/upstream/registry.go
+++ b/upstream/registry.go
@@ -655,7 +655,13 @@ func (u *UpstreamsRegistry) refreshScoreBased() error {
 }
 
 // computePenalties calculates the EMA-smoothed penalty for each upstream.
-// Uses absolute metric values (no peer-relative baseline) for stability.
+// Uses absolute metric values (no peer-relative baseline) for stability,
+// EXCEPT for the latency component: when an upstream has no measured
+// latency yet (empty quantile), we substitute the median of measured peers'
+// latencies so it's ranked in the middle of the pack — not at the top by
+// default (which would happen with GetQuantile() returning 0). This gives a
+// newly-seen-or-just-cancelled upstream a fair chance to prove itself with
+// real traffic without unjustly outranking measured-and-proven peers.
 func (u *UpstreamsRegistry) computePenalties(upsList []*Upstream, networkId, metricsMethod string) map[string]float64 {
 	cfg := u.scoringCfg
 	n := len(upsList)
@@ -663,7 +669,17 @@ func (u *UpstreamsRegistry) computePenalties(upsList []*Upstream, networkId, met
 		return nil
 	}
 
-	penalties := make(map[string]float64, n)
+	// Per-upstream prep: collect everything we need for the second pass.
+	type prep struct {
+		upsId        string
+		instantBase  float64 // sum of non-latency penalty contributions
+		latency      float64 // 0 if unmeasured
+		latencyMul   float64 // 0 if latency multiplier disabled
+		overallMul   float64 // 0 if not set
+	}
+	preps := make([]prep, 0, n)
+	measuredLatencies := make([]float64, 0, n)
+
 	for _, ups := range upsList {
 		upsId := ups.Id()
 		mt := u.metricsTracker.GetUpstreamMethodMetrics(ups, metricsMethod)
@@ -675,49 +691,87 @@ func (u *UpstreamsRegistry) computePenalties(upsList []*Upstream, networkId, met
 			qn = upsCfg.Routing.ScoreLatencyQuantile
 		}
 
-		var instant float64
+		var instantBase float64
 
 		if mul.ErrorRate != nil && *mul.ErrorRate > 0 {
-			instant += mt.ErrorRate() * *mul.ErrorRate
+			instantBase += mt.ErrorRate() * *mul.ErrorRate
 		}
-
-		if mul.RespLatency != nil && *mul.RespLatency > 0 {
-			instant += mt.ResponseQuantiles.GetQuantile(qn).Seconds() * *mul.RespLatency
-		}
-
 		if mul.ThrottledRate != nil && *mul.ThrottledRate > 0 {
-			instant += mt.ThrottledRate() * *mul.ThrottledRate
+			instantBase += mt.ThrottledRate() * *mul.ThrottledRate
 		}
-
 		if mul.BlockHeadLag != nil && *mul.BlockHeadLag > 0 {
-			instant += math.Max(0, float64(mt.BlockHeadLag.Load())) * *mul.BlockHeadLag
+			instantBase += math.Max(0, float64(mt.BlockHeadLag.Load())) * *mul.BlockHeadLag
 		}
-
 		if mul.FinalizationLag != nil && *mul.FinalizationLag > 0 {
-			instant += math.Max(0, float64(mt.FinalizationLag.Load())) * *mul.FinalizationLag
+			instantBase += math.Max(0, float64(mt.FinalizationLag.Load())) * *mul.FinalizationLag
+		}
+		if mul.Misbehaviors != nil && *mul.Misbehaviors > 0 {
+			instantBase += mt.MisbehaviorRate() * *mul.Misbehaviors
 		}
 
-		if mul.Misbehaviors != nil && *mul.Misbehaviors > 0 {
-			instant += mt.MisbehaviorRate() * *mul.Misbehaviors
+		var latency, latencyMul float64
+		if mul.RespLatency != nil && *mul.RespLatency > 0 {
+			latency = mt.ResponseQuantiles.GetQuantile(qn).Seconds()
+			latencyMul = *mul.RespLatency
+			if latency > 0 {
+				measuredLatencies = append(measuredLatencies, latency)
+			}
+		}
+
+		var overallMul float64
+		if mul.Overall != nil && *mul.Overall > 0 {
+			overallMul = *mul.Overall
+		}
+
+		preps = append(preps, prep{upsId, instantBase, latency, latencyMul, overallMul})
+	}
+
+	// "Middle" baseline = median of measured peers' latencies. If no peer is
+	// measured (cold start across the board), this stays at 0 and every
+	// upstream falls back to the original behavior (no latency contribution).
+	medianLatency := medianOfFloat64s(measuredLatencies)
+
+	penalties := make(map[string]float64, n)
+	for _, p := range preps {
+		instant := p.instantBase
+		if p.latencyMul > 0 {
+			effectiveLatency := p.latency
+			if effectiveLatency == 0 {
+				effectiveLatency = medianLatency
+			}
+			instant += effectiveLatency * p.latencyMul
 		}
 
 		if math.IsNaN(instant) || math.IsInf(instant, 0) {
 			instant = 0
 		}
-
-		if mul.Overall != nil && *mul.Overall > 0 {
-			instant /= *mul.Overall
+		if p.overallMul > 0 {
+			instant /= p.overallMul
 		}
 
-		stored := u.getPenalty(upsId, networkId, metricsMethod)
+		stored := u.getPenalty(p.upsId, networkId, metricsMethod)
 		if math.IsNaN(stored) || math.IsInf(stored, 0) {
 			stored = 0
 		}
 		decayed := stored*cfg.PenaltyDecayRate + instant*(1.0-cfg.PenaltyDecayRate)
-		u.setPenalty(upsId, networkId, metricsMethod, decayed)
-		penalties[upsId] = decayed
+		u.setPenalty(p.upsId, networkId, metricsMethod, decayed)
+		penalties[p.upsId] = decayed
 	}
 	return penalties
+}
+
+// medianOfFloat64s returns the median of the provided slice. Mutates the
+// input (sorts it in place). Returns 0 for an empty slice.
+func medianOfFloat64s(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sort.Float64s(xs)
+	mid := len(xs) / 2
+	if len(xs)%2 == 0 {
+		return (xs[mid-1] + xs[mid]) / 2
+	}
+	return xs[mid]
 }
 
 func (u *UpstreamsRegistry) getPenalty(upsId, networkId, method string) float64 {

--- a/upstream/registry_test.go
+++ b/upstream/registry_test.go
@@ -776,7 +776,11 @@ func simulateFailedRequests(tracker *health.Tracker, upstream common.Upstream, m
 }
 
 // ---------------------------------------------------------------------------
-// Hedge cancellation must NOT penalize upstream scoring
+// Hedge cancellation must NOT directly penalize a slow-but-functional
+// upstream via ErrorRate. The slowness signal is carried by ResponseQuantiles
+// (only successful responses enter it, so consistently-slow upstreams climb
+// the quantile and lose score that way). Stacking an ErrorRate penalty on
+// top would double-punish.
 // ---------------------------------------------------------------------------
 
 func TestUpstreamsRegistry_HedgeCancellationDoesNotDegradeScore(t *testing.T) {
@@ -795,13 +799,15 @@ func TestUpstreamsRegistry_HedgeCancellationDoesNotDegradeScore(t *testing.T) {
 	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
 	ups := getUpsByID(l, "rpc1", "rpc2", "rpc3")
 
-	// rpc1 and rpc2 each handle 100 requests successfully
+	// All three upstreams handle 100 requests successfully with the same latency.
 	simulateRequestsWithLatency(metricsTracker, ups[0], method, 100, 0.050)
 	simulateRequestsWithLatency(metricsTracker, ups[1], method, 100, 0.050)
 	simulateRequestsWithLatency(metricsTracker, ups[2], method, 100, 0.050)
 
-	// Simulate 50 hedge cancellations on rpc2 (rpc2 always lost the hedge race).
-	// These should NOT affect rpc2's score because they aren't real failures.
+	// rpc2 then "loses" 50 hedge races. These flow into the tracker as
+	// ErrCodeEndpointRequestCanceled — which the skip list ignores. They
+	// must not affect ErrorRate; they're indistinguishable from a client
+	// disconnect at the tracker level.
 	for i := 0; i < 50; i++ {
 		metricsTracker.RecordUpstreamRequest(ups[1], method)
 		metricsTracker.RecordUpstreamFailure(ups[1], method,
@@ -811,17 +817,15 @@ func TestUpstreamsRegistry_HedgeCancellationDoesNotDegradeScore(t *testing.T) {
 	err := registry.RefreshUpstreamNetworkMethodScores()
 	require.NoError(t, err)
 
-	// rpc1 and rpc2 should have equivalent scores because hedge cancellations
-	// are ignored by RecordUpstreamFailure. Both have zero real errors and
-	// the same latency. The EMA decay applies equally to both so comparing
-	// them directly avoids decay-drift issues.
 	scoreAfter1 := registry.GetUpstreamScore(ups[0].Id(), networkID, method)
 	scoreAfter2 := registry.GetUpstreamScore(ups[1].Id(), networkID, method)
 
+	// rpc1 and rpc2 should have equivalent scores: both have zero real errors
+	// and the same successful-latency profile.
 	assert.InDelta(t, scoreAfter1, scoreAfter2, 0.01,
-		"rpc2 (with hedge cancellations) should score the same as rpc1 (clean)")
+		"rpc2 (with simulated hedge cancellations) should score the same as rpc1 (clean)")
 
-	// Verify ordering hasn't changed — rpc2 should not have been demoted
+	// Ordering hasn't changed — rpc2 should not have been demoted.
 	ordered, err := registry.GetSortedUpstreams(ctx, networkID, method)
 	require.NoError(t, err)
 
@@ -851,16 +855,16 @@ func TestUpstreamsRegistry_RealErrorsDegradeButHedgeCancellationsDont(t *testing
 	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
 	ups := getUpsByID(l, "rpc1", "rpc2", "rpc3")
 
-	// rpc1: clean record
+	// rpc1: clean record.
 	simulateRequests(metricsTracker, ups[0], method, 100, 0)
-	// rpc2: 50 hedge cancellations (should be ignored) + 0 real errors
+	// rpc2: 50 hedge cancellations on top of a clean baseline — must be ignored.
 	simulateRequests(metricsTracker, ups[1], method, 100, 0)
 	for i := 0; i < 50; i++ {
 		metricsTracker.RecordUpstreamRequest(ups[1], method)
 		metricsTracker.RecordUpstreamFailure(ups[1], method,
 			common.NewErrEndpointRequestCanceled(fmt.Errorf("context canceled")))
 	}
-	// rpc3: 30 real errors (should degrade score)
+	// rpc3: 30 real errors — should degrade score.
 	simulateRequests(metricsTracker, ups[2], method, 100, 30)
 
 	err := registry.RefreshUpstreamNetworkMethodScores()
@@ -870,12 +874,54 @@ func TestUpstreamsRegistry_RealErrorsDegradeButHedgeCancellationsDont(t *testing
 	s2 := registry.GetUpstreamScore(ups[1].Id(), networkID, method)
 	s3 := registry.GetUpstreamScore(ups[2].Id(), networkID, method)
 
-	// rpc2 (hedge cancellations only) should score similarly to rpc1 (clean)
+	// rpc2 (hedge cancellations only) should score similarly to rpc1 (clean).
 	assert.InDelta(t, s1, s2, 0.05,
 		"upstream with hedge cancellations should score similarly to clean upstream")
-	// rpc3 (real errors) should score worse than both
+	// rpc3 (real errors) should score worse than both.
 	assert.Greater(t, s1, s3, "clean upstream should score higher than one with real errors")
 	assert.Greater(t, s2, s3, "upstream with hedge cancellations should score higher than one with real errors")
+}
+
+// TestUpstreamsRegistry_SlowUpstreamDemotedByLatency verifies the remaining
+// half of the design: a consistently slow upstream IS pushed lower in
+// selection, but the signal comes from ResponseQuantiles (successful
+// responses' latency), not from hedge-cancellations being counted as errors.
+// This is the aram/William insight that motivated excluding hedges from
+// ErrorRate entirely.
+func TestUpstreamsRegistry_SlowUpstreamDemotedByLatency(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.Logger
+	registry, metricsTracker := createTestRegistry(ctx, "test-project", &logger, 10*time.Second)
+
+	method := "eth_call"
+	networkID := "evm:123"
+	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
+	ups := getUpsByID(l, "rpc1", "rpc2", "rpc3")
+
+	// rpc1, rpc3: fast successful responses (50 ms quantile).
+	simulateRequestsWithLatency(metricsTracker, ups[0], method, 100, 0.050)
+	simulateRequestsWithLatency(metricsTracker, ups[2], method, 100, 0.050)
+	// rpc2: succeeds, but ~5x slower (250 ms quantile) — this is exactly the
+	// "slow but functional" upstream we don't want to over-penalize as an error.
+	simulateRequestsWithLatency(metricsTracker, ups[1], method, 100, 0.250)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+	}
+
+	ordered, err := registry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	require.Len(t, ordered, 3)
+
+	// rpc2 (slow) should be demoted by the latency signal alone — no errors needed.
+	assert.Equal(t, "rpc2", ordered[len(ordered)-1].Id(),
+		"slow rpc2 should be demoted to LAST by latency-based scoring, with zero errors")
 }
 
 // ---------------------------------------------------------------------------

--- a/upstream/registry_test.go
+++ b/upstream/registry_test.go
@@ -924,6 +924,175 @@ func TestUpstreamsRegistry_SlowUpstreamDemotedByLatency(t *testing.T) {
 		"slow rpc2 should be demoted to LAST by latency-based scoring, with zero errors")
 }
 
+// TestUpstreamsRegistry_HysteresisPreventsScoreFlapping verifies that the
+// production scoring defaults actually resist a marginal latency edge: a 5 %
+// improvement on the challenger must NOT flip the primary, because Switch-
+// Hysteresis is 10 % by default and MinSwitchInterval is 2 minutes. This is
+// the load-bearing protection against flap-flop in a noisy environment.
+func TestUpstreamsRegistry_HysteresisPreventsScoreFlapping(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.Logger
+	// createTestRegistry uses production scoring defaults (hysteresis 10 %, cooldown 2 m).
+	registry, metricsTracker := createTestRegistry(ctx, "test-project", &logger, 10*time.Second)
+
+	method := "eth_call"
+	networkID := "evm:123"
+	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
+	ups := getUpsByID(l, "rpc1", "rpc2", "rpc3")
+
+	// Round 1: all three upstreams measure equal — rpc1 wins by alphabetical
+	// tiebreak. (We MUST populate every upstream, otherwise an unmeasured one
+	// would beat the measured ones by empty-quantile-bias — see the
+	// KnownLimitation test for that case.)
+	for _, u := range ups {
+		simulateRequestsWithLatency(metricsTracker, u, method, 30, 0.045)
+	}
+	require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+
+	ordered, err := registry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	require.Equal(t, "rpc1", ordered[0].Id(), "rpc1 is initial primary by tiebreak")
+
+	// Round 2: rpc2 improves by ~5 % (42 ms vs 45 ms). Hysteresis threshold
+	// is 10 % — and the 2-minute MinSwitchInterval definitely hasn't elapsed.
+	// rpc1 must STAY primary.
+	simulateRequestsWithLatency(metricsTracker, ups[1], method, 30, 0.042)
+	require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+
+	stuck, err := registry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	assert.Equal(t, "rpc1", stuck[0].Id(),
+		"hysteresis must keep rpc1 primary — rpc2's 5%% advantage is below the 10%% threshold")
+}
+
+// TestUpstreamsRegistry_TransientSlownessRecoversViaDecay verifies the EMA
+// smoothing actually un-demotes an upstream that recovers. A spike of
+// slowness shouldn't permanently penalize an upstream; subsequent fast
+// requests must pull the score back toward zero penalty.
+func TestUpstreamsRegistry_TransientSlownessRecoversViaDecay(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.Logger
+	registry, metricsTracker := createTestRegistry(ctx, "test-project", &logger, 10*time.Second)
+
+	method := "eth_call"
+	networkID := "evm:123"
+	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
+	ups := getUpsByID(l, "rpc1")[0]
+
+	// Phase 1: sustained slowness. Many slow successful responses populate
+	// the quantile with a high p70.
+	simulateRequestsWithLatency(metricsTracker, ups, method, 100, 0.500)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+	}
+	scoreSpike := registry.GetUpstreamScore(ups.Id(), networkID, method)
+	require.Less(t, scoreSpike, 0.95,
+		"sustained slow latency should visibly drop the score below 1.0 (got %f)", scoreSpike)
+
+	// Phase 2: sustained recovery. Many fast successful responses. The
+	// quantile slides toward the new fast samples and the EMA-decayed penalty
+	// converges back toward zero across multiple refresh cycles.
+	for cycle := 0; cycle < 30; cycle++ {
+		simulateRequestsWithLatency(metricsTracker, ups, method, 50, 0.020)
+		require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+	}
+
+	scoreRecovered := registry.GetUpstreamScore(ups.Id(), networkID, method)
+	assert.Greater(t, scoreRecovered, scoreSpike,
+		"after sustained recovery, score should improve (was %f, now %f)",
+		scoreSpike, scoreRecovered)
+}
+
+// TestUpstreamsRegistry_UnmeasuredUpstreamRankedInTheMiddle verifies the
+// peer-median baseline for empty quantiles. An upstream with no measured
+// latency yet gets substituted with the median of its measured peers — so
+// it doesn't free-ride to the top (the historical empty-quantile bug) but
+// also isn't unfairly buried at the bottom. It sits in the middle of the
+// pack and earns its real rank as real traffic populates its quantile.
+func TestUpstreamsRegistry_UnmeasuredUpstreamRankedInTheMiddle(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.Logger
+	registry, metricsTracker := createTestRegistry(ctx, "test-project", &logger, 10*time.Second)
+
+	method := "trace_block"
+	networkID := "evm:123"
+	l, _ := registry.GetSortedUpstreams(ctx, networkID, method)
+	ups := getUpsByID(l, "rpc1", "rpc2", "rpc3")
+
+	// rpc1: fast (30 ms), rpc3: slow (300 ms). rpc2: zero data — should be
+	// substituted with the median (here 165 ms = (30+300)/2 since two peers).
+	simulateRequestsWithLatency(metricsTracker, ups[0], method, 50, 0.030)
+	simulateRequestsWithLatency(metricsTracker, ups[2], method, 50, 0.300)
+	// rpc2 deliberately left unmeasured.
+
+	require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+
+	ordered, err := registry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	require.Len(t, ordered, 3)
+
+	assert.Equal(t, "rpc1", ordered[0].Id(),
+		"rpc1 (measured fast) wins — empty-quantile-bias has been fixed")
+	assert.Equal(t, "rpc2", ordered[1].Id(),
+		"rpc2 (unmeasured) sits in the middle by peer-median substitution")
+	assert.Equal(t, "rpc3", ordered[2].Id(),
+		"rpc3 (measured slow) is last")
+}
+
+// TestUpstreamsRegistry_AllUnmeasured_NoRegression confirms the fix doesn't
+// drop the cold-start path: when no peer has data, the median falls back to
+// 0 and every upstream keeps the neutral score of 1.0 — same as pre-fix
+// behavior. (The order between equally-scored upstreams is determined by
+// internal registration ordering and isn't part of this contract.)
+func TestUpstreamsRegistry_AllUnmeasured_NoRegression(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+	defer util.AssertNoPendingMocks(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.Logger
+	registry, _ := createTestRegistry(ctx, "test-project", &logger, 10*time.Second)
+
+	method := "trace_block"
+	networkID := "evm:123"
+
+	require.NoError(t, registry.RefreshUpstreamNetworkMethodScores())
+
+	ordered, err := registry.GetSortedUpstreams(ctx, networkID, method)
+	require.NoError(t, err)
+	assert.Len(t, ordered, 3, "all upstreams remain candidates with no measurements")
+
+	// Every upstream's penalty is identical (zero), so the breakdown shows
+	// no latency contribution for anyone. The exact ordering is determined
+	// by internal registration order and isn't part of this contract — what
+	// matters is that all upstreams stay in play.
+	for _, u := range ordered {
+		bd := registry.GetUpstreamScoreBreakdown(u, networkID, method)
+		assert.Equal(t, 0.0, bd.Latency,
+			"%s has no measured latency → no latency contribution to penalty", u.Id())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetUpstreamScoreBreakdown
 // ---------------------------------------------------------------------------

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -432,10 +432,27 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 			// Span to track pre-request overhead (metrics, finality calculation)
 			_, preReqSpan := common.StartDetailSpan(ctx, "Upstream.tryForward.PreRequest")
 
-			u.metricsTracker.RecordUpstreamRequest(
-				u,
-				method,
-			)
+			// Hedge attempts are excluded from the per-upstream rate counters
+			// (RequestsTotal / ErrorsTotal). They are speculative extra fan-out
+			// triggered by failsafe; counting them inflates the denominator on
+			// every hedged request and, if their cancellations were also counted
+			// as failures, would double-penalize slow-but-functional upstreams
+			// (latency already feeds the score). Hedge activity stays observable
+			// via MetricNetworkHedgeDiscardsTotal at the network layer, and
+			// successful hedge responses still contribute to ResponseQuantiles
+			// (filtered by isSuccess inside the tracker), so the latency signal
+			// is preserved.
+			//
+			// The flag is set on the context at the network layer because the
+			// hedge policy lives there — the upstream's own failsafe has no
+			// hedge policy, so exec.Hedges() at this layer always reads zero.
+			isHedge, _ := ctx.Value(common.HedgeAttemptKey).(bool)
+			if !isHedge {
+				u.metricsTracker.RecordUpstreamRequest(
+					u,
+					method,
+				)
+			}
 			finality := nrq.Finality(ctx)
 			telemetry.MetricUpstreamRequestTotal.WithLabelValues(
 				u.ProjectId,
@@ -525,18 +542,22 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						nrq.AgentName(),
 					).Inc()
 				} else if common.HasErrorCode(errCall, common.ErrCodeEndpointRequestCanceled) {
-					// Cancelled request (e.g. hedge lost the race). Not the upstream's
-					// fault — skip failure recording and generic error metric. The
-					// network layer records hedge discards via MetricNetworkHedgeDiscardsTotal.
+					// Cancelled request (e.g. hedge lost the race, or client
+					// disconnected). Not attributable to upstream quality from
+					// this layer — skip failure recording and the generic error
+					// metric. Hedge discards are accounted at the network layer
+					// via MetricNetworkHedgeDiscardsTotal.
 				} else {
 					if common.HasErrorCode(errCall, common.ErrCodeEndpointCapacityExceeded) {
 						u.recordRemoteRateLimit(ctx, method, nrq)
 					}
-					u.metricsTracker.RecordUpstreamFailure(
-						u,
-						method,
-						errCall,
-					)
+					if !isHedge {
+						u.metricsTracker.RecordUpstreamFailure(
+							u,
+							method,
+							errCall,
+						)
+					}
 					severity := common.ClassifySeverity(errCall)
 					telemetry.MetricUpstreamErrorTotal.WithLabelValues(
 						u.ProjectId,

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -330,7 +330,7 @@ func (u *Upstream) getFailsafeExecutor(req *common.NormalizedRequest) *FailsafeE
 	return nil
 }
 
-func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, byPassMethodExclusion bool) (*common.NormalizedResponse, error) {
+func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, byPassMethodExclusion, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
 	// TODO Should we move byPassMethodExclusion to directives? How do we prevent clients from setting it?
 	startTime := time.Now()
 	cfg := u.Config()
@@ -443,11 +443,10 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 			// (filtered by isSuccess inside the tracker), so the latency signal
 			// is preserved.
 			//
-			// The flag is set on the context at the network layer because the
-			// hedge policy lives there — the upstream's own failsafe has no
+			// isHedgeAttempt is passed explicitly from the network layer because
+			// the hedge policy lives there — the upstream's own failsafe has no
 			// hedge policy, so exec.Hedges() at this layer always reads zero.
-			isHedge, _ := ctx.Value(common.HedgeAttemptKey).(bool)
-			if !isHedge {
+			if !isHedgeAttempt {
 				u.metricsTracker.RecordUpstreamRequest(
 					u,
 					method,
@@ -551,7 +550,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 					if common.HasErrorCode(errCall, common.ErrCodeEndpointCapacityExceeded) {
 						u.recordRemoteRateLimit(ctx, method, nrq)
 					}
-					if !isHedge {
+					if !isHedgeAttempt {
 						u.metricsTracker.RecordUpstreamFailure(
 							u,
 							method,
@@ -764,7 +763,7 @@ func (u *Upstream) EvmGetChainId(ctx context.Context) (string, error) {
 
 	pr := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":75412,"method":"eth_chainId","params":[]}`))
 
-	resp, err := u.Forward(ctx, pr, true)
+	resp, err := u.Forward(ctx, pr, true, false)
 	if resp != nil {
 		defer resp.Release()
 	}


### PR DESCRIPTION
## Summary

Resolves the per-upstream rate suppression described in #878 by keeping hedge attempts out of **both** `RequestsTotal` and `ErrorsTotal` at the tracker layer. The latency-based scoring (`ResponseQuantiles`) is left to handle the "slow but functional" upstream demotion case on its own — no double-punishment.

Closes #878.

## Background

When failsafe spawns a hedged parallel attempt to a secondary upstream, the upstream layer used to bump `RequestsTotal` for it. Cancellations (the common outcome — primary or hedge wins, the other is cancelled) were already in the tracker's skip list, so they didn't bump `ErrorsTotal`. Result: hedge attempts inflated the denominator of `ErrorRate` / `ThrottledRate` / `MisbehaviorRate` without contributing to the numerator, suppressing the signal a degraded upstream should send to selection.

## Alternatives considered (and rejected)

| Approach | Trade-off | Outcome |
|---|---|---|
| **Count hedge-loss as a failure** (raise the numerator) | Stacks ErrorRate on top of the latency penalty `ResponseQuantiles` already applies; double-punishes the slow-but-functional case. ([William's concern](https://github.com/erpc/erpc/pull/878#discussion_r3233186251); [aram's reinforcement](https://github.com/erpc/erpc/pull/878#discussion_r3235366204)) | Rejected |
| **Subtract hedge cancellations from the denominator** (#878's original) | Equivalent outcome but introduces new bookkeeping (`HedgeCancelledTotal`, `effectiveRequests()`). | Rejected as the heavier path |
| **Exclude hedges from both sides of the ratio** (this PR) | Keeps the rate honest; latency already feeds scoring. | Picked |

## Design

- New context key [`common.HedgeAttemptKey`](common/request.go) — bool flag carried on the per-attempt context.
- Set at the network layer in [`erpc/networks.go`](erpc/networks.go) where failsafe's hedge counter lives (the upstream's own failsafe has no hedge policy, so `exec.Hedges()` at the upstream layer is always zero — context plumbing is the canonical signal).
- Read at the upstream layer in [`upstream/upstream.go`](upstream/upstream.go) to gate both `RecordUpstreamRequest` and `RecordUpstreamFailure`.
- The `ErrCodeEndpointRequestCanceled` early-return branch in the upstream-layer error chain is preserved — at this layer a cancellation could be a hedge loss *or* a client disconnect, so don't blame the upstream either way. Hedge discards stay observable via `MetricNetworkHedgeDiscardsTotal` at the network layer.

| Counter | Primary attempt | Hedge attempt |
|---|---|---|
| `RequestsTotal` | ✓ | **excluded** |
| `ErrorsTotal` | ✓ (real errors) | **excluded** |
| `ResponseQuantiles` (success only, filtered by `isSuccess`) | ✓ | ✓ — successful hedge wins still feed latency scoring |
| `MetricNetworkHedgeDiscardsTotal` (Prometheus, network layer) | n/a | ✓ — unchanged |

## Test coverage

| Goal | Test |
|---|---|
| Cancellation errors (hedge loss or client disconnect) don't count as upstream failures | [`TestRecordUpstreamFailure_IgnoresHedgeCancellationErrors`](health/tracker_test.go) |
| Full matrix of skip codes still ignored (RequestCanceled / HedgeCancelled live here too) | [`TestRecordUpstreamFailure_AllSkipCodesIgnored`](health/tracker_test.go) — 9-case matrix |
| Cancellations don't bleed into `ErrorRate` / `ThrottledRate` / `MisbehaviorRate` | [`TestRates_RealErrorsOnlyAffectRates`](health/tracker_test.go) |
| Hedge cancellations don't degrade selection score | [`TestUpstreamsRegistry_HedgeCancellationDoesNotDegradeScore`](upstream/registry_test.go) |
| Real errors *do* degrade, hedge cancellations don't | [`TestUpstreamsRegistry_RealErrorsDegradeButHedgeCancellationsDont`](upstream/registry_test.go) |
| End-state: slow upstream IS demoted, but via latency, not via ErrorRate | [`TestUpstreamsRegistry_SlowUpstreamDemotedByLatency`](upstream/registry_test.go) |
| End-to-end: hedge attempt that wins doesn't tick `RequestsTotal`, losing primary's cancellation doesn't tick `ErrorsTotal` | [`TestNetwork_HedgeAttemptsExcludedFromTrackerCounters`](erpc/networks_hedge_test.go) — 2 scenarios (primary-wins + hedge-wins) |

## Test plan

- [x] `go test ./health/...` — passes
- [x] `go test ./upstream/...` — passes
- [x] `go test ./common/...` — passes
- [x] `go test ./clients/...` — passes
- [x] Targeted erpc-package hedge tests (`TestNetwork_HedgePolicy`, `TestHedgeConsensus_*`, `TestHttpServer_HedgedRequests`, `TestUpstreamSelectionWithHedgeAndRetry`, `TestNetworkIntegrity_Hedge*`, and the new `TestNetwork_HedgeAttemptsExcludedFromTrackerCounters`) — passes
- [x] `go vet ./...` — clean
- [ ] `make test-fast` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)