### PR TITLE
fix(health): lag exclusion silently no-ops at per-method eval scope

### DIFF
--- a/health/tracker.go
+++ b/health/tracker.go
@@ -1205,6 +1205,18 @@ func (t *Tracker) updateNetworkLagMetrics(
 				}
 				lag := networkValue - upsValue
 				setLag(tm, lag)
+				// Block-head/finalization lag is a per-upstream property, but the
+				// (ups,method) dedup index stores a single, arbitrary-finality key
+				// per method. Selection slots at the network and network-method
+				// grains read the {method, All} rollup; if the indexed key was a
+				// specific finality, that rollup is left starved and lag-based
+				// predicates/scoring silently no-op. Mirror onto the All rollup
+				// (which getUpsKeys always populates) so lag is seen at every grain.
+				if k.finality != common.DataFinalityStateAll {
+					if av, ok := t.upsMetrics.Load(upstreamKey{k.ups, k.method, common.DataFinalityStateAll}); ok {
+						setLag(av.(*TrackedMetrics), lag)
+					}
+				}
 				gauge := getGauge(t.projectId, k.ups.VendorName(), k.ups.NetworkLabel(), k.ups.Id())
 				gauge.Set(float64(lag))
 			}
@@ -1244,6 +1256,13 @@ func (t *Tracker) updateSingleUpstreamLag(
 				if v, ok := t.upsMetrics.Load(k); ok {
 					tm := v.(*TrackedMetrics)
 					setLag(tm, lag)
+				}
+				// Mirror onto the {method, All} rollup the indexed key may not be
+				// (see updateNetworkLagMetrics) so per-method-grain slots see lag.
+				if k.finality != common.DataFinalityStateAll {
+					if av, ok := t.upsMetrics.Load(upstreamKey{k.ups, k.method, common.DataFinalityStateAll}); ok {
+						setLag(av.(*TrackedMetrics), lag)
+					}
 				}
 			}
 		}

--- a/internal/policy/stdlib/headlag_grain_test.go
+++ b/internal/policy/stdlib/headlag_grain_test.go
@@ -1,0 +1,101 @@
+package stdlib_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// blockNumberLagAbove must exclude a lagging upstream at EVERY eval-scope grain,
+// not just the network (wildcard) grain. With per-finality tracking on, requests
+// recorded at a concrete (method, finality) register that specific bucket in the
+// (ups,method) dedup index; lag is a per-upstream value, but the optimized
+// lag-write only touched indexed keys — leaving the {method, All} rollup that
+// network/network-method slots read starved, so the predicate silently no-oped.
+func TestSelectionPolicy_HeadLagExclusion_AllScopes(t *testing.T) {
+	const eval = `(upstreams, ctx) => upstreams.excludeIf(blockNumberLagAbove(16))`
+
+	scopes := []struct {
+		name     string
+		scope    common.EvalScope
+		tickMeth string // method to tick/read the slot at
+	}{
+		{"network", common.EvalScopeNetwork, "*"},
+		{"network-method", common.EvalScopeNetworkMethod, "eth_getLogs"},
+		{"network-method-finality", common.EvalScopeNetworkMethodFinality, "eth_getLogs"},
+	}
+
+	for _, sc := range scopes {
+		t.Run(sc.name, func(t *testing.T) {
+			engine, _, tracker, cancel := newTestEngine(t, eval)
+			defer cancel()
+			defer engine.Stop()
+			tracker.EnableFinalityTracking()
+
+			ups := mkUps("rpc1", "rpc2")
+			cfg := &common.SelectionPolicyConfig{
+				EvalInterval: 0,
+				EvalTimeout:  common.Duration(50 * time.Millisecond),
+				EvalFunc:     eval,
+				EvalScope:    sc.scope,
+			}
+			require.NoError(t, cfg.SetDefaults())
+			require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+
+			// Specific-finality records create {method,fin} first → it wins the
+			// (ups,method) dedup slot; {method,All} stays out of the index.
+			fin := common.DataFinalityStateUnfinalized
+			for _, u := range ups {
+				for i := 0; i < 20; i++ {
+					tracker.RecordUpstreamRequest(u, "eth_getLogs", fin)
+					tracker.RecordUpstreamDuration(u, "eth_getLogs", 10*time.Millisecond, true, "none", fin, "n/a")
+				}
+			}
+
+			// Real lag path: rpc2 at tip (1000), rpc1 frozen far behind (lag 900).
+			tracker.SetLatestBlockNumber(ups[1], 1000, 0)
+			tracker.SetLatestBlockNumber(ups[0], 100, 0)
+
+			_ = engine.GetOrdered("evm:1", sc.tickMeth, "*") // lazy-create the per-grain slot
+			policy.TickForTest(engine, "evm:1", sc.tickMeth)
+			ordered := ids(engine.GetOrdered("evm:1", sc.tickMeth, "*"))
+
+			require.NotContains(t, ordered, "rpc1",
+				"rpc1 (lag 900) must be excluded by blockNumberLagAbove(16) at %s grain (got %v)", sc.name, ordered)
+			require.Contains(t, ordered, "rpc2", "rpc2 (at tip) must survive")
+		})
+	}
+}
+
+// Tracker-level invariant: after SetLatestBlockNumber with per-finality tracking
+// on, the per-upstream lag must reach the {method, All} rollup (the bucket
+// non-finality-grain readers normalize to), not only the specific-finality
+// bucket that happened to win the (ups,method) dedup index.
+func TestTracker_BlockHeadLag_ReachesMethodAllRollup(t *testing.T) {
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "p1", time.Minute)
+	tracker.EnableFinalityTracking()
+
+	ups := mkUps("rpc1", "rpc2")
+	fin := common.DataFinalityStateUnfinalized
+	for _, u := range ups {
+		tracker.RecordUpstreamRequest(u, "eth_getLogs", fin)
+		tracker.RecordUpstreamDuration(u, "eth_getLogs", 5*time.Millisecond, true, "none", fin, "n/a")
+	}
+
+	tracker.SetLatestBlockNumber(ups[1], 1000, 0) // network tip
+	tracker.SetLatestBlockNumber(ups[0], 100, 0)  // lag 900
+
+	got := tracker.GetUpstreamMethodMetrics(ups[0], "eth_getLogs", common.DataFinalityStateAll).BlockHeadLag.Load()
+	require.EqualValues(t, 900, got,
+		"{eth_getLogs, All} rollup must carry the upstream lag (was starved before the fix)")
+
+	// The full-wildcard and specific-finality buckets must agree too.
+	require.EqualValues(t, 900, tracker.GetUpstreamMethodMetrics(ups[0], "*", common.DataFinalityStateAll).BlockHeadLag.Load())
+	require.EqualValues(t, 900, tracker.GetUpstreamMethodMetrics(ups[0], "eth_getLogs", fin).BlockHeadLag.Load())
+}


### PR DESCRIPTION
### Problem

`blockNumberLagAbove` / `blockSecondsLagAbove` (and lag-weighted scoring) never exclude a lagging upstream when the selection policy runs at the **`network-method`** (or `network-method-finality`) eval scope with per-finality tracking enabled. The lagging upstream stays in rotation.

### Cause

Block-head/finalization lag is a per-upstream value. The **optimized** lag-write path (`updateNetworkLagMetrics` / `updateSingleUpstreamLag`) only writes to the keys in the `(ups,method)` dedup index — one arbitrary-finality key per method. Selection slots at the `network` / `network-method` grains read the `{method, All}` rollup (`parseFinality("*") == All`). Once per-finality tracking is on, a concrete `(method, finality)` record registers the `{method, <finality>}` key first, so `{method, All}` is left out of the index and never receives the lag → the predicate reads `0` and no-ops.

(The fallback paths already iterate every bucket, so only the optimized paths were affected.)

### Fix

Mirror the computed lag onto the `{method, All}` rollup — which `getUpsKeys` always populates — in both optimized paths. Two small writes; no change to the fallback paths or the index.

### Tests

- Exclusion now fires at **network**, **network-method**, and **network-method-finality** scopes (table test).
- Tracker-level invariant: the `{method, All}` rollup carries the upstream lag after `SetLatestBlockNumber` with finality tracking on.

All added tests fail without the fix. `go test ./health/... ./internal/policy/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upstream selection health metrics on the hot lag-update path; behavior change is narrow (duplicate lag write to an existing rollup) but affects which upstreams get excluded in production routing.
> 
> **Overview**
> Fixes **silent no-op** for lag-based upstream exclusion (`blockNumberLagAbove`, `blockSecondsLagAbove`, lag scoring) when selection policies run at **`network-method`** or **`network-method-finality`** scope with **per-finality tracking** enabled.
> 
> The optimized lag writers in `updateNetworkLagMetrics` and `updateSingleUpstreamLag` only updated the single `(upstream, method)` key stored in the dedup index—often a **specific finality** bucket—while eval at those grains reads the **`{method, All}`** rollup. That rollup stayed at lag `0`, so predicates never excluded lagging upstreams.
> 
> The change **mirrors** the computed block-head/finalization lag onto the **`{method, DataFinalityStateAll}`** bucket whenever the indexed key is not already `All`. Fallback full-map paths are unchanged.
> 
> New tests cover exclusion at **network**, **network-method**, and **network-method-finality** scopes and assert the **`{method, All}`** rollup receives lag after `SetLatestBlockNumber`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec24cdcad4a9d79554df349146fb3e9df1caf38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->