### PR TITLE
feat: restore x402 nanopayment auth strategy

### DIFF
--- a/auth/authorizer.go
+++ b/auth/authorizer.go
@@ -63,6 +63,14 @@ func NewAuthorizer(appCtx context.Context, logger *zerolog.Logger, projectId str
 		if err != nil {
 			return nil, err
 		}
+	case common.AuthTypeX402:
+		if cfg.X402 == nil {
+			return nil, common.NewErrInvalidConfig("x402 strategy config is nil")
+		}
+		strategy, err = NewX402Strategy(logger, cfg.X402)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, common.NewErrInvalidConfig(fmt.Sprintf("unknown auth strategy type: %s", cfg.Type))
 	}

--- a/auth/http.go
+++ b/auth/http.go
@@ -77,9 +77,20 @@ func NewPayloadFromHttp(method string, remoteAddr string, headers http.Header, a
 				Message:   normalizeSiweMessage(msg),
 			}
 		}
+	} else if payment := headers.Get("X-PAYMENT"); payment != "" {
+		ap.Type = common.AuthTypeX402
+		ap.X402 = &X402Payload{
+			Payment: payment,
+		}
+	} else if payment := headers.Get("Payment-Signature"); payment != "" {
+		ap.Type = common.AuthTypeX402
+		ap.X402 = &X402Payload{
+			Payment: payment,
+		}
 	}
 
 	// Default to network strategy when no other auth signals are present.
+	// The x402 strategy also supports this type to return 402 for unpaid requests.
 	if ap.Type == "" {
 		ap.Type = common.AuthTypeNetwork
 	}

--- a/auth/payload.go
+++ b/auth/payload.go
@@ -8,6 +8,7 @@ type AuthPayload struct {
 	Secret *SecretPayload
 	Jwt    *JwtPayload
 	Siwe   *SiwePayload
+	X402   *X402Payload
 }
 
 // This payload is used by both "secret" and "database" strategies
@@ -22,4 +23,18 @@ type JwtPayload struct {
 type SiwePayload struct {
 	Signature string
 	Message   string
+}
+
+// X402Payload carries the base64-encoded X-PAYMENT header value for x402 authentication.
+type X402Payload struct {
+	Payment    string
+	RequestURL string // Full request URL, used for the 402 response resource field
+}
+
+// x402RequestURL safely returns the RequestURL from the X402 payload, or empty string if nil.
+func (ap *AuthPayload) x402RequestURL() string {
+	if ap.X402 != nil {
+		return ap.X402.RequestURL
+	}
+	return ""
 }

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -91,8 +91,52 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		return nil, common.NewErrAuthUnauthorized("n/a", "no auth strategy matched make sure correct headers or query strings are provided")
 	}
 
+	// If multiple strategies returned ErrPaymentRequired (e.g. several x402
+	// strategies advertising different chains/assets), merge their Accepts
+	// arrays into a single 402 response so the challenge advertises every
+	// accepted option. Otherwise SDK clients only ever see the first chain
+	// in the response and signed payments for other chains never get tried.
+	var payErrs []*common.ErrPaymentRequired
+	for _, e := range errs {
+		var payErr *common.ErrPaymentRequired
+		if errors.As(e, &payErr) {
+			payErrs = append(payErrs, payErr)
+		}
+	}
+	if len(payErrs) > 0 {
+		return nil, mergePaymentRequired(payErrs)
+	}
+
 	// If no strategy matched or succeeded, consider the request unauthorized
 	return nil, common.NewErrAuthUnauthorized("n/a", errors.Join(errs...).Error())
+}
+
+// mergePaymentRequired combines multiple ErrPaymentRequired errors into a
+// single error whose Accepts list is the concatenation of all inputs. The
+// X402Version, Error, and Resource fields are taken from the first error
+// since they don't vary across x402 strategies for a given request.
+//
+// If any payErr wraps a payload that isn't an X402PaymentRequirementsResponse
+// (some future scheme), we fall back to the first error verbatim rather than
+// dropping foreign entries silently.
+func mergePaymentRequired(errs []*common.ErrPaymentRequired) error {
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	base, ok := errs[0].PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		return errs[0]
+	}
+	merged := append([]X402PaymentRequirement{}, base.Accepts...)
+	for _, e := range errs[1:] {
+		next, ok := e.PaymentRequirements.(X402PaymentRequirementsResponse)
+		if !ok {
+			return errs[0]
+		}
+		merged = append(merged, next.Accepts...)
+	}
+	base.Accepts = merged
+	return common.NewErrPaymentRequired(base)
 }
 
 // FindDatabaseConnector finds a database connector by ID from the strategies

--- a/auth/registry_payment_required_merge_test.go
+++ b/auth/registry_payment_required_merge_test.go
@@ -1,0 +1,209 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/upstream"
+	"github.com/rs/zerolog"
+)
+
+func newPaymentRequired(network, asset string) *common.ErrPaymentRequired {
+	resp := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "Payment required for this resource",
+		Accepts: []X402PaymentRequirement{
+			{Scheme: "exact", Network: network, Asset: asset, Amount: "5", PayTo: "0xSeller"},
+		},
+	}
+	err := common.NewErrPaymentRequired(resp)
+	var pe *common.ErrPaymentRequired
+	if !errors.As(err, &pe) {
+		panic("expected *common.ErrPaymentRequired")
+	}
+	return pe
+}
+
+func TestMergePaymentRequired_SingleErrorPassesThrough(t *testing.T) {
+	in := newPaymentRequired("eip155:8453", "0xUSDC-base")
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{in})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 1 {
+		t.Fatalf("Accepts: want 1, got %d", len(resp.Accepts))
+	}
+	if resp.Accepts[0].Network != "eip155:8453" {
+		t.Errorf("Network: want eip155:8453, got %q", resp.Accepts[0].Network)
+	}
+}
+
+func TestMergePaymentRequired_MultipleErrorsConcatAccepts(t *testing.T) {
+	errs := []*common.ErrPaymentRequired{
+		newPaymentRequired("eip155:8453", "0xUSDC-base"),
+		newPaymentRequired("eip155:1", "0xUSDC-eth"),
+		newPaymentRequired("eip155:42161", "0xUSDC-arb"),
+	}
+	got := mergePaymentRequired(errs)
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 3 {
+		t.Fatalf("Accepts: want 3, got %d", len(resp.Accepts))
+	}
+	wantNetworks := []string{"eip155:8453", "eip155:1", "eip155:42161"}
+	for i, want := range wantNetworks {
+		if resp.Accepts[i].Network != want {
+			t.Errorf("Accepts[%d].Network: want %q, got %q", i, want, resp.Accepts[i].Network)
+		}
+	}
+}
+
+func TestMergePaymentRequired_PreservesFirstResponseHeaderFields(t *testing.T) {
+	first := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "Payment required for this resource",
+		Accepts:     []X402PaymentRequirement{{Scheme: "exact", Network: "eip155:8453"}},
+		Resource:    map[string]string{"url": "https://edge.test/standard/evm/1"},
+	}
+	second := X402PaymentRequirementsResponse{
+		X402Version: 2,
+		Error:       "different error string that should be ignored",
+		Accepts:     []X402PaymentRequirement{{Scheme: "exact", Network: "eip155:1"}},
+		Resource:    map[string]string{"url": "https://different.example/"},
+	}
+	wrap := func(r X402PaymentRequirementsResponse) *common.ErrPaymentRequired {
+		err := common.NewErrPaymentRequired(r)
+		var pe *common.ErrPaymentRequired
+		errors.As(err, &pe)
+		return pe
+	}
+
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{wrap(first), wrap(second)})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	resp := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if resp.Error != first.Error {
+		t.Errorf("Error: want %q (from first), got %q", first.Error, resp.Error)
+	}
+	if got, want := resp.Resource.(map[string]string)["url"], "https://edge.test/standard/evm/1"; got != want {
+		t.Errorf("Resource.url: want %q (from first), got %q", want, got)
+	}
+}
+
+// Authenticate-level integration test: configure an AuthRegistry with two real
+// x402 strategies (different chains) and verify an unauthenticated request
+// gets back ONE merged ErrPaymentRequired containing both networks in Accepts.
+func TestAuthRegistry_Authenticate_MergesMultiX402_402(t *testing.T) {
+	logger := zerolog.Nop()
+	rlReg, err := upstream.NewRateLimitersRegistry(context.Background(), nil, &logger)
+	if err != nil {
+		t.Fatalf("NewRateLimitersRegistry: %v", err)
+	}
+
+	// Stub facilitator returns /supported with both chains advertised so each
+	// strategy initializes successfully (it consults /supported at construction).
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/supported" {
+			_ = json.NewEncoder(w).Encode(X402SupportedResponse{
+				Kinds: []X402SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:8453"},
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer facilitator.Close()
+
+	mkStrategy := func(network, asset string) common.AuthStrategyConfig {
+		return common.AuthStrategyConfig{
+			Type: common.AuthTypeX402,
+			X402: &common.X402StrategyConfig{
+				FacilitatorURL:    facilitator.URL,
+				SellerAddress:     "0xSeller",
+				PricePerRequest:   "5",
+				Network:           network,
+				Asset:             asset,
+				Scheme:            "exact",
+				MaxTimeoutSeconds: 604800,
+			},
+		}
+	}
+	cfg := &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{
+			pointer(mkStrategy("eip155:8453", "0xUSDC-base")),
+			pointer(mkStrategy("eip155:1", "0xUSDC-eth")),
+		},
+	}
+	registry, err := NewAuthRegistry(context.Background(), &logger, "test-project", cfg, rlReg)
+	if err != nil {
+		t.Fatalf("NewAuthRegistry: %v", err)
+	}
+
+	ap := &AuthPayload{Type: common.AuthTypeNetwork, Method: "eth_chainId"}
+	_, err = registry.Authenticate(context.Background(), nil, "eth_chainId", ap)
+	if err == nil {
+		t.Fatal("expected ErrPaymentRequired, got nil")
+	}
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T: %v", err, err)
+	}
+	resp, ok := pe.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected merged X402PaymentRequirementsResponse, got %T", pe.PaymentRequirements)
+	}
+	if len(resp.Accepts) != 2 {
+		t.Fatalf("Accepts: want 2 networks (merged), got %d: %+v", len(resp.Accepts), resp.Accepts)
+	}
+	if resp.Accepts[0].Network != "eip155:8453" || resp.Accepts[1].Network != "eip155:1" {
+		t.Errorf("Accepts order: want [eip155:8453, eip155:1], got [%s, %s]",
+			resp.Accepts[0].Network, resp.Accepts[1].Network)
+	}
+}
+
+func pointer[T any](v T) *T { return &v }
+
+func TestMergePaymentRequired_NonX402PayloadFallsBackToFirst(t *testing.T) {
+	// First entry is well-formed x402; second carries a foreign payload.
+	first := newPaymentRequired("eip155:8453", "0xUSDC-base")
+	foreignErr := common.NewErrPaymentRequired(map[string]string{"scheme": "future-non-x402"})
+	var foreign *common.ErrPaymentRequired
+	if !errors.As(foreignErr, &foreign) {
+		t.Fatalf("expected *common.ErrPaymentRequired")
+	}
+
+	got := mergePaymentRequired([]*common.ErrPaymentRequired{first, foreign})
+
+	var pe *common.ErrPaymentRequired
+	if !errors.As(got, &pe) {
+		t.Fatalf("expected *common.ErrPaymentRequired, got %T", got)
+	}
+	// Should be the first error verbatim, not a merged response.
+	if pe != first {
+		t.Errorf("expected first error verbatim on type-assertion failure")
+	}
+}

--- a/auth/strategy_x402.go
+++ b/auth/strategy_x402.go
@@ -1,0 +1,310 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
+	"github.com/rs/zerolog"
+)
+
+type X402Strategy struct {
+	logger       *zerolog.Logger
+	cfg          *common.X402StrategyConfig
+	facilitator  *X402FacilitatorClient
+	requirements []X402PaymentRequirement
+	x402Version  int
+}
+
+var _ AuthStrategy = &X402Strategy{}
+
+func NewX402Strategy(logger *zerolog.Logger, cfg *common.X402StrategyConfig) (*X402Strategy, error) {
+	if cfg.FacilitatorURL == "" {
+		return nil, fmt.Errorf("x402 strategy requires facilitatorUrl")
+	}
+	if cfg.SellerAddress == "" {
+		return nil, fmt.Errorf("x402 strategy requires sellerAddress")
+	}
+	if cfg.PricePerRequest == "" {
+		return nil, fmt.Errorf("x402 strategy requires pricePerRequest")
+	}
+	if cfg.Network == "" {
+		return nil, fmt.Errorf("x402 strategy requires network")
+	}
+
+	scheme := cfg.Scheme
+	if scheme == "" {
+		scheme = "exact"
+	}
+
+	maxTimeout := cfg.MaxTimeoutSeconds
+	if maxTimeout == 0 {
+		maxTimeout = 300
+	}
+
+	requirement := X402PaymentRequirement{
+		Scheme:            scheme,
+		Network:           cfg.Network,
+		MaxAmountRequired: cfg.PricePerRequest,
+		Amount:            cfg.PricePerRequest,
+		Asset:             cfg.Asset,
+		PayTo:             cfg.SellerAddress,
+		Description:       cfg.Description,
+		MaxTimeoutSeconds: maxTimeout,
+	}
+
+	// Merge config-level extra fields (e.g. EIP-712 domain params) into the requirement.
+	// These serve as defaults; facilitator-provided values will override them below.
+	if len(cfg.Extra) > 0 {
+		if requirement.Extra == nil {
+			requirement.Extra = make(map[string]interface{})
+		}
+		for k, v := range cfg.Extra {
+			requirement.Extra[k] = v
+		}
+	}
+
+	facilitator := NewX402FacilitatorClient(strings.TrimRight(cfg.FacilitatorURL, "/"))
+
+	x402Version := 1
+
+	// Fetch supported payment kinds from the facilitator to get extra fields
+	// (e.g. Circle Gateway's verifyingContract, name, version).
+	supported, err := facilitator.Supported(context.Background())
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to fetch x402 supported kinds from facilitator, using defaults")
+	} else {
+		for _, kind := range supported.Kinds {
+			if kind.Scheme == requirement.Scheme && kind.Network == requirement.Network {
+				if kind.X402Version > x402Version {
+					x402Version = kind.X402Version
+				}
+				if kind.Extra != nil {
+					if requirement.Extra == nil {
+						requirement.Extra = make(map[string]interface{})
+					}
+					for k, v := range kind.Extra {
+						requirement.Extra[k] = v
+					}
+				}
+				break
+			}
+			// If the facilitator doesn't list our exact scheme but reports a
+			// higher version for our network, adopt that version.
+			if kind.Network == requirement.Network && kind.X402Version > x402Version {
+				x402Version = kind.X402Version
+			}
+		}
+	}
+
+	return &X402Strategy{
+		logger:       logger,
+		cfg:          cfg,
+		facilitator:  facilitator,
+		requirements: []X402PaymentRequirement{requirement},
+		x402Version:  x402Version,
+	}, nil
+}
+
+// Supports returns true for x402 payloads (X-PAYMENT or Payment-Signature header present)
+// and for network-type payloads (no auth headers). The latter allows the strategy to
+// return 402 Payment Required for unauthenticated requests.
+func (s *X402Strategy) Supports(ap *AuthPayload) bool {
+	return ap.Type == common.AuthTypeX402 || ap.Type == common.AuthTypeNetwork
+}
+
+func (s *X402Strategy) Authenticate(ctx context.Context, req *common.NormalizedRequest, ap *AuthPayload) (*common.User, error) {
+	if ap.X402 == nil || ap.X402.Payment == "" {
+		return nil, common.NewErrPaymentRequired(s.paymentRequirementsResponse(ap.x402RequestURL()))
+	}
+
+	payment, err := decodeX402Payment(ap.X402.Payment)
+	if err != nil {
+		s.logger.Debug().Err(err).Msg("failed to decode x402 payment header")
+		return nil, common.NewErrPaymentRequired(s.paymentRequirementsResponse(ap.x402RequestURL()))
+	}
+
+	// Ensure the payment includes the resource object — some clients (e.g. Circle
+	// GatewayClient) omit it, but facilitators require it for settlement.
+	if _, ok := payment["resource"]; !ok {
+		if reqURL := ap.x402RequestURL(); reqURL != "" {
+			desc := s.cfg.Description
+			if desc == "" {
+				desc = "eRPC x402 endpoint"
+			}
+			payment["resource"] = map[string]string{
+				"url":         reqURL,
+				"mimeType":    "application/json",
+				"description": desc,
+			}
+		}
+	}
+
+	matchedRequirement, err := findMatchingRequirement(payment, s.requirements)
+	if err != nil {
+		s.logger.Debug().Err(err).Msg("no matching x402 payment requirement for provided scheme/network")
+		return nil, common.NewErrPaymentRequired(s.paymentRequirementsResponse(ap.x402RequestURL()))
+	}
+
+	// Resolve metric labels from the request context.
+	project, network, facilitator := s.metricLabels(req)
+
+	if s.cfg.VerifyOnly {
+		// VerifyOnly mode: call verify for testing/dry-run without collecting payment.
+		return s.authenticateWithVerify(ctx, payment, matchedRequirement, project, network, facilitator)
+	}
+
+	return s.authenticateWithSettle(ctx, payment, matchedRequirement, project, network, facilitator)
+}
+
+// settlePayment calls the facilitator settle endpoint and emits metrics.
+func (s *X402Strategy) settlePayment(ctx context.Context, payment interface{}, req X402PaymentRequirement, project, network, facilitator string) (*X402SettlementResponse, error) {
+	settleStart := time.Now()
+	settleResp, err := s.facilitator.Settle(ctx, s.x402Version, payment, req)
+	settleDur := time.Since(settleStart).Seconds()
+	if err != nil {
+		telemetry.ObserverHandle(telemetry.MetricX402FacilitatorRequestDuration, project, network, facilitator, "settle", "error").Observe(settleDur)
+		telemetry.CounterHandle(telemetry.MetricX402FacilitatorRequestTotal, project, network, facilitator, "settle", "error").Inc()
+		telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "settle_error").Inc()
+		return nil, fmt.Errorf("settlement request failed: %w", err)
+	}
+	telemetry.ObserverHandle(telemetry.MetricX402FacilitatorRequestDuration, project, network, facilitator, "settle", "ok").Observe(settleDur)
+	telemetry.CounterHandle(telemetry.MetricX402FacilitatorRequestTotal, project, network, facilitator, "settle", "ok").Inc()
+
+	if !settleResp.Success {
+		telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "settle_rejected").Inc()
+		return nil, fmt.Errorf("settlement rejected: %s", settleResp.ErrorReason)
+	}
+	telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "settled").Inc()
+	return settleResp, nil
+}
+
+// authenticateWithSettle settles payment immediately during auth (used for "exact" scheme).
+func (s *X402Strategy) authenticateWithSettle(ctx context.Context, payment interface{}, req *X402PaymentRequirement, project, network, facilitator string) (*common.User, error) {
+	settleResp, err := s.settlePayment(ctx, payment, *req, project, network, facilitator)
+	if err != nil {
+		s.logger.Warn().Err(err).Msg("x402 exact payment settlement failed")
+		return nil, common.NewErrAuthUnauthorized("x402", fmt.Sprintf("payment failed: %v", err))
+	}
+
+	// Prefer the facilitator-verified payer address from the settle response;
+	// fall back to client-supplied payload only if the facilitator didn't return one.
+	payer := settleResp.Payer
+	if payer == "" {
+		payer = extractPayerFromRaw(payment)
+	}
+	if payer == "" {
+		payer = "x402-unknown"
+	}
+
+	user := &common.User{Id: strings.ToLower(payer)}
+	if s.cfg.RateLimitBudget != "" {
+		user.RateLimitBudget = s.cfg.RateLimitBudget
+	}
+
+	s.logger.Debug().Str("payer", user.Id).Msg("x402 exact payment settled")
+	return user, nil
+}
+
+// authenticateWithVerify uses the verify endpoint for VerifyOnly/dry-run mode.
+func (s *X402Strategy) authenticateWithVerify(ctx context.Context, payment interface{}, req *X402PaymentRequirement, project, network, facilitator string) (*common.User, error) {
+	verifyStart := time.Now()
+	verifyResp, err := s.facilitator.Verify(ctx, s.x402Version, payment, *req)
+	verifyDur := time.Since(verifyStart).Seconds()
+	if err != nil {
+		telemetry.ObserverHandle(telemetry.MetricX402FacilitatorRequestDuration, project, network, facilitator, "verify", "error").Observe(verifyDur)
+		telemetry.CounterHandle(telemetry.MetricX402FacilitatorRequestTotal, project, network, facilitator, "verify", "error").Inc()
+		telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "verify_error").Inc()
+		s.logger.Warn().Err(err).Msg("x402 payment verification failed")
+		return nil, common.NewErrAuthUnauthorized("x402", fmt.Sprintf("payment verification failed: %v", err))
+	}
+	telemetry.ObserverHandle(telemetry.MetricX402FacilitatorRequestDuration, project, network, facilitator, "verify", "ok").Observe(verifyDur)
+	telemetry.CounterHandle(telemetry.MetricX402FacilitatorRequestTotal, project, network, facilitator, "verify", "ok").Inc()
+
+	if !verifyResp.IsValid {
+		telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "verify_invalid").Inc()
+		s.logger.Debug().Str("reason", verifyResp.InvalidReason).Msg("x402 payment invalid")
+		return nil, common.NewErrAuthUnauthorized("x402", fmt.Sprintf("payment invalid: %s", verifyResp.InvalidReason))
+	}
+	telemetry.CounterHandle(telemetry.MetricX402PaymentTotal, project, network, facilitator, "verify_valid").Inc()
+
+	payer := verifyResp.Payer
+	if payer == "" {
+		payer = "x402-unknown"
+	}
+	user := &common.User{Id: strings.ToLower(payer)}
+	if s.cfg.RateLimitBudget != "" {
+		user.RateLimitBudget = s.cfg.RateLimitBudget
+	}
+	s.logger.Debug().Str("payer", user.Id).Msg("x402 payment verified (verify-only mode)")
+	return user, nil
+}
+
+// metricLabels resolves project, network, and facilitator labels for metrics.
+func (s *X402Strategy) metricLabels(req *common.NormalizedRequest) (project, network, facilitator string) {
+	project = "n/a"
+	network = s.cfg.Network
+	facilitator = s.facilitatorLabel()
+	if req != nil {
+		if n := req.Network(); n != nil {
+			project = n.ProjectId()
+			network = req.NetworkLabel()
+		}
+	}
+	return
+}
+
+// facilitatorLabel returns a short label for the facilitator URL (e.g. "circle", "x402org").
+func (s *X402Strategy) facilitatorLabel() string {
+	url := s.facilitator.BaseURL
+	if strings.Contains(url, "x402.org") {
+		return "x402org"
+	}
+	if strings.Contains(url, "circle") {
+		return "circle"
+	}
+	// Fallback: extract hostname
+	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "http://"), "/")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return "unknown"
+}
+
+func (s *X402Strategy) paymentRequirementsResponse(requestURL string) X402PaymentRequirementsResponse {
+	requirements := make([]X402PaymentRequirement, len(s.requirements))
+	copy(requirements, s.requirements)
+	// Deep-copy the Extra map so downstream code can't mutate strategy state.
+	for i, r := range requirements {
+		if r.Extra != nil {
+			cp := make(map[string]interface{}, len(r.Extra))
+			for k, v := range r.Extra {
+				cp[k] = v
+			}
+			requirements[i].Extra = cp
+		}
+	}
+
+	resp := X402PaymentRequirementsResponse{
+		X402Version: s.x402Version,
+		Error:       "Payment required for this resource",
+		Accepts:     requirements,
+	}
+
+	if requestURL != "" {
+		desc := s.cfg.Description
+		if desc == "" {
+			desc = "eRPC x402 endpoint"
+		}
+		resp.Resource = map[string]string{
+			"url":         requestURL,
+			"mimeType":    "application/json",
+			"description": desc,
+		}
+	}
+
+	return resp
+}

--- a/auth/strategy_x402_test.go
+++ b/auth/strategy_x402_test.go
@@ -1,0 +1,398 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+)
+
+func newTestFacilitator(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/verify":
+			json.NewEncoder(w).Encode(X402VerifyResponse{
+				IsValid: true,
+				Payer:   "0xTestPayer123",
+			})
+		case "/settle":
+			json.NewEncoder(w).Encode(X402SettlementResponse{
+				Success:     true,
+				Transaction: "0xfaketx",
+				Network:     "base",
+				Payer:       "0xTestPayer123",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func newTestX402Strategy(t *testing.T, facilitatorURL string) *X402Strategy {
+	t.Helper()
+	logger := zerolog.Nop()
+	s, err := NewX402Strategy(&logger, &common.X402StrategyConfig{
+		FacilitatorURL:    facilitatorURL,
+		SellerAddress:     "0xSeller",
+		PricePerRequest:   "5",
+		Network:           "base",
+		Asset:             "0xUSDC",
+		Scheme:            "exact",
+		MaxTimeoutSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("NewX402Strategy: %v", err)
+	}
+	return s
+}
+
+func makePaymentHeader(scheme, network string) string {
+	payment := X402PaymentPayload{
+		X402Version: 1,
+		Scheme:      scheme,
+		Network:     network,
+		Payload: map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"from": "0xTestPayer123",
+				"to":   "0xSeller",
+			},
+			"signature": "0xfakesig",
+		},
+	}
+	data, _ := json.Marshal(payment)
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func TestX402Strategy_Supports(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	tests := []struct {
+		name     string
+		payload  *AuthPayload
+		expected bool
+	}{
+		{"x402 type", &AuthPayload{Type: common.AuthTypeX402}, true},
+		{"network type (fallback)", &AuthPayload{Type: common.AuthTypeNetwork}, true},
+		{"secret type", &AuthPayload{Type: common.AuthTypeSecret}, false},
+		{"jwt type", &AuthPayload{Type: common.AuthTypeJwt}, false},
+		{"siwe type", &AuthPayload{Type: common.AuthTypeSiwe}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.Supports(tt.payload)
+			if got != tt.expected {
+				t.Errorf("Supports() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestX402Strategy_NoPayment_Returns402(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	ap := &AuthPayload{Type: common.AuthTypeNetwork}
+	user, err := s.Authenticate(context.Background(), nil, ap)
+
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var payErr *common.ErrPaymentRequired
+	if !common.HasErrorCode(err, common.ErrCodePaymentRequired) {
+		t.Fatalf("expected ErrPaymentRequired, got %T: %v", err, err)
+	}
+
+	// Verify the error contains payment requirements
+	if ok := json.Unmarshal([]byte("{}"), &payErr); ok != nil {
+		// Just check the error code is correct
+	}
+}
+
+func TestX402Strategy_ValidPayment_Authenticates(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	paymentHeader := makePaymentHeader("exact", "base")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if user.Id != "0xtestpayer123" {
+		t.Errorf("expected user.Id = '0xtestpayer123', got '%s'", user.Id)
+	}
+}
+
+func TestX402Strategy_InvalidBase64_Returns402(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: "not-valid-base64!!!"},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+	if !common.HasErrorCode(err, common.ErrCodePaymentRequired) {
+		t.Fatalf("expected ErrPaymentRequired, got %T: %v", err, err)
+	}
+}
+
+func TestX402Strategy_WrongScheme_Returns402(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	paymentHeader := makePaymentHeader("wrong-scheme", "wrong-network")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+	if !common.HasErrorCode(err, common.ErrCodePaymentRequired) {
+		t.Fatalf("expected ErrPaymentRequired, got %T: %v", err, err)
+	}
+}
+
+func TestX402Strategy_VerifyOnly_SkipsSettle(t *testing.T) {
+	settledCalled := false
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/verify":
+			json.NewEncoder(w).Encode(X402VerifyResponse{
+				IsValid: true,
+				Payer:   "0xTestPayer123",
+			})
+		case "/settle":
+			settledCalled = true
+			json.NewEncoder(w).Encode(X402SettlementResponse{
+				Success: true,
+				Payer:   "0xTestPayer123",
+			})
+		}
+	}))
+	defer facilitator.Close()
+
+	logger := zerolog.Nop()
+	s, err := NewX402Strategy(&logger, &common.X402StrategyConfig{
+		FacilitatorURL:  facilitator.URL,
+		SellerAddress:   "0xSeller",
+		PricePerRequest: "5",
+		Network:         "base",
+		VerifyOnly:      true,
+	})
+	if err != nil {
+		t.Fatalf("NewX402Strategy: %v", err)
+	}
+
+	paymentHeader := makePaymentHeader("exact", "base")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if settledCalled {
+		t.Error("settle was called but verifyOnly is true")
+	}
+}
+
+func TestX402Strategy_FailedVerification_Returns401(t *testing.T) {
+	// This test exercises the VerifyOnly (dry-run) path where verify returns
+	// IsValid: false. Without VerifyOnly, the strategy skips verify and goes
+	// straight to settle — so this must explicitly enable VerifyOnly.
+	verifyCalled := false
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/verify" {
+			verifyCalled = true
+			json.NewEncoder(w).Encode(X402VerifyResponse{
+				IsValid:       false,
+				InvalidReason: "insufficient funds",
+			})
+			return
+		}
+		if r.URL.Path == "/supported" {
+			json.NewEncoder(w).Encode(X402SupportedResponse{})
+			return
+		}
+		t.Errorf("unexpected request to %s (verify-only should not call settle)", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer facilitator.Close()
+
+	logger := zerolog.Nop()
+	s, err := NewX402Strategy(&logger, &common.X402StrategyConfig{
+		FacilitatorURL:    facilitator.URL,
+		SellerAddress:     "0xSeller",
+		PricePerRequest:   "5",
+		Network:           "base",
+		Asset:             "0xUSDC",
+		Scheme:            "exact",
+		MaxTimeoutSeconds: 300,
+		VerifyOnly:        true,
+	})
+	if err != nil {
+		t.Fatalf("NewX402Strategy: %v", err)
+	}
+
+	paymentHeader := makePaymentHeader("exact", "base")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, authErr := s.Authenticate(context.Background(), nil, ap)
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+	if !verifyCalled {
+		t.Fatal("expected /verify to be called")
+	}
+	if !common.HasErrorCode(authErr, common.ErrCodeAuthUnauthorized) {
+		t.Fatalf("expected ErrAuthUnauthorized, got %T: %v", authErr, authErr)
+	}
+}
+
+func TestX402Strategy_FailedSettlement_Returns401(t *testing.T) {
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/verify":
+			json.NewEncoder(w).Encode(X402VerifyResponse{
+				IsValid: true,
+				Payer:   "0xTestPayer123",
+			})
+		case "/settle":
+			json.NewEncoder(w).Encode(X402SettlementResponse{
+				Success:     false,
+				ErrorReason: "nonce already used",
+			})
+		}
+	}))
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	paymentHeader := makePaymentHeader("exact", "base")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+	if !common.HasErrorCode(err, common.ErrCodeAuthUnauthorized) {
+		t.Fatalf("expected ErrAuthUnauthorized, got %T: %v", err, err)
+	}
+}
+
+func TestX402Strategy_RateLimitBudget(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+
+	logger := zerolog.Nop()
+	s, err := NewX402Strategy(&logger, &common.X402StrategyConfig{
+		FacilitatorURL:  facilitator.URL,
+		SellerAddress:   "0xSeller",
+		PricePerRequest: "5",
+		Network:         "base",
+		RateLimitBudget: "x402-budget",
+	})
+	if err != nil {
+		t.Fatalf("NewX402Strategy: %v", err)
+	}
+
+	paymentHeader := makePaymentHeader("exact", "base")
+	ap := &AuthPayload{
+		Type: common.AuthTypeX402,
+		X402: &X402Payload{Payment: paymentHeader},
+	}
+
+	user, err := s.Authenticate(context.Background(), nil, ap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.RateLimitBudget != "x402-budget" {
+		t.Errorf("expected RateLimitBudget = 'x402-budget', got '%s'", user.RateLimitBudget)
+	}
+}
+
+func TestX402Strategy_PaymentRequirementsResponse_Format(t *testing.T) {
+	facilitator := newTestFacilitator(t)
+	defer facilitator.Close()
+	s := newTestX402Strategy(t, facilitator.URL)
+
+	ap := &AuthPayload{Type: common.AuthTypeNetwork}
+	_, err := s.Authenticate(context.Background(), nil, ap)
+
+	var payErr *common.ErrPaymentRequired
+	if !errors.As(err, &payErr) {
+		t.Fatalf("expected *ErrPaymentRequired, got %T", err)
+	}
+
+	resp, ok := payErr.PaymentRequirements.(X402PaymentRequirementsResponse)
+	if !ok {
+		t.Fatalf("expected X402PaymentRequirementsResponse, got %T", payErr.PaymentRequirements)
+	}
+
+	if resp.X402Version != 1 {
+		t.Errorf("expected X402Version=1, got %d", resp.X402Version)
+	}
+	if len(resp.Accepts) != 1 {
+		t.Fatalf("expected 1 accept, got %d", len(resp.Accepts))
+	}
+	accept := resp.Accepts[0]
+	if accept.Scheme != "exact" {
+		t.Errorf("expected scheme=exact, got %s", accept.Scheme)
+	}
+	if accept.Network != "base" {
+		t.Errorf("expected network=base, got %s", accept.Network)
+	}
+	if accept.PayTo != "0xSeller" {
+		t.Errorf("expected payTo=0xSeller, got %s", accept.PayTo)
+	}
+	if accept.MaxAmountRequired != "5" {
+		t.Errorf("expected maxAmountRequired=5, got %s", accept.MaxAmountRequired)
+	}
+}

--- a/auth/x402_types.go
+++ b/auth/x402_types.go
@@ -1,0 +1,293 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// x402 protocol types and facilitator client, inlined to avoid heavy transitive
+// dependencies from external x402 libraries (solana-go, mongodb, etc.).
+
+// X402PaymentRequirement represents a single payment option in a 402 response.
+type X402PaymentRequirement struct {
+	Scheme            string                 `json:"scheme"`
+	Network           string                 `json:"network"`
+	MaxAmountRequired string                 `json:"maxAmountRequired,omitempty"`
+	Amount            string                 `json:"amount,omitempty"`
+	Asset             string                 `json:"asset"`
+	PayTo             string                 `json:"payTo"`
+	Resource          string                 `json:"resource,omitempty"`
+	Description       string                 `json:"description,omitempty"`
+	MimeType          string                 `json:"mimeType,omitempty"`
+	MaxTimeoutSeconds int                    `json:"maxTimeoutSeconds"`
+	Extra             map[string]interface{} `json:"extra,omitempty"`
+}
+
+// X402PaymentRequirementsResponse is the HTTP 402 response per the x402 spec.
+// Sent both as the response body and base64-encoded in the PAYMENT-REQUIRED header.
+type X402PaymentRequirementsResponse struct {
+	X402Version int                      `json:"x402Version"`
+	Error       string                   `json:"error"`
+	Accepts     []X402PaymentRequirement `json:"accepts"`
+	Resource    interface{}              `json:"resource,omitempty"`
+}
+
+// X402PaymentPayload is a signed payment sent by the client.
+// V1 uses X-PAYMENT header, v2 uses Payment-Signature header.
+type X402PaymentPayload struct {
+	X402Version int         `json:"x402Version,omitempty"`
+	Scheme      string      `json:"scheme,omitempty"`
+	Network     string      `json:"network,omitempty"`
+	Payload     interface{} `json:"payload,omitempty"`
+	// V2 fields (Circle Gateway)
+	Resource interface{} `json:"resource,omitempty"`
+	Accepted interface{} `json:"accepted,omitempty"`
+}
+
+// X402SettlementResponse is the facilitator's response after settling a payment.
+type X402SettlementResponse struct {
+	Success     bool   `json:"success"`
+	ErrorReason string `json:"errorReason,omitempty"`
+	Transaction string `json:"transaction,omitempty"`
+	Network     string `json:"network"`
+	Payer       string `json:"payer"`
+}
+
+// X402VerifyResponse is the facilitator's response after verifying a payment.
+type X402VerifyResponse struct {
+	IsValid       bool   `json:"isValid"`
+	InvalidReason string `json:"invalidReason,omitempty"`
+	Payer         string `json:"payer"`
+}
+
+// X402SupportedKind describes a payment type supported by the facilitator.
+type X402SupportedKind struct {
+	X402Version int                    `json:"x402Version"`
+	Scheme      string                 `json:"scheme"`
+	Network     string                 `json:"network"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
+}
+
+// X402SupportedResponse is the facilitator's response listing supported payment types.
+type X402SupportedResponse struct {
+	Kinds []X402SupportedKind `json:"kinds"`
+}
+
+// x402FacilitatorRequest is the JSON body sent to the facilitator for verify/settle.
+type x402FacilitatorRequest struct {
+	X402Version         int                    `json:"x402Version"`
+	PaymentPayload      interface{}            `json:"paymentPayload"`
+	PaymentRequirements X402PaymentRequirement `json:"paymentRequirements"`
+}
+
+// X402FacilitatorClient communicates with an x402 facilitator for payment verification and settlement.
+type X402FacilitatorClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewX402FacilitatorClient creates a facilitator client.
+func NewX402FacilitatorClient(baseURL string) *X402FacilitatorClient {
+	return &X402FacilitatorClient{
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Supported fetches the payment types supported by the facilitator.
+func (c *X402FacilitatorClient) Supported(ctx context.Context) (*X402SupportedResponse, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.BaseURL+"/supported", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create supported request: %w", err)
+	}
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("facilitator supported request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("facilitator supported returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var supported X402SupportedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&supported); err != nil {
+		return nil, fmt.Errorf("failed to decode supported response: %w", err)
+	}
+
+	return &supported, nil
+}
+
+func (c *X402FacilitatorClient) Verify(ctx context.Context, x402Version int, payment interface{}, requirement X402PaymentRequirement) (*X402VerifyResponse, error) {
+	req := x402FacilitatorRequest{
+		X402Version:         x402Version,
+		PaymentPayload:      payment,
+		PaymentRequirements: requirement,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal verify request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/verify", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create verify request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("facilitator verify request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	// CDP returns 400 with a valid verify response body for invalid payloads.
+	// Parse the body for both 200 and 400 status codes.
+	var verifyResp X402VerifyResponse
+	if err := json.Unmarshal(body, &verifyResp); err != nil {
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("facilitator verify returned status %d: %s", resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("failed to decode verify response: %w", err)
+	}
+
+	// If we got a parseable response with status >= 400, surface it as an invalid payment
+	// rather than an HTTP error.
+	if resp.StatusCode >= 400 && !verifyResp.IsValid {
+		return &verifyResp, nil
+	} else if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("facilitator verify returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if verifyResp.Payer == "" {
+		verifyResp.Payer = extractPayerFromRaw(payment)
+	}
+
+	return &verifyResp, nil
+}
+
+func (c *X402FacilitatorClient) Settle(ctx context.Context, x402Version int, payment interface{}, requirement X402PaymentRequirement) (*X402SettlementResponse, error) {
+	req := x402FacilitatorRequest{
+		X402Version:         x402Version,
+		PaymentPayload:      payment,
+		PaymentRequirements: requirement,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal settle request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/settle", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create settle request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("facilitator settle request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("facilitator settle returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read settle response body: %w", err)
+	}
+
+	var settleResp X402SettlementResponse
+	if err := json.Unmarshal(body, &settleResp); err != nil {
+		return nil, fmt.Errorf("failed to decode settle response: %w (body: %s)", err, string(body))
+	}
+
+	if !settleResp.Success {
+		settleResp.ErrorReason = fmt.Sprintf("%s (raw: %s)", settleResp.ErrorReason, string(body))
+	}
+
+	return &settleResp, nil
+}
+
+// decodeX402Payment decodes a base64-encoded payment header (X-PAYMENT or Payment-Signature).
+func decodeX402Payment(encoded string) (map[string]interface{}, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		// Try URL-safe base64
+		decoded, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode base64: %w", err)
+		}
+	}
+
+	var payment map[string]interface{}
+	if err := json.Unmarshal(decoded, &payment); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal payment: %w", err)
+	}
+
+	return payment, nil
+}
+
+// findMatchingRequirement finds a payment requirement matching the payment's scheme and network.
+// Supports both v1 (top-level scheme/network) and v2 (inside "accepted" object).
+func findMatchingRequirement(payment map[string]interface{}, requirements []X402PaymentRequirement) (*X402PaymentRequirement, error) {
+	scheme, _ := payment["scheme"].(string)
+	network, _ := payment["network"].(string)
+
+	// V2: scheme/network may be inside the "accepted" object
+	if accepted, ok := payment["accepted"].(map[string]interface{}); ok {
+		if s, ok := accepted["scheme"].(string); ok && s != "" {
+			scheme = s
+		}
+		if n, ok := accepted["network"].(string); ok && n != "" {
+			network = n
+		}
+	}
+
+	for i := range requirements {
+		if requirements[i].Scheme == scheme && requirements[i].Network == network {
+			return &requirements[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no matching payment requirement for scheme=%q network=%q", scheme, network)
+}
+
+// extractPayerFromRaw attempts to get the payer address from a raw payment payload.
+func extractPayerFromRaw(payment interface{}) string {
+	paymentMap, ok := payment.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	// V2: payload is at top level
+	if payloadMap, ok := paymentMap["payload"].(map[string]interface{}); ok {
+		if authMap, ok := payloadMap["authorization"].(map[string]interface{}); ok {
+			if from, ok := authMap["from"].(string); ok {
+				return from
+			}
+		}
+	}
+
+	// V1: might also have authorization at top level
+	if authMap, ok := paymentMap["authorization"].(map[string]interface{}); ok {
+		if from, ok := authMap["from"].(string); ok {
+			return from
+		}
+	}
+
+	return ""
+}

--- a/common/config.go
+++ b/common/config.go
@@ -2328,6 +2328,7 @@ const (
 	AuthTypeJwt      AuthType = "jwt"
 	AuthTypeSiwe     AuthType = "siwe"
 	AuthTypeNetwork  AuthType = "network"
+	AuthTypeX402     AuthType = "x402"
 )
 
 type AuthConfig struct {
@@ -2345,6 +2346,7 @@ type AuthStrategyConfig struct {
 	Database *DatabaseStrategyConfig `yaml:"database,omitempty" json:"database,omitempty"`
 	Jwt      *JwtStrategyConfig      `yaml:"jwt,omitempty" json:"jwt,omitempty"`
 	Siwe     *SiweStrategyConfig     `yaml:"siwe,omitempty" json:"siwe,omitempty"`
+	X402     *X402StrategyConfig     `yaml:"x402,omitempty" json:"x402,omitempty"`
 }
 
 type SecretStrategyConfig struct {
@@ -2421,6 +2423,51 @@ type NetworkStrategyConfig struct {
 	// RateLimitBudget, if set, is applied to the authenticated user (client IP)
 	RateLimitBudget string `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget,omitempty"`
 	IPAsUser        bool   `yaml:"ipAsUser,omitempty" json:"ipAsUser,omitempty"`
+}
+
+// X402StrategyConfig enables x402 payment authentication (HTTP 402 Payment Required).
+// Clients without an API key can pay per-request via the x402 protocol. The payer's
+// wallet address becomes their eRPC user ID, enabling per-payer rate limiting and metrics.
+type X402StrategyConfig struct {
+	// FacilitatorURL is the x402 facilitator endpoint for verify/settle operations.
+	FacilitatorURL string `yaml:"facilitatorUrl" json:"facilitatorUrl"`
+	// SellerAddress is the wallet address that receives payments (e.g. USDC on Base).
+	SellerAddress string `yaml:"sellerAddress" json:"sellerAddress"`
+	// PricePerRequest is the cost per request in atomic units (e.g. "5" for $0.000005 USDC).
+	PricePerRequest string `yaml:"pricePerRequest" json:"pricePerRequest"`
+	// Network is the x402 network name for payment (e.g. "base", "base-sepolia").
+	Network string `yaml:"network" json:"network"`
+	// Asset is the token contract address used for payment.
+	Asset string `yaml:"asset,omitempty" json:"asset,omitempty"`
+	// Scheme is the x402 payment scheme (defaults to "exact").
+	Scheme string `yaml:"scheme,omitempty" json:"scheme,omitempty"`
+	// Description is a human-readable description included in 402 responses.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// MaxTimeoutSeconds is the payment authorization validity period (default: 300).
+	MaxTimeoutSeconds int `yaml:"maxTimeoutSeconds,omitempty" json:"maxTimeoutSeconds,omitempty"`
+	// RateLimitBudget, if set, is applied to the authenticated payer.
+	RateLimitBudget string `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget,omitempty"`
+	// VerifyOnly when true skips settlement (useful for testing).
+	VerifyOnly bool `yaml:"verifyOnly,omitempty" json:"verifyOnly,omitempty"`
+	// Extra contains additional fields merged into the payment requirement's extra object.
+	// Useful for providing EIP-712 domain params when the facilitator doesn't supply them.
+	Extra map[string]interface{} `yaml:"extra,omitempty" json:"extra,omitempty"`
+}
+
+func (c *X402StrategyConfig) Validate() error {
+	if c.FacilitatorURL == "" {
+		return fmt.Errorf("auth.*.x402.facilitatorUrl is required")
+	}
+	if c.SellerAddress == "" {
+		return fmt.Errorf("auth.*.x402.sellerAddress is required")
+	}
+	if c.PricePerRequest == "" {
+		return fmt.Errorf("auth.*.x402.pricePerRequest is required")
+	}
+	if c.Network == "" {
+		return fmt.Errorf("auth.*.x402.network is required")
+	}
+	return nil
 }
 
 type LabelMode string

--- a/common/errors.go
+++ b/common/errors.go
@@ -542,6 +542,28 @@ func (e *ErrAuthUnauthorized) ErrorStatusCode() int {
 	return http.StatusUnauthorized
 }
 
+type ErrPaymentRequired struct {
+	BaseError
+	// PaymentRequirements holds the raw x402 PaymentRequirementsResponse to return to the client.
+	PaymentRequirements interface{} `json:"-"`
+}
+
+const ErrCodePaymentRequired ErrorCode = "ErrPaymentRequired"
+
+var NewErrPaymentRequired = func(paymentRequirements interface{}) error {
+	return &ErrPaymentRequired{
+		BaseError: BaseError{
+			Code:    ErrCodePaymentRequired,
+			Message: "payment required for this resource",
+		},
+		PaymentRequirements: paymentRequirements,
+	}
+}
+
+func (e *ErrPaymentRequired) ErrorStatusCode() int {
+	return http.StatusPaymentRequired
+}
+
 type ErrAuthRateLimitRuleExceeded struct{ BaseError }
 
 const ErrCodeAuthRateLimitRuleExceeded ErrorCode = "ErrAuthRateLimitRuleExceeded"

--- a/common/validation.go
+++ b/common/validation.go
@@ -712,6 +712,13 @@ func (s *AuthStrategyConfig) Validate() error {
 		if err := s.Database.Validate(); err != nil {
 			return err
 		}
+	case AuthTypeX402:
+		if s.X402 == nil {
+			return fmt.Errorf("auth.*.x402 is required for x402 strategy")
+		}
+		if err := s.X402.Validate(); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("auth.*.type '%s' is invalid must be one of: %v", s.Type, []AuthType{
 			AuthTypeNetwork,
@@ -719,6 +726,7 @@ func (s *AuthStrategyConfig) Validate() error {
 			AuthTypeJwt,
 			AuthTypeSiwe,
 			AuthTypeDatabase,
+			AuthTypeX402,
 		})
 	}
 	return nil

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -563,6 +564,18 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 					return
 				}
 
+				// Set the full request URL for x402 402 response resource field.
+				// Only computed when an x402 payload is present.
+				if ap != nil && ap.Type == common.AuthTypeX402 && ap.X402 != nil {
+					scheme := "https"
+					if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+						scheme = proto
+					} else if r.TLS == nil {
+						scheme = "http"
+					}
+					ap.X402.RequestURL = scheme + "://" + r.Host + r.URL.String()
+				}
+
 				if isAdmin {
 					_, err := s.erpc.AdminAuthenticate(requestCtx, nq, method, ap)
 					if err != nil {
@@ -573,7 +586,19 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 				} else {
 					user, err := project.AuthenticateConsumer(requestCtx, nq, method, ap)
 					if err != nil {
-						responses[index] = processErrorBody(&rlg, &startedAt, nq, err, s.serverCfg.IncludeErrorDetails)
+						var payErr *common.ErrPaymentRequired
+						if errors.As(err, &payErr) {
+							var reqId interface{}
+							if jrr, jrrErr := nq.JsonRpcRequest(); jrrErr == nil && jrr != nil {
+								reqId = jrr.ID
+							}
+							responses[index] = &HttpX402PaymentRequiredResponse{
+								PaymentRequirements: payErr.PaymentRequirements,
+								RequestId:           reqId,
+							}
+						} else {
+							responses[index] = processErrorBody(&rlg, &startedAt, nq, err, s.serverCfg.IncludeErrorDetails)
+						}
 						common.EndRequestSpan(requestCtx, nil, err)
 						return
 					}
@@ -701,6 +726,22 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 		common.InjectHTTPResponseTraceContext(httpCtx, w)
 
 		if isBatch {
+			// JSON-RPC batches always return HTTP 200; x402 payment-required responses
+			// cannot use their native 402 format here, so convert them to JSON-RPC errors.
+			for i, resp := range responses {
+				if x402Resp, ok := resp.(*HttpX402PaymentRequiredResponse); ok {
+					responses[i] = &HttpJsonRpcErrorResponse{
+						Jsonrpc: "2.0",
+						Id:      x402Resp.RequestId,
+						Error: map[string]interface{}{
+							"code":    -32000,
+							"message": "payment required for this resource (x402)",
+							"data":    x402Resp.PaymentRequirements,
+						},
+						Cause: common.NewErrPaymentRequired(nil),
+					}
+				}
+			}
 			w.WriteHeader(http.StatusOK)
 
 			bw := NewBatchResponseWriter(responses)
@@ -721,6 +762,19 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 		} else {
 			res := responses[0]
 			setResponseHeaders(httpCtx, res, w, s.executionHeadersMode())
+			// x402 Payment Required: set headers before WriteHeader, then write raw x402 JSON.
+			if v, ok := res.(*HttpX402PaymentRequiredResponse); ok {
+				reqJSON, _ := common.SonicCfg.Marshal(v.PaymentRequirements)
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("PAYMENT-REQUIRED", base64.StdEncoding.EncodeToString(reqJSON))
+				w.WriteHeader(http.StatusPaymentRequired)
+				if _, werr := w.Write(reqJSON); werr != nil {
+					writeFatalError(httpCtx, http.StatusInternalServerError, werr)
+					return
+				}
+				common.EnrichHTTPServerSpan(httpCtx, http.StatusPaymentRequired, nil)
+				return
+			}
 
 			// Determine HTTP status code - defaults to 200 for JSON-RPC responses,
 			// but transport-level errors (auth, rate limit, etc.) get appropriate status codes
@@ -1327,6 +1381,13 @@ type HttpJsonRpcErrorResponse struct {
 	Request *common.NormalizedRequest `json:"-"`
 }
 
+// HttpX402PaymentRequiredResponse carries the raw x402 PaymentRequirementsResponse
+// to be written directly as HTTP 402 without JSON-RPC wrapping.
+type HttpX402PaymentRequiredResponse struct {
+	PaymentRequirements interface{}
+	RequestId           interface{}
+}
+
 func (r *HttpJsonRpcErrorResponse) MarshalZerologObject(e *zerolog.Event) {
 	if r == nil {
 		return
@@ -1466,6 +1527,19 @@ func handleErrorResponse(
 	includeErrorDetails *bool,
 	mode common.ExecutionHeadersMode,
 ) {
+	// x402 Payment Required: write the raw x402 response directly, not JSON-RPC wrapped
+	var payErr *common.ErrPaymentRequired
+	if errors.As(err, &payErr) {
+		reqJSON, _ := common.SonicCfg.Marshal(payErr.PaymentRequirements)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("PAYMENT-REQUIRED", base64.StdEncoding.EncodeToString(reqJSON))
+		w.WriteHeader(http.StatusPaymentRequired)
+		if _, encErr := w.Write(reqJSON); encErr != nil {
+			logger.Error().Err(encErr).Msg("failed to write x402 payment requirements response")
+			writeFatalError(httpCtx, http.StatusInternalServerError, encErr)
+		}
+		return
+	}
 	resp := processErrorBody(logger, startedAt, nq, err, includeErrorDetails)
 	// Transport defaults to 200 for JSON-RPC, with limited exceptions.
 	// Non-200 codes are reserved for transport/infrastructure level issues,

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -647,6 +647,18 @@ var (
 		Name:      "network_evm_block_range_requested_total",
 		Help:      "Total requests observed by block-number buckets for heatmap.",
 	}, []string{"project", "network", "vendor", "upstream", "category", "user", "finality", "bucket", "size"})
+
+	MetricX402FacilitatorRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "x402_facilitator_request_total",
+		Help:      "Total number of requests to x402 facilitator endpoints.",
+	}, []string{"project", "network", "facilitator", "operation", "status"})
+
+	MetricX402PaymentTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "x402_payment_total",
+		Help:      "Total number of x402 payments processed (verified, settled, rejected).",
+	}, []string{"project", "network", "facilitator", "outcome"})
 )
 
 var DefaultHistogramBuckets = []float64{
@@ -673,6 +685,7 @@ var (
 	MetricNetworkTimeoutDurationSeconds       *LabeledHistogram
 	MetricConsensusResponsesCollected         *LabeledHistogram
 	MetricConsensusAgreementCount             *LabeledHistogram
+	MetricX402FacilitatorRequestDuration      *LabeledHistogram
 	MetricConsensusDuration                   *LabeledHistogram
 	MetricCacheSetSuccessDuration             *LabeledHistogram
 	MetricCacheSetErrorDuration               *LabeledHistogram
@@ -748,6 +761,13 @@ func buildFilterAwareHistograms(bucketsStr string) error {
 		Help:      "Number of upstreams agreeing on the most common result.",
 		Buckets:   prometheus.LinearBuckets(1, 1, 10),
 	}, []string{"project", "network", "category", "finality"})
+
+	MetricX402FacilitatorRequestDuration = NewLabeledHistogram(prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "x402_facilitator_request_duration_seconds",
+		Help:      "Duration of HTTP requests to x402 facilitator endpoints (verify, settle, supported).",
+		Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
+	}, []string{"project", "network", "facilitator", "operation", "status"})
 
 	MetricConsensusDuration = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
@@ -853,6 +873,7 @@ func SetHistogramBuckets(bucketsStr string) error {
 	MetricNetworkTimeoutDurationSeconds = registerOrReuse(MetricNetworkTimeoutDurationSeconds)
 	MetricConsensusResponsesCollected = registerOrReuse(MetricConsensusResponsesCollected)
 	MetricConsensusAgreementCount = registerOrReuse(MetricConsensusAgreementCount)
+	MetricX402FacilitatorRequestDuration = registerOrReuse(MetricX402FacilitatorRequestDuration)
 	MetricConsensusDuration = registerOrReuse(MetricConsensusDuration)
 	MetricCacheSetSuccessDuration = registerOrReuse(MetricCacheSetSuccessDuration)
 	MetricCacheSetErrorDuration = registerOrReuse(MetricCacheSetErrorDuration)


### PR DESCRIPTION
x402 payment authentication (HTTP 402) landed in #831/#854, then was dropped as collateral when #889 (in-house failsafe refactor) was squash-merged from a branch that predated it. This brings the strategy back and re-grafts its integration points onto current main.

Brought back verbatim (identical to pre-removal state):
- auth/strategy_x402.go, auth/x402_types.go and their tests
- auth/registry_payment_required_merge_test.go

Re-grafted onto current main:
- auth: authorizer wiring, X-PAYMENT/Payment-Signature parsing, X402Payload, and Accepts merging across multiple x402 402 responses
- common: AuthTypeX402, X402StrategyConfig + validation, ErrPaymentRequired
- telemetry: x402 facilitator/payment metrics

Scope kept minimal: excludes the deferred upto-scheme/CDP work and the separately-dropped Grafana dashboard. TypeScript config types still need regenerating from the Go config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds authentication and payment settlement via external facilitators; misconfiguration or facilitator trust could block or incorrectly authorize paid access.
> 
> **Overview**
> Restores **x402 (HTTP 402) per-request payment auth** after it was dropped from main, wiring it back into project auth and the HTTP server.
> 
> Clients can pay via `X-PAYMENT` / `Payment-Signature` headers (or get a **402** with payment requirements when no payment is present). The new **`x402` auth strategy** talks to a configured facilitator (`/supported`, `/verify`, `/settle`), maps the payer wallet to a `User` (with optional rate-limit budget), and supports **verify-only** mode. Config adds `AuthTypeX402`, `X402StrategyConfig`, and `ErrPaymentRequired`.
> 
> When several x402 strategies are configured (e.g. different chains), **`mergePaymentRequired`** concatenates all `Accepts` entries into one 402 so clients see every payment option. The server returns **raw x402 JSON** at HTTP 402 with a base64 **`PAYMENT-REQUIRED`** header; JSON-RPC **batches** still use HTTP 200 and embed payment requirements in a JSON-RPC error.
> 
> Adds **Prometheus metrics** for facilitator calls and payment outcomes. Tests cover strategy behavior, merge logic, and registry integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2a7b1a10406a681f8c3c223131cd5a694e3243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->