### PR TITLE
fix: preserve null wildcard at non-terminal topic positions

### DIFF
--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -595,37 +595,9 @@ func (c *GenericGrpcBdsClient) handleGetLogs(ctx context.Context, req *common.No
 		}
 	}
 
-	var topics []*evm.TopicFilter
-	if topicsParam, ok := filterParams["topics"].([]interface{}); ok {
-		for _, topicParam := range topicsParam {
-			topicFilter := &evm.TopicFilter{}
-
-			switch v := topicParam.(type) {
-			case string:
-				// Single topic value
-				topic, err := parseHexBytes(v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse topic: %w", err)
-				}
-				topicFilter.Values = append(topicFilter.Values, topic)
-			case []interface{}:
-				// Multiple possible values for this topic position
-				for _, t := range v {
-					if topicStr, ok := t.(string); ok {
-						topic, err := parseHexBytes(topicStr)
-						if err != nil {
-							return nil, fmt.Errorf("failed to parse topic: %w", err)
-						}
-						topicFilter.Values = append(topicFilter.Values, topic)
-					}
-				}
-			case nil:
-				// null topic means any value at this position
-				continue
-			}
-
-			topics = append(topics, topicFilter)
-		}
+	topics, err := buildTopicFilters(filterParams["topics"])
+	if err != nil {
+		return nil, err
 	}
 
 	grpcReq := &evm.GetLogsRequest{
@@ -962,6 +934,47 @@ func (c *GenericGrpcBdsClient) QueryClient() evm.QueryServiceClient {
 
 func parseHexBytes(hexStr string) ([]byte, error) {
 	return evm.HexToBytes(hexStr)
+}
+
+// buildTopicFilters converts the JSON-RPC topics array (where each entry may be
+// a string, an array of strings, or null) into the proto TopicFilter slice.
+//
+// A null entry is a wildcard at that position and MUST emit an empty
+// TopicFilter so positional alignment with subsequent filters is preserved:
+// dropping the entry would shift later filters left, e.g. [selector, null, to]
+// would be sent as [selector, to] and match logs where topic[1]=to instead of
+// topic[2]=to — silently returning zero results.
+func buildTopicFilters(topicsParam interface{}) ([]*evm.TopicFilter, error) {
+	raw, ok := topicsParam.([]interface{})
+	if !ok {
+		return nil, nil
+	}
+	topics := make([]*evm.TopicFilter, 0, len(raw))
+	for _, topicParam := range raw {
+		topicFilter := &evm.TopicFilter{}
+		switch v := topicParam.(type) {
+		case string:
+			topic, err := parseHexBytes(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse topic: %w", err)
+			}
+			topicFilter.Values = append(topicFilter.Values, topic)
+		case []interface{}:
+			for _, t := range v {
+				if topicStr, ok := t.(string); ok {
+					topic, err := parseHexBytes(topicStr)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse topic: %w", err)
+					}
+					topicFilter.Values = append(topicFilter.Values, topic)
+				}
+			}
+		case nil:
+			// wildcard: leave Values empty, fall through to append below
+		}
+		topics = append(topics, topicFilter)
+	}
+	return topics, nil
 }
 
 // ensureQueryClient returns an error if the gRPC QueryService client has not

--- a/clients/grpc_bds_client_test.go
+++ b/clients/grpc_bds_client_test.go
@@ -9,6 +9,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBuildTopicFiltersPreservesNullPositions guards against a regression where
+// a null wildcard at a non-terminal topic position was silently dropped, which
+// collapsed later filters into earlier positions and caused eth_getLogs to
+// return zero results for valid queries (e.g. viem's
+// getLogs({event, args:{to:[addr]}}) which encodes as [selector, null, to]).
+// Empty TopicFilter Values is the proto-level wildcard at that position.
+func TestBuildTopicFiltersPreservesNullPositions(t *testing.T) {
+	const (
+		transferSig = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+		from        = "0x000000000000000000000000b92fe925dc43a0ecde6c8b1a2709c170ec4fff4f"
+		to          = "0x0000000000000000000000008ca997c0e5d38cf34ecb061f5374aead7728d86b"
+		otherTo     = "0x0000000000000000000000001111111111111111111111111111111111111111"
+	)
+
+	tests := []struct {
+		name        string
+		topics      interface{}
+		wantLengths []int // expected len(Values) per position; -1 means must be present (wildcard)
+	}{
+		{
+			name:        "nil topics param",
+			topics:      nil,
+			wantLengths: nil,
+		},
+		{
+			name:        "trailing null is preserved as wildcard",
+			topics:      []interface{}{transferSig, nil},
+			wantLengths: []int{1, 0},
+		},
+		{
+			name:        "leading null is preserved as wildcard",
+			topics:      []interface{}{nil, to},
+			wantLengths: []int{0, 1},
+		},
+		{
+			name:        "null in middle does not collapse subsequent positions",
+			topics:      []interface{}{transferSig, nil, to},
+			wantLengths: []int{1, 0, 1},
+		},
+		{
+			name:        "null in middle followed by array value",
+			topics:      []interface{}{transferSig, nil, []interface{}{to, otherTo}},
+			wantLengths: []int{1, 0, 2},
+		},
+		{
+			name:        "array of OR values at position",
+			topics:      []interface{}{transferSig, []interface{}{from, to}},
+			wantLengths: []int{1, 2},
+		},
+		{
+			name:        "all nulls preserved",
+			topics:      []interface{}{nil, nil, nil},
+			wantLengths: []int{0, 0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filters, err := buildTopicFilters(tc.topics)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.wantLengths), len(filters),
+				"positional alignment lost: a null entry was silently dropped")
+			for i, want := range tc.wantLengths {
+				require.NotNil(t, filters[i], "position %d must be present (wildcard or filter)", i)
+				require.Equal(t, want, len(filters[i].Values),
+					"position %d: expected %d values, got %d", i, want, len(filters[i].Values))
+			}
+		})
+	}
+}
+
+func TestBuildTopicFiltersRejectsInvalidHex(t *testing.T) {
+	_, err := buildTopicFilters([]interface{}{"not-hex"})
+	require.Error(t, err)
+}
+
 // TestGrpcBdsClientQueryMethodsDoNotShortCircuit verifies that query methods
 // are routed to the streaming QueryService handlers rather than being
 // rejected outright by SendRequest. With no live queryClient wired in, the


### PR DESCRIPTION
## Summary

The gRPC BDS client's `eth_getLogs` handler silently drops `null` topic entries at non-terminal positions, collapsing later filters into earlier ones. `[selector, null, to]` is sent over the wire as `[selector, to]` — meaning "topic[0]=selector AND **topic[1]=to**" instead of "topic[0]=selector AND **topic[2]=to**" — silently returning zero matching logs.

This breaks the standard `viem` pattern of filtering by a non-first indexed parameter:

```ts
client.getLogs({ event: erc20Abi[1], args: { to: [SAFE_ADDR] }, ... })
// viem encodes this as topics: [transferSig, null, paddedSafe]
```

## Root cause

[`clients/grpc_bds_client.go`](https://github.com/erpc/erpc/blob/main/clients/grpc_bds_client.go) in `handleGetLogs`:

```go
case nil:
    // null topic means any value at this position
    continue   // ← skips append(topics, topicFilter) below, COLLAPSES the array
```

`continue` skips the `append`, so the topics slice shrinks by one for every null. The resulting `GetLogsRequest.Topics` lists filters out of alignment with their intended positions.

Made worse by `DefaultEmptyResultAccept` (which legitimately covers `eth_getLogs`) — the bogus empty response is accepted and cached under the *correct* cache key (`hashValue` properly distinguishes `[selector, null, to]` from `[selector, to]`). So the breakage is sticky: every subsequent identical request gets the same empty cache hit until TTL expires.

Bug has existed since the initial gRPC BDS client (#341).

## Fix

Emit an empty `TopicFilter{}` at null positions instead of skipping. Per the proto comment on `TopicFilter`, empty `Values` is the wildcard at that position. This matches:

- The canonical CACHE-side parser at `proto/manifesto/evm/query_json_rpc.go:380` (appends `&TopicFilter{Values: values}` for every position, with empty `values` for null).
- erpc's own `eth_query` topic parser at `architecture/evm/eth_query.go:418` (falls through on `case nil:`, appending an empty group).

Extracted the conversion into `buildTopicFilters` so it's unit-testable without a live gRPC server.

## Verification

Reproduced against a deployed erpc instance backed by a gRPC cache connector — `[selector, null, to]` returned `x-erpc-cache: HIT` with `result: []`. Bypassing the cache (`X-ERPC-Skip-Cache-Read`) routed to an HTTP upstream and returned the expected log correctly, confirming the bug was specific to the gRPC fast-path.

After the fix, `buildTopicFilters` produces the correct positional alignment for every shape in the reproduction matrix:

| Input topics                      | Before (broken) | After (fixed) |
| --------------------------------- | --------------- | ------------- |
| `[selector, null, to]`            | 2 filters       | 3 filters     |
| `[null, to]`                      | 1 filter        | 2 filters     |
| `[selector, null, [to_a, to_b]]`  | 2 filters       | 3 filters     |
| `[selector, null]`                | 1 filter        | 2 filters     |
| `[null, null, null]`              | 0 filters       | 3 filters     |

## Test plan

- [x] `TestBuildTopicFiltersPreservesNullPositions` — 7 sub-cases (trailing, leading, middle, multiple, OR-array-after-null, all-null, nil-input).
- [x] `TestBuildTopicFiltersRejectsInvalidHex` — invalid hex still surfaces an error.
- [x] Verified the new test catches the bug by re-introducing the `continue` — every null-containing case fails with `positional alignment lost: a null entry was silently dropped`.
- [x] `go test ./clients/...` passes.
- [x] `go build ./...` clean.

## Notes for operators

Deploying the fix is necessary but not sufficient — any gRPC-BDS-backed cache connector that has already served the bogus empty response will keep returning the cached empty until TTL. Plan to invalidate cached `[selector, null, X]`-shaped entries on impacted networks after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes log-filter translation logic for `eth_getLogs`, which can alter which logs are returned for topic-based queries; impact is limited to gRPC-BDS log retrieval but affects correctness and cached results.
> 
> **Overview**
> Fixes a `eth_getLogs` bug in the gRPC BDS client where `null` entries in the `topics` array were effectively dropped, shifting later topic filters into the wrong positions and causing valid queries to return empty results.
> 
> The PR extracts topic parsing into `buildTopicFilters`, ensuring `null` emits an empty `TopicFilter` (wildcard) to preserve positional alignment, and adds unit tests covering null placement, OR-topic arrays, and invalid-hex handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbaad5ef0d667db0aaa418a31548c1c1daa8558a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->