### PR TITLE
fix: escape parsing issues in selection policy docs

### DIFF
--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -1015,7 +1015,7 @@ latencyDeviationAbove(10, { dampingMs: 50 })
 latencyDeviationAbove(10, { quantile: 95, mode: 'majority', dampingMs: 100 })
 ```
 
-**Why per-method**: an upstream's aggregate p<q> is a sample-count-
+**Why per-method**: an upstream's aggregate `p<q>` is a sample-count-
 weighted percentile of whatever methods landed in its bucket. A primary
 that serves 95% fast `eth_call` and a runner-up that only sees
 hedge-fired `eth_getLogs` look 20-40× apart at the aggregate level
@@ -1065,11 +1065,11 @@ excluding a broken one:
 **Per-method samples gate** (`minMethodSamples`, default 50): methods
 with fewer than this many samples on an upstream are skipped from
 BOTH the peer-baseline pool AND the per-upstream ratio loop. Below
-~50 samples the p<q> CI is too wide to be a reliable comparison
+~50 samples the `p<q>` CI is too wide to be a reliable comparison
 signal; multiple unstable methods otherwise conspire on the geomean.
 
 **Peer baseline**: for each method, the "fastest peer" is the minimum
-p<q> among OTHER upstreams (self excluded). When this upstream IS the
+`p<q>` among OTHER upstreams (self excluded). When this upstream IS the
 fastest, its peer is the runner-up — so a 2-pool with one fast (10ms)
 and one slow (12s) upstream still trips the slow one against the fast
 one's 10ms (subject to damping).


### PR DESCRIPTION
## Problem

The Railway docs deploy (`docs.erpc.cloud`) fails at `next build`:

```
[nextra] Error compiling /app/pages/config/projects/selection-policies.mdx.
Expected a closing tag for `<q>` (1015:46-1015:49) before the end of `paragraph`
> Build failed because of webpack errors
```

`selection-policies.mdx` uses `p<q>` (p-quantile shorthand) in three prose spans. MDX treats `<q>` as an opening JSX/HTML `<q>` (quotation) tag and demands a closing `</q>`, which aborts the build.

## Fix

Wrap each `p<q>` in backticks so it renders as literal inline code and is no longer parsed as JSX. Three occurrences, prose only — no semantic change.

## Verification

Reproduced the Railway build locally in an **isolated copy of `docs/`** (matching the Dockerfile: bare `pnpm install`, then `pnpm build`). Before the fix it failed on the `<q>` error; after, all 41 pages compile, including `/config/projects/selection-policies`.

## Test plan

- [ ] `cd docs && pnpm install && pnpm build` succeeds
- [ ] Railway docs deploy goes green
- [ ] `selection-policies` page renders `p<q>` as inline code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting only; no runtime or API changes.
> 
> **Overview**
> **Docs-only fix** in `selection-policies.mdx`: three prose mentions of the p-quantile shorthand `p<q>` are wrapped in **inline code** (backticks) so MDX no longer treats `<q>` as an HTML/JSX tag and `next build` can compile the page.
> 
> No selection-policy behavior or config semantics change—only how that notation is written in the doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8e60ae38fa4d2611df859c968a6862628d7712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->