### PR TITLE
fix(consensus): respect use-upstream directive in participant pool

### DIFF
--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -486,6 +486,14 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			upsList = append(upsList, u)
 		}
 	}
+	// Honor the use-upstream directive at the pool level so every downstream
+	// consumer operates on the targeted upstream(s): the consensus participant
+	// fan-out (and its maxParticipants count), the sequential sweep, and the
+	// stateful-method guard. NextUpstream also enforces this per-slot; filtering
+	// here keeps the request's upstream set consistent with what is dispatched.
+	if dr := req.Directives(); dr != nil && dr.UseUpstream != "" {
+		upsList = filterUpstreamsByUseUpstream(upsList, dr.UseUpstream)
+	}
 	upstreamSpan.SetAttributes(attribute.Int("upstreams.count", len(upsList)))
 	if common.IsTracingDetailed {
 		ids := make([]string, len(upsList))

--- a/erpc/use_upstream.go
+++ b/erpc/use_upstream.go
@@ -1,0 +1,34 @@
+package erpc
+
+import "github.com/erpc/erpc/common"
+
+// filterUpstreamsByUseUpstream restricts a request's candidate upstream pool to
+// those whose id matches the `use-upstream` directive.
+//
+// This is applied once, where the request's upstream set is established, so the
+// directive is honored uniformly by every downstream consumer — the consensus
+// participant fan-out (and its maxParticipants count), the sequential sweep, and
+// the stateful-method guard. NextUpstream still enforces the directive per-slot;
+// filtering the pool up front keeps the request's upstream set consistent with
+// what will actually be dispatched.
+//
+// Semantics:
+//   - Empty pattern or empty pool is a no-op (returns ups unchanged).
+//   - A pattern that matches nothing leaves the pool untouched, preserving the
+//     existing no-upstreams handling/error path rather than emptying the pool.
+//   - Order is preserved.
+func filterUpstreamsByUseUpstream(ups []common.Upstream, pattern string) []common.Upstream {
+	if pattern == "" || len(ups) == 0 {
+		return ups
+	}
+	filtered := make([]common.Upstream, 0, len(ups))
+	for _, u := range ups {
+		if match, err := common.WildcardMatch(pattern, u.Id()); err == nil && match {
+			filtered = append(filtered, u)
+		}
+	}
+	if len(filtered) == 0 {
+		return ups
+	}
+	return filtered
+}

--- a/erpc/use_upstream_test.go
+++ b/erpc/use_upstream_test.go
@@ -1,0 +1,47 @@
+package erpc
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterUpstreamsByUseUpstream(t *testing.T) {
+	ups := func(ids ...string) []common.Upstream {
+		out := make([]common.Upstream, len(ids))
+		for i, id := range ids {
+			out[i] = common.NewFakeUpstream(id)
+		}
+		return out
+	}
+	idsOf := func(us []common.Upstream) []string {
+		out := make([]string, len(us))
+		for i, u := range us {
+			out[i] = u.Id()
+		}
+		return out
+	}
+
+	t.Run("empty pattern is a no-op", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, idsOf(filterUpstreamsByUseUpstream(ups("a", "b"), "")))
+	})
+
+	t.Run("exact id narrows to one upstream", func(t *testing.T) {
+		got := filterUpstreamsByUseUpstream(ups("alpha-quicknode", "alpha-nanoreth", "beta-chainstack"), "alpha-nanoreth")
+		require.Equal(t, []string{"alpha-nanoreth"}, idsOf(got))
+	})
+
+	t.Run("glob pattern keeps matching upstreams in order", func(t *testing.T) {
+		got := filterUpstreamsByUseUpstream(ups("a-nanoreth", "b-evm", "c-nanoreth"), "*nanoreth*")
+		require.Equal(t, []string{"a-nanoreth", "c-nanoreth"}, idsOf(got))
+	})
+
+	t.Run("no match leaves the pool untouched (never empties)", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, idsOf(filterUpstreamsByUseUpstream(ups("a", "b"), "does-not-exist")))
+	})
+
+	t.Run("empty pool is a no-op", func(t *testing.T) {
+		require.Empty(t, filterUpstreamsByUseUpstream(nil, "anything"))
+	})
+}


### PR DESCRIPTION
The consensus executor builds its participant pool from the full network upstream list, so the `use-upstream` directive is only enforced per-slot in `NextUpstream`. With consensus enabled, a request pinned via `use-upstream` can still fan out and require agreement across upstreams it never targeted.

This filters the participant pool by the directive at the top of the executor, before any slot is spawned. A pattern that matches nothing leaves the pool untouched (per-slot enforcement still applies). Unit test included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upstream selection and consensus fan-out for pinned requests; behavior is intentional but affects routing under consensus and stateful-method checks.
> 
> **Overview**
> Requests pinned with **`use-upstream`** (header/query) now narrow the **upstream pool** when `Network.Forward` builds `upsList`, not only when `NextUpstream` picks a slot.
> 
> A new **`filterUpstreamsByUseUpstream`** helper applies wildcard matching on upstream ids, preserves order, and **does not empty** the pool when nothing matches (same as before for “no match” cases). With **consensus** enabled, participant fan-out, `maxParticipants`, sequential sweeps, and the **stateful-method** upstream count all see the same reduced set the client intended.
> 
> Unit tests cover exact id, globs, no-op patterns, and the no-match fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f85b7d61162ffcc4b84e7ff5d3ae62ca3e1d90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->