### PR TITLE
feat: velocity-gate block-head ingestion to reject implausible forward jumps

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -26,6 +26,30 @@ const FullySyncedThreshold = 4
 // (e.g. when a new network is lazy-loaded from a Repository Provider)
 const DefaultToleratedBlockHeadRollback = 1024
 
+// The latest-block ingestion guard reuses the served-tip velocity bound
+// (VelocityForwardBound) to reject a reported head that jumps further forward
+// than the chain could plausibly have advanced since the upstream's own head
+// last moved — the signature of bad data such as a node serving another
+// chain's head. Rejection happens at the shared counter, so a bad value never
+// reaches the tracker, routing metrics, or peer instances.
+//
+// The ingestion gate is deliberately slower-twitch than the served-tip pick
+// gate: a false positive there costs one pick and self-heals; here it cordons
+// the upstream. blockHeadForwardJumpFloor bounds the gate from below — a jump
+// smaller than this is never rejected — absorbing burst block production
+// (chains that idle and then mint many blocks at once) that elapsed-time
+// velocity alone would misjudge.
+const (
+	blockHeadVelocitySlack    = 2.0
+	blockHeadVelocityBuffer   = int64(5)
+	blockHeadForwardJumpFloor = int64(10_000)
+
+	// blockHeadForwardJumpSitOut is how long an upstream stays cordoned after a
+	// forward-jump detection before it is automatically uncordoned and
+	// re-evaluated against live data.
+	blockHeadForwardJumpSitOut = 30 * time.Second
+)
+
 var _ common.EvmStatePoller = &EvmStatePoller{}
 
 type EvmStatePoller struct {
@@ -92,6 +116,15 @@ type EvmStatePoller struct {
 	earliestSchedulerStarted     map[common.EvmAvailabilityProbeType]bool
 	earliestInitialDetectionDone map[common.EvmAvailabilityProbeType]bool // tracks if THIS instance did initial detection
 	earliestMu                   sync.RWMutex
+
+	// forwardJumpSitOut is how long the upstream stays cordoned after a
+	// forward-jump detection (overridable in tests).
+	forwardJumpSitOut time.Duration
+	// Guards the forward-jump cordon/sit-out so repeated detections (which can
+	// fire on every poll while an upstream keeps serving a bad head) don't stack
+	// timers or churn the cordon. A non-nil timer means a sit-out is in flight.
+	forwardJumpSitOutMu    sync.Mutex
+	forwardJumpSitOutTimer *time.Timer
 }
 
 func NewEvmStatePoller(
@@ -121,7 +154,24 @@ func NewEvmStatePoller(
 		earliestByProbe:              make(map[common.EvmAvailabilityProbeType]data.CounterInt64SharedVariable),
 		earliestSchedulerStarted:     make(map[common.EvmAvailabilityProbeType]bool),
 		earliestInitialDetectionDone: make(map[common.EvmAvailabilityProbeType]bool),
+		forwardJumpSitOut:            blockHeadForwardJumpSitOut,
 	}
+
+	// Latest-block ingestion guard: the same physics bound the served-tip
+	// velocity gate uses, anchored at the upstream's own established head and
+	// the time since it last moved. Inactive until the chain's block time EMA
+	// is known, and floored so burst block production is never misjudged.
+	lbs.SetForwardBound(func(currentVal int64, sinceChange time.Duration) int64 {
+		bt := tracker.GetNetworkBlockTime(networkId)
+		if bt <= 0 {
+			return 0
+		}
+		bound := VelocityForwardBound(currentVal, sinceChange, bt.Seconds(), blockHeadVelocitySlack, blockHeadVelocityBuffer)
+		if bound > 0 && bound < currentVal+blockHeadForwardJumpFloor {
+			bound = currentVal + blockHeadForwardJumpFloor
+		}
+		return bound
+	})
 
 	lbs.OnValue(func(value int64) {
 		// Always pass 0 timestamp to avoid using stale/incorrect timestamps from remote updates
@@ -139,7 +189,42 @@ func NewEvmStatePoller(
 		e.tracker.RecordBlockHeadLargeRollback(e.upstream, "finalized", currentVal, newVal)
 	})
 
+	// An implausible forward jump on the latest-block head means the upstream is
+	// almost certainly serving bad data. The counter has already rejected the
+	// value (so it can't poison anything downstream); here we cordon the
+	// upstream out of routing until it starts reporting a sane head again.
+	lbs.OnLargeForwardJump(func(currentVal, newVal int64) {
+		e.handleLatestBlockForwardJump(currentVal, newVal)
+	})
+
 	return e
+}
+
+// handleLatestBlockForwardJump records the rejected jump and cordons the
+// upstream for a sit-out window. The metric is recorded on every detection so
+// ongoing badness stays visible, but the cordon and its auto-recovery timer are
+// deduped: while a sit-out is already in flight we don't stack timers.
+func (e *EvmStatePoller) handleLatestBlockForwardJump(currentVal, newVal int64) {
+	e.tracker.RecordImplausibleBlockHeadForwardJump(e.upstream, "latest", currentVal, newVal)
+
+	e.forwardJumpSitOutMu.Lock()
+	defer e.forwardJumpSitOutMu.Unlock()
+
+	if e.forwardJumpSitOutTimer != nil {
+		return
+	}
+
+	sitOut := e.forwardJumpSitOut
+	if sitOut <= 0 {
+		sitOut = blockHeadForwardJumpSitOut
+	}
+	e.upstream.Cordon("*", fmt.Sprintf("implausible forward block-head jump (%d -> %d)", currentVal, newVal))
+	e.forwardJumpSitOutTimer = time.AfterFunc(sitOut, func() {
+		e.upstream.Uncordon("*", "end of forward-jump sit-out")
+		e.forwardJumpSitOutMu.Lock()
+		e.forwardJumpSitOutTimer = nil
+		e.forwardJumpSitOutMu.Unlock()
+	})
 }
 
 func (e *EvmStatePoller) Bootstrap(ctx context.Context) error {

--- a/architecture/evm/evm_state_poller_forward_jump_test.go
+++ b/architecture/evm/evm_state_poller_forward_jump_test.go
@@ -1,0 +1,276 @@
+package evm
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/telemetry"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Generic representative heads: an upstream with an established head abruptly
+// reports a far-future head (e.g. a node serving another chain's data).
+const (
+	fjSaneHead    = int64(1_000_000)
+	fjOutlierHead = int64(60_000_000)
+	fjJumpSize    = fjOutlierHead - fjSaneHead
+)
+
+// fjFakeUpstream returns the concrete *common.FakeUpstream so tests can read
+// cordon status via CordonedReason(), which is not on the common.Upstream
+// interface. It still satisfies common.Upstream where the pollers need it.
+func fjFakeUpstream(id string) *common.FakeUpstream {
+	return common.NewFakeUpstream(id).(*common.FakeUpstream)
+}
+
+func fjTestPoller(ups common.Upstream, sitOut time.Duration) *EvmStatePoller {
+	lg := zerolog.Nop()
+	return &EvmStatePoller{
+		projectId:         "test-project",
+		appCtx:            context.Background(),
+		logger:            &lg,
+		upstream:          ups,
+		tracker:           health.NewTracker(&lg, "test-project", 2*time.Second),
+		forwardJumpSitOut: sitOut,
+	}
+}
+
+func fjGaugeValue(projectId string, ups common.Upstream) float64 {
+	g := telemetry.MetricUpstreamBlockHeadLargeForwardJump.WithLabelValues(
+		projectId, ups.VendorName(), ups.NetworkLabel(), ups.Id(),
+	)
+	return promUtil.ToFloat64(g)
+}
+
+func fjTestSharedStateRegistry(t *testing.T, ctx context.Context) data.SharedStateRegistry {
+	t.Helper()
+	lg := zerolog.Nop()
+	cfg := &common.SharedStateConfig{
+		ClusterKey:      "test",
+		FallbackTimeout: common.Duration(1 * time.Second),
+		LockTtl:         common.Duration(30 * time.Second),
+		Connector: &common.ConnectorConfig{
+			Id:     "test-memory",
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{
+				MaxItems:     1000,
+				MaxTotalSize: "10MB",
+			},
+		},
+	}
+	require.NoError(t, cfg.SetDefaults("test"))
+	registry, err := data.NewSharedStateRegistry(ctx, &lg, cfg)
+	require.NoError(t, err)
+	return registry
+}
+
+// warmBlockTime feeds enough strictly-increasing (block, timestamp) samples
+// into the tracker for the network block-time EMA to become available — the
+// signal that arms the ingestion guard.
+func warmBlockTime(t *testing.T, tracker *health.Tracker, ups common.Upstream, startBlock int64, blockTimeSecs int64) {
+	t.Helper()
+	ts := time.Now().Unix() - 100
+	for i := int64(0); i < 5; i++ {
+		tracker.SetLatestBlockNumber(ups, startBlock+i, ts+i*blockTimeSecs)
+	}
+	require.Greater(t, tracker.GetNetworkBlockTime(ups.NetworkId()), time.Duration(0),
+		"block-time EMA must be warmed for the guard to arm")
+}
+
+// ─── cordon / sit-out mechanics (detection handler level) ────────────────
+
+func TestEvmStatePoller_ForwardJump_CordonsAndRecordsMetric(t *testing.T) {
+	ups := fjFakeUpstream("forward-jump-happy")
+	e := fjTestPoller(ups, 50*time.Millisecond)
+
+	e.handleLatestBlockForwardJump(fjSaneHead, fjOutlierHead)
+
+	reason, cordoned := ups.CordonedReason()
+	assert.True(t, cordoned, "upstream must be cordoned on a forward-jump detection")
+	assert.Contains(t, reason, "forward block-head jump", "cordon reason should describe the forward jump")
+
+	assert.Equal(t, float64(fjJumpSize), fjGaugeValue("test-project", ups),
+		"forward-jump gauge must record the magnitude of the rejected jump")
+}
+
+func TestEvmStatePoller_ForwardJump_RecoversAfterSitOut(t *testing.T) {
+	ups := fjFakeUpstream("forward-jump-recovery")
+	e := fjTestPoller(ups, 60*time.Millisecond)
+
+	e.handleLatestBlockForwardJump(fjSaneHead, fjOutlierHead)
+	_, cordoned := ups.CordonedReason()
+	require.True(t, cordoned, "upstream must be cordoned immediately after detection")
+
+	require.Eventually(t, func() bool {
+		_, c := ups.CordonedReason()
+		return !c
+	}, 2*time.Second, 5*time.Millisecond, "upstream must auto-uncordon after the sit-out window")
+
+	// Once the sit-out timer fires it must clear itself so a future
+	// detection can start a fresh penalty.
+	e.forwardJumpSitOutMu.Lock()
+	timerCleared := e.forwardJumpSitOutTimer == nil
+	e.forwardJumpSitOutMu.Unlock()
+	assert.True(t, timerCleared, "sit-out timer must be cleared after it fires")
+}
+
+func TestEvmStatePoller_ForwardJump_DedupesRepeatedDetections(t *testing.T) {
+	ups := fjFakeUpstream("forward-jump-dedupe")
+	// Long sit-out so the first timer never fires during the repeated calls.
+	e := fjTestPoller(ups, 5*time.Second)
+
+	e.handleLatestBlockForwardJump(fjSaneHead, fjOutlierHead)
+
+	e.forwardJumpSitOutMu.Lock()
+	firstTimer := e.forwardJumpSitOutTimer
+	e.forwardJumpSitOutMu.Unlock()
+	require.NotNil(t, firstTimer, "first detection must start a sit-out timer")
+
+	for i := 0; i < 20; i++ {
+		e.handleLatestBlockForwardJump(fjSaneHead, fjOutlierHead)
+	}
+
+	e.forwardJumpSitOutMu.Lock()
+	sameTimer := e.forwardJumpSitOutTimer == firstTimer
+	e.forwardJumpSitOutMu.Unlock()
+	assert.True(t, sameTimer, "repeated detections must not stack or replace the sit-out timer")
+
+	_, cordoned := ups.CordonedReason()
+	assert.True(t, cordoned, "upstream stays cordoned across repeated detections")
+}
+
+func TestEvmStatePoller_ForwardJump_ConcurrentDetections(t *testing.T) {
+	ups := fjFakeUpstream("forward-jump-concurrent")
+	e := fjTestPoller(ups, 5*time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.handleLatestBlockForwardJump(fjSaneHead, fjOutlierHead)
+		}()
+	}
+	wg.Wait()
+
+	_, cordoned := ups.CordonedReason()
+	assert.True(t, cordoned, "concurrent detections must leave the upstream cordoned")
+
+	e.forwardJumpSitOutMu.Lock()
+	timerSet := e.forwardJumpSitOutTimer != nil
+	e.forwardJumpSitOutMu.Unlock()
+	assert.True(t, timerSet, "exactly one sit-out timer must be in flight after concurrent detections")
+}
+
+// ─── end-to-end through the real counter + velocity bound ────────────────
+
+// Full wiring: NewEvmStatePoller installs the velocity bound and the
+// OnLargeForwardJump -> cordon hook on the latest-block counter. With the
+// chain's block-time EMA known, an implausible forward jump is rejected at
+// ingestion (the stored value is NOT poisoned) and the upstream is cordoned.
+func TestEvmStatePoller_ForwardJump_EndToEndThroughCounter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := fjTestSharedStateRegistry(t, ctx)
+	lg := zerolog.Nop()
+	tracker := health.NewTracker(&lg, "test-project", 2*time.Second)
+	ups := fjFakeUpstream("forward-jump-e2e")
+
+	_ = NewEvmStatePoller("test-project", ctx, &lg, ups, tracker, registry)
+
+	warmBlockTime(t, tracker, ups, fjSaneHead-10, 2)
+
+	// Re-fetch the SAME counter instance (LoadOrStore by key) to drive values.
+	key := "latestBlock/" + common.UniqueUpstreamKey(ups)
+	lbs := registry.GetCounterInt64(key, DefaultToleratedBlockHeadRollback)
+
+	// Establish a sane head (cold-start from 0 is always accepted).
+	require.Equal(t, fjSaneHead, lbs.TryUpdate(ctx, fjSaneHead))
+
+	// A far-future jump (way past what the chain could have minted) is
+	// rejected: value unchanged, upstream cordoned.
+	got := lbs.TryUpdate(ctx, fjOutlierHead)
+	assert.Equal(t, fjSaneHead, got, "implausible forward jump must not be stored")
+	assert.Equal(t, fjSaneHead, lbs.GetValue(), "head source value must not be poisoned")
+
+	_, cordoned := ups.CordonedReason()
+	assert.True(t, cordoned, "forward jump must cordon the upstream end-to-end")
+}
+
+// Normal forward progression — including a burst up to the floor — is
+// accepted and never cordons, proving the guard does not misfire on
+// legitimate catch-up or bursty block production.
+func TestEvmStatePoller_ForwardJump_NormalProgressionAndBurstNotCordoned(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := fjTestSharedStateRegistry(t, ctx)
+	lg := zerolog.Nop()
+	tracker := health.NewTracker(&lg, "test-project", 2*time.Second)
+	ups := fjFakeUpstream("forward-jump-normal")
+
+	_ = NewEvmStatePoller("test-project", ctx, &lg, ups, tracker, registry)
+
+	warmBlockTime(t, tracker, ups, fjSaneHead-10, 2)
+
+	key := "latestBlock/" + common.UniqueUpstreamKey(ups)
+	lbs := registry.GetCounterInt64(key, DefaultToleratedBlockHeadRollback)
+
+	require.Equal(t, fjSaneHead, lbs.TryUpdate(ctx, fjSaneHead))
+
+	// Steady progression: a few blocks per poll.
+	assert.Equal(t, fjSaneHead+3, lbs.TryUpdate(ctx, fjSaneHead+3), "steady progression must be accepted")
+
+	// Burst: a jump below the floor is never rejected, even though elapsed-time
+	// velocity alone would not allow it (chains can idle then mint many blocks).
+	burst := fjSaneHead + 3 + blockHeadForwardJumpFloor - 1
+	assert.Equal(t, burst, lbs.TryUpdate(ctx, burst), "a burst below the floor must be accepted")
+
+	_, cordoned := ups.CordonedReason()
+	assert.False(t, cordoned, "legitimate progression must not cordon the upstream")
+}
+
+// Until the chain's block-time EMA is known the guard must stay inactive:
+// rejecting with an unknown chain pace would misjudge fast chains. A huge
+// jump in that window is accepted and the upstream is not cordoned.
+func TestEvmStatePoller_ForwardJump_GuardInactiveUntilBlockTimeKnown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := fjTestSharedStateRegistry(t, ctx)
+	lg := zerolog.Nop()
+	tracker := health.NewTracker(&lg, "test-project", 2*time.Second)
+	ups := fjFakeUpstream("forward-jump-cold-ema")
+
+	_ = NewEvmStatePoller("test-project", ctx, &lg, ups, tracker, registry)
+
+	// No EMA warm-up: block time unknown.
+	require.Equal(t, time.Duration(0), tracker.GetNetworkBlockTime(ups.NetworkId()))
+
+	key := "latestBlock/" + common.UniqueUpstreamKey(ups)
+	lbs := registry.GetCounterInt64(key, DefaultToleratedBlockHeadRollback)
+
+	require.Equal(t, fjSaneHead, lbs.TryUpdate(ctx, fjSaneHead))
+	assert.Equal(t, fjOutlierHead, lbs.TryUpdate(ctx, fjOutlierHead),
+		"with chain pace unknown the guard must stay inactive (accept, don't guess)")
+
+	_, cordoned := ups.CordonedReason()
+	assert.False(t, cordoned, "no cordon while the guard is inactive")
+}
+
+// The elapsed-since-change semantics that make long-stall catch-up safe are
+// pinned at the data layer (TestCounterInt64_ForwardBound "stall" subtest):
+// the bound receives time since the value last CHANGED, so the velocity term
+// scales with the true stall duration. At the poller level the floor already
+// covers every catch-up smaller than blockHeadForwardJumpFloor (burst test
+// above); a velocity-term-dominated catch-up needs hours of wall-clock time
+// and is intentionally not simulated here.

--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -92,6 +92,20 @@ type ServedTipResult struct {
 	Outliers []string
 }
 
+// VelocityForwardBound returns the highest block number plausibly reachable
+// from anchor after elapsed wall-clock time on a chain with the given block
+// time: anchor + ceil(elapsedBlocks × slack) + buffer. Returns 0 ("no bound")
+// when the anchor or the block time is unknown — callers must treat 0 as
+// "gate inactive". This is the single physics bound shared by the served-tip
+// velocity gate and the block-head ingestion guard in the state poller.
+func VelocityForwardBound(anchor int64, elapsed time.Duration, blockTimeSeconds float64, slack float64, buffer int64) int64 {
+	if anchor <= 0 || blockTimeSeconds <= 0 {
+		return 0
+	}
+	elapsedBlocks := elapsed.Seconds() / blockTimeSeconds
+	return anchor + int64(math.Ceil(elapsedBlocks*slack)) + buffer
+}
+
 // ComputeServedTipCandidate clusters the inputs and returns the MIN block
 // number of the dominant cluster — the most conservative tip that the
 // dominant agreement cluster of upstreams can all serve.
@@ -148,13 +162,10 @@ func ComputeServedTipCandidate(
 	}
 
 	// 2. Velocity gate: only active when BOTH a prior anchor exists AND the
-	//    chain's block time is known. Without either, we can't predict an
-	//    expected max — leave all candidates in and let clustering do the work.
-	if lastServedBlock > 0 && cfg.BlockTimeSeconds > 0 {
-		elapsedBlocks := elapsedSinceLast.Seconds() / cfg.BlockTimeSeconds
-		expectedAdvance := int64(math.Ceil(elapsedBlocks * velocitySlack))
-		expectedMax := lastServedBlock + expectedAdvance + velocityBuffer
-
+	//    chain's block time is known (VelocityForwardBound returns 0 otherwise).
+	//    Without either, we can't predict an expected max — leave all
+	//    candidates in and let clustering do the work.
+	if expectedMax := VelocityForwardBound(lastServedBlock, elapsedSinceLast, cfg.BlockTimeSeconds, velocitySlack, velocityBuffer); expectedMax > 0 {
 		filtered := make([]ServedTipInput, 0, len(valid))
 		for _, t := range valid {
 			if t.BlockNumber > expectedMax {

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -358,3 +358,40 @@ func TestComputeServedTipCandidate_ClusterDelta_ExplicitOverride(t *testing.T) {
 		"explicit delta=5 overrides; 7-block gap excludes the lagger")
 	assert.Equal(t, 2, res.ClusterCount)
 }
+
+// ─── VelocityForwardBound (shared physics bound) ─────────────────────────
+
+// VelocityForwardBound is the single bound shared by the served-tip velocity
+// gate and the state poller's block-head ingestion guard. These tests pin its
+// contract: 0 means "gate inactive" (unknown anchor or chain pace), otherwise
+// anchor + ceil(elapsedBlocks × slack) + buffer.
+func TestVelocityForwardBound(t *testing.T) {
+	t.Run("unknown anchor disables the bound", func(t *testing.T) {
+		assert.Equal(t, int64(0), VelocityForwardBound(0, 10*time.Second, 2.0, 2.0, 5))
+		assert.Equal(t, int64(0), VelocityForwardBound(-5, 10*time.Second, 2.0, 2.0, 5))
+	})
+
+	t.Run("unknown block time disables the bound", func(t *testing.T) {
+		assert.Equal(t, int64(0), VelocityForwardBound(100, 10*time.Second, 0, 2.0, 5))
+		assert.Equal(t, int64(0), VelocityForwardBound(100, 10*time.Second, -1, 2.0, 5))
+	})
+
+	t.Run("formula: anchor + ceil(elapsedBlocks x slack) + buffer", func(t *testing.T) {
+		// 10s elapsed / 2s blocks = 5 blocks; x2.0 slack = 10; +5 buffer.
+		assert.Equal(t, int64(115), VelocityForwardBound(100, 10*time.Second, 2.0, 2.0, 5))
+		// Fractional blocks round up: 3s / 2s = 1.5 blocks; x2.0 = 3; +5.
+		assert.Equal(t, int64(108), VelocityForwardBound(100, 3*time.Second, 2.0, 2.0, 5))
+	})
+
+	t.Run("bound grows with elapsed time (stall catch-up tolerance)", func(t *testing.T) {
+		short := VelocityForwardBound(1_000_000, time.Second, 2.0, 2.0, 5)
+		long := VelocityForwardBound(1_000_000, time.Hour, 2.0, 2.0, 5)
+		assert.Greater(t, long, short, "a longer stall must allow a larger catch-up")
+		// 1h / 2s = 1800 blocks; x2.0 = 3600; +5.
+		assert.Equal(t, int64(1_003_605), long)
+	})
+
+	t.Run("zero elapsed still allows the buffer", func(t *testing.T) {
+		assert.Equal(t, int64(105), VelocityForwardBound(100, 0, 2.0, 2.0, 5))
+	})
+}

--- a/data/shared_state_variable.go
+++ b/data/shared_state_variable.go
@@ -24,6 +24,16 @@ type CounterInt64SharedVariable interface {
 	TryUpdate(ctx context.Context, newValue int64) int64
 	OnValue(callback func(int64))
 	OnLargeRollback(callback func(currentVal, newVal int64))
+	// SetForwardBound installs a plausibility bound on forward movement. On every
+	// forward update the function receives the current value and the time since
+	// that value was last CHANGED (not merely refreshed), and returns the highest
+	// acceptable new value — or 0 for "no bound" (e.g. chain block time unknown).
+	// A new value above the bound is rejected: not stored, OnValue not fired,
+	// surfaced via OnLargeForwardJump instead. nil (default) disables the guard.
+	SetForwardBound(fn func(currentVal int64, sinceChange time.Duration) int64)
+	// OnLargeForwardJump registers a callback fired when a forward update is
+	// rejected by the bound installed via SetForwardBound.
+	OnLargeForwardJump(callback func(currentVal, newVal int64))
 }
 
 type baseSharedVariable struct {
@@ -108,7 +118,19 @@ type counterInt64 struct {
 	valueCallbacks         []func(int64)
 	ignoreRollbackOf       int64
 	largeRollbackCallbacks []func(localVal, newVal int64)
-	callbackMu             sync.RWMutex
+	// forwardBound (optional) bounds forward movement: a new value above
+	// fn(currentValue, sinceChange) is rejected as bad data (e.g. an upstream
+	// serving another chain's head) and surfaced via largeForwardJumpCallbacks,
+	// rather than stored and propagated. Guarded by callbackMu.
+	forwardBound              func(currentVal int64, sinceChange time.Duration) int64
+	largeForwardJumpCallbacks []func(currentVal, newVal int64)
+	// valueChangedAtUnixMs is when c.value last actually CHANGED. Distinct from
+	// updatedAtUnixMs, which is also bumped by value-unchanged refresh attempts
+	// (TryUpdateIfStale debouncing) and so under-measures elapsed time across a
+	// stall. The forward bound must see true elapsed-since-change so that
+	// legitimate catch-up after a stall is not rejected.
+	valueChangedAtUnixMs atomic.Int64
+	callbackMu           sync.RWMutex
 	// bgPushInProgress dedupes best-effort remote reconciliation/push operations.
 	// It MUST NOT be held while waiting on updateMu; remote sync should never block request flow.
 	bgPushInProgress sync.Mutex
@@ -179,9 +201,29 @@ func (c *counterInt64) processNewState(source string, st CounterInt64State) bool
 	}
 
 	if newVal > currentValue {
-		// Forward progress: always accept
+		// Forward progress: accept unless it violates the forward bound. A value
+		// beyond the bound is bad data (e.g. an upstream serving another chain's
+		// head): neither stored nor propagated via OnValue. For remote updates we
+		// advance our local timestamp past the remote's so our lower (sane) value
+		// wins reconciliation and overwrites the poisoned remote value — mirrors
+		// the small-rollback rejection behavior.
+		if c.exceedsForwardBound(currentValue, newVal) {
+			if isRemoteUpdate {
+				c.advanceTimestampPast(st.UpdatedAt)
+			}
+			c.registry.logger.Warn().
+				Str("source", source).
+				Str("key", c.key).
+				Int64("currentValue", currentValue).
+				Int64("newVal", newVal).
+				Int64("jump", newVal-currentValue).
+				Msg("implausible forward jump rejected (remote)")
+			c.triggerLargeForwardJumpCallback(currentValue, newVal)
+			return false
+		}
 		for {
 			if c.value.CompareAndSwap(currentValue, newVal) {
+				c.markValueChanged()
 				// Update timestamp AFTER accepting the value (for remote updates)
 				if isRemoteUpdate {
 					c.updateUpdatedAtMs(st.UpdatedAt)
@@ -230,6 +272,7 @@ func (c *counterInt64) processNewState(source string, st CounterInt64State) bool
 	// Large rollback exceeds threshold - apply it and trigger callback
 	for {
 		if c.value.CompareAndSwap(currentValue, newVal) {
+			c.markValueChanged()
 			// Update timestamp AFTER accepting the value (for remote updates)
 			if isRemoteUpdate {
 				c.updateUpdatedAtMs(st.UpdatedAt)
@@ -278,9 +321,24 @@ func (c *counterInt64) processNewValue(source string, newVal int64) bool {
 	}
 
 	if newVal > currentValue {
-		// Forward progress: always accept
+		// Forward progress: accept unless it violates the forward bound. A value
+		// beyond the bound is bad data (e.g. an upstream serving another chain's
+		// head): neither stored nor propagated via OnValue, so it cannot poison
+		// anything downstream of this counter. Surfaced via OnLargeForwardJump.
+		if c.exceedsForwardBound(currentValue, newVal) {
+			c.registry.logger.Warn().
+				Str("source", source).
+				Str("key", c.key).
+				Int64("currentValue", currentValue).
+				Int64("newVal", newVal).
+				Int64("jump", newVal-currentValue).
+				Msg("implausible forward jump rejected (local)")
+			c.triggerLargeForwardJumpCallback(currentValue, newVal)
+			return false
+		}
 		for {
 			if c.value.CompareAndSwap(currentValue, newVal) {
+				c.markValueChanged()
 				c.allocateUpdatedAtMs() // Mark as fresh
 				c.registry.logger.Trace().
 					Str("source", source).
@@ -319,6 +377,7 @@ func (c *counterInt64) processNewValue(source string, newVal int64) bool {
 	// Large rollback exceeds threshold - apply it and trigger callback
 	for {
 		if c.value.CompareAndSwap(currentValue, newVal) {
+			c.markValueChanged()
 			c.allocateUpdatedAtMs() // Mark as fresh
 			c.registry.logger.Trace().
 				Str("source", source).
@@ -344,6 +403,42 @@ func (c *counterInt64) processNewValue(source string, newVal int64) bool {
 		currentValue = c.value.Load()
 		if newVal >= currentValue {
 			return false
+		}
+	}
+}
+
+// exceedsForwardBound reports whether advancing from currentValue to newVal
+// violates the installed forward bound. No bound installed, no established
+// value, or a 0 bound (unknown chain pace) all mean "no rejection".
+func (c *counterInt64) exceedsForwardBound(currentValue, newVal int64) bool {
+	c.callbackMu.RLock()
+	fn := c.forwardBound
+	c.callbackMu.RUnlock()
+	if fn == nil || currentValue <= 0 {
+		return false
+	}
+	var sinceChange time.Duration
+	if changedAt := c.valueChangedAtUnixMs.Load(); changedAt > 0 {
+		sinceChange = time.Since(time.UnixMilli(changedAt))
+	}
+	bound := fn(currentValue, sinceChange)
+	return bound > 0 && newVal > bound
+}
+
+// markValueChanged stamps the moment c.value actually changed — the anchor
+// timestamp the forward bound measures elapsed time from.
+func (c *counterInt64) markValueChanged() {
+	c.valueChangedAtUnixMs.Store(time.Now().UnixMilli())
+}
+
+func (c *counterInt64) triggerLargeForwardJumpCallback(currentVal, newVal int64) {
+	c.callbackMu.RLock()
+	callbacks := make([]func(currentVal, newVal int64), len(c.largeForwardJumpCallbacks))
+	copy(callbacks, c.largeForwardJumpCallbacks)
+	c.callbackMu.RUnlock()
+	for _, cb := range callbacks {
+		if cb != nil {
+			cb(currentVal, newVal)
 		}
 	}
 }
@@ -478,6 +573,18 @@ func (c *counterInt64) OnLargeRollback(cb func(currentVal, newVal int64)) {
 	c.callbackMu.Lock()
 	defer c.callbackMu.Unlock()
 	c.largeRollbackCallbacks = append(c.largeRollbackCallbacks, cb)
+}
+
+func (c *counterInt64) SetForwardBound(fn func(currentVal int64, sinceChange time.Duration) int64) {
+	c.callbackMu.Lock()
+	defer c.callbackMu.Unlock()
+	c.forwardBound = fn
+}
+
+func (c *counterInt64) OnLargeForwardJump(cb func(currentVal, newVal int64)) {
+	c.callbackMu.Lock()
+	defer c.callbackMu.Unlock()
+	c.largeForwardJumpCallbacks = append(c.largeForwardJumpCallbacks, cb)
 }
 
 func (c *counterInt64) markFreshAttempt() {

--- a/data/shared_state_variable_test.go
+++ b/data/shared_state_variable_test.go
@@ -1742,3 +1742,223 @@ func TestCounterInt64_FresherLocalPushesToStaleRemote(t *testing.T) {
 		setCallMu.Unlock()
 	})
 }
+
+// TestCounterInt64_ForwardBound verifies the forward-movement guard: once a
+// counter holds an established value, a forward update above the installed
+// bound is rejected as bad data (not stored, OnValue not fired) and surfaced
+// via OnLargeForwardJump — the inverse of the large-rollback guard. The bound
+// is a function of the current value and the time since it last CHANGED, so
+// legitimate catch-up after a stall is accepted while an abrupt implausible
+// jump (e.g. an upstream serving another chain's head) is rejected.
+func TestCounterInt64_ForwardBound(t *testing.T) {
+	newCounter := func() *counterInt64 {
+		return &counterInt64{
+			ignoreRollbackOf: 1024,
+			registry: &sharedStateRegistry{
+				logger:     &log.Logger,
+				instanceId: "test",
+			},
+		}
+	}
+	// A fixed-width bound: accept advances up to 10k blocks past current.
+	fixedBound := func(width int64) func(int64, time.Duration) int64 {
+		return func(cur int64, _ time.Duration) int64 { return cur + width }
+	}
+
+	t.Run("local: forward progress within bound is accepted", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+
+		var cbCount atomic.Int32
+		c.OnLargeForwardJump(func(_, _ int64) { cbCount.Add(1) })
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 1_000_100)
+		assert.True(t, updated, "in-bound forward progress should be accepted")
+		assert.Equal(t, int64(1_000_100), c.GetValue())
+		assert.Equal(t, int32(0), cbCount.Load(), "no forward-jump callback for normal progress")
+	})
+
+	t.Run("local: jump beyond bound is rejected and not stored", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+
+		var mu sync.Mutex
+		var calls []struct{ current, new int64 }
+		c.OnLargeForwardJump(func(currentVal, newVal int64) {
+			mu.Lock()
+			calls = append(calls, struct{ current, new int64 }{currentVal, newVal})
+			mu.Unlock()
+		})
+		var valueCbCount atomic.Int32
+		c.OnValue(func(int64) { valueCbCount.Add(1) })
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 60_000_000)
+		assert.False(t, updated, "implausible forward jump should be rejected")
+		assert.Equal(t, int64(1_000_000), c.GetValue(), "value must be unchanged after rejection")
+		assert.Equal(t, int32(0), valueCbCount.Load(), "OnValue must not fire for a rejected value")
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(t, calls, 1, "OnLargeForwardJump should fire exactly once")
+		if len(calls) == 1 {
+			assert.Equal(t, int64(1_000_000), calls[0].current)
+			assert.Equal(t, int64(60_000_000), calls[0].new)
+		}
+	})
+
+	t.Run("cold start: first value from zero is accepted regardless of magnitude", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		// value defaults to 0: no established self-history to check against.
+
+		var cbCount atomic.Int32
+		c.OnLargeForwardJump(func(_, _ int64) { cbCount.Add(1) })
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 60_000_000)
+		assert.True(t, updated, "cold-start value must be accepted")
+		assert.Equal(t, int64(60_000_000), c.GetValue())
+		assert.Equal(t, int32(0), cbCount.Load(), "no forward-jump callback on cold start")
+	})
+
+	t.Run("disabled: no bound installed accepts arbitrarily large jumps (backward compatible)", func(t *testing.T) {
+		c := newCounter()
+		c.value.Store(1_000_000)
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 60_000_000)
+		assert.True(t, updated, "without a bound, large jumps are accepted as before")
+		assert.Equal(t, int64(60_000_000), c.GetValue())
+	})
+
+	t.Run("inactive: bound function returning 0 accepts everything (chain pace unknown)", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(func(int64, time.Duration) int64 { return 0 })
+		c.value.Store(1_000_000)
+
+		var cbCount atomic.Int32
+		c.OnLargeForwardJump(func(_, _ int64) { cbCount.Add(1) })
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 60_000_000)
+		assert.True(t, updated, "a 0 bound means 'gate inactive', never 'reject all'")
+		assert.Equal(t, int64(60_000_000), c.GetValue())
+		assert.Equal(t, int32(0), cbCount.Load())
+	})
+
+	t.Run("boundary: value equal to bound accepted, one above rejected", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 1_010_000)
+		assert.True(t, updated, "value exactly at the bound should be accepted")
+		assert.Equal(t, int64(1_010_000), c.GetValue())
+
+		updated = c.processNewValue(UpdateSourceTryUpdate, 1_020_001)
+		assert.False(t, updated, "value one above the bound should be rejected")
+		assert.Equal(t, int64(1_010_000), c.GetValue())
+	})
+
+	t.Run("recovery: an in-bound value after a rejected jump is accepted", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+
+		assert.False(t, c.processNewValue(UpdateSourceTryUpdate, 60_000_000))
+		assert.Equal(t, int64(1_000_000), c.GetValue())
+
+		// Upstream recovers and reports a sane next block.
+		assert.True(t, c.processNewValue(UpdateSourceTryUpdate, 1_000_012))
+		assert.Equal(t, int64(1_000_012), c.GetValue())
+	})
+
+	t.Run("stall: bound sees elapsed-since-CHANGE so catch-up is accepted", func(t *testing.T) {
+		c := newCounter()
+		c.value.Store(0)
+		// Establish a value through the normal path so valueChangedAt is stamped.
+		assert.True(t, c.processNewValue(UpdateSourceTryUpdate, 1_000_000))
+
+		// Simulate a refresh-only stall: updatedAtUnixMs keeps being bumped by
+		// value-unchanged poll attempts, but the VALUE hasn't moved for an hour.
+		c.valueChangedAtUnixMs.Store(time.Now().Add(-1 * time.Hour).UnixMilli())
+		c.allocateUpdatedAtMs() // freshness timestamp says "just now"
+
+		var seenElapsed atomic.Int64
+		// A velocity-style bound: ~1 block per 2s plus a small buffer. After a
+		// 1h stall this allows ~1800 blocks of catch-up.
+		c.SetForwardBound(func(cur int64, sinceChange time.Duration) int64 {
+			seenElapsed.Store(int64(sinceChange))
+			return cur + int64(sinceChange.Seconds()/2) + 5
+		})
+
+		updated := c.processNewValue(UpdateSourceTryUpdate, 1_001_700)
+		assert.True(t, updated, "catch-up within the elapsed-derived bound must be accepted after a stall")
+		assert.GreaterOrEqual(t, time.Duration(seenElapsed.Load()), time.Hour,
+			"the bound must be given elapsed-since-change, not elapsed-since-refresh")
+	})
+
+	t.Run("remote: jump beyond bound is rejected and timestamp advanced", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+		c.updatedAtUnixMs.Store(100)
+
+		var cbCount atomic.Int32
+		c.OnLargeForwardJump(func(_, _ int64) { cbCount.Add(1) })
+		var valueCbCount atomic.Int32
+		c.OnValue(func(int64) { valueCbCount.Add(1) })
+
+		// A peer instance propagates a poisoned value with a fresher timestamp.
+		updated := c.processNewState(UpdateSourceRemoteSync, CounterInt64State{
+			Value:     60_000_000,
+			UpdatedAt: 200, // fresher than local 100
+			UpdatedBy: "peer-instance",
+		})
+		assert.False(t, updated, "remote forward jump should be rejected")
+		assert.Equal(t, int64(1_000_000), c.GetValue(), "remote poison must not be stored")
+		assert.Equal(t, int32(0), valueCbCount.Load(), "OnValue must not fire for a rejected remote value")
+		assert.Equal(t, int32(1), cbCount.Load(), "OnLargeForwardJump should fire once")
+		// Local timestamp advanced past the remote's so our sane value wins
+		// reconciliation and overwrites the poisoned remote value (mirrors the
+		// small-rollback rejection behavior).
+		assert.Greater(t, c.updatedAtMs(), int64(200), "local timestamp should be advanced past remote")
+	})
+
+	t.Run("remote: in-bound forward progress is accepted", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+		c.updatedAtUnixMs.Store(100)
+
+		updated := c.processNewState(UpdateSourceRemoteSync, CounterInt64State{
+			Value:     1_000_500,
+			UpdatedAt: 200,
+			UpdatedBy: "peer-instance",
+		})
+		assert.True(t, updated, "in-bound remote progress should be accepted")
+		assert.Equal(t, int64(1_000_500), c.GetValue())
+	})
+
+	t.Run("concurrent rejected jumps do not corrupt value or panic", func(t *testing.T) {
+		c := newCounter()
+		c.SetForwardBound(fixedBound(10_000))
+		c.value.Store(1_000_000)
+
+		var cbCount atomic.Int32
+		c.OnLargeForwardJump(func(_, _ int64) { cbCount.Add(1) })
+
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				c.processNewValue(UpdateSourceTryUpdate, 60_000_000)
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int64(1_000_000), c.GetValue(), "value must remain at the last good block")
+		assert.Equal(t, int32(goroutines), cbCount.Load(), "each rejected call fires the callback exactly once")
+	})
+}

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -293,6 +293,7 @@ type Tracker struct {
 	finalizationLagGaugeCache     sync.Map // map[ubKey]prometheus.Gauge
 	cordonedGaugeCache            sync.Map // map[cordKey]prometheus.Gauge
 	rollbackGaugeCache            sync.Map // map[ubKey]prometheus.Gauge
+	forwardJumpGaugeCache         sync.Map // map[ubKey]prometheus.Gauge
 }
 
 // urdoKey uniquely identifies a MetricUpstreamRequestDuration time series.
@@ -475,6 +476,18 @@ func (t *Tracker) getRollbackGauge(up common.Upstream) prometheus.Gauge {
 		t.projectId, up.VendorName(), up.NetworkLabel(), up.Id(),
 	)
 	actual, _ := t.rollbackGaugeCache.LoadOrStore(key, g)
+	return actual.(prometheus.Gauge)
+}
+
+func (t *Tracker) getForwardJumpGauge(up common.Upstream) prometheus.Gauge {
+	key := ubKey{t.projectId, up.VendorName(), up.NetworkLabel(), up.Id()}
+	if v, ok := t.forwardJumpGaugeCache.Load(key); ok {
+		return v.(prometheus.Gauge)
+	}
+	g := telemetry.MetricUpstreamBlockHeadLargeForwardJump.WithLabelValues(
+		t.projectId, up.VendorName(), up.NetworkLabel(), up.Id(),
+	)
+	actual, _ := t.forwardJumpGaugeCache.LoadOrStore(key, g)
 	return actual.(prometheus.Gauge)
 }
 
@@ -1562,4 +1575,19 @@ func (t *Tracker) RecordBlockHeadLargeRollback(upstream common.Upstream, finalit
 		Msgf("recording block rollback in tracker")
 
 	t.getRollbackGauge(upstream).Set(float64(rollback))
+}
+
+func (t *Tracker) RecordImplausibleBlockHeadForwardJump(upstream common.Upstream, finality string, currentVal, newVal int64) {
+	jump := newVal - currentVal
+
+	net := upstream.NetworkId()
+	lg := upstream.Logger().With().Str("networkId", net).Logger()
+	lg.Warn().
+		Int64("currentValue", currentVal).
+		Int64("newValue", newVal).
+		Int64("jump", jump).
+		Str("finality", finality).
+		Msgf("upstream reported an implausible forward block-head jump; rejecting value")
+
+	t.getForwardJumpGauge(upstream).Set(float64(jump))
 }

--- a/internal/policy/cordon_routing_test.go
+++ b/internal/policy/cordon_routing_test.go
@@ -1,0 +1,102 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/erpc/erpc/internal/policy/stdlib"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEngine_RemoveCordoned_HonorsWildcardCordon proves the routing-level
+// half of the forward-jump guard: the guard (and the consensus misbehavior
+// path) cordon an upstream at method "*", and the default policy's first
+// step — removeCordoned() — must drop that upstream from selection at EVERY
+// EvalScope grain, not just the wildcard slot.
+//
+// Before the fix, removeCordoned() read only the per-method bucket
+// (u.metrics.cordonedReason). Under EvalScope=network-method the per-method
+// slot's u.metrics is the {ups, eth_call, All} bucket, which never sees a
+// "*"-scoped cordon — so the cordoned upstream stayed routable for real user
+// methods. The fix also consults the cross-method aggregate
+// (u.metricsAcrossMethods), where the wildcard cordon actually lives. The
+// network-method subtest below fails on the pre-fix stdlib and passes after.
+func TestEngine_RemoveCordoned_HonorsWildcardCordon(t *testing.T) {
+	// setup builds a frozen-ticker engine running the rich default policy
+	// (EvalFunc == DefaultSelectionPolicySource triggers the upgrade at
+	// RegisterNetwork) with one healthy and one offending upstream, at the
+	// given EvalScope. Returns the shared tracker + the exact upstream
+	// instances (cordon must target the SAME instance the engine snapshots).
+	setup := func(t *testing.T, scope common.EvalScope) (*policy.Engine, *health.Tracker, common.Upstream, common.Upstream) {
+		t.Helper()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		logger := zerolog.Nop()
+		tracker := health.NewTracker(&logger, "test", time.Minute)
+
+		cfg := &common.SelectionPolicyConfig{
+			// Frozen: only our explicit TickForTest fires, so background
+			// re-eval can't race the assertions.
+			EvalInterval:         common.Duration(0),
+			EvalTimeout:          common.Duration(500 * time.Millisecond),
+			EvalScope:            scope,
+			EvalFunc:             common.DefaultSelectionPolicySource, // upgraded to default_policy.js
+			DisableTickerForTest: true,
+		}
+		require.NoError(t, cfg.SetDefaults())
+
+		engine := policy.NewEngine(ctx, &logger, "p1", tracker, stdlib.Install, nil)
+		t.Cleanup(engine.Stop)
+
+		healthy := &fakeUpstream{id: "healthy"}
+		offender := &fakeUpstream{id: "offender"}
+		ups := []common.Upstream{healthy, offender}
+		require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+
+		return engine, tracker, healthy, offender
+	}
+
+	const cordonReason = "implausible forward block-head jump (1000000 -> 60000000)"
+
+	t.Run("network-method scope drops a wildcard-cordoned upstream", func(t *testing.T) {
+		engine, tracker, _, offender := setup(t, common.EvalScopeNetworkMethod)
+
+		// Lazy-create the narrow eth_call slot FIRST. Without this,
+		// TickForTest/LatestDecisionOutputForTest fall back to the wildcard
+		// ("*","*") slot — which evaluates at method "*" and would mask the
+		// per-method gap (its u.metrics already reads the cordoned bucket).
+		engine.GetOrdered("evm:1", "eth_call", "*")
+
+		// Cordon at "*" exactly as the poller's forward-jump handler does.
+		tracker.Cordon(offender, "*", cordonReason)
+
+		// Re-eval the narrow slot post-cordon and read its decision.
+		policy.TickForTest(engine, "evm:1", "eth_call")
+		order, excluded := policy.LatestDecisionOutputForTest(engine, "evm:1", "eth_call")
+
+		require.NotContains(t, order, "offender",
+			"wildcard-cordoned upstream must not be routable for eth_call under network-method scope")
+		require.Contains(t, order, "healthy", "healthy upstream must remain routable")
+		require.Contains(t, excluded, "offender", "offender must be reported in the excluded set")
+	})
+
+	t.Run("default network scope drops a wildcard-cordoned upstream", func(t *testing.T) {
+		engine, tracker, _, offender := setup(t, common.EvalScopeNetwork)
+
+		tracker.Cordon(offender, "*", cordonReason)
+
+		// Default scope has a single ("*","*") slot created at register.
+		policy.TickForTest(engine, "evm:1", "*")
+		order, excluded := policy.LatestDecisionOutputForTest(engine, "evm:1", "*")
+
+		require.NotContains(t, order, "offender", "wildcard-cordoned upstream must not be routable")
+		require.Contains(t, order, "healthy", "healthy upstream must remain routable")
+		require.Contains(t, excluded, "offender", "offender must be reported in the excluded set")
+	})
+}

--- a/internal/policy/stdlib/stdlib.js
+++ b/internal/policy/stdlib/stdlib.js
@@ -340,7 +340,11 @@
     return this.filter(u => u.metrics.requestsTotal >= min);
   });
   define('removeCordoned', function () {
-    return this.filter(u => !u.metrics.cordonedReason);
+    // Cordons set at method "*" (poller forward-jump guard, consensus
+    // misbehavior) live only on the wildcard bucket, so under a per-method
+    // EvalScope u.metrics would miss them — check the cross-method
+    // aggregate too.
+    return this.filter(u => !u.metrics.cordonedReason && !u.metricsAcrossMethods.cordonedReason);
   });
   define('removeByLatency', function (opts) {
     return this.filter(u => {

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -381,6 +381,12 @@ var (
 		Help:      "Number of times block head rolled back by a large number vs previous latest block returned by the same upstream.",
 	}, []string{"project", "vendor", "network", "upstream"})
 
+	MetricUpstreamBlockHeadLargeForwardJump = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "upstream_block_head_large_forward_jump",
+		Help:      "Size of an implausible forward jump in block head reported by an upstream that was rejected as bad data (e.g. a node serving another chain's head). The upstream is cordoned when this fires.",
+	}, []string{"project", "vendor", "network", "upstream"})
+
 	MetricUpstreamWrongEmptyResponseTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_wrong_empty_response_total",


### PR DESCRIPTION
## Summary

An upstream that abruptly reports a far-future latest block (e.g. a node serving another chain's data) used to poison everything fed from the per-upstream head counter: the network chain head and per-upstream lag metrics, integrity bounds, and peer instances via shared state — making every healthy upstream look far behind.

This PR rejects such values at ingestion, reusing the **same physics bound the served-tip velocity gate already applies at pick time**: a head may only advance as far as the chain's observed block time allows for the time elapsed since that upstream's head last moved. No new threshold concept, no new config — the guard arms itself once the chain's block-time EMA is known, and a floor (10k blocks) keeps burst block production from ever being misjudged.

On detection the upstream is cordoned for a self-recovering 30s sit-out, and the rejected jump is exposed via the `erpc_upstream_block_head_large_forward_jump` gauge.

## What changed

| File | What |
|---|---|
| `architecture/evm/served_tip.go` | `VelocityForwardBound` extracted; the served-tip gate now uses the shared helper |
| `data/shared_state_variable.go` | optional `SetForwardBound` / `OnLargeForwardJump` on the counter; rejection on both local and remote paths (a rejected remote value also loses reconciliation, so the sane value overwrites the poisoned one cluster-wide) |
| `architecture/evm/evm_state_poller.go` | installs the bound on the latest-block counter; cordon + deduped sit-out timer on detection |
| `internal/policy/stdlib/stdlib.js` | `removeCordoned()` honors wildcard (`*`) cordons under per-method eval scopes |
| `health/tracker.go`, `telemetry/metrics.go` | new gauge |

The bound measures elapsed time since the value last **changed** (not since the last refresh attempt), so legitimate catch-up after a stall scales with the true stall duration and is accepted.

## Tests

- `data`: bound accept/reject, cold start, inactive bound, boundary, recovery, stall catch-up (elapsed-since-change semantics), remote rejection + reconciliation timestamp, concurrency
- `architecture/evm`: `VelocityForwardBound` contract; cordon/sit-out mechanics (dedupe, auto-recovery, concurrency); end-to-end through the real counter wiring (reject + cordon, burst-below-floor accepted, guard inactive until block time known)
- `internal/policy`: wildcard cordon honored by `removeCordoned` at network and network-method scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
