### PR TITLE
chore: pin xray-pr/xray-pr action to commit SHA

### DIFF
--- a/.github/workflows/xray.yml
+++ b/.github/workflows/xray.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 0
-      - uses: xray-pr/xray-pr@main
+      - uses: xray-pr/xray-pr@489e56199b92f696dbc3757964dffd2503ec68e2 # v0.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
@@ -51,7 +51,7 @@ jobs:
         with:
           ref: ${{ steps.pr-info.outputs.sha }}
           fetch-depth: 0
-      - uses: xray-pr/xray-pr@main
+      - uses: xray-pr/xray-pr@489e56199b92f696dbc3757964dffd2503ec68e2 # v0.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

Pin `xray-pr/xray-pr@main` to the v0.2.0 commit SHA (`489e561`) in both jobs of `.github/workflows/xray.yml`.

## Motivation

The `xray-pr/xray-pr` action currently floats on `@main` and runs on every PR with access to `GITHUB_TOKEN` (write to PRs) and `OPENROUTER_API_KEY`. A force-push or compromise of the action's `main` branch would let an attacker exfiltrate those secrets or modify PRs in this repository. Pinning to an immutable commit SHA closes that window.

The chosen SHA `489e56199b92f696dbc3757964dffd2503ec68e2` is the head of [release v0.2.0](https://github.com/xray-pr/xray-pr/releases/tag/v0.2.0) (2026-04-10), which is the latest tagged release of the action.

This matches the pinning style already used in this workflow for `step-security/harden-runner` and `actions/checkout` (SHA + `# vX.Y.Z` comment).

## Test plan

- [ ] Workflow YAML parses (verified locally; only `uses:` value changed)
- [ ] `xray-on-pr` job triggers normally on this draft PR being marked ready
- [ ] `xray-on-command` job triggers normally when an owner/member comments `/xray`

## References

- OpenSSF guidance: [Pin actions to a full length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- Follow-up to #474 and #475 (supply-chain hardening)