### PR TITLE
feat: add skip-consensus directive

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1217,9 +1217,9 @@ func (c *TimeoutPolicyConfig) Copy() *TimeoutPolicyConfig {
 func (c *TimeoutPolicyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type legacy struct {
 		Duration    *AdaptiveDuration `yaml:"duration,omitempty"`
-		Quantile    float64       `yaml:"quantile,omitempty"`
-		MinDuration Duration      `yaml:"minDuration,omitempty"`
-		MaxDuration Duration      `yaml:"maxDuration,omitempty"`
+		Quantile    float64           `yaml:"quantile,omitempty"`
+		MinDuration Duration          `yaml:"minDuration,omitempty"`
+		MaxDuration Duration          `yaml:"maxDuration,omitempty"`
 	}
 	var raw legacy
 	if err := unmarshal(&raw); err != nil {
@@ -1236,10 +1236,10 @@ func (c *TimeoutPolicyConfig) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	type legacy struct {
-		Duration    *AdaptiveDuration   `json:"duration,omitempty"`
-		Quantile    float64         `json:"quantile,omitempty"`
-		MinDuration json.RawMessage `json:"minDuration,omitempty"`
-		MaxDuration json.RawMessage `json:"maxDuration,omitempty"`
+		Duration    *AdaptiveDuration `json:"duration,omitempty"`
+		Quantile    float64           `json:"quantile,omitempty"`
+		MinDuration json.RawMessage   `json:"minDuration,omitempty"`
+		MaxDuration json.RawMessage   `json:"maxDuration,omitempty"`
 	}
 	var raw legacy
 	if err := SonicCfg.Unmarshal(data, &raw); err != nil {
@@ -1285,7 +1285,7 @@ func (c *TimeoutPolicyConfig) applyLegacySiblings(quantile float64, minD, maxD D
 // siblings get folded into Delay at YAML/JSON unmarshal time.
 type HedgePolicyConfig struct {
 	Delay    *AdaptiveDuration `yaml:"delay,omitempty" json:"delay,omitempty" tstype:"Duration | AdaptiveDuration"`
-	MaxCount int           `yaml:"maxCount" json:"maxCount"`
+	MaxCount int               `yaml:"maxCount" json:"maxCount"`
 }
 
 func (c *HedgePolicyConfig) Copy() *HedgePolicyConfig {
@@ -1304,10 +1304,10 @@ func (c *HedgePolicyConfig) Copy() *HedgePolicyConfig {
 func (c *HedgePolicyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type legacy struct {
 		Delay    *AdaptiveDuration `yaml:"delay,omitempty"`
-		MaxCount int           `yaml:"maxCount,omitempty"`
-		Quantile float64       `yaml:"quantile,omitempty"`
-		MinDelay Duration      `yaml:"minDelay,omitempty"`
-		MaxDelay Duration      `yaml:"maxDelay,omitempty"`
+		MaxCount int               `yaml:"maxCount,omitempty"`
+		Quantile float64           `yaml:"quantile,omitempty"`
+		MinDelay Duration          `yaml:"minDelay,omitempty"`
+		MaxDelay Duration          `yaml:"maxDelay,omitempty"`
 	}
 	var raw legacy
 	if err := unmarshal(&raw); err != nil {
@@ -1325,11 +1325,11 @@ func (c *HedgePolicyConfig) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	type legacy struct {
-		Delay    *AdaptiveDuration   `json:"delay,omitempty"`
-		MaxCount int             `json:"maxCount,omitempty"`
-		Quantile float64         `json:"quantile,omitempty"`
-		MinDelay json.RawMessage `json:"minDelay,omitempty"`
-		MaxDelay json.RawMessage `json:"maxDelay,omitempty"`
+		Delay    *AdaptiveDuration `json:"delay,omitempty"`
+		MaxCount int               `json:"maxCount,omitempty"`
+		Quantile float64           `json:"quantile,omitempty"`
+		MinDelay json.RawMessage   `json:"minDelay,omitempty"`
+		MaxDelay json.RawMessage   `json:"maxDelay,omitempty"`
 	}
 	var raw legacy
 	if err := SonicCfg.Unmarshal(data, &raw); err != nil {
@@ -1873,6 +1873,7 @@ type DirectiveDefaultsConfig struct {
 	SkipCacheRead     interface{} `yaml:"skipCacheRead,omitempty" json:"skipCacheRead"`
 	UseUpstream       *string     `yaml:"useUpstream,omitempty" json:"useUpstream"`
 	SkipInterpolation *bool       `yaml:"skipInterpolation,omitempty" json:"skipInterpolation"`
+	SkipConsensus     *bool       `yaml:"skipConsensus,omitempty" json:"skipConsensus"`
 
 	// Validation: Block Integrity
 	EnforceHighestBlock        *bool `yaml:"enforceHighestBlock,omitempty" json:"enforceHighestBlock"`

--- a/common/request.go
+++ b/common/request.go
@@ -41,6 +41,7 @@ const (
 	headerDirectiveSkipCacheRead              = "X-ERPC-Skip-Cache-Read"
 	headerDirectiveUseUpstream                = "X-ERPC-Use-Upstream"
 	headerDirectiveSkipInterpolation          = "X-ERPC-Skip-Interpolation"
+	headerDirectiveSkipConsensus              = "X-ERPC-Skip-Consensus"
 	headerDirectiveEnforceHighestBlock        = "X-ERPC-Enforce-Highest-Block"
 	headerDirectiveEnforceGetLogsRange        = "X-ERPC-Enforce-GetLogs-Range"
 	headerDirectiveEnforceNonNullTaggedBlocks = "X-ERPC-Enforce-Non-Null-Tagged-Blocks"
@@ -66,6 +67,7 @@ const (
 	queryDirectiveSkipCacheRead              = "skip-cache-read"
 	queryDirectiveUseUpstream                = "use-upstream"
 	queryDirectiveSkipInterpolation          = "skip-interpolation"
+	queryDirectiveSkipConsensus              = "skip-consensus"
 	queryDirectiveEnforceHighestBlock        = "enforce-highest-block"
 	queryDirectiveEnforceGetLogsRange        = "enforce-getlogs-range"
 	queryDirectiveEnforceNonNullTaggedBlocks = "enforce-non-null-tagged-blocks"
@@ -91,6 +93,7 @@ var directiveKeyRegistry = []directiveKeyNames{
 	{header: headerDirectiveSkipCacheRead, query: queryDirectiveSkipCacheRead},
 	{header: headerDirectiveUseUpstream, query: queryDirectiveUseUpstream},
 	{header: headerDirectiveSkipInterpolation, query: queryDirectiveSkipInterpolation},
+	{header: headerDirectiveSkipConsensus, query: queryDirectiveSkipConsensus},
 	{header: headerDirectiveEnforceHighestBlock, query: queryDirectiveEnforceHighestBlock},
 	{header: headerDirectiveEnforceGetLogsRange, query: queryDirectiveEnforceGetLogsRange},
 	{header: headerDirectiveEnforceNonNullTaggedBlocks, query: queryDirectiveEnforceNonNullTaggedBlocks},
@@ -148,6 +151,14 @@ type RequestDirectives struct {
 	// When true, the system will still compute and cache block references (for finality/metrics),
 	// but will NOT replace tags like "latest"/"finalized" with hex numbers in outbound requests.
 	SkipInterpolation bool `json:"skipInterpolation"`
+
+	// Instruct the proxy to bypass the consensus policy for this request and
+	// route through the standard retry+hedge+breaker+timeout path instead.
+	// Retry, hedge, breaker, and timeout policies still apply — only the
+	// consensus dispute / agreement step is skipped. Useful when the caller
+	// has its own correctness checks downstream and prefers first-response
+	// latency over multi-upstream agreement.
+	SkipConsensus bool `json:"skipConsensus"`
 
 	// Validation: Block Integrity
 	EnforceHighestBlock        bool `json:"enforceHighestBlock,omitempty"`
@@ -234,6 +245,7 @@ func (d *RequestDirectives) Clone() *RequestDirectives {
 		UseUpstream:                     d.UseUpstream,
 		ByPassMethodExclusion:           d.ByPassMethodExclusion,
 		SkipInterpolation:               d.SkipInterpolation,
+		SkipConsensus:                   d.SkipConsensus,
 		EnforceHighestBlock:             d.EnforceHighestBlock,
 		EnforceGetLogsBlockRange:        d.EnforceGetLogsBlockRange,
 		EnforceNonNullTaggedBlocks:      d.EnforceNonNullTaggedBlocks,
@@ -580,6 +592,9 @@ func (r *NormalizedRequest) ApplyDirectiveDefaults(directiveDefaults *DirectiveD
 	if directiveDefaults.SkipInterpolation != nil {
 		r.directives.SkipInterpolation = *directiveDefaults.SkipInterpolation
 	}
+	if directiveDefaults.SkipConsensus != nil {
+		r.directives.SkipConsensus = *directiveDefaults.SkipConsensus
+	}
 
 	// Validation: Block Integrity
 	if directiveDefaults.EnforceHighestBlock != nil {
@@ -728,6 +743,9 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 	if hv := headers.Get(headerDirectiveSkipInterpolation); hv != "" {
 		r.directives.SkipInterpolation = strings.ToLower(strings.TrimSpace(hv)) == "true"
 	}
+	if hv := headers.Get(headerDirectiveSkipConsensus); hv != "" {
+		r.directives.SkipConsensus = strings.ToLower(strings.TrimSpace(hv)) == "true"
+	}
 
 	// Validation Headers
 	if hv := headers.Get(headerDirectiveEnforceHighestBlock); hv != "" {
@@ -808,6 +826,10 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 
 	if skipInterpolation := queryArgs.Get(queryDirectiveSkipInterpolation); skipInterpolation != "" {
 		r.directives.SkipInterpolation = strings.ToLower(strings.TrimSpace(skipInterpolation)) == "true"
+	}
+
+	if skipConsensus := queryArgs.Get(queryDirectiveSkipConsensus); skipConsensus != "" {
+		r.directives.SkipConsensus = strings.ToLower(strings.TrimSpace(skipConsensus)) == "true"
 	}
 
 	// Validation query parameters

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -380,3 +380,159 @@ func TestHeaderOverridesConfigDefault_ValidateTransactionsRoot(t *testing.T) {
 		}
 	})
 }
+
+// ----------------------------------------------------------------------------
+// SkipConsensus directive
+// ----------------------------------------------------------------------------
+
+func TestSkipConsensusDirective_DefaultIsFalse(t *testing.T) {
+	req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+	req.EnrichFromHttp(http.Header{}, url.Values{}, UserAgentTrackingModeSimplified)
+
+	if dir := req.Directives(); dir != nil && dir.SkipConsensus {
+		t.Fatalf("expected SkipConsensus=false by default, got true")
+	}
+}
+
+func TestSkipConsensusDirective_FromHeader(t *testing.T) {
+	cases := []struct {
+		header string
+		value  string
+		want   bool
+	}{
+		{"X-ERPC-Skip-Consensus", "true", true},
+		{"X-ERPC-Skip-Consensus", "TRUE", true},
+		{"X-ERPC-Skip-Consensus", "  true  ", true},
+		{"X-ERPC-Skip-Consensus", "false", false},
+		{"X-ERPC-Skip-Consensus", "1", false}, // only "true" is truthy
+		{"X-ERPC-Skip-Consensus", "yes", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s=%s", tc.header, tc.value), func(t *testing.T) {
+			req := NewNormalizedRequest(nil)
+			h := http.Header{}
+			h.Set(tc.header, tc.value)
+			req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+			dir := req.Directives()
+			if dir == nil {
+				t.Fatalf("expected directives to be initialized")
+			}
+			if dir.SkipConsensus != tc.want {
+				t.Fatalf("expected SkipConsensus=%v, got %v", tc.want, dir.SkipConsensus)
+			}
+		})
+	}
+}
+
+func TestSkipConsensusDirective_FromQuery(t *testing.T) {
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{" true ", true},
+		{"false", false},
+		{"", false}, // empty doesn't change default
+		{"yes", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("?skip-consensus=%q", tc.query), func(t *testing.T) {
+			req := NewNormalizedRequest(nil)
+			q := url.Values{}
+			if tc.query != "" {
+				q.Set("skip-consensus", tc.query)
+			}
+			req.EnrichFromHttp(nil, q, UserAgentTrackingModeSimplified)
+			dir := req.Directives()
+			if dir == nil {
+				if tc.want {
+					t.Fatalf("expected SkipConsensus=%v but directives are nil", tc.want)
+				}
+				return
+			}
+			if dir.SkipConsensus != tc.want {
+				t.Fatalf("expected SkipConsensus=%v, got %v", tc.want, dir.SkipConsensus)
+			}
+		})
+	}
+}
+
+func TestSkipConsensusDirective_QueryOverridesHeader(t *testing.T) {
+	// Documented precedence: query parameters apply after headers in the
+	// parser, so an explicit query value wins.
+	req := NewNormalizedRequest(nil)
+	h := http.Header{}
+	h.Set("X-ERPC-Skip-Consensus", "true")
+	q := url.Values{}
+	q.Set("skip-consensus", "false")
+	req.EnrichFromHttp(h, q, UserAgentTrackingModeSimplified)
+
+	if dir := req.Directives(); dir == nil || dir.SkipConsensus {
+		t.Fatalf("expected SkipConsensus=false (query override), got %+v", dir)
+	}
+}
+
+func TestSkipConsensusDirective_DefaultsFromConfig(t *testing.T) {
+	tr := true
+	fa := false
+
+	t.Run("default_true_applies_when_no_request_override", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipConsensus: &tr})
+		if dir := req.Directives(); dir == nil || !dir.SkipConsensus {
+			t.Fatalf("expected SkipConsensus=true from defaults")
+		}
+	})
+
+	t.Run("default_false_applies_when_no_request_override", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipConsensus: &fa})
+		if dir := req.Directives(); dir == nil || dir.SkipConsensus {
+			t.Fatalf("expected SkipConsensus=false from defaults")
+		}
+	})
+
+	t.Run("header_overrides_default_true_to_false", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipConsensus: &tr})
+
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Consensus", "false")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+
+		if dir := req.Directives(); dir == nil || dir.SkipConsensus {
+			t.Fatalf("expected SkipConsensus=false after header override, got %+v", dir)
+		}
+	})
+
+	t.Run("query_overrides_default_false_to_true", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipConsensus: &fa})
+
+		q := url.Values{}
+		q.Set("skip-consensus", "true")
+		req.EnrichFromHttp(nil, q, UserAgentTrackingModeSimplified)
+
+		if dir := req.Directives(); dir == nil || !dir.SkipConsensus {
+			t.Fatalf("expected SkipConsensus=true after query override, got %+v", dir)
+		}
+	})
+}
+
+func TestSkipConsensusDirective_ClonePreservesValue(t *testing.T) {
+	for _, v := range []bool{true, false} {
+		t.Run(fmt.Sprintf("SkipConsensus=%v", v), func(t *testing.T) {
+			d := &RequestDirectives{SkipConsensus: v}
+			cloned := d.Clone()
+			if cloned.SkipConsensus != v {
+				t.Fatalf("Clone() did not preserve SkipConsensus: got %v, want %v", cloned.SkipConsensus, v)
+			}
+			// Mutating the clone must not affect the original.
+			cloned.SkipConsensus = !v
+			if d.SkipConsensus != v {
+				t.Fatalf("Clone() returned an aliased reference; original mutated")
+			}
+		})
+	}
+}

--- a/erpc/network_executor.go
+++ b/erpc/network_executor.go
@@ -170,8 +170,17 @@ func (e *networkExecutor) Run(
 		}
 	}
 
-	if e.HasConsensus() && e.consensus != nil {
-		// Consensus branch: each slot is retry(hedge(tryOneUpstream)).
+	// Consensus branch: each slot is retry(hedge(tryOneUpstream)).
+	// Skipped when the request carries the SkipConsensus directive (header
+	// `X-ERPC-Skip-Consensus: true`, query `?skip-consensus=true`, or
+	// `directiveDefaults.skipConsensus: true` in the network/project config).
+	// Falls through to the standard non-consensus retry+hedge path; all
+	// other policies (retry, hedge, breaker, timeout) still apply.
+	skipConsensus := false
+	if rds := req.Directives(); rds != nil {
+		skipConsensus = rds.SkipConsensus
+	}
+	if e.HasConsensus() && e.consensus != nil && !skipConsensus {
 		slotInner := func(slotCtx context.Context, slotReq *common.NormalizedRequest) (*common.NormalizedResponse, error) {
 			return e.runRetryHedge(slotCtx, slotReq, tryOneUpstream)
 		}

--- a/erpc/skip_consensus_directive_test.go
+++ b/erpc/skip_consensus_directive_test.go
@@ -1,0 +1,277 @@
+package erpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the SkipConsensus directive end-to-end through the
+// network executor. They reuse the consensus test harness in
+// networks_consensus_test.go (mock servers, network setup, etc.) and add a
+// directive-injection step before Network.Forward.
+//
+// The contract under test:
+//   - When SkipConsensus is set on the request, the consensus branch in
+//     networkExecutor.Invoke is bypassed and the request flows through the
+//     standard retry+hedge+timeout path.
+//   - When SkipConsensus is unset (or false), the consensus branch runs as
+//     usual. This file's "control" test confirms the harness still drives the
+//     consensus path correctly when the directive is absent.
+//
+// We assert observable behavior by:
+//   (a) Per-upstream call counts via httptest servers — consensus(2,3) hits
+//       all three upstreams to collect responses; the non-consensus path
+//       picks one upstream and returns its result.
+//   (b) Wall-clock latency — consensus dispute/agreement adds extra time
+//       even on agreement; the non-consensus path returns as soon as one
+//       upstream answers.
+
+func TestSkipConsensusDirective_Bypass_ViaHeader(t *testing.T) {
+	tc := skipConsensusTestCase(t)
+	// With SkipConsensus, only one upstream should be queried. Other slots
+	// may receive an in-flight cancellation but should not produce work.
+	tc.expectedCalls = []int{1, 0, 0}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, upsReg := setupNetworkForConsensusTest(t, ctx, tc)
+	_ = upsReg
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	headers := http.Header{}
+	headers.Set("X-ERPC-Skip-Consensus", "true")
+	req.EnrichFromHttp(headers, nil, common.UserAgentTrackingModeSimplified)
+	require.True(t, req.Directives().SkipConsensus, "precondition: directive must be set")
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	jrr, jrrErr := resp.JsonRpcResponse()
+	require.NoError(t, jrrErr)
+	require.NotNil(t, jrr)
+	assert.Equal(t, `"0xaaa"`, jrr.GetResultString(),
+		"response should come from the first upstream's mock, proving the request went down the non-consensus single-upstream path")
+}
+
+func TestSkipConsensusDirective_Bypass_ViaQueryParam(t *testing.T) {
+	tc := skipConsensusTestCase(t)
+	tc.expectedCalls = []int{1, 0, 0}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, _ := setupNetworkForConsensusTest(t, ctx, tc)
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	q := url.Values{}
+	q.Set("skip-consensus", "true")
+	req.EnrichFromHttp(nil, q, common.UserAgentTrackingModeSimplified)
+	require.True(t, req.Directives().SkipConsensus)
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestSkipConsensusDirective_Bypass_ViaDirectiveDefaults(t *testing.T) {
+	tc := skipConsensusTestCase(t)
+	tc.expectedCalls = []int{1, 0, 0}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, _ := setupNetworkForConsensusTest(t, ctx, tc)
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	tr := true
+	req.ApplyDirectiveDefaults(&common.DirectiveDefaultsConfig{SkipConsensus: &tr})
+	require.True(t, req.Directives().SkipConsensus,
+		"directiveDefaults.skipConsensus=true should populate the request directive")
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestSkipConsensusDirective_FalseValueDoesNotBypass(t *testing.T) {
+	// Control case: explicitly setting "false" must keep consensus active
+	// (proves the parser doesn't treat any non-empty string as truthy).
+	tc := skipConsensusTestCase(t)
+	// Consensus(2,3) with all agreeing: all 3 upstreams get called.
+	tc.expectedCalls = []int{1, 1, 1}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, _ := setupNetworkForConsensusTest(t, ctx, tc)
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	headers := http.Header{}
+	headers.Set("X-ERPC-Skip-Consensus", "false")
+	req.EnrichFromHttp(headers, nil, common.UserAgentTrackingModeSimplified)
+	require.False(t, req.Directives().SkipConsensus,
+		"explicit 'false' must keep SkipConsensus disabled")
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestSkipConsensusDirective_NoDirective_ConsensusStillRuns(t *testing.T) {
+	// Sanity check: with no directive at all, the consensus branch is taken
+	// and queries every participant. This validates that the harness alone
+	// (without our directive) reproduces the consensus path -- guarding
+	// against tests passing because the harness silently skipped consensus.
+	tc := skipConsensusTestCase(t)
+	tc.expectedCalls = []int{1, 1, 1}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, _ := setupNetworkForConsensusTest(t, ctx, tc)
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	// Intentionally NOT calling EnrichFromHttp/ApplyDirectiveDefaults.
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestSkipConsensusDirective_RetryStillAppliesOnUpstreamError(t *testing.T) {
+	// SkipConsensus only bypasses the consensus policy. Retry, hedge, and
+	// timeout still wrap the call. Mock the first upstream as a transient
+	// failure and expect erpc to retry on the next upstream.
+	tc := skipConsensusTestCase(t)
+	tc.mockResponses = []mockResponse{
+		// first upstream returns a retryable upstream error
+		{status: 500, body: jsonRpcError(-32603, "internal upstream error")},
+		// second succeeds
+		{status: 200, body: jsonRpcSuccess("0xbbb")},
+		// third should never be called
+		{status: 200, body: jsonRpcSuccess("0xccc")},
+	}
+	// Retry should advance from upstream-1 to upstream-2 and stop.
+	tc.expectedCalls = []int{1, 1, 0}
+	// Allow up to 3 attempts so retry can sweep to a healthy upstream.
+	maxAttempts := 3
+	delayZero := common.Duration(0)
+	tc.retryPolicy = &common.RetryPolicyConfig{
+		MaxAttempts: maxAttempts,
+		Delay:       delayZero,
+	}
+
+	startConsensusMockServers(t, tc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	ntw, _ := setupNetworkForConsensusTest(t, ctx, tc)
+	time.Sleep(200 * time.Millisecond)
+
+	req := buildSkipConsensusRequest(t, ntw)
+	headers := http.Header{}
+	headers.Set("X-ERPC-Skip-Consensus", "true")
+	req.EnrichFromHttp(headers, nil, common.UserAgentTrackingModeSimplified)
+
+	resp, err := ntw.Forward(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	jrr, jrrErr := resp.JsonRpcResponse()
+	require.NoError(t, jrrErr)
+	assert.Equal(t, `"0xbbb"`, jrr.GetResultString(),
+		"response should come from upstream-2 after upstream-1 failure was retried (retry policy is still active under SkipConsensus)")
+}
+
+// ----------------------------------------------------------------------------
+// helpers
+// ----------------------------------------------------------------------------
+
+// skipConsensusTestCase returns a base consensusTestCase configured with a
+// consensus policy that requires 2-of-3 agreement. With consensus engaged,
+// all three upstreams are expected to be queried; with consensus skipped,
+// only the first should be queried.
+func skipConsensusTestCase(_ *testing.T) consensusTestCase {
+	// All three upstreams return the same JSON-RPC success so a consensus
+	// path would short-circuit on the second matching response. The test
+	// assertions look at per-upstream call counts to distinguish the two
+	// code paths.
+	return consensusTestCase{
+		name:      "skip_consensus_directive",
+		upstreams: createTestUpstreams(3),
+		consensusConfig: &common.ConsensusPolicyConfig{
+			MaxParticipants:         3,
+			AgreementThreshold:      2,
+			DisputeBehavior:         common.ConsensusDisputeBehaviorAcceptMostCommonValidResult,
+			LowParticipantsBehavior: common.ConsensusLowParticipantsBehaviorAcceptMostCommonValidResult,
+		},
+		mockResponses: []mockResponse{
+			{status: 200, body: jsonRpcSuccess("0xaaa")},
+			{status: 200, body: jsonRpcSuccess("0xaaa")},
+			{status: 200, body: jsonRpcSuccess("0xaaa")},
+		},
+		requestMethod: "eth_blockNumber",
+		requestParams: []interface{}{},
+	}
+}
+
+func buildSkipConsensusRequest(t *testing.T, ntw *Network) *common.NormalizedRequest {
+	t.Helper()
+	reqBytes, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "eth_blockNumber",
+		"params":  []interface{}{},
+	})
+	require.NoError(t, err)
+	req := common.NewNormalizedRequest(reqBytes)
+	req.SetNetwork(ntw)
+	return req
+}
+
+// silence unused-import warnings if any test variant is later commented out
+var _ = atomic.Int32{}


### PR DESCRIPTION
Adds a `SkipConsensus` directive that bypasses the consensus policy on a per-request basis. Retry, hedge, breaker, and timeout policies still apply.

## How to use

- Header: `X-ERPC-Skip-Consensus: true`
- Query: `?skip-consensus=true`
- Config: `directiveDefaults.skipConsensus: true`

## Why

Some callers prefer first-response latency over multi-upstream agreement (for example, when downstream has its own correctness check). The existing all-or-nothing per-network consensus config doesn't allow that toggle at request time.

## Implementation

Mirrors the existing directive patterns (`RetryEmpty`, `SkipInterpolation`). The network executor already has a non-consensus branch — this PR adds one predicate to route to it.

- `common/request.go`: constants, struct field, parsing, `Clone()` preservation
- `common/config.go`: new optional `*bool` on `DirectiveDefaultsConfig`
- `erpc/network_executor.go`: read directive, fall through to existing non-consensus path when set

## Tests

`common/request_test.go` — 6 unit tests:
- Default value
- Header parsing (truthy/falsey variations, whitespace handling)
- Query parsing (truthy/falsey/empty)
- Query overrides header precedence
- Defaults application (true/false, header override, query override)
- `Clone()` preserves the field

`erpc/skip_consensus_directive_test.go` — 6 integration tests under `Consensus(2, 3)`:
- Bypass via header → only 1 upstream called
- Bypass via query → only 1 upstream called
- Bypass via `directiveDefaults` → only 1 upstream called
- Explicit `false` → consensus still active (3 upstreams)
- No directive (control) → consensus still active (3 upstreams)
- Retry still applies under `SkipConsensus` when first upstream errors

All pass against `go test ./common/... ./erpc/...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a per-request switch that bypasses network consensus, changing how requests are routed across upstreams and potentially impacting correctness/consistency guarantees when enabled.
> 
> **Overview**
> Adds a new **per-request `SkipConsensus` directive** (configurable via `X-ERPC-Skip-Consensus`, `?skip-consensus=`, or `directiveDefaults.skipConsensus`) that forces consensus-enabled networks to *skip the consensus branch* and fall back to the existing non-consensus `retry+hedge+breaker+timeout` execution path.
> 
> Updates directive parsing/default application and cloning to carry this flag, and adds unit + end-to-end executor tests to verify precedence (query over header), defaulting, bypass behavior, and that retry still functions when consensus is skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32479727543e1841e5bf166816e8b39f556be09b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->