### PR TITLE
feat(cache): gate realtime cache reads on connector freshness

### DIFF
--- a/architecture/evm/eth_getBlockByNumber_test.go
+++ b/architecture/evm/eth_getBlockByNumber_test.go
@@ -11,7 +11,8 @@ import (
 
 // testNetwork is a simple test implementation of common.Network interface for this file
 type testNetwork struct {
-	cfg *common.NetworkConfig
+	cfg           *common.NetworkConfig
+	finalityState common.DataFinalityState
 }
 
 func (t *testNetwork) Architecture() common.NetworkArchitecture {
@@ -67,7 +68,7 @@ func (t *testNetwork) GetMethodMetrics(method string) common.TrackedMetrics {
 }
 
 func (t *testNetwork) GetFinality(ctx context.Context, req *common.NormalizedRequest, resp *common.NormalizedResponse) common.DataFinalityState {
-	return common.DataFinalityStateFinalized
+	return t.finalityState
 }
 
 func TestAllPhantomTransactions(t *testing.T) {

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -831,11 +831,13 @@ func (c *EvmJsonRpcCache) IsObjectNull() bool {
 	return c == nil || c.logger == nil
 }
 
-// shouldAcceptCachedResult checks if a cached result should be accepted based on its age
-// It compares the block timestamp against the policy's TTL to ensure freshness.
-// This validation only applies to realtime finality data (e.g., eth_gasPrice, latest block).
-// For finalized/unfinalized/unknown finality, block data is immutable and should always be accepted
-// regardless of how old the block timestamp is.
+// shouldAcceptCachedResult checks if a cached realtime result is still fresh enough to serve, by
+// comparing a block timestamp against the policy's TTL. The timestamp is taken from the response
+// when present; for responses that carry none (eth_blockNumber, eth_gasPrice, eth_getLogs) it falls
+// back to the serving connector's reported latest-block timestamp (read-through connectors that
+// implement data.CacheHeadReporter), so a lagging source is still caught for those methods.
+// Applies only to realtime finality — finalized/unfinalized/unknown block data is immutable and is
+// always accepted regardless of age.
 func (c *EvmJsonRpcCache) shouldAcceptCachedResult(
 	ctx context.Context,
 	req *common.NormalizedRequest,
@@ -865,16 +867,26 @@ func (c *EvmJsonRpcCache) shouldAcceptCachedResult(
 
 	blockTimestamp, err := ExtractBlockTimestampFromResponse(ctx, nr)
 	if err != nil || blockTimestamp <= 0 {
-		// If we can't extract a timestamp (e.g., for methods that don't have block data),
-		// we can't enforce age-based validation, so accept the result
-		if c.logger.GetLevel() <= zerolog.TraceLevel {
-			method, _ := req.Method()
-			c.logger.Trace().
-				Err(err).
-				Str("method", method).
-				Msg("cannot extract block timestamp for age validation, accepting cached result")
+		// The response carries no block timestamp (e.g. eth_blockNumber, eth_gasPrice, eth_getLogs).
+		// Fall back to the serving connector's reported latest-block timestamp so realtime freshness
+		// can still be enforced for these methods when the connector is head-aware (read-through).
+		blockTimestamp = 0
+		if reporter, ok := policy.GetConnector().(data.CacheHeadReporter); ok {
+			if ts, known := reporter.CacheLatestBlockTimestamp(req.NetworkId()); known && ts > 0 {
+				blockTimestamp = ts
+			}
 		}
-		return true
+		if blockTimestamp <= 0 {
+			// Still can't determine the age (connector not head-aware or head unknown), so accept.
+			if c.logger.GetLevel() <= zerolog.TraceLevel {
+				method, _ := req.Method()
+				c.logger.Trace().
+					Err(err).
+					Str("method", method).
+					Msg("cannot determine block timestamp for age validation, accepting cached result")
+			}
+			return true
+		}
 	}
 
 	// Calculate the age of the block

--- a/architecture/evm/json_rpc_cache_connector_freshness_test.go
+++ b/architecture/evm/json_rpc_cache_connector_freshness_test.go
@@ -1,0 +1,265 @@
+package evm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// headReportingConnector is a MockConnector that also implements data.CacheHeadReporter, exposing a
+// configurable latest-block timestamp so the connector-fallback path of the realtime age guard can
+// be exercised.
+type headReportingConnector struct {
+	*data.MockConnector
+	latestTs int64
+	known    bool
+}
+
+func (h *headReportingConnector) CacheLatestBlockTimestamp(networkId string) (int64, bool) {
+	return h.latestTs, h.known
+}
+
+func newHeadReportingConnector(id string, latestTs int64, known bool) *headReportingConnector {
+	mc := &data.MockConnector{}
+	mc.On("Id").Return(id)
+	return &headReportingConnector{MockConnector: mc, latestTs: latestTs, known: known}
+}
+
+func plainConnector(id string) *data.MockConnector {
+	mc := &data.MockConnector{}
+	mc.On("Id").Return(id)
+	return mc
+}
+
+func freshGuardCache() *EvmJsonRpcCache {
+	logger := log.Logger
+	return &EvmJsonRpcCache{projectId: "test-project", logger: &logger}
+}
+
+func realtimeReq(method, params string) *common.NormalizedRequest {
+	req := common.NewNormalizedRequest([]byte(
+		fmt.Sprintf(`{"jsonrpc":"2.0","method":%q,"params":%s,"id":1}`, method, params),
+	))
+	req.SetNetwork(&testNetwork{finalityState: common.DataFinalityStateRealtime})
+	return req
+}
+
+func tsPolicy(t *testing.T, conn data.Connector, ttl time.Duration) *data.CachePolicy {
+	t.Helper()
+	cfg := &common.CachePolicyConfig{
+		Connector: "conn",
+		Network:   "*",
+		Method:    "*",
+		Finality:  common.DataFinalityStateRealtime,
+	}
+	if ttl > 0 {
+		cfg.TTL = common.Duration(ttl)
+	}
+	policy, err := data.NewCachePolicy(cfg, conn)
+	require.NoError(t, err)
+	return policy
+}
+
+func blockJrr(tsUnix int64) *common.JsonRpcResponse {
+	return common.MustNewJsonRpcResponse(1, map[string]interface{}{
+		"number":    "0x1234",
+		"hash":      "0xabc",
+		"timestamp": fmt.Sprintf("0x%x", tsUnix),
+	}, nil)
+}
+
+func scalarJrr() *common.JsonRpcResponse {
+	return common.MustNewJsonRpcResponse(1, "0x3b9aca00", nil) // a gas price, no block reference
+}
+
+func logsJrr() *common.JsonRpcResponse {
+	return common.MustNewJsonRpcResponse(1, []interface{}{
+		map[string]interface{}{"address": "0xabc", "blockNumber": "0x1234", "data": "0x"},
+	}, nil)
+}
+
+// TestEvmJsonRpcCache_ConnectorFreshnessGuard exercises the realtime age guard: the block timestamp
+// is taken from the response when present, else from the serving connector's reported latest-block
+// timestamp, and the result is rejected when older than the policy TTL.
+func TestEvmJsonRpcCache_ConnectorFreshnessGuard(t *testing.T) {
+	ctx := context.Background()
+	cache := freshGuardCache()
+	now := time.Now().Unix()
+
+	// --- response-timestamp path (block-bearing methods; pre-existing behavior) ---
+
+	t.Run("ResponseTimestampFreshAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, plainConnector("conn"), time.Minute)
+		req := realtimeReq("eth_getBlockByNumber", `["latest",false]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, blockJrr(now-5), policy))
+	})
+
+	t.Run("ResponseTimestampStaleRejected", func(t *testing.T) {
+		policy := tsPolicy(t, plainConnector("conn"), time.Minute)
+		req := realtimeReq("eth_getBlockByNumber", `["latest",false]`)
+		assert.False(t, cache.shouldAcceptCachedResult(ctx, req, blockJrr(now-120), policy))
+	})
+
+	// --- connector-fallback path (methods whose response carries no block timestamp) ---
+
+	t.Run("NoResponseTsConnectorFreshAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-5, true), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	t.Run("NoResponseTsConnectorStaleRejected", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-120, true), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.False(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	// The motivating win: getLogs carries no top-level block timestamp, so only the connector's
+	// reported head can detect a lagging source.
+	t.Run("GetLogsConnectorStaleRejected", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-120, true), time.Minute)
+		req := realtimeReq("eth_getLogs", `[{"fromBlock":"latest","toBlock":"latest"}]`)
+		assert.False(t, cache.shouldAcceptCachedResult(ctx, req, logsJrr(), policy))
+	})
+
+	t.Run("EthBlockNumberConnectorStaleRejected", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-120, true), time.Minute)
+		req := realtimeReq("eth_blockNumber", `[]`)
+		assert.False(t, cache.shouldAcceptCachedResult(ctx, req, common.MustNewJsonRpcResponse(1, "0x1234", nil), policy))
+	})
+
+	// --- fail-open cases ---
+
+	t.Run("NoResponseTsConnectorNotHeadAwareAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, plainConnector("conn"), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	t.Run("NoResponseTsConnectorHeadUnknownAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", 0, false), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	// --- precedence + bypass ---
+
+	t.Run("ResponseTimestampPreferredOverConnector", func(t *testing.T) {
+		// Response is fresh but the connector's polled head looks stale: the per-response timestamp
+		// wins (fresher, no poll lag), so the result is accepted.
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-120, true), time.Minute)
+		req := realtimeReq("eth_getBlockByNumber", `["latest",false]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, blockJrr(now-5), policy))
+	})
+
+	t.Run("NonRealtimeFinalityAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-100000, true), time.Minute)
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}`))
+		req.SetNetwork(&testNetwork{finalityState: common.DataFinalityStateFinalized})
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	t.Run("NoTTLAccepted", func(t *testing.T) {
+		policy := tsPolicy(t, newHeadReportingConnector("conn", now-100000, true), 0)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+}
+
+// TestEvmJsonRpcCache_ConnectorFreshnessThroughFailsafeWrapper verifies the connector-fallback path
+// still works when the head-aware connector is wrapped by a FailsafeConnector — the production setup,
+// since NewConnector wraps any connector that configures failsafeForGets/Sets (the prism cache does).
+func TestEvmJsonRpcCache_ConnectorFreshnessThroughFailsafeWrapper(t *testing.T) {
+	ctx := context.Background()
+	cache := freshGuardCache()
+	logger := log.Logger
+	now := time.Now().Unix()
+
+	wrap := func(t *testing.T, base data.Connector) data.Connector {
+		t.Helper()
+		w, err := data.NewFailsafeConnector(&logger, base, nil, nil)
+		require.NoError(t, err)
+		return w
+	}
+
+	t.Run("RejectsWhenWrappedConnectorStale", func(t *testing.T) {
+		policy := tsPolicy(t, wrap(t, newHeadReportingConnector("conn", now-120, true)), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.False(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	t.Run("AcceptsWhenWrappedConnectorFresh", func(t *testing.T) {
+		policy := tsPolicy(t, wrap(t, newHeadReportingConnector("conn", now-5, true)), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+
+	t.Run("FailsOpenWhenWrappedBaseNotHeadAware", func(t *testing.T) {
+		policy := tsPolicy(t, wrap(t, plainConnector("conn")), time.Minute)
+		req := realtimeReq("eth_gasPrice", `[]`)
+		assert.True(t, cache.shouldAcceptCachedResult(ctx, req, scalarJrr(), policy))
+	})
+}
+
+// TestEvmJsonRpcCache_ConnectorFreshnessThroughGet proves the guard is wired into the Get fan-out
+// for realtime finality: a stale realtime hit becomes a miss (nil → caller falls through), a fresh
+// one is served from cache.
+func TestEvmJsonRpcCache_ConnectorFreshnessThroughGet(t *testing.T) {
+	ctx := context.Background()
+	logger := log.Logger
+
+	// Connectors store the bare JSON-RPC result (not the full envelope); see doGet.
+	blockResult := func(tsUnix int64) []byte {
+		b, _ := json.Marshal(map[string]interface{}{
+			"number":    "0x1234",
+			"hash":      "0xabc",
+			"timestamp": fmt.Sprintf("0x%x", tsUnix),
+		})
+		return b
+	}
+
+	setup := func(blockTs int64, ttl time.Duration) (*EvmJsonRpcCache, *common.NormalizedRequest) {
+		mc := &data.MockConnector{}
+		mc.On("Id").Return("conn")
+		b := blockResult(blockTs)
+		mc.On("Get", mock.Anything, data.ConnectorMainIndex, mock.Anything, mock.Anything, mock.Anything).Return(b, nil)
+		mc.On("Get", mock.Anything, data.ConnectorReverseIndex, mock.Anything, mock.Anything, mock.Anything).Return(b, nil).Maybe()
+
+		policy, err := data.NewCachePolicy(&common.CachePolicyConfig{
+			Connector: "conn",
+			Network:   "*",
+			Method:    "eth_getBlockByNumber",
+			Finality:  common.DataFinalityStateRealtime,
+			TTL:       common.Duration(ttl),
+		}, mc)
+		require.NoError(t, err)
+
+		cache := &EvmJsonRpcCache{projectId: "test-project", logger: &logger, policies: []*data.CachePolicy{policy}}
+		req := realtimeReq("eth_getBlockByNumber", `["latest",false]`)
+		return cache, req
+	}
+
+	t.Run("ServesFresh", func(t *testing.T) {
+		cache, req := setup(time.Now().Unix()-5, time.Minute)
+		resp, err := cache.Get(ctx, req)
+		assert.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, resp.FromCache())
+	})
+
+	t.Run("MissesStale", func(t *testing.T) {
+		cache, req := setup(time.Now().Unix()-120, time.Minute)
+		resp, err := cache.Get(ctx, req)
+		assert.NoError(t, err)
+		assert.Nil(t, resp, "stale realtime hit should be treated as a miss")
+	})
+}

--- a/data/connector.go
+++ b/data/connector.go
@@ -50,6 +50,16 @@ type Connector interface {
 	PublishCounterInt64(ctx context.Context, key string, value CounterInt64State) error
 }
 
+// CacheHeadReporter is an optional capability implemented by read-through connectors that can report
+// the timestamp of the latest block they currently serve. It lets the realtime cache age guard be
+// enforced even for responses that carry no block timestamp of their own (eth_blockNumber,
+// eth_gasPrice, eth_getLogs). Connectors that serve locally-written data do not implement it.
+type CacheHeadReporter interface {
+	// CacheLatestBlockTimestamp returns the unix timestamp (seconds) of the latest block this
+	// connector can currently serve for networkId, and whether it is known.
+	CacheLatestBlockTimestamp(networkId string) (unixSeconds int64, ok bool)
+}
+
 func NewConnector(
 	ctx context.Context,
 	logger *zerolog.Logger,

--- a/data/failsafe.go
+++ b/data/failsafe.go
@@ -103,6 +103,7 @@ type FailsafeConnector struct {
 }
 
 var _ Connector = (*FailsafeConnector)(nil)
+var _ CacheHeadReporter = (*FailsafeConnector)(nil)
 
 // NewFailsafeConnector constructs a FailsafeConnector backed by per-direction
 // cacheExecutor instances for Get vs Set/Delete operations.
@@ -203,6 +204,15 @@ func pickCacheExecutor(executors []*cacheExecutor, ctx context.Context) *cacheEx
 
 func (f *FailsafeConnector) Id() string {
 	return f.wrapped.Id()
+}
+
+// CacheLatestBlockTimestamp forwards to the wrapped connector when it is head-aware, so the realtime
+// cache age guard keeps working through the failsafe wrapper. Returns (0, false) otherwise.
+func (f *FailsafeConnector) CacheLatestBlockTimestamp(networkId string) (int64, bool) {
+	if r, ok := f.wrapped.(CacheHeadReporter); ok {
+		return r.CacheLatestBlockTimestamp(networkId)
+	}
+	return 0, false
 }
 
 func (f *FailsafeConnector) Get(ctx context.Context, index, partitionKey, rangeKey string, metadata interface{}) ([]byte, error) {

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -327,9 +327,12 @@ func (g *GrpcConnector) pollBlockHeadsOnce(ctx context.Context) {
 		if num, ts, ok := g.fetchTaggedBlock(ctx, cli, "latest"); ok {
 			g.mu.Lock()
 			g.latestByNetwork[nid] = num
-			if ts > 0 {
-				g.latestTsByNetwork[nid] = ts
-			}
+			// Store the timestamp in lockstep with the number (even when ts is 0/unknown) so the
+			// reported head timestamp always corresponds to the current latest block. Retaining a
+			// previous ts after the number advances would make CacheLatestBlockTimestamp report a
+			// stale head time; storing 0 instead makes it report "unknown" so the realtime guard
+			// fails open rather than judging an advanced head by an older block's timestamp.
+			g.latestTsByNetwork[nid] = ts
 			g.mu.Unlock()
 			telemetry.MetricCacheConnectorLatestBlockNumber.WithLabelValues(g.id, nid).Set(float64(num))
 			if ts > 0 {

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -43,6 +43,8 @@ type GrpcConnector struct {
 	earliestByNetwork  map[string]uint64
 	latestByNetwork    map[string]uint64
 	finalizedByNetwork map[string]uint64
+	// unix timestamp (seconds) of the latest block per network (0 if unknown)
+	latestTsByNetwork map[string]int64
 	// headers to apply to all clients
 	headers     map[string]string
 	initializer *util.Initializer
@@ -50,6 +52,7 @@ type GrpcConnector struct {
 }
 
 var _ Connector = (*GrpcConnector)(nil)
+var _ CacheHeadReporter = (*GrpcConnector)(nil)
 
 // supportedMethods is a fast allowlist for methods served by gRPC BDS.
 var supportedMethods = map[string]struct{}{
@@ -99,6 +102,7 @@ func NewGrpcConnector(
 		earliestByNetwork:  make(map[string]uint64),
 		latestByNetwork:    make(map[string]uint64),
 		finalizedByNetwork: make(map[string]uint64),
+		latestTsByNetwork:  make(map[string]int64),
 		headers:            map[string]string{},
 		initializer:        util.NewInitializer(ctx, &lg, nil),
 		getTimeout:         cfg.GetTimeout.Duration(),
@@ -184,6 +188,17 @@ func NewGrpcConnector(
 }
 
 func (g *GrpcConnector) Id() string { return g.id }
+
+// CacheLatestBlockTimestamp reports the unix timestamp (seconds) of the latest block this
+// read-through cache currently has for networkId (refreshed by the background head poller), and
+// whether it is known. Implements CacheHeadReporter so the realtime cache age guard can be enforced
+// for responses that carry no block timestamp of their own.
+func (g *GrpcConnector) CacheLatestBlockTimestamp(networkId string) (int64, bool) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	ts := g.latestTsByNetwork[networkId]
+	return ts, ts > 0
+}
 
 func (g *GrpcConnector) Get(ctx context.Context, index, partitionKey, rangeKey string, metadata interface{}) ([]byte, error) {
 	span := trace.SpanFromContext(ctx)
@@ -312,6 +327,9 @@ func (g *GrpcConnector) pollBlockHeadsOnce(ctx context.Context) {
 		if num, ts, ok := g.fetchTaggedBlock(ctx, cli, "latest"); ok {
 			g.mu.Lock()
 			g.latestByNetwork[nid] = num
+			if ts > 0 {
+				g.latestTsByNetwork[nid] = ts
+			}
 			g.mu.Unlock()
 			telemetry.MetricCacheConnectorLatestBlockNumber.WithLabelValues(g.id, nid).Set(float64(num))
 			if ts > 0 {


### PR DESCRIPTION
## What

Rejects a **realtime**-finality cache hit when its data is older than the policy TTL. The block timestamp is taken from the response when present (existing behavior); for responses that carry none — `eth_blockNumber`, `eth_gasPrice`, `eth_getLogs` — it falls back to the **serving connector's reported latest-block timestamp**, so a lagging read-through source is caught for those methods too.

## Why

A read-through cache backed by a lagging source can serve stale realtime data, and the per-response age guard can't help for methods whose payload has no block timestamp. Using the connector's head timestamp closes that gap — with no new config, reusing the realtime policy's TTL.

## How

- Optional `Connector` capability `CacheHeadReporter` (`CacheLatestBlockTimestamp(networkId)`), implemented by the gRPC read-through connector — it stores the latest-block timestamp its head poller already fetches (#909) — and forwarded through `FailsafeConnector` so it survives the production failsafe wrapper.
- The realtime age guard prefers the response timestamp, then falls back to the connector's head timestamp; rejects when older than TTL (existing `cache_get_age_guard_reject_total` metric).

## Behavior

- Applies only to `realtime` finality; finalized/unfinalized/unknown data is immutable and always accepted.
- Fails open when it can't determine age (connector not head-aware, or head unknown).
- No new config — reuses the policy TTL. ⚠️ The TTL should exceed the connector's head-poll interval (#909's poller is 60s), otherwise normal poll staleness reads as lag.

## Config

```yaml
cache:
  policies:
    - connector: my-grpc-cache
      finality: realtime
      ttl: 90s
```

Covered by unit tests (response-timestamp path + connector fallback for `getLogs`/`gasPrice`/`blockNumber`, fail-open cases, response-vs-connector precedence), a `FailsafeConnector`-wrapper test (the production path), and a Get-level serve-vs-miss test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime cache serve/miss behavior for head-aware connectors; mis-tuned TTL vs the 60s gRPC head poll could increase false cache misses, though unknown head still fails open.
> 
> **Overview**
> Extends the **realtime** JSON-RPC cache age guard so lagging read-through sources can be detected even when the cached payload has **no block timestamp** (`eth_gasPrice`, `eth_blockNumber`, `eth_getLogs`).
> 
> When the response timestamp is missing, `shouldAcceptCachedResult` now falls back to the policy connector’s **`CacheLatestBlockTimestamp`** (optional `data.CacheHeadReporter`), still compared against the existing realtime policy TTL; stale hits are treated as cache misses in `Get`. Response timestamps stay preferred when present; non-realtime finality and unknown age **fail open** (unchanged semantics).
> 
> **`GrpcConnector`** tracks per-network latest-block unix time from its head poller (timestamp updated in lockstep with latest block number so an advanced head without a new ts does not reuse an old timestamp). **`FailsafeConnector`** forwards the capability for production-wrapped caches. Broad unit coverage includes failsafe wrapping and end-to-end `Get` serve vs miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14f521cecb5033cd4dbf9999828a3cee930716f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->