### PR TITLE
fix: accept empty results for state-reads + trace filters by default

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1988,10 +1988,45 @@ const DefaultDynamicBlockTimeDebounceMultiplier = 0.7
 const DefaultBlockUnavailableDelayMultiplier = 0.8
 
 // DefaultEmptyResultAccept returns a fresh copy of the methods for which an
-// empty/null result is considered valid (e.g. eth_getLogs, eth_call). A new
-// slice is returned on every call so callers cannot mutate the shared default.
+// empty/null/zero result is the canonical, final answer — NOT a "data is
+// missing, retry elsewhere" signal. For these methods an emptyish response
+// (`[]`, `0x`, `0x0`, `null`) is accepted immediately instead of burning the
+// retry budget (and its emptyResultDelay sleeps) chasing a non-empty answer
+// that will never come. A fresh slice is returned every call so callers
+// cannot mutate the shared default.
+//
+// Safety: this only governs what to do once a response arrives. The
+// per-upstream block-availability gate still runs BEFORE the call — an
+// upstream that doesn't yet have the requested block is skipped, so we never
+// accept a stale empty from a lagging node.
+//
+// Two categories qualify:
+//
+//   - Filter / range queries that return an array; `[]` means "nothing
+//     matched in this range", which is a complete answer:
+//     eth_getLogs, trace_filter, arbtrace_filter.
+//
+//   - Point state reads where the zero value is a real value, not absence:
+//     eth_call (empty/0x return), eth_getBalance (0x0 = zero balance),
+//     eth_getCode (0x = EOA / no code), eth_getStorageAt (0x0 = empty slot),
+//     eth_getTransactionCount (0x0 = nonce zero / no txns).
+//
+// Methods deliberately EXCLUDED — for these, empty/null means "not found
+// yet, try another upstream": eth_getBlockByNumber, eth_getBlockByHash,
+// eth_getTransactionByHash, eth_getTransactionReceipt, eth_getBlockReceipts.
 func DefaultEmptyResultAccept() []string {
-	return []string{"eth_getLogs", "eth_call"}
+	return []string{
+		// Filter / range queries — empty array is a valid "no matches".
+		"eth_getLogs",
+		"trace_filter",
+		"arbtrace_filter",
+		// Point state reads — zero value is a real value, not absence.
+		"eth_call",
+		"eth_getBalance",
+		"eth_getCode",
+		"eth_getStorageAt",
+		"eth_getTransactionCount",
+	}
 }
 
 // DefaultMarkEmptyAsErrorMethods returns a fresh copy of the methods for which

--- a/docs/pages/config/failsafe/retry.mdx
+++ b/docs/pages/config/failsafe/retry.mdx
@@ -150,7 +150,14 @@ Example with `delay: 200ms`, `backoffFactor: 1.5`, `jitter: 50ms`, `backoffMaxDe
 
 Many JSON-RPC methods legitimately return empty results. `eth_getLogs` for a block with no matching events returns `[]`. `eth_call` for a cleanly reverting contract returns `0x`. Retrying these is wasteful and can hide correctness bugs. Three knobs control this:
 
-**`emptyResultAccept`** lists methods where empty IS valid data. These methods are never retried purely because their result was empty. The default list is `["eth_getLogs", "eth_call"]`. Add methods freely; the cost of a false entry is one extra round trip, not a correctness problem.
+**`emptyResultAccept`** lists methods where empty IS valid data. These methods are never retried purely because their result was empty. The default list covers filter/range queries (where `[]` means "no matches") and point state reads (where the zero value is a real value, not absence):
+
+```
+eth_getLogs, trace_filter, arbtrace_filter,
+eth_call, eth_getBalance, eth_getCode, eth_getStorageAt, eth_getTransactionCount
+```
+
+Methods like `eth_getBlockByNumber` / `eth_getTransactionReceipt` are deliberately excluded — for those, `null` means "not found yet, try another upstream". The per-upstream block-availability gate still runs before the call, so accepting an empty here never returns a stale empty from a lagging node. Add methods freely; the cost of a false entry is one extra round trip, not a correctness problem.
 
 **`emptyResultConfidence`** decides when to trust an empty from an accepted method. `blockHead` (default) trusts empty responses even for chain-tip data. `finalizedBlock` is more conservative: if the requested block isn't yet finalized, an empty result is treated as potentially missing data and retried. Use `finalizedBlock` when you're consuming data from nodes that sometimes serve stale state.
 
@@ -171,7 +178,7 @@ When `blockUnavailableDelay` is not set, block-unavailable retries use the norma
 | `backoffFactor` | `1.2` | Gentle exponential ramp. |
 | `backoffMaxDelay` | `3s` | Delay ceiling. |
 | `jitter` | `0ms` | No jitter by default; add to avoid thundering herd. |
-| `emptyResultAccept` | `["eth_getLogs", "eth_call"]` | Methods where empty is valid. |
+| `emptyResultAccept` | filter queries (`eth_getLogs`, `trace_filter`, `arbtrace_filter`) + state reads (`eth_call`, `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`) | Methods where empty/zero is valid data, not "missing". |
 | `emptyResultConfidence` | `blockHead` | Trust empties at chain tip. |
 | `emptyResultMaxAttempts` | = `maxAttempts` | Inherits the error retry cap if not set. |
 | `emptyResultDelay` | = `delay` | Inherits the error delay if not set. |

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -2843,6 +2843,9 @@ func TestHttpServer_MultipleUpstreams(t *testing.T) {
 									Retry: &common.RetryPolicyConfig{
 										MaxAttempts: 8,
 										Delay:       common.Duration(100 * time.Millisecond),
+										// Pin empty accept list so this still sweeps both upstreams on
+										// empty (eth_getBalance is accepted by default now).
+										EmptyResultAccept: []string{},
 									},
 								},
 							},
@@ -2986,7 +2989,10 @@ func TestHttpServer_MultipleUpstreams(t *testing.T) {
 							Evm:          &common.EvmNetworkConfig{ChainId: 123},
 							Failsafe: []*common.FailsafeConfig{
 								{
-									Retry: &common.RetryPolicyConfig{MaxAttempts: 8, Delay: common.Duration(100 * time.Millisecond)},
+									// Pin empty accept list so the sweep still visits both
+									// upstreams on empty (eth_getBalance is accepted by
+									// default now); this test asserts no empty-RETRY rounds.
+									Retry: &common.RetryPolicyConfig{MaxAttempts: 8, Delay: common.Duration(100 * time.Millisecond), EmptyResultAccept: []string{}},
 								},
 							},
 						},

--- a/erpc/networks_empty_result_shortcircuit_test.go
+++ b/erpc/networks_empty_result_shortcircuit_test.go
@@ -166,13 +166,14 @@ func TestEmptyResultAcceptShortCircuit(t *testing.T) {
 
 		var rpc1Calls, rpc2Calls atomic.Int32
 
-		// eth_getTransactionCount returns "0x0" which is emptyish, but this
-		// method is NOT in the emptyResultAccept list so both upstreams must
-		// be tried before returning to the failsafe layer.
+		// eth_getBlockReceipts returns "[]" which is emptyish, but this
+		// method is NOT in the emptyResultAccept list (nor the
+		// mark-empty-as-error list) so both upstreams must be tried before
+		// returning to the failsafe layer.
 		gock.New("http://rpc1.localhost").
 			Post("").
 			Filter(func(r *http.Request) bool {
-				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionCount")
+				return strings.Contains(util.SafeReadBody(r), "eth_getBlockReceipts")
 			}).
 			Persist().
 			Reply(200).
@@ -180,13 +181,13 @@ func TestEmptyResultAcceptShortCircuit(t *testing.T) {
 			JSON(map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      1,
-				"result":  "0x0",
+				"result":  []interface{}{},
 			})
 
 		gock.New("http://rpc2.localhost").
 			Post("").
 			Filter(func(r *http.Request) bool {
-				return strings.Contains(util.SafeReadBody(r), "eth_getTransactionCount")
+				return strings.Contains(util.SafeReadBody(r), "eth_getBlockReceipts")
 			}).
 			Persist().
 			Reply(200).
@@ -194,7 +195,7 @@ func TestEmptyResultAcceptShortCircuit(t *testing.T) {
 			JSON(map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      1,
-				"result":  "0x0",
+				"result":  []interface{}{},
 			})
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -210,7 +211,7 @@ func TestEmptyResultAcceptShortCircuit(t *testing.T) {
 			},
 		)
 
-		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionCount","params":["0xabc","latest"]}`)
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts","params":["0x1234"]}`)
 		req := common.NewNormalizedRequest(requestBytes)
 		req.ApplyDirectiveDefaults(network.cfg.DirectiveDefaults)
 

--- a/erpc/networks_test.go
+++ b/erpc/networks_test.go
@@ -214,6 +214,9 @@ func TestNetwork_Forward(t *testing.T) {
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts:            4,
 				EmptyResultMaxAttempts: 2, // cap empties at 2 total attempts
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
@@ -336,7 +339,12 @@ func TestNetwork_Forward(t *testing.T) {
 		}
 		clr := clients.NewClientRegistry(&log.Logger, "prjA", nil, evm.NewJsonRpcErrorExtractor())
 		fsCfg := &common.FailsafeConfig{
-			Retry: &common.RetryPolicyConfig{MaxAttempts: 3}, // no EmptyResultMaxAttempts set
+			Retry: &common.RetryPolicyConfig{
+				MaxAttempts: 3, // no EmptyResultMaxAttempts set
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
+			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
 		if err != nil {
@@ -737,6 +745,9 @@ func TestNetwork_Forward(t *testing.T) {
 				MaxAttempts:      2,
 				Delay:            common.Duration(10 * time.Millisecond),  // normal error delay: 10ms
 				EmptyResultDelay: common.Duration(300 * time.Millisecond), // empty result delay: 300ms
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
@@ -952,6 +963,9 @@ func TestNetwork_Forward(t *testing.T) {
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2,
 				Delay:       common.Duration(10 * time.Millisecond), // normal delay only, no emptyResultDelay
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{Budgets: []*common.RateLimitBudgetConfig{}}, &log.Logger)
@@ -1965,6 +1979,9 @@ func TestNetwork_Forward(t *testing.T) {
 			Timeout: nil,
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2, // Allow up to 2 retry attempts
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -2733,6 +2750,9 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2, // Allow up to 2 retry attempts
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -2942,6 +2962,9 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2, // Allow up to 2 retry attempts
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -3133,6 +3156,9 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2, // Allow up to 2 retry attempts
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -3520,6 +3546,10 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 4, // Allow up to 4 attempts (1 initial + 3 retries)
+				// Pin an empty accept list so this test exercises the
+				// retry-on-empty path regardless of DefaultEmptyResultAccept
+				// (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -6968,6 +6998,9 @@ func TestNetwork_Forward(t *testing.T) {
 		fsCfg := &common.FailsafeConfig{
 			Retry: &common.RetryPolicyConfig{
 				MaxAttempts: 2,
+				// Pin empty accept list so this exercises retry-on-empty regardless of
+				// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+				EmptyResultAccept: []string{},
 			},
 		}
 		rlr, err := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{
@@ -7347,6 +7380,9 @@ func TestNetwork_Forward(t *testing.T) {
 				Failsafe: []*common.FailsafeConfig{{
 					Retry: &common.RetryPolicyConfig{
 						MaxAttempts: 2,
+						// Pin empty accept list so this exercises retry-on-empty regardless of
+						// DefaultEmptyResultAccept (eth_getBalance is now accepted by default).
+						EmptyResultAccept: []string{},
 					}},
 				},
 				DirectiveDefaults: &common.DirectiveDefaultsConfig{


### PR DESCRIPTION
## What & why

Methods that legitimately return an emptyish body were being treated as "missing data" and retried, wasting the retry budget (each empty-result retry also sleeps `emptyResultDelay`) and discarding fast hedge wins — even though the empty value was already the correct, final answer.

Examples of legitimately-empty responses that were retried:

- `eth_getBalance` → `"0x0"` for a zero-balance account
- `eth_getCode` → `"0x"` for an EOA
- `eth_getStorageAt` → `0x0` for an empty slot
- `eth_getTransactionCount` → `"0x0"` for nonce zero
- `trace_filter` / `arbtrace_filter` → `"[]"` for a block range with no matching traces

The only methods in `DefaultEmptyResultAccept` were `eth_getLogs` and `eth_call`, so all of the above fell into the empty-result retry path.

## The change

Expand `DefaultEmptyResultAccept()` to also cover the methods where empty/zero is the canonical final answer:

| Category | Methods |
|---|---|
| Filter / range queries (empty array = no matches) | `eth_getLogs`, `trace_filter`, `arbtrace_filter` |
| Point state reads (zero is a real value, not absence) | `eth_call`, `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount` |

`trace_filter` / `arbtrace_filter` are already wired as range/filter queries (fromBlock/toBlock refs, auto-splitting) — direct `eth_getLogs` analogues.

## Safety

- This only governs what to do **once a response arrives**. The per-upstream block-availability gate still runs **before** the call, so an upstream that doesn't yet have the requested block is skipped — a stale empty from a lagging node is never accepted.
- Stays **disjoint** from `DefaultMarkEmptyAsErrorMethods` (block/tx lookups like `eth_getBlockByNumber`, `*Receipt`, `*ByHash`), whose `null` still correctly triggers failover to another upstream.
- All code paths (`SetDefaults` fallback, network + upstream executors) already funnel through `DefaultEmptyResultAccept()`, so this single change propagates everywhere — no narrower hardcoded list remains.

## Tests

- `TestEmptyResultAcceptShortCircuit`'s "method not in accept list" case switched from `eth_getTransactionCount` (now accepted) to `eth_getBlockReceipts` (still retried).
- Retry-on-empty *mechanism* tests that used now-accepted methods as examples pin `EmptyResultAccept: []string{}` so they exercise the retry path independent of the default.

## Note for operators

Configs that previously pinned `emptyResultAccept: ['eth_getLogs', 'eth_call']` to opt into empty acceptance can drop the override to inherit this broader default. Configs that intentionally retry all empties (e.g. a sentinel method list) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
