### PR TITLE
chore: add Maestro config with public-repo security gate

### DIFF
--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://maestro.goldsky.com/maestrorc/schema",
+  "agent": {
+    "model": "opus",
+    "effort": "high"
+  },
+  "planning": {
+    "enabled": true
+  },
+  "security": {
+    "trusted_author_associations": ["OWNER", "MEMBER", "COLLABORATOR"]
+  }
+}

--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -16,7 +16,7 @@
         "curl -fsSL https://go.dev/dl/go1.25.3.linux-amd64.tar.gz | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
         "corepack enable && corepack prepare pnpm@10.28.2 --activate",
         "go mod download",
-        "pnpm install --frozen-lockfile"
+        "pnpm install --frozen-lockfile --ignore-scripts"
       ]
     }
   }

--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -13,8 +13,8 @@
   "sandbox": {
     "setup_commands": {
       "post_clone": [
-        "curl -fsSL https://go.dev/dl/go1.25.3.linux-amd64.tar.gz | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
-        "corepack enable && corepack prepare pnpm@10.28.2 --activate",
+        "GO_VERSION=$(grep -m1 '^toolchain go' go.mod | sed 's/.*go//'); GO_VERSION=${GO_VERSION:-$(grep -m1 '^go [0-9]' go.mod | awk '{print $2}')}; echo \"Installing Go ${GO_VERSION} from go.mod\" && curl -fsSL \"https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz\" | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
+        "PNPM_VERSION=$(jq -r .packageManager package.json | cut -d@ -f2); echo \"Activating pnpm ${PNPM_VERSION} from package.json packageManager\" && corepack enable && corepack prepare \"pnpm@${PNPM_VERSION}\" --activate",
         "go mod download",
         "pnpm install --frozen-lockfile --ignore-scripts"
       ]

--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -9,5 +9,15 @@
   },
   "security": {
     "trusted_author_associations": ["OWNER", "MEMBER", "COLLABORATOR"]
+  },
+  "sandbox": {
+    "setup_commands": {
+      "post_clone": [
+        "curl -fsSL https://go.dev/dl/go1.25.1.linux-amd64.tar.gz | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
+        "corepack enable && corepack prepare pnpm@10.28.2 --activate",
+        "go mod download",
+        "pnpm install --frozen-lockfile"
+      ]
+    }
   }
 }

--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -13,7 +13,7 @@
   "sandbox": {
     "setup_commands": {
       "post_clone": [
-        "curl -fsSL https://go.dev/dl/go1.25.1.linux-amd64.tar.gz | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
+        "curl -fsSL https://go.dev/dl/go1.25.3.linux-amd64.tar.gz | tar -C /usr/local -xz && ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
         "corepack enable && corepack prepare pnpm@10.28.2 --activate",
         "go mod download",
         "pnpm install --frozen-lockfile"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,75 +1,49 @@
 # AGENTS.md — eRPC
 
-Guidance for AI coding agents (Maestro, Codex, Cursor, Claude Code) working in this repo.
+Pointer file for cross-tool AI coding agents (Maestro, Codex, Cursor,
+Claude Code). The canonical project rules live in
+[`.cursor/rules/erpc.md`](.cursor/rules/erpc.md) — read that file first;
+it applies to all agents, not just Cursor.
+
+This file only repeats the bare minimum needed to bootstrap.
 
 ## Project
 
-eRPC is a fault-tolerant EVM RPC proxy with re-org-aware permanent caching, written in Go. The `cmd/erpc` binary is the server; `erpc.yaml` is the user-facing config schema.
+- **eRPC** — fault-tolerant EVM RPC proxy with re-org-aware permanent caching.
+- Go server (`cmd/erpc`) + TypeScript packages under `typescript/` (`@erpc-cloud/config`, `@erpc-cloud/cli`).
+- Module: `github.com/erpc/erpc`. Docs: <https://docs.erpc.cloud/>.
 
-- Language: Go (`go` directive `1.25.1`, `toolchain go1.25.3` — see [go.mod](go.mod))
-- Module: `github.com/erpc/erpc`
-- Auxiliary JS workspace: pnpm 10.28.2 (typed config under `@erpc-cloud/config`)
-- Docs: https://docs.erpc.cloud/
-
-## Build & test
-
-All targets run via `make`:
+## Bootstrap commands
 
 ```bash
-make build          # build the eRPC server
-make test           # go clean -testcache && go test ./cmd/... -count 1 -parallel 1
-make test-fast      # faster, no race detector
-make test-race      # race detector
-make fmt            # format
-make run            # run from source
-make up / down      # docker compose for local deps
+make setup           # go mod tidy
+pnpm install --ignore-scripts   # JS workspace (skip postinstall, matches CI)
+
+make fmt             # format Go (also Biome for TS via pnpm)
+make build           # build the eRPC server
+make test-fast       # parallel-sharded unit tests (daily-driver)
+make test            # full suite with -race (slow, run before merge / CI runs this)
+make test-race       # race detector on a slimmer scope
 ```
 
-JS workspace:
-
-```bash
-pnpm install --frozen-lockfile
-pnpm -r build
-```
-
-Always run `make fmt` and `make test` before opening a PR. Tests are sequential (`-parallel 1`) because some integration tests share fake-RPC ports.
-
-## Conventions
-
-- See [.cursor/rules/](.cursor/rules/) for the canonical project rules — applies to all agents, not just Cursor.
-- Code style: idiomatic Go. `gofmt` / `make fmt` is the source of truth.
-- Logging: zerolog. Don't introduce new logging libs.
-- Errors: wrap with context (`fmt.Errorf("...: %w", err)`); avoid creating ad-hoc error types unless they need to be matched downstream.
-- Concurrency: this is a high-throughput proxy — be deliberate about goroutines, channel sizing, and lock granularity. Prefer existing patterns in `health/`, `upstream/`, `evm/`.
-
-## Architecture quick map
-
-- `cmd/erpc` — entrypoint and pprof
-- `upstream/` — upstream RPC client, failover, health tracking
-- `health/` — failure tracking, scoring, circuit breaking
-- `evm/` — EVM-specific logic (block, log, state polling, re-org detection)
-- `data/` — cache backends (memory, redis, postgres, dynamodb)
-- `consensus/` — multi-upstream consensus and dispute resolution
-- `failsafe/` — retry / hedging / circuit breaker policies
-- `auth/` — auth strategies
-- `common/` — shared types & helpers
-- High-level architecture diagram: [assets/hla-diagram.svg](assets/hla-diagram.svg)
-
-## When adding chain configs (JS workspace)
-
-- Always query the live RPC for `eth_chainId` rather than relying on training data.
-- All chain configs use TypeScript with `@erpc-cloud/config` types.
-- Run `bun cli.ts validate --all` (or the equivalent pnpm script) before committing.
-
-## What to avoid
-
-- Don't add new third-party Go dependencies without justification — runtime footprint matters.
-- Don't change the public `erpc.yaml` schema without bumping the relevant version markers and updating docs.
-- Don't disable failing tests; fix the root cause or ask in the PR.
-- Don't introduce blocking I/O on hot paths (request handling, health scoring loops).
+Single test: `LOG_LEVEL=trace go test -run <pattern> ./...`
 
 ## PR expectations
 
 - One logical change per PR.
-- Include a brief test plan in the description.
-- CI must pass before requesting review.
+- `make fmt` clean.
+- `make test-fast` green locally; `make test` (race) green in CI.
+- Brief test plan in the description.
+
+## Hard rules from `.cursor/rules/erpc.md`
+
+These bite hard if missed; read the cursor rules for the full version:
+
+- **Test logger init:** every test file that logs must include
+  `func init() { util.ConfigureTestLogger() }`.
+- **Gock setup order:** set up *all* gock mocks **before** initializing any
+  network components. Always `util.ResetGock()` + `defer util.ResetGock()`.
+- **Logging:** zerolog only (`log.Logger` from `github.com/rs/zerolog/log`).
+- **Errors:** wrap with context (`fmt.Errorf("...: %w", err)`).
+- **Don't** change the public `erpc.yaml` schema without version markers + docs.
+- **Don't** disable failing tests — fix the root cause or surface it in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI coding agents (Maestro, Codex, Cursor, Claude Code) working in t
 
 eRPC is a fault-tolerant EVM RPC proxy with re-org-aware permanent caching, written in Go. The `cmd/erpc` binary is the server; `erpc.yaml` is the user-facing config schema.
 
-- Language: Go 1.25.1 (see [go.mod](go.mod))
+- Language: Go (`go` directive `1.25.1`, `toolchain go1.25.3` — see [go.mod](go.mod))
 - Module: `github.com/erpc/erpc`
 - Auxiliary JS workspace: pnpm 10.28.2 (typed config under `@erpc-cloud/config`)
 - Docs: https://docs.erpc.cloud/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md — eRPC
+
+Guidance for AI coding agents (Maestro, Codex, Cursor, Claude Code) working in this repo.
+
+## Project
+
+eRPC is a fault-tolerant EVM RPC proxy with re-org-aware permanent caching, written in Go. The `cmd/erpc` binary is the server; `erpc.yaml` is the user-facing config schema.
+
+- Language: Go 1.25.1 (see [go.mod](go.mod))
+- Module: `github.com/erpc/erpc`
+- Auxiliary JS workspace: pnpm 10.28.2 (typed config under `@erpc-cloud/config`)
+- Docs: https://docs.erpc.cloud/
+
+## Build & test
+
+All targets run via `make`:
+
+```bash
+make build          # build the eRPC server
+make test           # go clean -testcache && go test ./cmd/... -count 1 -parallel 1
+make test-fast      # faster, no race detector
+make test-race      # race detector
+make fmt            # format
+make run            # run from source
+make up / down      # docker compose for local deps
+```
+
+JS workspace:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+```
+
+Always run `make fmt` and `make test` before opening a PR. Tests are sequential (`-parallel 1`) because some integration tests share fake-RPC ports.
+
+## Conventions
+
+- See [.cursor/rules/](.cursor/rules/) for the canonical project rules — applies to all agents, not just Cursor.
+- Code style: idiomatic Go. `gofmt` / `make fmt` is the source of truth.
+- Logging: zerolog. Don't introduce new logging libs.
+- Errors: wrap with context (`fmt.Errorf("...: %w", err)`); avoid creating ad-hoc error types unless they need to be matched downstream.
+- Concurrency: this is a high-throughput proxy — be deliberate about goroutines, channel sizing, and lock granularity. Prefer existing patterns in `health/`, `upstream/`, `evm/`.
+
+## Architecture quick map
+
+- `cmd/erpc` — entrypoint and pprof
+- `upstream/` — upstream RPC client, failover, health tracking
+- `health/` — failure tracking, scoring, circuit breaking
+- `evm/` — EVM-specific logic (block, log, state polling, re-org detection)
+- `data/` — cache backends (memory, redis, postgres, dynamodb)
+- `consensus/` — multi-upstream consensus and dispute resolution
+- `failsafe/` — retry / hedging / circuit breaker policies
+- `auth/` — auth strategies
+- `common/` — shared types & helpers
+- High-level architecture diagram: [assets/hla-diagram.svg](assets/hla-diagram.svg)
+
+## When adding chain configs (JS workspace)
+
+- Always query the live RPC for `eth_chainId` rather than relying on training data.
+- All chain configs use TypeScript with `@erpc-cloud/config` types.
+- Run `bun cli.ts validate --all` (or the equivalent pnpm script) before committing.
+
+## What to avoid
+
+- Don't add new third-party Go dependencies without justification — runtime footprint matters.
+- Don't change the public `erpc.yaml` schema without bumping the relevant version markers and updating docs.
+- Don't disable failing tests; fix the root cause or ask in the PR.
+- Don't introduce blocking I/O on hot paths (request handling, health scoring loops).
+
+## PR expectations
+
+- One logical change per PR.
+- Include a brief test plan in the description.
+- CI must pass before requesting review.


### PR DESCRIPTION
Opts erpc into Goldsky's Maestro agent — a Linear-driven coding agent that turns tickets into PRs.

- `.maestrorc.json` — opus / high effort, planning enabled, public-repo security gate (OWNER/MEMBER/COLLABORATOR only; gate enforced upstream in [goldsky-io/maestro#388](https://github.com/goldsky-io/maestro/pull/388)). Post-clone installs Go 1.25.1 + pnpm 10.28.2 in the default maestro sandbox; no custom Daytona snapshot required.
- `AGENTS.md` — cross-tool agent guide (build/test commands, conventions, directory map, PR expectations). Also picked up by Codex, Cursor, and Claude Code.

Maestro is invoked from Linear (Goldsky-internal). No public-PR exposure happens until a Goldsky engineer assigns a Linear ticket targeting this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and external agent tooling only; no runtime, auth, or data-path code changes.
> 
> **Overview**
> Adds **Maestro** agent configuration and a repo-root **`AGENTS.md`** bootstrap guide for AI coding tools—no application or RPC behavior changes.
> 
> **`.maestrorc.json`** opts the repo into Goldsky Maestro with **opus** / **high** effort, planning on, and a **security** gate limiting trusted authors to **OWNER**, **MEMBER**, and **COLLABORATOR**. **Post-clone** sandbox steps install Go from `go.mod`, activate **pnpm** from `package.json`, then run `go mod download` and `pnpm install --frozen-lockfile --ignore-scripts`.
> 
> **`AGENTS.md`** points agents at **`.cursor/rules/erpc.md`** for full rules and documents minimal **make** / **pnpm** workflows, PR expectations, and a short list of high-impact test/logging conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210e4424b039c878f93e2ae1b3081cf2c71a2f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->