### PR TITLE
feat(clients/grpc): apply jsonRpc.headers on gRPC upstream requests

### DIFF
--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -75,6 +75,17 @@ func NewGrpcBdsClient(
 		headers:         make(map[string]string),
 	}
 
+	// Apply any jsonRpc.headers configured on the upstream as gRPC metadata on
+	// every outbound request, mirroring the HTTP client
+	// (http_json_rpc_client.go) and the gRPC cache connector (data/grpc.go).
+	// This is how an edge-api auth key (authorization: Bearer <token>) reaches
+	// the wire for a grpc:// upstream.
+	if upstream != nil {
+		if cfg := upstream.Config(); cfg != nil && cfg.JsonRpc != nil {
+			client.SetHeaders(cfg.JsonRpc.Headers)
+		}
+	}
+
 	target, useTLS := pickTargetForBDS(parsedUrl)
 
 	// Determine whether to use TLS based on port or URL scheme.

--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -75,14 +75,14 @@ func NewGrpcBdsClient(
 		headers:         make(map[string]string),
 	}
 
-	// Apply any jsonRpc.headers configured on the upstream as gRPC metadata on
-	// every outbound request, mirroring the HTTP client
-	// (http_json_rpc_client.go) and the gRPC cache connector (data/grpc.go).
-	// This is how an edge-api auth key (authorization: Bearer <token>) reaches
-	// the wire for a grpc:// upstream.
+	// Apply any grpc.headers configured on the upstream as gRPC metadata on
+	// every outbound request, mirroring how the HTTP client applies
+	// jsonRpc.headers (http_json_rpc_client.go) and the gRPC cache connector
+	// applies its headers (data/grpc.go). This is how an edge-api auth key
+	// (authorization: Bearer <token>) reaches the wire for a grpc:// upstream.
 	if upstream != nil {
-		if cfg := upstream.Config(); cfg != nil && cfg.JsonRpc != nil {
-			client.SetHeaders(cfg.JsonRpc.Headers)
+		if cfg := upstream.Config(); cfg != nil && cfg.Grpc != nil {
+			client.SetHeaders(cfg.Grpc.Headers)
 		}
 	}
 

--- a/clients/grpc_bds_client_test.go
+++ b/clients/grpc_bds_client_test.go
@@ -94,6 +94,48 @@ func TestBuildTopicFiltersRejectsInvalidHex(t *testing.T) {
 // handler surfaces a transport-failure error — but critically NOT
 // ErrEndpointUnsupported, which would disqualify the upstream from carrying
 // eth_query* traffic.
+func TestGrpcBdsClientAppliesUpstreamJsonRpcHeaders(t *testing.T) {
+	parsedURL, err := url.Parse("grpc://127.0.0.1:1")
+	require.NoError(t, err)
+
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ups := common.NewFakeUpstream("test-ups", common.WithJsonRpcConfig(&common.JsonRpcUpstreamConfig{
+		Headers: map[string]string{
+			"authorization":   "Bearer secret-token",
+			"x-goldsky-chain": "abstract",
+		},
+	}))
+
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL)
+	require.NoError(t, err)
+
+	gc, ok := client.(*GenericGrpcBdsClient)
+	require.True(t, ok)
+	require.Equal(t, "Bearer secret-token", gc.headers["authorization"])
+	require.Equal(t, "abstract", gc.headers["x-goldsky-chain"])
+}
+
+// TestGrpcBdsClientNilUpstreamNoHeaders guards the nil-upstream and nil-JsonRpc
+// paths: construction must not panic and headers stay empty.
+func TestGrpcBdsClientNilUpstreamNoHeaders(t *testing.T) {
+	parsedURL, err := url.Parse("grpc://127.0.0.1:1")
+	require.NoError(t, err)
+
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	require.NoError(t, err)
+
+	gc, ok := client.(*GenericGrpcBdsClient)
+	require.True(t, ok)
+	require.Empty(t, gc.headers)
+}
+
 func TestGrpcBdsClientQueryMethodsDoNotShortCircuit(t *testing.T) {
 	parsedURL, err := url.Parse("grpc://127.0.0.1:1")
 	require.NoError(t, err)

--- a/clients/grpc_bds_client_test.go
+++ b/clients/grpc_bds_client_test.go
@@ -94,7 +94,7 @@ func TestBuildTopicFiltersRejectsInvalidHex(t *testing.T) {
 // handler surfaces a transport-failure error — but critically NOT
 // ErrEndpointUnsupported, which would disqualify the upstream from carrying
 // eth_query* traffic.
-func TestGrpcBdsClientAppliesUpstreamJsonRpcHeaders(t *testing.T) {
+func TestGrpcBdsClientAppliesUpstreamGrpcHeaders(t *testing.T) {
 	parsedURL, err := url.Parse("grpc://127.0.0.1:1")
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestGrpcBdsClientAppliesUpstreamJsonRpcHeaders(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ups := common.NewFakeUpstream("test-ups", common.WithJsonRpcConfig(&common.JsonRpcUpstreamConfig{
+	ups := common.NewFakeUpstream("test-ups", common.WithGrpcConfig(&common.GrpcUpstreamConfig{
 		Headers: map[string]string{
 			"authorization":   "Bearer secret-token",
 			"x-goldsky-chain": "abstract",
@@ -118,7 +118,7 @@ func TestGrpcBdsClientAppliesUpstreamJsonRpcHeaders(t *testing.T) {
 	require.Equal(t, "abstract", gc.headers["x-goldsky-chain"])
 }
 
-// TestGrpcBdsClientNilUpstreamNoHeaders guards the nil-upstream and nil-JsonRpc
+// TestGrpcBdsClientNilUpstreamNoHeaders guards the nil-upstream and nil-Grpc
 // paths: construction must not panic and headers stay empty.
 func TestGrpcBdsClientNilUpstreamNoHeaders(t *testing.T) {
 	parsedURL, err := url.Parse("grpc://127.0.0.1:1")

--- a/clients/grpc_bds_resilience_extras_test.go
+++ b/clients/grpc_bds_resilience_extras_test.go
@@ -193,7 +193,7 @@ func TestSendRequest_HeadersPassedAsMetadata(t *testing.T) {
 }
 
 // TestSendRequest_ConfigHeadersReachWireAsMetadata closes the config→wire
-// seam: headers configured via jsonRpc.headers on the upstream (the path
+// seam: headers configured via grpc.headers on the upstream (the path
 // NewGrpcBdsClient wires) must reach the server as gRPC metadata. The other
 // tests cover config→headers map and SetHeaders→wire separately; this proves
 // the full chain end-to-end, mirroring the HTTP client's header test.
@@ -207,7 +207,7 @@ func TestSendRequest_ConfigHeadersReachWireAsMetadata(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	ups := common.NewFakeUpstream("test-ups", common.WithJsonRpcConfig(&common.JsonRpcUpstreamConfig{
+	ups := common.NewFakeUpstream("test-ups", common.WithGrpcConfig(&common.GrpcUpstreamConfig{
 		Headers: map[string]string{"authorization": "Bearer secret-token"},
 	}))
 	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL)
@@ -219,7 +219,7 @@ func TestSendRequest_ConfigHeadersReachWireAsMetadata(t *testing.T) {
 
 	md := server.snapshotMetadata()
 	require.Equal(t, []string{"Bearer secret-token"}, md.Get("authorization"),
-		"jsonRpc.headers configured on the upstream must reach the server as gRPC metadata")
+		"grpc.headers configured on the upstream must reach the server as gRPC metadata")
 }
 
 // TestSendRequest_ConcurrentRequests_AllSucceed fires many simultaneous

--- a/clients/grpc_bds_resilience_extras_test.go
+++ b/clients/grpc_bds_resilience_extras_test.go
@@ -192,6 +192,36 @@ func TestSendRequest_HeadersPassedAsMetadata(t *testing.T) {
 		"client-set header must reach the server as gRPC metadata")
 }
 
+// TestSendRequest_ConfigHeadersReachWireAsMetadata closes the config→wire
+// seam: headers configured via jsonRpc.headers on the upstream (the path
+// NewGrpcBdsClient wires) must reach the server as gRPC metadata. The other
+// tests cover config→headers map and SetHeaders→wire separately; this proves
+// the full chain end-to-end, mirroring the HTTP client's header test.
+func TestSendRequest_ConfigHeadersReachWireAsMetadata(t *testing.T) {
+	addr, server, stop := startHappyServer(t, 1, 0)
+	defer stop()
+
+	parsedURL, err := url.Parse(fmt.Sprintf("grpc://%s", addr))
+	require.NoError(t, err)
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ups := common.NewFakeUpstream("test-ups", common.WithJsonRpcConfig(&common.JsonRpcUpstreamConfig{
+		Headers: map[string]string{"authorization": "Bearer secret-token"},
+	}))
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL)
+	require.NoError(t, err)
+
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}`))
+	_, err = client.SendRequest(ctx, req)
+	require.NoError(t, err)
+
+	md := server.snapshotMetadata()
+	require.Equal(t, []string{"Bearer secret-token"}, md.Get("authorization"),
+		"jsonRpc.headers configured on the upstream must reach the server as gRPC metadata")
+}
+
 // TestSendRequest_ConcurrentRequests_AllSucceed fires many simultaneous
 // requests against a healthy server. Asserts no races, no goroutine
 // leaks, and every caller gets a response. The pool has shared mutable

--- a/common/config.go
+++ b/common/config.go
@@ -727,6 +727,7 @@ type UpstreamConfig struct {
 	Endpoint                     string                   `yaml:"endpoint,omitempty" json:"endpoint"`
 	Evm                          *EvmUpstreamConfig       `yaml:"evm,omitempty" json:"evm"`
 	JsonRpc                      *JsonRpcUpstreamConfig   `yaml:"jsonRpc,omitempty" json:"jsonRpc"`
+	Grpc                         *GrpcUpstreamConfig      `yaml:"grpc,omitempty" json:"grpc"`
 	IgnoreMethods                []string                 `yaml:"ignoreMethods,omitempty" json:"ignoreMethods"`
 	AllowMethods                 []string                 `yaml:"allowMethods,omitempty" json:"allowMethods"`
 	AutoIgnoreUnsupportedMethods *bool                    `yaml:"autoIgnoreUnsupportedMethods,omitempty" json:"autoIgnoreUnsupportedMethods"`
@@ -859,6 +860,7 @@ func (u *UpstreamConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		Endpoint                     string                   `yaml:"endpoint,omitempty"`
 		Evm                          *EvmUpstreamConfig       `yaml:"evm,omitempty"`
 		JsonRpc                      *JsonRpcUpstreamConfig   `yaml:"jsonRpc,omitempty"`
+		Grpc                         *GrpcUpstreamConfig      `yaml:"grpc,omitempty"`
 		IgnoreMethods                []string                 `yaml:"ignoreMethods,omitempty"`
 		AllowMethods                 []string                 `yaml:"allowMethods,omitempty"`
 		AutoIgnoreUnsupportedMethods *bool                    `yaml:"autoIgnoreUnsupportedMethods,omitempty"`
@@ -880,6 +882,7 @@ func (u *UpstreamConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	u.Endpoint = old.Endpoint
 	u.Evm = old.Evm
 	u.JsonRpc = old.JsonRpc
+	u.Grpc = old.Grpc
 	u.IgnoreMethods = old.IgnoreMethods
 	u.AllowMethods = old.AllowMethods
 	u.AutoIgnoreUnsupportedMethods = old.AutoIgnoreUnsupportedMethods
@@ -955,6 +958,9 @@ func (c *UpstreamConfig) Copy() *UpstreamConfig {
 	}
 	if c.JsonRpc != nil {
 		copied.JsonRpc = c.JsonRpc.Copy()
+	}
+	if c.Grpc != nil {
+		copied.Grpc = c.Grpc.Copy()
 	}
 	if c.RateLimitAutoTune != nil {
 		copied.RateLimitAutoTune = c.RateLimitAutoTune.Copy()
@@ -1081,6 +1087,30 @@ func (c *JsonRpcUpstreamConfig) Copy() *JsonRpcUpstreamConfig {
 	*copied = *c
 
 	if c.Headers != nil {
+		maps.Copy(copied.Headers, c.Headers)
+	}
+
+	return copied
+}
+
+// GrpcUpstreamConfig tunes a gRPC (grpc:// / grpc+bds://) upstream. It is the
+// gRPC analogue of JsonRpcUpstreamConfig: JsonRpc holds JSON-RPC/HTTP-specific
+// knobs, this holds gRPC-specific ones. Headers are applied as gRPC metadata on
+// every outbound request (e.g. an edge-api auth key: authorization: Bearer ...).
+type GrpcUpstreamConfig struct {
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers"`
+}
+
+func (c *GrpcUpstreamConfig) Copy() *GrpcUpstreamConfig {
+	if c == nil {
+		return nil
+	}
+
+	copied := &GrpcUpstreamConfig{}
+	*copied = *c
+
+	if c.Headers != nil {
+		copied.Headers = make(map[string]string, len(c.Headers))
 		maps.Copy(copied.Headers, c.Headers)
 	}
 

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1557,6 +1557,9 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 			Headers:       defaults.JsonRpc.Headers,
 		}
 	}
+	if u.Grpc == nil && defaults.Grpc != nil {
+		u.Grpc = defaults.Grpc.Copy()
+	}
 	// Integrity moved under Evm.Integrity
 	if u.Evm != nil && defaults.Evm != nil {
 		if u.Evm.Integrity == nil && defaults.Evm.Integrity != nil {

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -56,11 +56,11 @@ func WithTags(tags ...string) func(*FakeUpstream) {
 	}
 }
 
-// WithJsonRpcConfig sets the upstream's jsonRpc config block (headers, batch
-// settings, etc.). Used by client tests that exercise jsonRpc.headers handling.
-func WithJsonRpcConfig(cfg *JsonRpcUpstreamConfig) func(*FakeUpstream) {
+// WithGrpcConfig sets the upstream's grpc config block (headers, etc.). Used by
+// client tests that exercise grpc.headers handling.
+func WithGrpcConfig(cfg *GrpcUpstreamConfig) func(*FakeUpstream) {
 	return func(u *FakeUpstream) {
-		u.config.JsonRpc = cfg
+		u.config.Grpc = cfg
 	}
 }
 

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -56,6 +56,14 @@ func WithTags(tags ...string) func(*FakeUpstream) {
 	}
 }
 
+// WithJsonRpcConfig sets the upstream's jsonRpc config block (headers, batch
+// settings, etc.). Used by client tests that exercise jsonRpc.headers handling.
+func WithJsonRpcConfig(cfg *JsonRpcUpstreamConfig) func(*FakeUpstream) {
+	return func(u *FakeUpstream) {
+		u.config.JsonRpc = cfg
+	}
+}
+
 // WithFakeUpstreamNetworkID overrides the network ID this fake reports.
 // Tests that exercise per-network indexing (e.g.
 // `tracker.GetUpstreamMetrics`'s `upstreamsByNetwork` lookup) need

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -547,6 +547,7 @@ export interface UpstreamConfig {
   endpoint?: string;
   evm?: EvmUpstreamConfig;
   jsonRpc?: JsonRpcUpstreamConfig;
+  grpc?: GrpcUpstreamConfig;
   ignoreMethods?: string[];
   allowMethods?: string[];
   autoIgnoreUnsupportedMethods?: boolean;
@@ -680,6 +681,15 @@ export interface JsonRpcUpstreamConfig {
   enableGzip?: boolean;
   headers?: { [key: string]: string};
   proxyPool?: string;
+}
+/**
+ * GrpcUpstreamConfig tunes a gRPC (grpc:// / grpc+bds://) upstream. It is the
+ * gRPC analogue of JsonRpcUpstreamConfig: JsonRpc holds JSON-RPC/HTTP-specific
+ * knobs, this holds gRPC-specific ones. Headers are applied as gRPC metadata on
+ * every outbound request (e.g. an edge-api auth key: authorization: Bearer ...).
+ */
+export interface GrpcUpstreamConfig {
+  headers?: { [key: string]: string};
 }
 export interface EvmUpstreamConfig {
   chainId: number /* int64 */;


### PR DESCRIPTION
## Why

Header injection is inconsistent across eRPC's two gRPC paths:

- ✅ **gRPC cache / data connector** — works. `GrpcConnectorConfig.Headers` is applied via `data/grpc.go` → `cli.SetHeaders(...)`.
- ❌ **gRPC RPC upstream** — not wired. `NewGrpcBdsClient` initialized `headers` to an empty map and never read the upstream's `JsonRpc.Headers`, so the existing header→metadata machinery in `SendRequest` (`metadata.New(c.headers)`) was dead for upstreams.

For contrast, the **HTTP** upstream client already does this correctly (`http_json_rpc_client.go`: `client.headers = jsonRpcCfg.Headers`).

This makes `jsonRpc.headers` behave consistently across the HTTP client, the gRPC cache connector, and now the gRPC upstream — so a `grpc://` reader upstream can inject an auth header (e.g. `authorization: Bearer <token>`) on every outbound request.

## What

- **gRPC upstream:** `NewGrpcBdsClient` now reads `upstream.Config().JsonRpc.Headers` and applies them via the existing `SetHeaders(...)`, mirroring the HTTP client. Fully nil-guarded (`upstream`, `Config()`, `JsonRpc`), and `SetHeaders` already guards a nil map — the existing nil-upstream construction path is preserved.
- Reuses the existing `SetHeaders` method and `metadata.New` translation (no duplicated logic). `SetHeaders` copies entries into the client's own map, so config mutation can't bleed in.

## Tests

- `TestGrpcBdsClientAppliesUpstreamJsonRpcHeaders` — config → `headers` map.
- `TestGrpcBdsClientNilUpstreamNoHeaders` — nil upstream / nil JsonRpc construct without panic, headers stay empty.
- `TestSendRequest_ConfigHeadersReachWireAsMetadata` — full chain: `jsonRpc.headers` on the upstream → `NewGrpcBdsClient` → outgoing gRPC metadata observed server-side. Complements the existing `TestSendRequest_HeadersPassedAsMetadata` (which exercised `SetHeaders` directly).
- Added `common.WithJsonRpcConfig` fake-upstream test helper, following the existing `func(*FakeUpstream)` opt convention.

All `clients` and `common` package tests pass (incl. `-race` on the header tests).

## Note on transport security

A `grpc://` upstream uses insecure credentials (TLS kicks in only on port 443 or a `grpcs://`-style scheme), so a configured auth header transits in cleartext — same behavior as the HTTP client for `http://`. The first consumer is in-cluster (`grpc://...svc.cluster.local:50051`). Broader TLS-policy enforcement for credential-bearing headers is intentionally out of scope here; this PR only wires header parity.

Closes ERPC-530.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auth and custom headers are sent to gRPC upstreams; misconfiguration could break authenticated backends, and headers on insecure `grpc://` still transit in cleartext like HTTP.
> 
> **Overview**
> Adds a dedicated **`grpc`** upstream config block (with **`headers`**) as the gRPC counterpart to **`jsonRpc`**, including YAML/JSON unmarshaling, deep copy, upstream defaults inheritance, and TypeScript schema generation.
> 
> **`NewGrpcBdsClient`** now reads **`upstream.grpc.headers`** at construction and applies them through the existing **`SetHeaders` → outgoing gRPC metadata** path in **`SendRequest`**, so auth and routing keys (e.g. **`authorization: Bearer …`**) reach **`grpc://`** upstreams the same way HTTP and the gRPC cache connector already do.
> 
> Tests cover config → client header map, nil-safe construction, and an integration check that configured headers appear as server-side metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1016034edf2914a3cca78ad72f75c0a0ac36fbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->