### PR TITLE
feat(data/grpc): report earliest/latest/finalized block heads per network

### DIFF
--- a/data/grpc.go
+++ b/data/grpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/erpc/erpc/clients"
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
@@ -26,7 +27,10 @@ const GrpcDriverName = "grpc"
 // It is read-only: Set/Delete/List/Lock/Watch/Publish are no-ops or unsupported.
 // It bootstraps from an endpoint that returns a list of gRPC server URLs.
 // Each server is probed for chainId to map it to a network.
-// A background poller tracks the earliest available block per network for fast misses.
+// A background poller tracks the earliest/latest/finalized block per network:
+// earliest powers fast-miss rejection in Get, while each block's number and
+// timestamp are exported as gauges so operators can observe how far the
+// read-through cache trails each network's head.
 type GrpcConnector struct {
 	id     string
 	logger *zerolog.Logger
@@ -35,8 +39,10 @@ type GrpcConnector struct {
 	mu     sync.RWMutex
 	// networkId -> single client
 	clientByNetwork map[string]clients.GrpcBdsClient
-	// earliest block per network (0 if unknown)
-	earliestByNetwork map[string]uint64
+	// earliest/latest/finalized block per network (0 if unknown)
+	earliestByNetwork  map[string]uint64
+	latestByNetwork    map[string]uint64
+	finalizedByNetwork map[string]uint64
 	// headers to apply to all clients
 	headers     map[string]string
 	initializer *util.Initializer
@@ -86,14 +92,16 @@ func NewGrpcConnector(
 	}
 
 	gc := &GrpcConnector{
-		id:                id,
-		logger:            &lg,
-		appCtx:            ctx,
-		clientByNetwork:   make(map[string]clients.GrpcBdsClient),
-		earliestByNetwork: make(map[string]uint64),
-		headers:           map[string]string{},
-		initializer:       util.NewInitializer(ctx, &lg, nil),
-		getTimeout:        cfg.GetTimeout.Duration(),
+		id:                 id,
+		logger:             &lg,
+		appCtx:             ctx,
+		clientByNetwork:    make(map[string]clients.GrpcBdsClient),
+		earliestByNetwork:  make(map[string]uint64),
+		latestByNetwork:    make(map[string]uint64),
+		finalizedByNetwork: make(map[string]uint64),
+		headers:            map[string]string{},
+		initializer:        util.NewInitializer(ctx, &lg, nil),
+		getTimeout:         cfg.GetTimeout.Duration(),
 	}
 	if cfg.Headers != nil {
 		for k, v := range cfg.Headers {
@@ -169,8 +177,8 @@ func NewGrpcConnector(
 		}
 	}
 
-	// Start earliest poller per network
-	go gc.startEarliestPoller(ctx)
+	// Start background poller for per-network block heads (earliest/latest/finalized)
+	go gc.startBlockHeadPoller(ctx)
 
 	return gc, nil
 }
@@ -259,7 +267,7 @@ func (g *GrpcConnector) Get(ctx context.Context, index, partitionKey, rangeKey s
 	return resultBytes, nil
 }
 
-func (g *GrpcConnector) startEarliestPoller(ctx context.Context) {
+func (g *GrpcConnector) startBlockHeadPoller(ctx context.Context) {
 	t := time.NewTicker(60 * time.Second)
 	defer t.Stop()
 	for {
@@ -267,12 +275,19 @@ func (g *GrpcConnector) startEarliestPoller(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			g.pollEarliestOnce(ctx)
+			g.pollBlockHeadsOnce(ctx)
 		}
 	}
 }
 
-func (g *GrpcConnector) pollEarliestOnce(ctx context.Context) {
+// pollBlockHeadsOnce refreshes the earliest, latest, and finalized block per
+// network from the backing gRPC servers. earliest also feeds fast-miss rejection
+// in Get; each block's number and timestamp are reported as gauges so operators
+// can observe how far the read-through cache trails each network's head. Each tag
+// is best-effort: a failed/unparsable response leaves the prior value (and its
+// gauges) untouched rather than zeroing them on a transient error. The block
+// timestamp gauge is only set when present (>0).
+func (g *GrpcConnector) pollBlockHeadsOnce(ctx context.Context) {
 	g.mu.RLock()
 	// snapshot to avoid holding lock during RPCs
 	snapshot := make(map[string]clients.GrpcBdsClient)
@@ -284,36 +299,77 @@ func (g *GrpcConnector) pollEarliestOnce(ctx context.Context) {
 	g.mu.RUnlock()
 
 	for nid, cli := range snapshot {
-		jr := common.NewJsonRpcRequest("eth_getBlockByNumber", []interface{}{"earliest", false})
-		nrq := common.NewNormalizedRequestFromJsonRpcRequest(jr)
-		resp, err := cli.SendRequest(ctx, nrq)
-		if err != nil || resp == nil {
-			continue
+		if num, ts, ok := g.fetchTaggedBlock(ctx, cli, "earliest"); ok {
+			g.mu.Lock()
+			g.earliestByNetwork[nid] = num
+			g.mu.Unlock()
+			telemetry.MetricCacheConnectorEarliestBlockNumber.WithLabelValues(g.id, nid).Set(float64(num))
+			if ts > 0 {
+				telemetry.MetricCacheConnectorEarliestBlockTimestamp.WithLabelValues(g.id, nid).Set(float64(ts))
+			}
 		}
-		jrr, err := resp.JsonRpcResponse(ctx)
-		if err != nil || jrr == nil {
-			continue
+
+		if num, ts, ok := g.fetchTaggedBlock(ctx, cli, "latest"); ok {
+			g.mu.Lock()
+			g.latestByNetwork[nid] = num
+			g.mu.Unlock()
+			telemetry.MetricCacheConnectorLatestBlockNumber.WithLabelValues(g.id, nid).Set(float64(num))
+			if ts > 0 {
+				telemetry.MetricCacheConnectorLatestBlockTimestamp.WithLabelValues(g.id, nid).Set(float64(ts))
+			}
 		}
-		// Parse number field
-		num := parseBlockNumberHex(jrr.GetResultBytes())
-		if num == "" {
-			continue
+
+		if num, ts, ok := g.fetchTaggedBlock(ctx, cli, "finalized"); ok {
+			g.mu.Lock()
+			g.finalizedByNetwork[nid] = num
+			g.mu.Unlock()
+			telemetry.MetricCacheConnectorFinalizedBlockNumber.WithLabelValues(g.id, nid).Set(float64(num))
+			if ts > 0 {
+				telemetry.MetricCacheConnectorFinalizedBlockTimestamp.WithLabelValues(g.id, nid).Set(float64(ts))
+			}
 		}
-		u, err := evm.HexToUint64(num)
-		if err != nil {
-			continue
-		}
-		g.mu.Lock()
-		g.earliestByNetwork[nid] = u
-		g.mu.Unlock()
 	}
 }
 
-func parseBlockNumberHex(b []byte) string {
+// fetchTaggedBlock requests a block by tag ("earliest"/"latest"/"finalized") from
+// a single gRPC client and returns its number and unix timestamp (seconds). ok is
+// false when the call fails or the result has no parsable block number; timestamp
+// is best-effort and may be 0 even when ok is true.
+func (g *GrpcConnector) fetchTaggedBlock(ctx context.Context, cli clients.GrpcBdsClient, tag string) (number uint64, timestamp int64, ok bool) {
+	jr := common.NewJsonRpcRequest("eth_getBlockByNumber", []interface{}{tag, false})
+	nrq := common.NewNormalizedRequestFromJsonRpcRequest(jr)
+	resp, err := cli.SendRequest(ctx, nrq)
+	if err != nil || resp == nil {
+		return 0, 0, false
+	}
+	jrr, err := resp.JsonRpcResponse(ctx)
+	if err != nil || jrr == nil {
+		return 0, 0, false
+	}
+	result := jrr.GetResultBytes()
+	numStr := parseBlockField(result, "number")
+	if numStr == "" {
+		return 0, 0, false
+	}
+	num, err := evm.HexToUint64(numStr)
+	if err != nil {
+		return 0, 0, false
+	}
+	if tsStr := parseBlockField(result, "timestamp"); tsStr != "" {
+		if v, terr := common.HexToInt64(tsStr); terr == nil {
+			timestamp = v
+		}
+	}
+	return num, timestamp, true
+}
+
+// parseBlockField extracts a top-level string field (e.g. "number" or
+// "timestamp") from a JSON block result. Returns "" when absent or unparsable.
+func parseBlockField(b []byte, field string) string {
 	if len(b) == 0 {
 		return ""
 	}
-	node, err := sonic.Get(b, "number")
+	node, err := sonic.Get(b, field)
 	if err == nil {
 		v, _ := node.String()
 		return v

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -70,6 +70,42 @@ var (
 		Help:      "Finalized block number of upstreams.",
 	}, []string{"project", "vendor", "network", "upstream"})
 
+	MetricCacheConnectorEarliestBlockNumber = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_earliest_block_number",
+		Help:      "Earliest block number available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
+	MetricCacheConnectorLatestBlockNumber = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_latest_block_number",
+		Help:      "Latest block number available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
+	MetricCacheConnectorFinalizedBlockNumber = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_finalized_block_number",
+		Help:      "Finalized block number available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
+	MetricCacheConnectorEarliestBlockTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_earliest_block_timestamp_seconds",
+		Help:      "Unix timestamp (seconds) of the earliest block available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
+	MetricCacheConnectorLatestBlockTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_latest_block_timestamp_seconds",
+		Help:      "Unix timestamp (seconds) of the latest block available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
+	MetricCacheConnectorFinalizedBlockTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "cache_connector_finalized_block_timestamp_seconds",
+		Help:      "Unix timestamp (seconds) of the finalized block available in a read-through cache connector, per network.",
+	}, []string{"connector", "network"})
+
 	MetricNetworkLatestBlockTimestampDistance = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "erpc",
 		Name:      "network_latest_block_timestamp_distance_seconds",


### PR DESCRIPTION
The read-through gRPC cache connector only tracked the earliest available block (for fast-miss rejection) and never reported how current its data was, so operators had no signal for how far the cache trailed each network's head.

Extend the background poller to also fetch the latest and finalized block (plus the latest block timestamp) per network and export them as gauges:

  - erpc_cache_connector_earliest_block_number{connector,network}
  - erpc_cache_connector_latest_block_number{connector,network}
  - erpc_cache_connector_finalized_block_number{connector,network}
  - erpc_cache_connector_latest_block_timestamp_seconds{connector,network}

This makes cache-vs-network head lag observable in both block-height and wall-clock terms. Each tag is best-effort: a failed or unparsable response leaves the prior value and its gauge untouched instead of zeroing on a transient error. Also adds a BlockHeads() snapshot accessor for diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only observability and background polling; request-path behavior for cache misses still depends only on earliest, with no auth or persistence changes.
> 
> **Overview**
> The gRPC read-through cache connector’s **60s background poller** now refreshes **earliest, latest, and finalized** block heads per network (not just earliest). **Earliest** still drives fast-miss rejection in `Get`; **latest** and **finalized** are stored in new per-network maps for visibility.
> 
> Polling is refactored through **`fetchTaggedBlock`** and **`parseBlockField`** so each tag returns block **number** and optional **timestamp**. Failed or unparsable RPCs are **best-effort**: in-memory values and Prometheus gauges are **not cleared** on transient errors; timestamp gauges update only when `timestamp > 0`.
> 
> **Six new gauges** are registered under `telemetry` and set from the poller: `erpc_cache_connector_{earliest,latest,finalized}_block_number` and matching `*_block_timestamp_seconds`, labeled by `connector` and `network`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8599046b0749c0f80374cf2bbcc2528b762ac527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->