### PR TITLE
fix(eth_sendRawTransaction): verify on-chain before returning 'all upstreams failed'

### DIFF
--- a/architecture/evm/eth_sendRawTransaction.go
+++ b/architecture/evm/eth_sendRawTransaction.go
@@ -228,6 +228,107 @@ func verifyAndHandleNonceTooLow(
 	return createSyntheticSuccessResponse(ctx, rq, txHash)
 }
 
+// networkPostForward_eth_sendRawTransaction is the LAST-LINE idempotency check.
+//
+// Context: upstreamPostForward_eth_sendRawTransaction only fires when an upstream
+// returns a recognized nonce exception ("already known" / "nonce too low") via the
+// string-match list in error_normalizer.go. When upstreams are degraded and return
+// generic HTTP 5xx, transport errors, or vendor-specific wordings outside that list,
+// the per-upstream hook is bypassed. The failsafe loop then exhausts all retries
+// and surfaces ErrUpstreamsExhausted (-32603 "all upstream attempts failed") to the
+// client — even though the tx may already be in mempool or mined on some upstream.
+//
+// This network-level hook runs once after the failsafe loop has finished. If the
+// final error is an exhausted-class failure, it issues a single eth_getTransactionByHash
+// against the network: if the tx is present anywhere, the broadcast effectively
+// succeeded and we return a synthetic success. If the tx is genuinely missing,
+// the original error propagates unchanged.
+func networkPostForward_eth_sendRawTransaction(
+	ctx context.Context,
+	n common.Network,
+	nq *common.NormalizedRequest,
+	nr *common.NormalizedResponse,
+	re error,
+) (*common.NormalizedResponse, error) {
+	ctx, span := common.StartDetailSpan(ctx, "Network.PostForwardHook.eth_sendRawTransaction")
+	defer span.End()
+
+	// No error — let the response flow through untouched.
+	if re == nil {
+		return nr, nil
+	}
+
+	lg := n.Logger().With().Str("hook", "network.eth_sendRawTransaction").Logger()
+
+	// Only intervene on exhausted-class failures. Clean client-side rejections
+	// (insufficient funds, replacement underpriced, normalized -32003 nonce-too-low
+	// where on-chain verification already happened, etc.) must propagate as-is —
+	// and we shouldn't even consult the network config to make that decision, so
+	// this gate runs before any other inspection.
+	if !common.HasErrorCode(re,
+		common.ErrCodeUpstreamsExhausted,
+		common.ErrCodeFailsafeRetryExceeded,
+	) {
+		lg.Debug().Str("errorCode", string(common.ErrorFingerprint(re))).Msg("error is not exhausted-class, skipping verification")
+		return nr, re
+	}
+
+	// Respect the same opt-out as the per-upstream hook. When idempotent broadcast
+	// is explicitly disabled, do not synthesize success from a verification probe.
+	if cfg := n.Config(); cfg != nil && cfg.Evm != nil && cfg.Evm.IdempotentTransactionBroadcast != nil && !*cfg.Evm.IdempotentTransactionBroadcast {
+		span.SetAttributes(attribute.Bool("idempotent_broadcast_disabled", true))
+		lg.Debug().Msg("idempotent transaction broadcast is disabled, skipping network verification")
+		return nr, re
+	}
+
+	span.SetAttributes(attribute.Bool("exhausted_class_error", true))
+
+	// Extract the tx hash from the request (deterministic from signed bytes).
+	txHash, err := extractTxHashFromSendRawTransaction(ctx, nq)
+	if err != nil {
+		span.SetAttributes(attribute.String("parse_error", err.Error()))
+		lg.Debug().Err(err).Msg("failed to extract txHash for verification, returning original error")
+		return nr, re
+	}
+	span.SetAttributes(attribute.String("tx_hash", txHash))
+
+	// Probe the network for the tx. Use the same network-level Forward so the
+	// query is routed through normal upstream selection (any healthy upstream
+	// — including ones that just rejected the broadcast — can answer this read).
+	getTxReq := common.NewNormalizedRequest([]byte(fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":"eth_getTransactionByHash","params":[%q]}`,
+		util.RandomID(),
+		txHash,
+	)))
+
+	verifyResp, verifyErr := n.Forward(ctx, getTxReq)
+	if verifyResp != nil {
+		defer verifyResp.Release()
+	}
+	if verifyErr != nil {
+		span.SetAttributes(attribute.String("verify_error", verifyErr.Error()))
+		lg.Debug().Err(verifyErr).Str("txHash", txHash).Msg("network verification failed, returning original error")
+		return nr, re
+	}
+	if verifyResp == nil || verifyResp.IsResultEmptyish(ctx) {
+		span.SetAttributes(attribute.Bool("tx_found", false))
+		lg.Debug().Str("txHash", txHash).Msg("tx not found in network, returning original error")
+		return nr, re
+	}
+	jrr, jrrErr := verifyResp.JsonRpcResponse()
+	if jrrErr != nil || jrr == nil || jrr.Error != nil {
+		span.SetAttributes(attribute.Bool("verify_response_invalid", true))
+		lg.Debug().Str("txHash", txHash).Msg("network verification response invalid, returning original error")
+		return nr, re
+	}
+
+	// Tx is present. The broadcast effectively succeeded — return a synthetic success.
+	span.SetAttributes(attribute.Bool("tx_found", true))
+	span.SetAttributes(attribute.Bool("synthetic_success", true))
+	lg.Info().Str("txHash", txHash).Msg("exhausted error overridden: tx found in network, returning synthetic success")
+	return createSyntheticSuccessResponse(ctx, nq, txHash)
+}
+
 // createNormalizedNonceTooLowError creates a normalized error for nonce-too-low mismatch cases.
 // Per the plan: use JSON-RPC code -32003 (Transaction rejected) while preserving the upstream message.
 func createNormalizedNonceTooLowError(originalErr error) error {

--- a/architecture/evm/eth_sendRawTransaction.go
+++ b/architecture/evm/eth_sendRawTransaction.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/util"
@@ -13,6 +14,36 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+// networkPostForwardVerifyTimeout caps how long the on-chain verification
+// probe (eth_getTransactionByHash) is allowed to run independently of the
+// caller's deadline. The probe sits on the error path after failsafe has
+// already burned its retry budget, so the parent deadline is usually
+// near-expired. Without an independent budget the probe would either fail
+// immediately on ctx.Err() (silent no-op for the feature) or, if the caller
+// has no deadline, run an unbounded failsafe loop against degraded upstreams.
+const networkPostForwardVerifyTimeout = 3 * time.Second
+
+// isIdempotentBroadcastDisabled reports whether the network has explicitly
+// opted out of eth_sendRawTransaction idempotency handling. A nil config or
+// nil pointer means "not disabled" (the default).
+func isIdempotentBroadcastDisabled(n common.Network) bool {
+	cfg := n.Config()
+	if cfg == nil || cfg.Evm == nil || cfg.Evm.IdempotentTransactionBroadcast == nil {
+		return false
+	}
+	return !*cfg.Evm.IdempotentTransactionBroadcast
+}
+
+// buildGetTransactionByHashRequest constructs a fresh internal eth_getTransactionByHash
+// request used by both the per-upstream and network-level postForward verification paths.
+func buildGetTransactionByHashRequest(txHash string) *common.NormalizedRequest {
+	return common.NewNormalizedRequest([]byte(fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":"eth_getTransactionByHash","params":[%q]}`,
+		util.RandomID(),
+		txHash,
+	)))
+}
 
 // upstreamPostForward_eth_sendRawTransaction handles idempotency for eth_sendRawTransaction.
 // It converts "already known" errors into success and verifies "nonce too low" errors
@@ -31,7 +62,7 @@ func upstreamPostForward_eth_sendRawTransaction(
 	lg := n.Logger().With().Str("hook", "eth_sendRawTransaction").Logger()
 
 	// Check if idempotent transaction broadcast is disabled
-	if cfg := n.Config(); cfg != nil && cfg.Evm != nil && cfg.Evm.IdempotentTransactionBroadcast != nil && !*cfg.Evm.IdempotentTransactionBroadcast {
+	if isIdempotentBroadcastDisabled(n) {
 		span.SetAttributes(attribute.Bool("idempotent_broadcast_disabled", true))
 		lg.Debug().Msg("idempotent transaction broadcast is disabled, skipping")
 		return rs, re
@@ -179,11 +210,7 @@ func verifyAndHandleNonceTooLow(
 
 	// Create a request for eth_getTransactionByHash
 	// Use a new random ID since this is an internal verification request
-	getTxReq := common.NewNormalizedRequest([]byte(fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":%d,"method":"eth_getTransactionByHash","params":[%q]}`,
-		util.RandomID(),
-		txHash,
-	)))
+	getTxReq := buildGetTransactionByHashRequest(txHash)
 
 	lg.Debug().Str("txHash", txHash).Str("upstream", u.Id()).Msg("sending eth_getTransactionByHash to verify tx exists")
 
@@ -250,7 +277,7 @@ func networkPostForward_eth_sendRawTransaction(
 	nr *common.NormalizedResponse,
 	re error,
 ) (*common.NormalizedResponse, error) {
-	ctx, span := common.StartDetailSpan(ctx, "Network.PostForwardHook.eth_sendRawTransaction")
+	ctx, span := common.StartDetailSpan(ctx, "Network.PostForward.eth_sendRawTransaction")
 	defer span.End()
 
 	// No error — let the response flow through untouched.
@@ -258,16 +285,23 @@ func networkPostForward_eth_sendRawTransaction(
 		return nr, nil
 	}
 
-	lg := n.Logger().With().Str("hook", "network.eth_sendRawTransaction").Logger()
+	lg := n.Logger().With().Str("hook", "eth_sendRawTransaction").Logger()
 
 	// Only intervene on exhausted-class failures. Clean client-side rejections
 	// (insufficient funds, replacement underpriced, normalized -32003 nonce-too-low
 	// where on-chain verification already happened, etc.) must propagate as-is —
 	// and we shouldn't even consult the network config to make that decision, so
 	// this gate runs before any other inspection.
+	//
+	// FailsafeTimeoutExceeded is included alongside UpstreamsExhausted and
+	// FailsafeRetryExceeded: when the network-scope timeout policy fires before
+	// retries exhaust, the broadcast may still have reached an upstream's mempool
+	// before the deadline. Same "we don't know whether it landed" semantics →
+	// same verification probe applies.
 	if !common.HasErrorCode(re,
 		common.ErrCodeUpstreamsExhausted,
 		common.ErrCodeFailsafeRetryExceeded,
+		common.ErrCodeFailsafeTimeoutExceeded,
 	) {
 		lg.Debug().Str("errorCode", string(common.ErrorFingerprint(re))).Msg("error is not exhausted-class, skipping verification")
 		return nr, re
@@ -275,7 +309,7 @@ func networkPostForward_eth_sendRawTransaction(
 
 	// Respect the same opt-out as the per-upstream hook. When idempotent broadcast
 	// is explicitly disabled, do not synthesize success from a verification probe.
-	if cfg := n.Config(); cfg != nil && cfg.Evm != nil && cfg.Evm.IdempotentTransactionBroadcast != nil && !*cfg.Evm.IdempotentTransactionBroadcast {
+	if isIdempotentBroadcastDisabled(n) {
 		span.SetAttributes(attribute.Bool("idempotent_broadcast_disabled", true))
 		lg.Debug().Msg("idempotent transaction broadcast is disabled, skipping network verification")
 		return nr, re
@@ -295,13 +329,24 @@ func networkPostForward_eth_sendRawTransaction(
 	// Probe the network for the tx. Use the same network-level Forward so the
 	// query is routed through normal upstream selection (any healthy upstream
 	// — including ones that just rejected the broadcast — can answer this read).
-	getTxReq := common.NewNormalizedRequest([]byte(fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":%d,"method":"eth_getTransactionByHash","params":[%q]}`,
-		util.RandomID(),
-		txHash,
-	)))
-
-	verifyResp, verifyErr := n.Forward(ctx, getTxReq)
+	//
+	// The probe runs with an INDEPENDENT timeout budget (context.WithoutCancel
+	// drops the parent's deadline and cancellation), capped at
+	// networkPostForwardVerifyTimeout. Without this, a caller whose deadline
+	// was already burned by the failsafe loop would always see the probe
+	// instantly fail on ctx.Err() — silently negating the entire feature.
+	// Tracing/values propagate through WithoutCancel; only cancellation does not.
+	//
+	// Note: defer Release() fires after all reads from verifyResp complete.
+	// The synthetic-success path returns only txHash (extracted before this
+	// probe) and the hash extracted via PeekStringByPath, so no jrr fields
+	// cross the release boundary in raw form. If a future maintainer adds a
+	// jrr.Result-derived value to the success return, copy it to a local
+	// before the function returns.
+	verifyCtx, cancelVerify := context.WithTimeout(context.WithoutCancel(ctx), networkPostForwardVerifyTimeout)
+	defer cancelVerify()
+	getTxReq := buildGetTransactionByHashRequest(txHash)
+	verifyResp, verifyErr := n.Forward(verifyCtx, getTxReq)
 	if verifyResp != nil {
 		defer verifyResp.Release()
 	}
@@ -310,7 +355,7 @@ func networkPostForward_eth_sendRawTransaction(
 		lg.Debug().Err(verifyErr).Str("txHash", txHash).Msg("network verification failed, returning original error")
 		return nr, re
 	}
-	if verifyResp == nil || verifyResp.IsResultEmptyish(ctx) {
+	if verifyResp == nil || verifyResp.IsResultEmptyish(verifyCtx) {
 		span.SetAttributes(attribute.Bool("tx_found", false))
 		lg.Debug().Str("txHash", txHash).Msg("tx not found in network, returning original error")
 		return nr, re
@@ -322,7 +367,24 @@ func networkPostForward_eth_sendRawTransaction(
 		return nr, re
 	}
 
-	// Tx is present. The broadcast effectively succeeded — return a synthetic success.
+	// Cross-check: the returned tx object's "hash" field MUST equal the hash
+	// we derived from the signed bytes locally. Without this check, a byzantine
+	// or buggy upstream that returns *any* non-null tx object (wrong hash, wrong
+	// from/to, fabricated entirely) would trigger a false synthetic success and
+	// mislead the caller into believing a tx landed when it did not.
+	returnedHash, peekErr := jrr.PeekStringByPath(verifyCtx, "hash")
+	if peekErr != nil {
+		span.SetAttributes(attribute.String("verify_peek_error", peekErr.Error()))
+		lg.Debug().Err(peekErr).Str("txHash", txHash).Msg("could not extract hash field from verification response, returning original error")
+		return nr, re
+	}
+	if !strings.EqualFold(returnedHash, txHash) {
+		span.SetAttributes(attribute.String("verify_hash_mismatch", returnedHash))
+		lg.Warn().Str("expectedTxHash", txHash).Str("returnedHash", returnedHash).Msg("verification response carries a different tx hash than submitted — refusing synthetic success")
+		return nr, re
+	}
+
+	// Tx is present and matches. The broadcast effectively succeeded — return a synthetic success.
 	span.SetAttributes(attribute.Bool("tx_found", true))
 	span.SetAttributes(attribute.Bool("synthetic_success", true))
 	lg.Info().Str("txHash", txHash).Msg("exhausted error overridden: tx found in network, returning synthetic success")

--- a/architecture/evm/eth_sendRawTransaction_test.go
+++ b/architecture/evm/eth_sendRawTransaction_test.go
@@ -3,14 +3,20 @@ package evm
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	util.ConfigureTestLogger()
+}
 
 // EIP-1559 signed transaction copied from networks_sendrawtx_test.go fixtures.
 // Hash is deterministic from the signed bytes.
@@ -60,7 +66,19 @@ func TestNetworkPostForward_eth_sendRawTransaction(t *testing.T) {
 		txObject := []byte(`{"hash":"` + sendRawTxFixtureHash + `","blockNumber":"0x123","from":"0x0","to":"0x0"}`)
 		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
 			m, _ := r.Method()
-			return m == "eth_getTransactionByHash"
+			if m != "eth_getTransactionByHash" {
+				return false
+			}
+			// Strengthen the matcher: the probe must carry the expected tx hash
+			// in params. A regression in extractTxHashFromSendRawTransaction
+			// (e.g. wrong type-N decode) would otherwise be invisible because
+			// the mocked response would still fire on method name alone.
+			jrpc, jerr := r.JsonRpcRequest()
+			if jerr != nil || jrpc == nil || len(jrpc.Params) == 0 {
+				return false
+			}
+			hash, ok := jrpc.Params[0].(string)
+			return ok && strings.EqualFold(hash, sendRawTxFixtureHash)
 		})).Return(
 			common.NewNormalizedResponse().WithJsonRpcResponse(
 				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
@@ -89,7 +107,19 @@ func TestNetworkPostForward_eth_sendRawTransaction(t *testing.T) {
 		// Verification call returns null result (tx not found anywhere).
 		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
 			m, _ := r.Method()
-			return m == "eth_getTransactionByHash"
+			if m != "eth_getTransactionByHash" {
+				return false
+			}
+			// Strengthen the matcher: the probe must carry the expected tx hash
+			// in params. A regression in extractTxHashFromSendRawTransaction
+			// (e.g. wrong type-N decode) would otherwise be invisible because
+			// the mocked response would still fire on method name alone.
+			jrpc, jerr := r.JsonRpcRequest()
+			if jerr != nil || jrpc == nil || len(jrpc.Params) == 0 {
+				return false
+			}
+			hash, ok := jrpc.Params[0].(string)
+			return ok && strings.EqualFold(hash, sendRawTxFixtureHash)
 		})).Return(
 			common.NewNormalizedResponse().WithJsonRpcResponse(
 				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), []byte(`null`), nil),
@@ -166,6 +196,177 @@ func TestNetworkPostForward_eth_sendRawTransaction(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
 			"original error must propagate untouched when idempotent broadcast is disabled")
+		n.AssertExpectations(t)
+	})
+
+	// --- Coverage for the P1 review findings (gated_auto fixes applied) ---
+
+	t.Run("failsafe_timeout_exceeded_triggers_verification", func(t *testing.T) {
+		// Regression guard for review finding #1: ErrCodeFailsafeTimeoutExceeded
+		// was missing from the exhausted-class gate. When the network-scope
+		// timeout policy fires before retries exhaust, the broadcast may still
+		// have reached an upstream's mempool. The same verification probe must
+		// apply.
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		txObject := []byte(`{"hash":"` + sendRawTxFixtureHash + `","blockNumber":"0x123","from":"0x0","to":"0x0"}`)
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
+			),
+			nil,
+		).Once()
+
+		// Construct a network-scope failsafe timeout error wrapping a context cause.
+		timeoutErr := common.NewErrFailsafeTimeoutExceeded(common.ScopeNetwork, context.DeadlineExceeded, nil)
+
+		req := makeSendRawTxRequest(t)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, timeoutErr,
+		)
+		require.NoError(t, err, "FailsafeTimeoutExceeded should trigger verification just like exhausted retries")
+		require.NotNil(t, resp)
+		n.AssertExpectations(t)
+	})
+
+	t.Run("returned_hash_mismatch_refuses_synthetic_success", func(t *testing.T) {
+		// Regression guard for review finding #3: a byzantine or buggy upstream
+		// returning *any* non-null tx object for the queried hash would have
+		// triggered false synthetic success. The hook now cross-checks the
+		// returned hash field against the locally-derived hash.
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		// The upstream returns a non-null tx object but with a DIFFERENT hash.
+		wrongHash := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		txObject := []byte(`{"hash":"` + wrongHash + `","blockNumber":"0x123","from":"0x0","to":"0x0"}`)
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
+			),
+			nil,
+		).Once()
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, origErr,
+		)
+		require.Error(t, err, "hash mismatch must NOT yield synthetic success")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
+			"original exhausted error must propagate on hash mismatch")
+		assert.Nil(t, resp)
+		n.AssertExpectations(t)
+	})
+
+	t.Run("missing_hash_field_in_response_refuses_synthetic_success", func(t *testing.T) {
+		// Defense-in-depth: if the verification response is a non-null object
+		// but the "hash" field is absent (malformed upstream), the cross-check
+		// must fail safe and propagate the original error.
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		// Non-null object with no "hash" field at all.
+		txObject := []byte(`{"blockNumber":"0x123","from":"0x0","to":"0x0"}`)
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
+			),
+			nil,
+		).Once()
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		_, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, origErr,
+		)
+		require.Error(t, err, "missing hash field must NOT yield synthetic success")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted))
+		n.AssertExpectations(t)
+	})
+
+	t.Run("verification_forward_error_returns_original_error", func(t *testing.T) {
+		// Coverage for the verifyErr != nil branch (review testing gap T-1).
+		// If the verification probe itself fails (transport error, all upstreams
+		// 5xx the read, etc.), the hook must fall back to the original error.
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			(*common.NormalizedResponse)(nil),
+			errors.New("verification transport failure"),
+		).Once()
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		_, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, origErr,
+		)
+		require.Error(t, err)
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
+			"original exhausted error must propagate when verification itself fails")
+		n.AssertExpectations(t)
+	})
+
+	t.Run("parent_context_already_cancelled_still_runs_probe", func(t *testing.T) {
+		// Critical: the independent verification timeout (context.WithoutCancel
+		// + WithTimeout) must allow the probe to run even when the parent
+		// context is already cancelled — otherwise the feature silently no-ops
+		// in the most common production failure mode (deadline already consumed
+		// by the failsafe retry loop).
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		txObject := []byte(`{"hash":"` + sendRawTxFixtureHash + `","blockNumber":"0x123","from":"0x0","to":"0x0"}`)
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			if m != "eth_getTransactionByHash" {
+				return false
+			}
+			// Inspect the ctx the probe was called with. It must be a fresh
+			// context with no Done channel triggered (because we used
+			// WithoutCancel + WithTimeout).
+			// We can't directly inspect the call's ctx from MatchedBy, but the
+			// fact that Forward gets called at all (mock fires) proves the
+			// probe wasn't short-circuited by the parent ctx.Err() check
+			// inside our hook.
+			return true
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
+			),
+			nil,
+		).Once()
+
+		// Parent ctx is already cancelled when the hook is called.
+		parentCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			parentCtx, n, req, nil, origErr,
+		)
+		require.NoError(t, err, "independent verification budget must allow probe even with cancelled parent ctx")
+		require.NotNil(t, resp)
 		n.AssertExpectations(t)
 	})
 }

--- a/architecture/evm/eth_sendRawTransaction_test.go
+++ b/architecture/evm/eth_sendRawTransaction_test.go
@@ -1,0 +1,171 @@
+package evm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// EIP-1559 signed transaction copied from networks_sendrawtx_test.go fixtures.
+// Hash is deterministic from the signed bytes.
+const sendRawTxFixture = "0x02f873010a8459682f008506fc23ac0082520894d8da6bf26964af9d7eed9e03e53415d37aa9604588016345785d8a000080c080a0a3d5fd825e582675933b2b6aea774b0454633edb49e94699d6f88d197cd26589a06295b0b43a9e93a3390b308272a65bb063d9f18deb4cb7db5ecf352bf9ba9fe7"
+const sendRawTxFixtureHash = "0xb9f61197f9c6c63a6981ba69fb22308469d03a4e013b10bcd69315745110acf7"
+
+// makeSendRawTxRequest builds a NormalizedRequest carrying the canonical fixture.
+func makeSendRawTxRequest(t *testing.T) *common.NormalizedRequest {
+	t.Helper()
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sendRawTxFixture + `"]}`)
+	return common.NewNormalizedRequest(body)
+}
+
+// makeExhaustedError builds an ErrUpstreamsExhausted with at least one upstream cause,
+// matching what the failsafe loop surfaces when every upstream attempt has failed.
+func makeExhaustedError() error {
+	causes := &sync.Map{}
+	causes.Store("u1", errors.New("upstream u1: HTTP 500"))
+	causes.Store("u2", errors.New("upstream u2: connection refused"))
+	return common.NewErrUpstreamsExhausted(
+		nil, // *NormalizedRequest only used for diagnostics
+		causes,
+		"test-project",
+		"evm:8453",
+		"eth_sendRawTransaction",
+		0, // duration
+		6, // attempts
+		6, // retries
+		0, // hedges
+		2, // upstreams
+	)
+}
+
+// TestNetworkPostForward_eth_sendRawTransaction covers the last-line idempotency
+// safeguard: when the failsafe loop has exhausted all upstreams for a tx that
+// has nevertheless landed in the network (mempool or chain), erpc must return a
+// synthetic success with the tx hash instead of -32603 "all upstream attempts
+// failed". This prevents misleading "send failed" errors for txs that actually
+// went through but where upstreams returned mis-classified server errors.
+func TestNetworkPostForward_eth_sendRawTransaction(t *testing.T) {
+	t.Run("exhausted_but_tx_in_network_returns_success", func(t *testing.T) {
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		// Mock the eth_getTransactionByHash verification call: tx IS in the network.
+		txObject := []byte(`{"hash":"` + sendRawTxFixtureHash + `","blockNumber":"0x123","from":"0x0","to":"0x0"}`)
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), txObject, nil),
+			),
+			nil,
+		).Once()
+
+		req := makeSendRawTxRequest(t)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, makeExhaustedError(),
+		)
+
+		require.NoError(t, err, "exhausted-but-tx-found should yield synthetic success, not error")
+		require.NotNil(t, resp)
+		jrr, err := resp.JsonRpcResponse()
+		require.NoError(t, err)
+		assert.Contains(t, jrr.GetResultString(), sendRawTxFixtureHash, "synthetic result should be the tx hash")
+		n.AssertExpectations(t)
+	})
+
+	t.Run("exhausted_and_tx_not_in_network_returns_original_error", func(t *testing.T) {
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		n.On("Config").Return(&common.NetworkConfig{Evm: &common.EvmNetworkConfig{}}).Maybe()
+
+		// Verification call returns null result (tx not found anywhere).
+		n.On("Forward", mock.Anything, mock.MatchedBy(func(r *common.NormalizedRequest) bool {
+			m, _ := r.Method()
+			return m == "eth_getTransactionByHash"
+		})).Return(
+			common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`1`), []byte(`null`), nil),
+			),
+			nil,
+		).Once()
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, origErr,
+		)
+
+		// When the tx genuinely isn't anywhere, we must not invent success.
+		require.Error(t, err)
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
+			"original exhausted error must propagate when verification confirms absence")
+		assert.Nil(t, resp)
+		n.AssertExpectations(t)
+	})
+
+	t.Run("non_exhausted_error_passes_through_unchanged", func(t *testing.T) {
+		n := new(mockNetwork)
+		// No Forward expectation — we should not trigger verification for non-exhausted errors.
+
+		// A clean client-side rejection (e.g. insufficient funds) must not be second-guessed.
+		clientErr := common.NewErrEndpointExecutionException(
+			common.NewErrJsonRpcExceptionInternal(
+				int(common.JsonRpcErrorTransactionRejected),
+				common.JsonRpcErrorTransactionRejected,
+				"insufficient funds",
+				nil,
+				nil,
+			),
+		)
+		req := makeSendRawTxRequest(t)
+		_, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, clientErr,
+		)
+		require.Error(t, err)
+		assert.Equal(t, clientErr, err, "non-exhausted errors should pass through verbatim")
+		n.AssertExpectations(t)
+	})
+
+	t.Run("no_error_passes_through", func(t *testing.T) {
+		n := new(mockNetwork)
+		req := makeSendRawTxRequest(t)
+		okResp := common.NewNormalizedResponse().WithJsonRpcResponse(
+			common.MustNewJsonRpcResponseFromBytes([]byte(`1`), []byte(`"`+sendRawTxFixtureHash+`"`), nil),
+		)
+		resp, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, okResp, nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Forward must NOT be called when there's no error.
+		n.AssertExpectations(t)
+	})
+
+	t.Run("idempotent_broadcast_disabled_skips_verification", func(t *testing.T) {
+		n := new(mockNetwork)
+		n.On("Id").Return("evm:8453").Maybe()
+		disabled := false
+		n.On("Config").Return(&common.NetworkConfig{
+			Evm: &common.EvmNetworkConfig{IdempotentTransactionBroadcast: &disabled},
+		}).Maybe()
+		// No Forward expectation — verification must be skipped.
+
+		origErr := makeExhaustedError()
+		req := makeSendRawTxRequest(t)
+		_, err := networkPostForward_eth_sendRawTransaction(
+			context.Background(), n, req, nil, origErr,
+		)
+		require.Error(t, err)
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
+			"original error must propagate untouched when idempotent broadcast is disabled")
+		n.AssertExpectations(t)
+	})
+}

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -74,6 +74,8 @@ func HandleNetworkPostForward(ctx context.Context, network common.Network, nq *c
 		return networkPostForward_eth_getBlockByNumber(ctx, network, nq, nr, re)
 	case "eth_getlogs":
 		return networkPostForward_eth_getLogs(ctx, network, nq, nr, re)
+	case "eth_sendrawtransaction":
+		return networkPostForward_eth_sendRawTransaction(ctx, network, nq, nr, re)
 	case "trace_filter", "arbtrace_filter":
 		return networkPostForward_trace_filter(ctx, network, nq, nr, re)
 	default:

--- a/erpc/networks_sendrawtx_test.go
+++ b/erpc/networks_sendrawtx_test.go
@@ -1534,7 +1534,12 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
 
-		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleSignedTx + `"]}`)
+		// Use the EIP-1559 fixture: its expectedEIP1559TxHash constant is the
+		// actual keccak256 of sampleEIP1559SignedTx. (The legacy sampleSignedTx
+		// + expectedTxHash pair is broken — see review finding P-1.) We need a
+		// fixture whose constant matches reality because the new postForward
+		// cross-checks the returned hash against the locally-derived hash.
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleEIP1559SignedTx + `"]}`)
 
 		// Every retry attempt to rpc1 returns HTTP 500. Persisted so all
 		// failsafe attempts hit the same outcome.
@@ -1560,9 +1565,10 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 			BodyString("Internal Server Error")
 
 		// But the tx IS actually in the network — eth_getTransactionByHash on
-		// either upstream returns a non-null tx object. This simulates an
-		// upstream that silently accepted the broadcast despite returning 5xx,
-		// or a different upstream that already saw the tx in its mempool.
+		// either upstream returns a non-null tx object whose hash field matches
+		// the locally-derived hash. This simulates an upstream that silently
+		// accepted the broadcast despite returning 5xx, or a different upstream
+		// that already saw the tx in its mempool.
 		gock.New("http://rpc1.localhost").
 			Post("").
 			Persist().
@@ -1575,10 +1581,10 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 				"jsonrpc": "2.0",
 				"id":      1,
 				"result": map[string]interface{}{
-					"hash":        expectedTxHash,
+					"hash":        expectedEIP1559TxHash,
 					"blockNumber": "0x123",
 					"from":        "0x0000000000000000000000000000000000000001",
-					"to":          "0x3535353535353535353535353535353535353535",
+					"to":          "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
 				},
 			})
 		gock.New("http://rpc2.localhost").
@@ -1593,10 +1599,10 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 				"jsonrpc": "2.0",
 				"id":      1,
 				"result": map[string]interface{}{
-					"hash":        expectedTxHash,
+					"hash":        expectedEIP1559TxHash,
 					"blockNumber": "0x123",
 					"from":        "0x0000000000000000000000000000000000000001",
-					"to":          "0x3535353535353535353535353535353535353535",
+					"to":          "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
 				},
 			})
 
@@ -1626,10 +1632,7 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 		require.NotNil(t, resp)
 		jrr, jrrErr := resp.JsonRpcResponse()
 		require.NoError(t, jrrErr)
-		// Actual keccak256 of the sample legacy signed tx (verified with `cast keccak`).
-		// Don't reuse the package-level `expectedTxHash` constant — it's stale.
-		const sampleSignedTxActualHash = "0x33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788"
-		assert.Contains(t, jrr.GetResultString(), sampleSignedTxActualHash,
+		assert.Contains(t, jrr.GetResultString(), expectedEIP1559TxHash,
 			"synthetic success should carry the tx hash extracted from the signed bytes")
 		log.Info().Str("result", jrr.GetResultString()).Msg("STAGE 2: postForward returned synthetic success (the fix)")
 	})
@@ -1639,7 +1642,9 @@ func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) 
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
 
-		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleSignedTx + `"]}`)
+		// Same EIP-1559 fixture as the sibling subtest (matching pair of
+		// fixture + correct hash constant).
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleEIP1559SignedTx + `"]}`)
 
 		// All broadcast attempts 500.
 		gock.New("http://rpc1.localhost").

--- a/erpc/networks_sendrawtx_test.go
+++ b/erpc/networks_sendrawtx_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
@@ -1507,6 +1508,196 @@ func TestNetwork_SendRawTransaction_Idempotency(t *testing.T) {
 		jrr, err := resp.JsonRpcResponse()
 		require.NoError(t, err)
 		assert.Contains(t, jrr.GetResultString(), "0x")
+	})
+}
+
+// TestNetwork_SendRawTransaction_NetworkPostForwardIntegration reproduces the
+// production bug pattern that PR #898 fixes:
+//
+//   - Customer broadcasts an eth_sendRawTransaction.
+//   - Every upstream returns a non-nonce error (HTTP 500, generic 5xx) — these
+//     bypass the per-upstream idempotency hook because they aren't classified as
+//     ErrCodeEndpointNonceException.
+//   - The failsafe retry budget exhausts, surfacing ErrUpstreamsExhausted /
+//     -32603 "all upstream attempts failed".
+//   - But the tx is actually in the network (mempool or chain) — some upstream
+//     accepted it silently.
+//   - The new network-level postForward hook issues eth_getTransactionByHash,
+//     finds the tx, and converts the misleading error into a synthetic success.
+//
+// This test drives the full stack: gock-mocked HTTP upstreams, real failsafe
+// retry loop, real ErrUpstreamsExhausted construction, then evm.HandleNetworkPostForward
+// (the same call site invoked by PreparedProject.doForward in production).
+func TestNetwork_SendRawTransaction_NetworkPostForwardIntegration(t *testing.T) {
+	t.Run("AllUpstreams500_TxInNetwork_ReturnsSyntheticSuccess", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleSignedTx + `"]}`)
+
+		// Every retry attempt to rpc1 returns HTTP 500. Persisted so all
+		// failsafe attempts hit the same outcome.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_sendRawTransaction")
+			}).
+			Reply(500).
+			BodyString("Internal Server Error")
+
+		// rpc2 also returns HTTP 500 for the broadcast.
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_sendRawTransaction")
+			}).
+			Reply(500).
+			BodyString("Internal Server Error")
+
+		// But the tx IS actually in the network — eth_getTransactionByHash on
+		// either upstream returns a non-null tx object. This simulates an
+		// upstream that silently accepted the broadcast despite returning 5xx,
+		// or a different upstream that already saw the tx in its mempool.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getTransactionByHash")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result": map[string]interface{}{
+					"hash":        expectedTxHash,
+					"blockNumber": "0x123",
+					"from":        "0x0000000000000000000000000000000000000001",
+					"to":          "0x3535353535353535353535353535353535353535",
+				},
+			})
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getTransactionByHash")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result": map[string]interface{}{
+					"hash":        expectedTxHash,
+					"blockNumber": "0x123",
+					"from":        "0x0000000000000000000000000000000000000001",
+					"to":          "0x3535353535353535353535353535353535353535",
+				},
+			})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupSendRawTxTestNetworkWithRetry(t, ctx, &common.RetryPolicyConfig{
+			MaxAttempts: 3,
+			Delay:       common.Duration(10 * time.Millisecond),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+
+		// Stage 1: bare network.Forward — failsafe loop exhausts on 500s.
+		// This is the "without the network postForward" behavior.
+		respRaw, errRaw := network.Forward(ctx, req)
+		require.Error(t, errRaw, "raw network.Forward should fail when all upstreams 500")
+		assert.True(t, common.HasErrorCode(errRaw, common.ErrCodeFailsafeRetryExceeded) ||
+			common.HasErrorCode(errRaw, common.ErrCodeUpstreamsExhausted),
+			"raw error should be exhausted-class, got: %v", errRaw)
+		log.Info().Err(errRaw).Msg("STAGE 1: bare network.Forward returned exhausted error (the bug)")
+
+		// Stage 2: feed that error through the network postForward hook (this
+		// is exactly what PreparedProject.doForward does at projects.go:265).
+		resp, err := evm.HandleNetworkPostForward(ctx, network, req, respRaw, errRaw)
+		require.NoError(t, err, "post-forward should override -32603 with synthetic success when tx is in network")
+		require.NotNil(t, resp)
+		jrr, jrrErr := resp.JsonRpcResponse()
+		require.NoError(t, jrrErr)
+		// Actual keccak256 of the sample legacy signed tx (verified with `cast keccak`).
+		// Don't reuse the package-level `expectedTxHash` constant — it's stale.
+		const sampleSignedTxActualHash = "0x33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788"
+		assert.Contains(t, jrr.GetResultString(), sampleSignedTxActualHash,
+			"synthetic success should carry the tx hash extracted from the signed bytes")
+		log.Info().Str("result", jrr.GetResultString()).Msg("STAGE 2: postForward returned synthetic success (the fix)")
+	})
+
+	t.Run("AllUpstreams500_TxNotInNetwork_PropagatesOriginalError", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		requestBytes := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["` + sampleSignedTx + `"]}`)
+
+		// All broadcast attempts 500.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_sendRawTransaction")
+			}).
+			Reply(500).BodyString("Internal Server Error")
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_sendRawTransaction")
+			}).
+			Reply(500).BodyString("Internal Server Error")
+
+		// Tx is NOT in network — both upstreams return null result.
+		gock.New("http://rpc1.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getTransactionByHash")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": nil})
+		gock.New("http://rpc2.localhost").
+			Post("").
+			Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getTransactionByHash")
+			}).
+			Reply(200).
+			JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": nil})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := setupSendRawTxTestNetworkWithRetry(t, ctx, &common.RetryPolicyConfig{
+			MaxAttempts: 3,
+			Delay:       common.Duration(10 * time.Millisecond),
+		})
+
+		req := common.NewNormalizedRequest(requestBytes)
+		respRaw, errRaw := network.Forward(ctx, req)
+		require.Error(t, errRaw)
+
+		resp, err := evm.HandleNetworkPostForward(ctx, network, req, respRaw, errRaw)
+		require.Error(t, err, "tx genuinely missing → original error must propagate")
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeFailsafeRetryExceeded) ||
+			common.HasErrorCode(err, common.ErrCodeUpstreamsExhausted),
+			"expected exhausted-class error to be preserved, got: %v", err)
+		_ = resp // may be nil — only the error matters here
+		log.Info().Err(err).Msg("regression guard: tx absent → original error preserved")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add `networkPostForward_eth_sendRawTransaction` as a last-line idempotency check that runs once after the failsafe loop exhausts.
- When the final error is exhausted-class (`ErrUpstreamsExhausted` / `ErrFailsafeRetryExceeded`), issue a single `eth_getTransactionByHash`; if the tx exists in the network, return a synthetic success with the tx hash. Otherwise propagate the original error unchanged.
- Honors `IdempotentTransactionBroadcast` config opt-out for parity with the existing per-upstream hook.

## Why

receiving `-32603 "all upstream attempts failed"` for tx `0x030d55cc…f09264, but the tx subsequently landed on-chain (block `0x2c35b1b`, `status: 0x1`) — meaning the broadcast actually succeeded somewhere despite the error response.

The existing per-upstream hook (`upstreamPostForward_eth_sendRawTransaction`) only fires on `ErrCodeEndpointNonceException`, which is assigned via a hardcoded substring list (`"already known"`, `"nonce too low"`, …) in `error_normalizer.go`. Degraded upstreams returning generic HTTP 5xx, transport errors, or vendor-specific wording fall through that classifier, get tagged as `ErrEndpointServerSideException`, bypass the hook, and exhaust the failsafe retry budget — surfacing `-32603` to the client even though the broadcast effectively succeeded.

| Network-level outcome | Count |
|---|---:|
| `ErrFailsafeRetryExceeded ErrUpstreamsExhausted` (→ -32603) | 3 |
| `ErrFailsafeRetryExceeded ErrEndpointClientSideException` (→ -32003, properly normalized) | 1 |

## Test plan

- [x] New unit tests in `architecture/evm/eth_sendRawTransaction_test.go` (5 subtests):
  - `exhausted_but_tx_in_network_returns_success` — fix case
  - `exhausted_and_tx_not_in_network_returns_original_error` — regression guard, no false synthetic successes
  - `non_exhausted_error_passes_through_unchanged` — clean -32003s aren't second-guessed
  - `no_error_passes_through`
  - `idempotent_broadcast_disabled_skips_verification`
- [x] Existing `TestNetwork_SendRawTransaction_*` suite (38 subtests) passes unchanged
- [x] Broader `TestNetwork_*` family in `./erpc/` passes (one unrelated timing flake in `QuantileBasedHedge_NoMetricsAvailable` cleared on re-run)
- [x] `go build ./...` + `go vet` clean

## Notes

- Purely additive: only changes behavior on exhausted-class errors for `eth_sendRawTransaction`, and only when verification confirms the tx exists. All uncertainty biases toward returning the original error.
- The verification call is a single `eth_getTransactionByHash` routed through normal upstream selection — any healthy upstream (including ones that just rejected the broadcast) can answer the read.
- Same opt-out as the per-upstream hook (`network.evm.idempotentTransactionBroadcast: false`) disables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-visible outcomes for transaction broadcast on error paths; mitigations (exhausted-only gate, hash cross-check, opt-out config) bias toward preserving failures, but a bad verification read could still report success incorrectly.
> 
> **Overview**
> Adds a **network-level post-forward** path for `eth_sendRawTransaction` so clients are not stuck with exhausted-class failures (`ErrUpstreamsExhausted`, `ErrFailsafeRetryExceeded`, `ErrFailsafeTimeoutExceeded`) when the transaction may already be in mempool or on-chain after upstreams returned generic 5xx/transport errors that skip the per-upstream nonce idempotency hook.
> 
> After the failsafe loop finishes, the hook issues one `eth_getTransactionByHash` via `n.Forward` (3s budget on `context.WithoutCancel` so a spent caller deadline does not skip the probe). It returns a **synthetic success** with the locally derived tx hash only if the result is non-empty and the response `hash` matches; otherwise the original error is unchanged. **`IdempotentTransactionBroadcast: false`** still disables this, same as the upstream hook.
> 
> Refactors shared helpers (`isIdempotentBroadcastDisabled`, `buildGetTransactionByHashRequest`) and registers the hook in `HandleNetworkPostForward`. New unit tests in `eth_sendRawTransaction_test.go` and stack integration tests in `networks_sendrawtx_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7040f02af7c2f0e268c05bbc9286bbc6394a359c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->