### PR TITLE
feat(selection-policy): add includeIf primitive and pool-level quantifiers

### DIFF
--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -448,12 +448,11 @@ Use `evalScope: 'network-method-finality'` to get one slot per `(method, finalit
     .stickyPrimary({ hysteresis: 0.30, minSwitchInterval: '30s' })
 ```
 
-This differs from a `preferTag` fallback: `preferTag` only reaches the
-fallback tier when the primary tier is **empty**, whereas `includeIf`
-brings the reserve in while primaries are still serving but
-**collectively degraded** (lagging / slow), letting `sortByScore` pick
-between them. Pair with `routing.probe: 'off'` on the reserve upstreams
-if you also want to keep shadow-probe traffic off them while they're out.
+The reserve is brought in while primaries are still serving but
+**collectively degraded** (lagging / slow) — not only when they're
+entirely gone — letting `sortByScore` pick between them. Pair with
+`routing.probe: 'off'` on the reserve upstreams if you also want to keep
+shadow-probe traffic off them while they're out.
 
 ### Per-method override
 

--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -441,9 +441,9 @@ Use `evalScope: 'network-method-finality'` to get one slot per `(method, finalit
     .removeCordoned()
     .excludeIf(all(samplesAbove(10), errorRateAbove(0.7)))
     .excludeTag('tier:reserve')
-    .includeIf((p) => p.length > 0 && p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
-    .includeIf((p) => p.length > 0 && p.every(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
-    .includeIf((p) => p.length < 1,                                      { tag: 'tier:reserve' })
+    .includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockSecondsLagAbove(30)))
+    .includeIf('tier:reserve', (p) => p.length > 0 && p.every(latencyAbove(2000, 99)))
+    .includeIf('tier:reserve', (p) => p.length < 1)
     .sortByScore(PREFER_FASTEST)
     .stickyPrimary({ hysteresis: 0.30, minSwitchInterval: '30s' })
 ```
@@ -930,15 +930,16 @@ Always include matching upstreams, even if prior filters dropped them.
 
 ```ts
 .includeIf(
-  condition: boolean | ((upstreams) => boolean),
-  opts: {
-    id?: string | string[],               // selector facets — AND together,
-    tag?: string | string[],              // at least one must resolve
-    vendor?: string | string[],
-    type?: string | string[],
-    where?: { id?, tag?, vendor?, type? }, // alternative to the flat facets
-    position?: 'head' | 'tail' = 'tail',
-  },
+  target:                                  // WHAT to admit — comes first
+    | string | string[]                    //   tag pattern (common case)
+    | {                                     //   or a selector object:
+        id?: string | string[],            //     facets AND together,
+        tag?: string | string[],           //     at least one must resolve
+        vendor?: string | string[],
+        type?: string | string[],
+        position?: 'head' | 'tail' = 'tail',
+      },
+  condition: boolean | ((upstreams) => boolean),   // WHEN to admit
 )
 ```
 
@@ -947,17 +948,18 @@ offender, `includeIf` **admits** a selected set of upstreams from the
 full universe when an aggregate condition over the surviving pool
 holds. It never removes an upstream.
 
-The function form of `condition` receives the **current** chain array
-— the pool that survived earlier steps — so it can ask aggregate
-("network-level") questions about what's left. The array is a normal
-JS array, so use native `every` / `some` / `length` / `filter` over the
-[predicate factories](#predicate-factories):
+`target` comes first so the policy reads "include _these_ if
+_condition_". The function form of `condition` receives the **current**
+chain array — the pool that survived earlier steps — so it can ask
+aggregate ("network-level") questions about what's left. The array is a
+normal JS array, so use native `every` / `some` / `length` / `filter`
+over the [predicate factories](#predicate-factories):
 
 ```js
 upstreams
-  .excludeTag('tier:reserve')                                             // reserve out of normal rotation
-  .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })  // admit if every survivor lags
-  .includeIf((p) => p.length < 2,                      { tag: 'tier:reserve' })  // ...or if too few remain
+  .excludeTag('tier:reserve')                                              // reserve out of normal rotation
+  .includeIf('tier:reserve', (p) => p.every(blockSecondsLagAbove(30)))     // admit if every survivor lags
+  .includeIf('tier:reserve', (p) => p.length < 2)                          // ...or if too few remain
   .sortByScore(PREFER_FASTEST)
 ```
 
@@ -974,10 +976,11 @@ decides the order.
 > if an empty pool should **not** trigger inclusion.
 
 At least one selector facet must resolve to a concrete value; otherwise
-it is a no-op (it never admits the whole universe — including for
-`where: {}`). Added upstreams default to the tail so the survivors keep
-priority. Already-present upstreams aren't duplicated. A malformed or
-throwing `condition` degrades to a no-op rather than failing the eval.
+it is a no-op (it never admits the whole universe — including for an
+empty or facet-less object target). Added upstreams default to the tail
+so the survivors keep priority. Already-present upstreams aren't
+duplicated. A malformed or throwing `condition` degrades to a no-op
+rather than failing the eval.
 
 </details>
 

--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -454,6 +454,15 @@ entirely gone — letting `sortByScore` pick between them. Pair with
 `routing.probe: 'off'` on the reserve upstreams if you also want to keep
 shadow-probe traffic off them while they're out.
 
+Keep the explicit `excludeTag('tier:reserve')` step even though `includeIf`
+targets the same tag: the two are not redundant, they cover the two
+directions of intent. `excludeTag` states "this tier is NOT in normal
+rotation" — without it the reserve is simply in the pool like any other
+upstream. `includeIf` states "this is the only condition under which it
+comes back". Reading the pair top-to-bottom is the policy's own
+documentation of why the reserve exists and when it's allowed to serve;
+dropping either half leaves that reasoning implicit.
+
 ### Per-method override
 
 ```js

--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -426,6 +426,33 @@ Use `evalScope: 'network-method-finality'` to get one slot per `(method, finalit
     .stickyPrimary({ hysteresis: 0.30, minSwitchInterval: '30s' })
 ```
 
+### Reserve tier (break-glass inclusion)
+
+```js
+// A reserve pool (e.g. a pricier or rate-limited provider, tagged
+// `tags: [tier:reserve]`) is kept OUT of normal rotation, then ranked in
+// only when the serving pool is collectively unfit — every survivor
+// lagging, or too few left. `includeIf` adds; it never evicts a survivor,
+// so a single slow primary alone does not pull the reserve in.
+(upstreams, ctx) =>
+  upstreams
+    .removeCordoned()
+    .excludeIf(all(samplesAbove(10), errorRateAbove(0.7)))
+    .preferTag('!tier:reserve', { minHealthy: 1, fallback: 'tier:reserve' })
+    .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+    .includeIf(forAll(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
+    .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })
+    .sortByScore(PREFER_FASTEST)
+    .stickyPrimary({ hysteresis: 0.30, minSwitchInterval: '30s' })
+```
+
+This differs from a `preferTag` fallback: `preferTag` only reaches the
+fallback tier when the primary tier is **empty**, whereas `includeIf`
+brings the reserve in while primaries are still serving but
+**collectively degraded** (lagging / slow), letting `sortByScore` pick
+between them. Pair with `routing.probe: 'off'` on the reserve upstreams
+if you also want to keep shadow-probe traffic off them while they're out.
+
 ### Per-method override
 
 ```js
@@ -897,6 +924,55 @@ Always include matching upstreams, even if prior filters dropped them.
 
 </details>
 
+<details>
+<summary>**`includeIf`**</summary>
+
+```ts
+.includeIf(
+  condition: boolean | ((upstreams) => boolean),
+  opts: {
+    id?: string | string[],          // selector facets — AND together,
+    tag?: string | string[],         // at least one is required
+    vendor?: string | string[],
+    where?: { id?, tag?, vendor? },  // alternative to the flat facets
+    position?: 'head' | 'tail' = 'tail',
+  },
+)
+```
+
+The dual of `excludeIf`: where `excludeIf` **drops** a per-upstream
+offender, `includeIf` **admits** a selected set of upstreams from the
+full universe when an aggregate condition over the surviving pool
+holds. It never removes an upstream.
+
+The function form of `condition` receives the **current** chain array
+— the pool that survived earlier steps — so it can ask aggregate
+("network-level") questions about what's left. Pair it with the
+[quantifiers](#quantifiers) (`forAll`, `fewerThan`, `sizeBelow`, …):
+
+```js
+upstreams
+  .preferTag('!tier:reserve', { fallback: 'tier:reserve' })   // reserve out of normal rotation
+  .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })  // admit if every survivor lags
+  .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })  // ...or if too few remain
+  .sortByScore(PREFER_FASTEST)
+```
+
+Use it for a **break-glass reserve tier**: kept out of rotation, but
+ranked in alongside the survivors only when the serving pool is
+collectively unfit (too few left, all lagging, all slow). Because it
+adds rather than excludes, a single degraded primary is never evicted
+— the reserve set is offered alongside it and a later `sortByScore`
+decides the order.
+
+At least one selector facet is required; with none it is a no-op (it
+never admits the whole universe). Added upstreams default to the tail
+so the survivors keep priority. Already-present upstreams aren't
+duplicated. A malformed or throwing `condition` degrades to a no-op
+rather than failing the eval.
+
+</details>
+
 ### Slicing & limits
 
 <details>
@@ -1127,6 +1203,41 @@ not(pred)        // NOT
 Composed predicates carry a joined `policyReason` —
 `any(errorRateAbove(0.5), latencyAbove(30_000))` displays as
 `any(errorRate>0.5,p70>30000ms)` (p70 is the default-quantile slug).
+
+</details>
+
+### Quantifiers
+
+Where `all` / `any` / `not` compose per-upstream predicates into
+another per-upstream predicate (for `excludeIf`), the quantifiers
+collapse a per-upstream predicate over the **whole** surviving pool
+into a single boolean — an aggregate, "network-level" question. They
+produce the conditions [`includeIf`](#probing--forced-inclusion)
+consumes.
+
+<details>
+<summary>**Pool-level conditions**</summary>
+
+```ts
+forAll(pred)         // every upstream satisfies pred (false on an empty pool)
+forAny(pred)         // at least one satisfies pred
+forNone(pred)        // no upstream satisfies pred
+atLeast(n, pred)     // at least n upstreams satisfy pred
+fewerThan(n, pred)   // fewer than n upstreams satisfy pred
+sizeBelow(n)         // pool has fewer than n upstreams
+sizeAtLeast(n)       // pool has at least n upstreams
+```
+
+`forAll` is deliberately **false on an empty pool** — "all of nothing
+are bad" should not trigger a break-glass inclusion; use `sizeBelow`
+for the empty / thin-pool case. Each takes a per-upstream predicate
+from the [predicate factories](#predicate-factories), so the full
+predicate library composes:
+
+```js
+.includeIf(forAll(any(blockSecondsLagAbove(30), latencyAbove(2000, 99))), { tag: 'tier:reserve' })
+.includeIf(fewerThan(2, not(any(errorRateAbove(0.5), blockNumberLagAbove(16)))), { tag: 'tier:reserve' })
+```
 
 </details>
 

--- a/docs/pages/config/projects/selection-policies.mdx
+++ b/docs/pages/config/projects/selection-policies.mdx
@@ -430,18 +430,20 @@ Use `evalScope: 'network-method-finality'` to get one slot per `(method, finalit
 
 ```js
 // A reserve pool (e.g. a pricier or rate-limited provider, tagged
-// `tags: [tier:reserve]`) is kept OUT of normal rotation, then ranked in
-// only when the serving pool is collectively unfit — every survivor
-// lagging, or too few left. `includeIf` adds; it never evicts a survivor,
-// so a single slow primary alone does not pull the reserve in.
+// `tags: [tier:reserve]`) is kept OUT of normal rotation with excludeTag,
+// then ranked in only when the serving pool is collectively unfit — every
+// survivor lagging or slow, or none left. `includeIf` adds; it never evicts
+// a survivor, so a single slow primary alone does not pull the reserve in.
+// The `length > 0 && ...` guard keeps the lag/latency rules from firing on
+// an empty pool; the `length < 1` line is the explicit empty-pool fallback.
 (upstreams, ctx) =>
   upstreams
     .removeCordoned()
     .excludeIf(all(samplesAbove(10), errorRateAbove(0.7)))
-    .preferTag('!tier:reserve', { minHealthy: 1, fallback: 'tier:reserve' })
-    .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
-    .includeIf(forAll(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
-    .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })
+    .excludeTag('tier:reserve')
+    .includeIf((p) => p.length > 0 && p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+    .includeIf((p) => p.length > 0 && p.every(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
+    .includeIf((p) => p.length < 1,                                      { tag: 'tier:reserve' })
     .sortByScore(PREFER_FASTEST)
     .stickyPrimary({ hysteresis: 0.30, minSwitchInterval: '30s' })
 ```
@@ -931,10 +933,11 @@ Always include matching upstreams, even if prior filters dropped them.
 .includeIf(
   condition: boolean | ((upstreams) => boolean),
   opts: {
-    id?: string | string[],          // selector facets — AND together,
-    tag?: string | string[],         // at least one is required
+    id?: string | string[],               // selector facets — AND together,
+    tag?: string | string[],              // at least one must resolve
     vendor?: string | string[],
-    where?: { id?, tag?, vendor? },  // alternative to the flat facets
+    type?: string | string[],
+    where?: { id?, tag?, vendor?, type? }, // alternative to the flat facets
     position?: 'head' | 'tail' = 'tail',
   },
 )
@@ -947,14 +950,15 @@ holds. It never removes an upstream.
 
 The function form of `condition` receives the **current** chain array
 — the pool that survived earlier steps — so it can ask aggregate
-("network-level") questions about what's left. Pair it with the
-[quantifiers](#quantifiers) (`forAll`, `fewerThan`, `sizeBelow`, …):
+("network-level") questions about what's left. The array is a normal
+JS array, so use native `every` / `some` / `length` / `filter` over the
+[predicate factories](#predicate-factories):
 
 ```js
 upstreams
-  .preferTag('!tier:reserve', { fallback: 'tier:reserve' })   // reserve out of normal rotation
-  .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })  // admit if every survivor lags
-  .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })  // ...or if too few remain
+  .excludeTag('tier:reserve')                                             // reserve out of normal rotation
+  .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })  // admit if every survivor lags
+  .includeIf((p) => p.length < 2,                      { tag: 'tier:reserve' })  // ...or if too few remain
   .sortByScore(PREFER_FASTEST)
 ```
 
@@ -965,11 +969,16 @@ adds rather than excludes, a single degraded primary is never evicted
 — the reserve set is offered alongside it and a later `sortByScore`
 decides the order.
 
-At least one selector facet is required; with none it is a no-op (it
-never admits the whole universe). Added upstreams default to the tail
-so the survivors keep priority. Already-present upstreams aren't
-duplicated. A malformed or throwing `condition` degrades to a no-op
-rather than failing the eval.
+> Native `every` returns `true` on an empty array, so
+> `(p) => p.every(...)` admits the reserve when the pool is empty
+> (usually what you want). Guard with `(p) => p.length > 0 && p.every(...)`
+> if an empty pool should **not** trigger inclusion.
+
+At least one selector facet must resolve to a concrete value; otherwise
+it is a no-op (it never admits the whole universe — including for
+`where: {}`). Added upstreams default to the tail so the survivors keep
+priority. Already-present upstreams aren't duplicated. A malformed or
+throwing `condition` degrades to a no-op rather than failing the eval.
 
 </details>
 
@@ -1203,41 +1212,6 @@ not(pred)        // NOT
 Composed predicates carry a joined `policyReason` —
 `any(errorRateAbove(0.5), latencyAbove(30_000))` displays as
 `any(errorRate>0.5,p70>30000ms)` (p70 is the default-quantile slug).
-
-</details>
-
-### Quantifiers
-
-Where `all` / `any` / `not` compose per-upstream predicates into
-another per-upstream predicate (for `excludeIf`), the quantifiers
-collapse a per-upstream predicate over the **whole** surviving pool
-into a single boolean — an aggregate, "network-level" question. They
-produce the conditions [`includeIf`](#probing--forced-inclusion)
-consumes.
-
-<details>
-<summary>**Pool-level conditions**</summary>
-
-```ts
-forAll(pred)         // every upstream satisfies pred (false on an empty pool)
-forAny(pred)         // at least one satisfies pred
-forNone(pred)        // no upstream satisfies pred
-atLeast(n, pred)     // at least n upstreams satisfy pred
-fewerThan(n, pred)   // fewer than n upstreams satisfy pred
-sizeBelow(n)         // pool has fewer than n upstreams
-sizeAtLeast(n)       // pool has at least n upstreams
-```
-
-`forAll` is deliberately **false on an empty pool** — "all of nothing
-are bad" should not trigger a break-glass inclusion; use `sizeBelow`
-for the empty / thin-pool case. Each takes a per-upstream predicate
-from the [predicate factories](#predicate-factories), so the full
-predicate library composes:
-
-```js
-.includeIf(forAll(any(blockSecondsLagAbove(30), latencyAbove(2000, 99))), { tag: 'tier:reserve' })
-.includeIf(fewerThan(2, not(any(errorRateAbove(0.5), blockNumberLagAbove(16)))), { tag: 'tier:reserve' })
-```
 
 </details>
 

--- a/internal/policy/stdlib/include_if_test.go
+++ b/internal/policy/stdlib/include_if_test.go
@@ -53,13 +53,12 @@ func setLag(tracker *health.Tracker, u common.Upstream, lag int64) {
 
 // ─── includeIf: core admit / no-admit behavior ──────────────────────────
 
-// When the gate holds, the selected reserve upstream is unioned in at the
-// tail (survivors keep priority). The condition uses a native `every` over a
-// per-upstream predicate factory.
+// When the gate holds, the tag-selected reserve upstream is unioned in at the
+// tail (survivors keep priority). Target comes first, condition second.
 func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockNumberLagAbove(16)))`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -80,7 +79,7 @@ func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockNumberLagAbove(16)))`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -96,12 +95,12 @@ func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
 		"one healthy survivor → reserve stays out AND the lagging primary is not evicted")
 }
 
-// A literal `true` condition always admits; the selector still scopes which
+// A literal `true` condition always admits; the target still scopes which
 // upstreams come in.
 func TestIncludeIf_BooleanTrueAlwaysAdmits(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -116,7 +115,7 @@ func TestIncludeIf_BooleanTrueAlwaysAdmits(t *testing.T) {
 func TestIncludeIf_BooleanFalseIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(false, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', false)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -127,11 +126,26 @@ func TestIncludeIf_BooleanFalseIsNoOp(t *testing.T) {
 		"condition=false admits nothing")
 }
 
-// position:'head' puts the admitted reserve in front of the survivors.
+// A tag-pattern array (OR) is accepted as the target shorthand.
+func TestIncludeIf_TagArrayTarget(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.excludeTag('tier:reserve')
+		.includeIf(['tier:reserve', 'tier:overflow'], true)`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"array target matches tier:reserve via OR")
+}
+
+// position:'head' (object target form) puts the admitted reserve in front.
 func TestIncludeIf_PositionHead(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { tag: 'tier:reserve', position: 'head' })`
+		.includeIf({ tag: 'tier:reserve', position: 'head' }, true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -146,7 +160,7 @@ func TestIncludeIf_PositionHead(t *testing.T) {
 func TestIncludeIf_DeduplicatesAlreadyPresent(t *testing.T) {
 	// No excludeTag → reserve1 is already in the pool. includeIf must not
 	// add a second copy.
-	eval := `(upstreams) => upstreams.includeIf(true, { tag: 'tier:reserve' })`
+	eval := `(upstreams) => upstreams.includeIf('tier:reserve', true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -157,12 +171,12 @@ func TestIncludeIf_DeduplicatesAlreadyPresent(t *testing.T) {
 		"reserve1 already present → not duplicated")
 }
 
-// With no selector facet, includeIf is a no-op — it must never admit the
-// entire universe.
-func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
+// An object target with NO selector facet (e.g. only `position`) resolves to
+// nothing and is a no-op — it must never admit the entire universe.
+func TestIncludeIf_TargetWithoutFacetIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, {})`
+		.includeIf({ position: 'tail' }, true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -170,17 +184,14 @@ func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
 	policy.TickForTest(engine, "evm:1", "*")
 	got := ids(engine.GetOrdered("evm:1", "*", "*"))
 	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
-		"selector-less includeIf admits nothing (never the whole universe)")
+		"facet-less target admits nothing (never the whole universe)")
 }
 
-// A present-but-empty `where` (and a `where` whose only keys resolve to
-// nothing) must ALSO be a no-op — the selector gate keys on the resolved
-// facets, not on `where != null`. Regression for the "empty where admits
-// universe" class.
-func TestIncludeIf_EmptyWhereIsNoOp(t *testing.T) {
+// An empty object target is likewise a no-op.
+func TestIncludeIf_EmptyObjectTargetIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { where: {} })`
+		.includeIf({}, true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -188,14 +199,14 @@ func TestIncludeIf_EmptyWhereIsNoOp(t *testing.T) {
 	policy.TickForTest(engine, "evm:1", "*")
 	got := ids(engine.GetOrdered("evm:1", "*", "*"))
 	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
-		"where:{} resolves no facets → no-op, must NOT admit the universe")
+		"{} resolves no facet → no-op, must NOT admit the universe")
 }
 
-// id and vendor selectors resolve against the universe.
+// id and vendor selectors (object target form) resolve against the universe.
 func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 	byId := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { id: 'reserve1' })`
+		.includeIf({ id: 'reserve1' }, true)`
 	engine, _, _, cancel := mkReserveEngine(t, byId)
 	defer cancel()
 	defer engine.Stop()
@@ -205,7 +216,7 @@ func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 
 	byVendor := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { vendor: 'premium' })`
+		.includeIf({ vendor: 'premium' }, true)`
 	engine2, _, _, cancel2 := mkReserveEngine(t, byVendor)
 	defer cancel2()
 	defer engine2.Stop()
@@ -221,7 +232,7 @@ func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 func TestIncludeIf_TypeSelectorIsApplied(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf(true, { type: 'evm' })`
+		.includeIf({ type: 'evm' }, true)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -232,11 +243,11 @@ func TestIncludeIf_TypeSelectorIsApplied(t *testing.T) {
 		"type:'evm' matches no upstream (all have empty type) → reserve not admitted")
 }
 
-// where{} facet form is equivalent to the flat facets.
-func TestIncludeIf_WhereSelectorForm(t *testing.T) {
+// The object-form tag selector behaves like the string shorthand.
+func TestIncludeIf_ObjectTagSelectorForm(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length < 3, { where: { tag: 'tier:reserve' } })`
+		.includeIf({ tag: 'tier:reserve' }, (p) => p.length < 3)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -244,7 +255,7 @@ func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 	policy.TickForTest(engine, "evm:1", "*")
 	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
 		ids(engine.GetOrdered("evm:1", "*", "*")),
-		"where:{tag} behaves like the flat tag facet")
+		"{ tag } behaves like the 'tier:reserve' shorthand")
 }
 
 // A throwing custom condition must NOT crash the eval (which would fall the
@@ -252,7 +263,7 @@ func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 func TestIncludeIf_ThrowingConditionDegradesToNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => { throw new Error('boom'); }, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => { throw new Error('boom'); })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -270,7 +281,7 @@ func TestIncludeIf_ConditionSeesSurvivingPool(t *testing.T) {
 	// proves the condition sees the survivors, not the full 3-upstream set.
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length === 2, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length === 2)`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -295,7 +306,7 @@ func TestIncludeIf_EveryVsSome(t *testing.T) {
 
 	everyEval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockNumberLagAbove(16)))`
 	engine, ups, tracker, cancel := mkReserveEngine(t, everyEval)
 	defer cancel()
 	defer engine.Stop()
@@ -307,7 +318,7 @@ func TestIncludeIf_EveryVsSome(t *testing.T) {
 
 	someEval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.some(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.some(blockNumberLagAbove(16)))`
 	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, someEval)
 	defer cancel2()
 	defer engine2.Stop()
@@ -326,7 +337,7 @@ func TestIncludeIf_EmptyPoolEveryNativeSemantics(t *testing.T) {
 	bare := `(upstreams) => upstreams
 		.byTag('tier:main')
 		.excludeId('primary*')
-		.includeIf((p) => p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.every(blockNumberLagAbove(16)))`
 	engine, _, _, cancel := mkReserveEngine(t, bare)
 	defer cancel()
 	defer engine.Stop()
@@ -339,7 +350,7 @@ func TestIncludeIf_EmptyPoolEveryNativeSemantics(t *testing.T) {
 	guarded := `(upstreams) => upstreams
 		.byTag('tier:main')
 		.excludeId('primary*')
-		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockNumberLagAbove(16)))`
 	engine2, _, _, cancel2 := mkReserveEngine(t, guarded)
 	defer cancel2()
 	defer engine2.Stop()
@@ -353,7 +364,7 @@ func TestIncludeIf_SizeGates(t *testing.T) {
 	// length < 3: 2 survivors → admit.
 	below := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length < 3, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length < 3)`
 	e1, _, _, c1 := mkReserveEngine(t, below)
 	defer c1()
 	defer e1.Stop()
@@ -364,7 +375,7 @@ func TestIncludeIf_SizeGates(t *testing.T) {
 	// length >= 3: only 2 survivors → false → no admit.
 	atLeast := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length >= 3, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.length >= 3)`
 	e2, _, _, c2 := mkReserveEngine(t, atLeast)
 	defer c2()
 	defer e2.Stop()
@@ -378,7 +389,7 @@ func TestIncludeIf_FilterCount(t *testing.T) {
 	// Both primaries lag → 2 match. Admit when at least 2 lag.
 	eval := `(upstreams) => upstreams
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.filter(blockNumberLagAbove(16)).length >= 2, { tag: 'tier:reserve' })`
+		.includeIf('tier:reserve', (p) => p.filter(blockNumberLagAbove(16)).length >= 2)`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -400,8 +411,8 @@ func TestIncludeIf_EndToEnd_ReserveTierBreakGlass(t *testing.T) {
 		.removeCordoned()
 		.excludeIf(all(samplesAbove(10), errorRateAbove(0.7)))
 		.excludeTag('tier:reserve')
-		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })
-		.includeIf((p) => p.length < 1, { tag: 'tier:reserve' })
+		.includeIf('tier:reserve', (p) => p.length > 0 && p.every(blockNumberLagAbove(16)))
+		.includeIf('tier:reserve', (p) => p.length < 1)
 		.sortByScore(PREFER_FASTEST)`
 
 	// Phase 1: primaries healthy → reserve excluded.

--- a/internal/policy/stdlib/include_if_test.go
+++ b/internal/policy/stdlib/include_if_test.go
@@ -1,0 +1,440 @@
+package stdlib_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/erpc/erpc/internal/policy/stdlib"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// mkReserveEngine builds a frozen-tick engine over the given eval with a
+// pool of two "primary" upstreams (tier:main) and one "reserve" upstream
+// (tier:reserve). Returns the engine + tracker so a test can shape metrics
+// before ticking.
+func mkReserveEngine(t *testing.T, eval string) (*policy.Engine, []common.Upstream, *health.Tracker, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "p1", time.Minute)
+	engine := policy.NewEngine(ctx, &logger, "p1", tracker, stdlib.Install, nil)
+
+	ups := mkUpsWithTags([]struct {
+		id     string
+		vendor string
+		tags   []string
+	}{
+		{id: "primary1", vendor: "cheap", tags: []string{"tier:main"}},
+		{id: "primary2", vendor: "cheap", tags: []string{"tier:main"}},
+		{id: "reserve1", vendor: "premium", tags: []string{"tier:reserve"}},
+	})
+
+	cfg := &common.SelectionPolicyConfig{
+		EvalInterval: 0,
+		EvalTimeout:  common.Duration(50 * time.Millisecond),
+		EvalFunc:     eval,
+	}
+	require.NoError(t, cfg.SetDefaults())
+	require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+	return engine, ups, tracker, cancel
+}
+
+// setLag force-creates the metric entry for an upstream and pins its
+// block-head lag (block-count) so the lag predicates are deterministic
+// without depending on the block-time EMA.
+func setLag(tracker *health.Tracker, u common.Upstream, lag int64) {
+	tracker.GetUpstreamMethodMetrics(u, "*", common.DataFinalityStateAll).BlockHeadLag.Store(lag)
+}
+
+// ─── includeIf: core admit / no-admit behavior ──────────────────────────
+
+// When the gate holds, the selected reserve upstream is unioned in at the
+// tail (survivors keep priority).
+func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	// Both primaries lag past the threshold; reserve is fresh.
+	setLag(tracker, ups[0], 50)
+	setLag(tracker, ups[1], 50)
+	setLag(tracker, ups[2], 0)
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.Equal(t, []string{"primary1", "primary2", "reserve1"}, got,
+		"all survivors lag → reserve admitted at the tail, survivors keep priority")
+}
+
+// When the gate does NOT hold, the reserve stays out and the survivors are
+// untouched — crucially, a degraded primary is never evicted by includeIf.
+func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	// primary1 lags, primary2 is healthy → forAll is false.
+	setLag(tracker, ups[0], 50)
+	setLag(tracker, ups[1], 0)
+	setLag(tracker, ups[2], 0)
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.Equal(t, []string{"primary1", "primary2"}, got,
+		"one healthy survivor → reserve stays out AND the lagging primary is not evicted")
+}
+
+// A literal `true` condition always admits; the selector still scopes which
+// upstreams come in.
+func TestIncludeIf_BooleanTrueAlwaysAdmits(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"}, got,
+		"condition=true admits the tag-selected reserve unconditionally")
+}
+
+// A literal `false` condition is a no-op.
+func TestIncludeIf_BooleanFalseIsNoOp(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(false, { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
+		"condition=false admits nothing")
+}
+
+// position:'head' puts the admitted reserve in front of the survivors.
+func TestIncludeIf_PositionHead(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { tag: 'tier:reserve', position: 'head' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.Equal(t, []string{"reserve1", "primary1", "primary2"}, got,
+		"position:head places admitted upstreams ahead of survivors")
+}
+
+// An upstream already present is not duplicated.
+func TestIncludeIf_DeduplicatesAlreadyPresent(t *testing.T) {
+	// No preferTag → reserve1 is already in the pool. includeIf must not
+	// add a second copy.
+	eval := `(upstreams) => upstreams.includeIf(true, { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.Equal(t, []string{"primary1", "primary2", "reserve1"}, got,
+		"reserve1 already present → not duplicated")
+}
+
+// With no selector facet, includeIf is a no-op — it must never admit the
+// entire universe.
+func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, {})`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
+		"selector-less includeIf admits nothing (never the whole universe)")
+}
+
+// id and vendor selectors resolve against the universe.
+func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
+	byId := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { id: 'reserve1' })`
+	engine, _, _, cancel := mkReserveEngine(t, byId)
+	defer cancel()
+	defer engine.Stop()
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")), "id selector admits reserve1")
+
+	byVendor := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { vendor: 'premium' })`
+	engine2, _, _, cancel2 := mkReserveEngine(t, byVendor)
+	defer cancel2()
+	defer engine2.Stop()
+	policy.TickForTest(engine2, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine2.GetOrdered("evm:1", "*", "*")), "vendor selector admits the premium reserve")
+}
+
+// where{} selector form is equivalent to the flat facets.
+func TestIncludeIf_WhereSelectorForm(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(sizeBelow(3), { where: { tag: 'tier:reserve' } })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"where:{tag} behaves like the flat tag facet")
+}
+
+// A throwing custom condition must NOT crash the eval (which would fall the
+// network back to the engine default) — it degrades to "do not include".
+func TestIncludeIf_ThrowingConditionDegradesToNoOp(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf((pool) => { throw new Error('boom'); }, { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
+		"a throwing condition is swallowed → no admission, eval still produces the survivors")
+}
+
+// The function condition receives the CURRENT (post-preferTag) pool, not the
+// original full universe — proving aggregate questions see only survivors.
+func TestIncludeIf_ConditionSeesSurvivingPool(t *testing.T) {
+	// After preferTag, only the 2 primaries remain. `pool.length === 2`
+	// proves the condition sees the survivors, not the full 3-upstream set.
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf((pool) => pool.length === 2, { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"condition observed pool.length==2 (survivors only), so it admitted the reserve")
+}
+
+// ─── quantifiers ────────────────────────────────────────────────────────
+
+// forAll is false unless EVERY survivor trips; forAny is true if at least
+// one does.
+func TestIncludeIf_Quantifier_ForAll_vs_ForAny(t *testing.T) {
+	// One primary lags, one is healthy.
+	shape := func(tracker *health.Tracker, ups []common.Upstream) {
+		setLag(tracker, ups[0], 50) // primary1 lags
+		setLag(tracker, ups[1], 0)  // primary2 healthy
+		setLag(tracker, ups[2], 0)
+	}
+
+	forAllEval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, ups, tracker, cancel := mkReserveEngine(t, forAllEval)
+	defer cancel()
+	defer engine.Stop()
+	shape(tracker, ups)
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"forAll: not every survivor lags → no admission")
+
+	forAnyEval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(forAny(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, forAnyEval)
+	defer cancel2()
+	defer engine2.Stop()
+	shape(tracker2, ups2)
+	policy.TickForTest(engine2, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine2.GetOrdered("evm:1", "*", "*")),
+		"forAny: at least one survivor lags → reserve admitted")
+}
+
+// forAll on an empty surviving pool must be FALSE (no break-glass on
+// "all of nothing"). sizeBelow is the primitive for the empty/thin case.
+func TestIncludeIf_ForAll_EmptyPoolIsFalse(t *testing.T) {
+	// excludeId drops both primaries → pool is empty before includeIf.
+	// forAll over an empty pool must be false, so the reserve is NOT pulled
+	// in by the forAll path...
+	forAllEval := `(upstreams) => upstreams
+		.byTag('tier:main')
+		.excludeId('primary*')
+		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, forAllEval)
+	defer cancel()
+	defer engine.Stop()
+	policy.TickForTest(engine, "evm:1", "*")
+	require.Empty(t, ids(engine.GetOrdered("evm:1", "*", "*")),
+		"forAll over an empty pool is false → no admission")
+
+	// ...but sizeBelow(1) IS the right primitive for the empty case.
+	sizeEval := `(upstreams) => upstreams
+		.byTag('tier:main')
+		.excludeId('primary*')
+		.includeIf(sizeBelow(1), { tag: 'tier:reserve' })`
+	engine2, _, _, cancel2 := mkReserveEngine(t, sizeEval)
+	defer cancel2()
+	defer engine2.Stop()
+	policy.TickForTest(engine2, "evm:1", "*")
+	require.Equal(t, []string{"reserve1"}, ids(engine2.GetOrdered("evm:1", "*", "*")),
+		"sizeBelow(1) catches the empty pool and admits the reserve")
+}
+
+// forNone admits only when NO survivor trips the predicate.
+func TestIncludeIf_Quantifier_ForNone(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(forNone(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+
+	// Case A: no survivor lags → forNone true → admit.
+	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+	setLag(tracker, ups[0], 0)
+	setLag(tracker, ups[1], 0)
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"forNone: no survivor lags → admit")
+
+	// Case B: one survivor lags → forNone false → no admit.
+	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, eval)
+	defer cancel2()
+	defer engine2.Stop()
+	setLag(tracker2, ups2[0], 50)
+	setLag(tracker2, ups2[1], 0)
+	policy.TickForTest(engine2, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2"},
+		ids(engine2.GetOrdered("evm:1", "*", "*")),
+		"forNone: a survivor lags → no admit")
+}
+
+// atLeast(n) / fewerThan(n) count matching survivors.
+func TestIncludeIf_Quantifier_AtLeast_FewerThan(t *testing.T) {
+	// Both primaries lag → 2 match.
+	shape := func(tracker *health.Tracker, ups []common.Upstream) {
+		setLag(tracker, ups[0], 50)
+		setLag(tracker, ups[1], 50)
+	}
+
+	// atLeast(2, lag) → 2 match → admit.
+	atLeastEval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(atLeast(2, blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	e1, u1, t1, c1 := mkReserveEngine(t, atLeastEval)
+	defer c1()
+	defer e1.Stop()
+	shape(t1, u1)
+	policy.TickForTest(e1, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(e1.GetOrdered("evm:1", "*", "*")), "atLeast(2): 2 lag → admit")
+
+	// fewerThan(2, healthy) where healthy = errorRateBelow(0.1). Both lag
+	// but both are still error-free, so "fewerThan 2 healthy" is false →
+	// no admit. (Sanity: counts the predicate, not the pool size.)
+	fewerEval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(fewerThan(2, errorRateBelow(0.1)), { tag: 'tier:reserve' })`
+	e2, u2, t2, c2 := mkReserveEngine(t, fewerEval)
+	defer c2()
+	defer e2.Stop()
+	shape(t2, u2)
+	policy.TickForTest(e2, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2"},
+		ids(e2.GetOrdered("evm:1", "*", "*")),
+		"fewerThan(2, healthy): 2 survivors are healthy → condition false → no admit")
+}
+
+// sizeAtLeast / sizeBelow gate purely on pool size.
+func TestIncludeIf_Quantifier_SizeGates(t *testing.T) {
+	// sizeBelow(3): 2 survivors < 3 → admit.
+	below := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(sizeBelow(3), { tag: 'tier:reserve' })`
+	e1, _, _, c1 := mkReserveEngine(t, below)
+	defer c1()
+	defer e1.Stop()
+	policy.TickForTest(e1, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(e1.GetOrdered("evm:1", "*", "*")), "sizeBelow(3): 2<3 → admit")
+
+	// sizeAtLeast(3): only 2 survivors → false → no admit.
+	atLeast := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(sizeAtLeast(3), { tag: 'tier:reserve' })`
+	e2, _, _, c2 := mkReserveEngine(t, atLeast)
+	defer c2()
+	defer e2.Stop()
+	policy.TickForTest(e2, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2"},
+		ids(e2.GetOrdered("evm:1", "*", "*")), "sizeAtLeast(3): only 2 → no admit")
+}
+
+// ─── end-to-end: the break-glass reserve-tier pattern ───────────────────
+
+// Full realistic chain: a reserve tier kept out of rotation, then ranked in
+// only when every serving upstream is lagging. Verifies the property that
+// matters operationally — the reserve is consulted ONLY under collective
+// degradation, and the survivors are never dropped.
+func TestIncludeIf_EndToEnd_ReserveTierBreakGlass(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.removeCordoned()
+		.preferTag('!tier:reserve', { minHealthy: 1, fallback: 'tier:reserve' })
+		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })
+		.sortByScore(PREFER_FASTEST)`
+
+	// Phase 1: primaries healthy → reserve excluded.
+	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+	for _, u := range ups {
+		for i := 0; i < 50; i++ {
+			tracker.RecordUpstreamRequest(u, "*", common.DataFinalityStateUnknown)
+			tracker.RecordUpstreamDuration(u, "*", 10*time.Millisecond, true, "none", common.DataFinalityStateUnknown, "n/a")
+		}
+	}
+	setLag(tracker, ups[0], 0)
+	setLag(tracker, ups[1], 0)
+	setLag(tracker, ups[2], 0)
+	policy.TickForTest(engine, "evm:1", "*")
+	require.NotContains(t, ids(engine.GetOrdered("evm:1", "*", "*")), "reserve1",
+		"healthy primaries → reserve stays out of rotation (no premium spend)")
+
+	// Phase 2: both primaries fall behind tip → reserve ranked in.
+	setLag(tracker, ups[0], 40)
+	setLag(tracker, ups[1], 40)
+	policy.TickForTest(engine, "evm:1", "*")
+	require.Contains(t, ids(engine.GetOrdered("evm:1", "*", "*")), "reserve1",
+		"all primaries lagging → reserve admitted as break-glass")
+}

--- a/internal/policy/stdlib/include_if_test.go
+++ b/internal/policy/stdlib/include_if_test.go
@@ -54,11 +54,12 @@ func setLag(tracker *health.Tracker, u common.Upstream, lag int64) {
 // ─── includeIf: core admit / no-admit behavior ──────────────────────────
 
 // When the gate holds, the selected reserve upstream is unioned in at the
-// tail (survivors keep priority).
+// tail (survivors keep priority). The condition uses a native `every` over a
+// per-upstream predicate factory.
 func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -79,12 +80,12 @@ func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
 
-	// primary1 lags, primary2 is healthy → forAll is false.
+	// primary1 lags, primary2 is healthy → `every` is false.
 	setLag(tracker, ups[0], 50)
 	setLag(tracker, ups[1], 0)
 	setLag(tracker, ups[2], 0)
@@ -172,6 +173,24 @@ func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
 		"selector-less includeIf admits nothing (never the whole universe)")
 }
 
+// A present-but-empty `where` (and a `where` whose only keys resolve to
+// nothing) must ALSO be a no-op — the selector gate keys on the resolved
+// facets, not on `where != null`. Regression for the "empty where admits
+// universe" class.
+func TestIncludeIf_EmptyWhereIsNoOp(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { where: {} })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	got := ids(engine.GetOrdered("evm:1", "*", "*"))
+	require.ElementsMatch(t, []string{"primary1", "primary2"}, got,
+		"where:{} resolves no facets → no-op, must NOT admit the universe")
+}
+
 // id and vendor selectors resolve against the universe.
 func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 	byId := `(upstreams) => upstreams
@@ -195,11 +214,29 @@ func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 		ids(engine2.GetOrdered("evm:1", "*", "*")), "vendor selector admits the premium reserve")
 }
 
-// where{} selector form is equivalent to the flat facets.
+// The type facet is honored, not silently ignored. The fake upstreams carry
+// an empty type, so a `type: 'evm'` selector must match NOTHING — proving the
+// facet is actually applied (an ignored facet would make matchFn match-all
+// and wrongly admit the reserve).
+func TestIncludeIf_TypeSelectorIsApplied(t *testing.T) {
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf(true, { type: 'evm' })`
+	engine, _, _, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2"},
+		ids(engine.GetOrdered("evm:1", "*", "*")),
+		"type:'evm' matches no upstream (all have empty type) → reserve not admitted")
+}
+
+// where{} facet form is equivalent to the flat facets.
 func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(sizeBelow(3), { where: { tag: 'tier:reserve' } })`
+		.includeIf((p) => p.length < 3, { where: { tag: 'tier:reserve' } })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -215,7 +252,7 @@ func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 func TestIncludeIf_ThrowingConditionDegradesToNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf((pool) => { throw new Error('boom'); }, { tag: 'tier:reserve' })`
+		.includeIf((p) => { throw new Error('boom'); }, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -233,7 +270,7 @@ func TestIncludeIf_ConditionSeesSurvivingPool(t *testing.T) {
 	// proves the condition sees the survivors, not the full 3-upstream set.
 	eval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf((pool) => pool.length === 2, { tag: 'tier:reserve' })`
+		.includeIf((p) => p.length === 2, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
 	defer engine.Stop()
@@ -244,11 +281,11 @@ func TestIncludeIf_ConditionSeesSurvivingPool(t *testing.T) {
 		"condition observed pool.length==2 (survivors only), so it admitted the reserve")
 }
 
-// ─── quantifiers ────────────────────────────────────────────────────────
+// ─── conditions via native array methods ────────────────────────────────
 
-// forAll is false unless EVERY survivor trips; forAny is true if at least
+// `every` admits only when EVERY survivor trips; `some` admits if at least
 // one does.
-func TestIncludeIf_Quantifier_ForAll_vs_ForAny(t *testing.T) {
+func TestIncludeIf_EveryVsSome(t *testing.T) {
 	// One primary lags, one is healthy.
 	shape := func(tracker *health.Tracker, ups []common.Upstream) {
 		setLag(tracker, ups[0], 50) // primary1 lags
@@ -256,162 +293,115 @@ func TestIncludeIf_Quantifier_ForAll_vs_ForAny(t *testing.T) {
 		setLag(tracker, ups[2], 0)
 	}
 
-	forAllEval := `(upstreams) => upstreams
+	everyEval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
-	engine, ups, tracker, cancel := mkReserveEngine(t, forAllEval)
+		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, ups, tracker, cancel := mkReserveEngine(t, everyEval)
 	defer cancel()
 	defer engine.Stop()
 	shape(tracker, ups)
 	policy.TickForTest(engine, "evm:1", "*")
 	require.ElementsMatch(t, []string{"primary1", "primary2"},
 		ids(engine.GetOrdered("evm:1", "*", "*")),
-		"forAll: not every survivor lags → no admission")
+		"every: not every survivor lags → no admission")
 
-	forAnyEval := `(upstreams) => upstreams
+	someEval := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(forAny(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
-	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, forAnyEval)
+		.includeIf((p) => p.some(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, someEval)
 	defer cancel2()
 	defer engine2.Stop()
 	shape(tracker2, ups2)
 	policy.TickForTest(engine2, "evm:1", "*")
 	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
 		ids(engine2.GetOrdered("evm:1", "*", "*")),
-		"forAny: at least one survivor lags → reserve admitted")
+		"some: at least one survivor lags → reserve admitted")
 }
 
-// forAll on an empty surviving pool must be FALSE (no break-glass on
-// "all of nothing"). sizeBelow is the primitive for the empty/thin case.
-func TestIncludeIf_ForAll_EmptyPoolIsFalse(t *testing.T) {
-	// excludeId drops both primaries → pool is empty before includeIf.
-	// forAll over an empty pool must be false, so the reserve is NOT pulled
-	// in by the forAll path...
-	forAllEval := `(upstreams) => upstreams
+// Native `every` is TRUE on an empty pool — so a bare `p.every(...)` admits
+// the reserve when the pool is empty, while a `p.length > 0 && p.every(...)`
+// guard suppresses that. Both behaviors are useful; the test pins them.
+func TestIncludeIf_EmptyPoolEveryNativeSemantics(t *testing.T) {
+	// Bare every over an empty pool → true → admit the reserve.
+	bare := `(upstreams) => upstreams
 		.byTag('tier:main')
 		.excludeId('primary*')
-		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
-	engine, _, _, cancel := mkReserveEngine(t, forAllEval)
+		.includeIf((p) => p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine, _, _, cancel := mkReserveEngine(t, bare)
 	defer cancel()
 	defer engine.Stop()
 	policy.TickForTest(engine, "evm:1", "*")
-	require.Empty(t, ids(engine.GetOrdered("evm:1", "*", "*")),
-		"forAll over an empty pool is false → no admission")
+	require.Equal(t, []string{"reserve1"}, ids(engine.GetOrdered("evm:1", "*", "*")),
+		"native every is true on [] → empty pool admits the reserve")
 
-	// ...but sizeBelow(1) IS the right primitive for the empty case.
-	sizeEval := `(upstreams) => upstreams
+	// Guarded every over an empty pool → false → no admit. Use `length < 1`
+	// instead if you DO want the empty pool to admit.
+	guarded := `(upstreams) => upstreams
 		.byTag('tier:main')
 		.excludeId('primary*')
-		.includeIf(sizeBelow(1), { tag: 'tier:reserve' })`
-	engine2, _, _, cancel2 := mkReserveEngine(t, sizeEval)
+		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
+	engine2, _, _, cancel2 := mkReserveEngine(t, guarded)
 	defer cancel2()
 	defer engine2.Stop()
 	policy.TickForTest(engine2, "evm:1", "*")
-	require.Equal(t, []string{"reserve1"}, ids(engine2.GetOrdered("evm:1", "*", "*")),
-		"sizeBelow(1) catches the empty pool and admits the reserve")
+	require.Empty(t, ids(engine2.GetOrdered("evm:1", "*", "*")),
+		"length>0 guard suppresses the empty-pool admit")
 }
 
-// forNone admits only when NO survivor trips the predicate.
-func TestIncludeIf_Quantifier_ForNone(t *testing.T) {
-	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(forNone(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
-
-	// Case A: no survivor lags → forNone true → admit.
-	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
-	defer cancel()
-	defer engine.Stop()
-	setLag(tracker, ups[0], 0)
-	setLag(tracker, ups[1], 0)
-	policy.TickForTest(engine, "evm:1", "*")
-	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
-		ids(engine.GetOrdered("evm:1", "*", "*")),
-		"forNone: no survivor lags → admit")
-
-	// Case B: one survivor lags → forNone false → no admit.
-	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, eval)
-	defer cancel2()
-	defer engine2.Stop()
-	setLag(tracker2, ups2[0], 50)
-	setLag(tracker2, ups2[1], 0)
-	policy.TickForTest(engine2, "evm:1", "*")
-	require.ElementsMatch(t, []string{"primary1", "primary2"},
-		ids(engine2.GetOrdered("evm:1", "*", "*")),
-		"forNone: a survivor lags → no admit")
-}
-
-// atLeast(n) / fewerThan(n) count matching survivors.
-func TestIncludeIf_Quantifier_AtLeast_FewerThan(t *testing.T) {
-	// Both primaries lag → 2 match.
-	shape := func(tracker *health.Tracker, ups []common.Upstream) {
-		setLag(tracker, ups[0], 50)
-		setLag(tracker, ups[1], 50)
-	}
-
-	// atLeast(2, lag) → 2 match → admit.
-	atLeastEval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(atLeast(2, blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
-	e1, u1, t1, c1 := mkReserveEngine(t, atLeastEval)
-	defer c1()
-	defer e1.Stop()
-	shape(t1, u1)
-	policy.TickForTest(e1, "evm:1", "*")
-	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
-		ids(e1.GetOrdered("evm:1", "*", "*")), "atLeast(2): 2 lag → admit")
-
-	// fewerThan(2, healthy) where healthy = errorRateBelow(0.1). Both lag
-	// but both are still error-free, so "fewerThan 2 healthy" is false →
-	// no admit. (Sanity: counts the predicate, not the pool size.)
-	fewerEval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(fewerThan(2, errorRateBelow(0.1)), { tag: 'tier:reserve' })`
-	e2, u2, t2, c2 := mkReserveEngine(t, fewerEval)
-	defer c2()
-	defer e2.Stop()
-	shape(t2, u2)
-	policy.TickForTest(e2, "evm:1", "*")
-	require.ElementsMatch(t, []string{"primary1", "primary2"},
-		ids(e2.GetOrdered("evm:1", "*", "*")),
-		"fewerThan(2, healthy): 2 survivors are healthy → condition false → no admit")
-}
-
-// sizeAtLeast / sizeBelow gate purely on pool size.
-func TestIncludeIf_Quantifier_SizeGates(t *testing.T) {
-	// sizeBelow(3): 2 survivors < 3 → admit.
+// `length` gates purely on pool size.
+func TestIncludeIf_SizeGates(t *testing.T) {
+	// length < 3: 2 survivors → admit.
 	below := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(sizeBelow(3), { tag: 'tier:reserve' })`
+		.includeIf((p) => p.length < 3, { tag: 'tier:reserve' })`
 	e1, _, _, c1 := mkReserveEngine(t, below)
 	defer c1()
 	defer e1.Stop()
 	policy.TickForTest(e1, "evm:1", "*")
 	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
-		ids(e1.GetOrdered("evm:1", "*", "*")), "sizeBelow(3): 2<3 → admit")
+		ids(e1.GetOrdered("evm:1", "*", "*")), "length<3: 2<3 → admit")
 
-	// sizeAtLeast(3): only 2 survivors → false → no admit.
+	// length >= 3: only 2 survivors → false → no admit.
 	atLeast := `(upstreams) => upstreams
 		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-		.includeIf(sizeAtLeast(3), { tag: 'tier:reserve' })`
+		.includeIf((p) => p.length >= 3, { tag: 'tier:reserve' })`
 	e2, _, _, c2 := mkReserveEngine(t, atLeast)
 	defer c2()
 	defer e2.Stop()
 	policy.TickForTest(e2, "evm:1", "*")
 	require.ElementsMatch(t, []string{"primary1", "primary2"},
-		ids(e2.GetOrdered("evm:1", "*", "*")), "sizeAtLeast(3): only 2 → no admit")
+		ids(e2.GetOrdered("evm:1", "*", "*")), "length>=3: only 2 → no admit")
+}
+
+// `filter(...).length` counts matching survivors for an N-of-M condition.
+func TestIncludeIf_FilterCount(t *testing.T) {
+	// Both primaries lag → 2 match. Admit when at least 2 lag.
+	eval := `(upstreams) => upstreams
+		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.includeIf((p) => p.filter(blockNumberLagAbove(16)).length >= 2, { tag: 'tier:reserve' })`
+	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
+	defer cancel()
+	defer engine.Stop()
+	setLag(tracker, ups[0], 50)
+	setLag(tracker, ups[1], 50)
+	policy.TickForTest(engine, "evm:1", "*")
+	require.ElementsMatch(t, []string{"primary1", "primary2", "reserve1"},
+		ids(engine.GetOrdered("evm:1", "*", "*")), "2 of 2 survivors lag → admit")
 }
 
 // ─── end-to-end: the break-glass reserve-tier pattern ───────────────────
 
-// Full realistic chain: a reserve tier kept out of rotation, then ranked in
-// only when every serving upstream is lagging. Verifies the property that
-// matters operationally — the reserve is consulted ONLY under collective
-// degradation, and the survivors are never dropped.
+// Full realistic chain: a reserve tier kept out of rotation via excludeTag,
+// then ranked in only when every serving upstream is lagging. Verifies the
+// property that matters operationally — the reserve is consulted ONLY under
+// collective degradation, and the survivors are never dropped.
 func TestIncludeIf_EndToEnd_ReserveTierBreakGlass(t *testing.T) {
 	eval := `(upstreams) => upstreams
 		.removeCordoned()
-		.preferTag('!tier:reserve', { minHealthy: 1, fallback: 'tier:reserve' })
-		.includeIf(forAll(blockNumberLagAbove(16)), { tag: 'tier:reserve' })
+		.excludeIf(all(samplesAbove(10), errorRateAbove(0.7)))
+		.excludeTag('tier:reserve')
+		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })
+		.includeIf((p) => p.length < 1, { tag: 'tier:reserve' })
 		.sortByScore(PREFER_FASTEST)`
 
 	// Phase 1: primaries healthy → reserve excluded.

--- a/internal/policy/stdlib/include_if_test.go
+++ b/internal/policy/stdlib/include_if_test.go
@@ -58,7 +58,7 @@ func setLag(tracker *health.Tracker, u common.Upstream, lag int64) {
 // per-upstream predicate factory.
 func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -79,7 +79,7 @@ func TestIncludeIf_AdmitsReserveWhenConditionHolds(t *testing.T) {
 // untouched — crucially, a degraded primary is never evicted by includeIf.
 func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -100,7 +100,7 @@ func TestIncludeIf_KeepsReserveOutWhenConditionFails(t *testing.T) {
 // upstreams come in.
 func TestIncludeIf_BooleanTrueAlwaysAdmits(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -115,7 +115,7 @@ func TestIncludeIf_BooleanTrueAlwaysAdmits(t *testing.T) {
 // A literal `false` condition is a no-op.
 func TestIncludeIf_BooleanFalseIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(false, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -130,7 +130,7 @@ func TestIncludeIf_BooleanFalseIsNoOp(t *testing.T) {
 // position:'head' puts the admitted reserve in front of the survivors.
 func TestIncludeIf_PositionHead(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { tag: 'tier:reserve', position: 'head' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -144,7 +144,7 @@ func TestIncludeIf_PositionHead(t *testing.T) {
 
 // An upstream already present is not duplicated.
 func TestIncludeIf_DeduplicatesAlreadyPresent(t *testing.T) {
-	// No preferTag → reserve1 is already in the pool. includeIf must not
+	// No excludeTag → reserve1 is already in the pool. includeIf must not
 	// add a second copy.
 	eval := `(upstreams) => upstreams.includeIf(true, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
@@ -161,7 +161,7 @@ func TestIncludeIf_DeduplicatesAlreadyPresent(t *testing.T) {
 // entire universe.
 func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, {})`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -179,7 +179,7 @@ func TestIncludeIf_NoSelectorIsNoOp(t *testing.T) {
 // universe" class.
 func TestIncludeIf_EmptyWhereIsNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { where: {} })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -194,7 +194,7 @@ func TestIncludeIf_EmptyWhereIsNoOp(t *testing.T) {
 // id and vendor selectors resolve against the universe.
 func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 	byId := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { id: 'reserve1' })`
 	engine, _, _, cancel := mkReserveEngine(t, byId)
 	defer cancel()
@@ -204,7 +204,7 @@ func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 		ids(engine.GetOrdered("evm:1", "*", "*")), "id selector admits reserve1")
 
 	byVendor := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { vendor: 'premium' })`
 	engine2, _, _, cancel2 := mkReserveEngine(t, byVendor)
 	defer cancel2()
@@ -220,7 +220,7 @@ func TestIncludeIf_SelectorsByIdAndVendor(t *testing.T) {
 // and wrongly admit the reserve).
 func TestIncludeIf_TypeSelectorIsApplied(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf(true, { type: 'evm' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -235,7 +235,7 @@ func TestIncludeIf_TypeSelectorIsApplied(t *testing.T) {
 // where{} facet form is equivalent to the flat facets.
 func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length < 3, { where: { tag: 'tier:reserve' } })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -251,7 +251,7 @@ func TestIncludeIf_WhereSelectorForm(t *testing.T) {
 // network back to the engine default) — it degrades to "do not include".
 func TestIncludeIf_ThrowingConditionDegradesToNoOp(t *testing.T) {
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => { throw new Error('boom'); }, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -263,13 +263,13 @@ func TestIncludeIf_ThrowingConditionDegradesToNoOp(t *testing.T) {
 		"a throwing condition is swallowed → no admission, eval still produces the survivors")
 }
 
-// The function condition receives the CURRENT (post-preferTag) pool, not the
+// The function condition receives the CURRENT (post-exclude) pool, not the
 // original full universe — proving aggregate questions see only survivors.
 func TestIncludeIf_ConditionSeesSurvivingPool(t *testing.T) {
-	// After preferTag, only the 2 primaries remain. `pool.length === 2`
+	// After excludeTag, only the 2 primaries remain. `pool.length === 2`
 	// proves the condition sees the survivors, not the full 3-upstream set.
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length === 2, { tag: 'tier:reserve' })`
 	engine, _, _, cancel := mkReserveEngine(t, eval)
 	defer cancel()
@@ -294,7 +294,7 @@ func TestIncludeIf_EveryVsSome(t *testing.T) {
 	}
 
 	everyEval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length > 0 && p.every(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, everyEval)
 	defer cancel()
@@ -306,7 +306,7 @@ func TestIncludeIf_EveryVsSome(t *testing.T) {
 		"every: not every survivor lags → no admission")
 
 	someEval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.some(blockNumberLagAbove(16)), { tag: 'tier:reserve' })`
 	engine2, ups2, tracker2, cancel2 := mkReserveEngine(t, someEval)
 	defer cancel2()
@@ -352,7 +352,7 @@ func TestIncludeIf_EmptyPoolEveryNativeSemantics(t *testing.T) {
 func TestIncludeIf_SizeGates(t *testing.T) {
 	// length < 3: 2 survivors → admit.
 	below := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length < 3, { tag: 'tier:reserve' })`
 	e1, _, _, c1 := mkReserveEngine(t, below)
 	defer c1()
@@ -363,7 +363,7 @@ func TestIncludeIf_SizeGates(t *testing.T) {
 
 	// length >= 3: only 2 survivors → false → no admit.
 	atLeast := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.length >= 3, { tag: 'tier:reserve' })`
 	e2, _, _, c2 := mkReserveEngine(t, atLeast)
 	defer c2()
@@ -377,7 +377,7 @@ func TestIncludeIf_SizeGates(t *testing.T) {
 func TestIncludeIf_FilterCount(t *testing.T) {
 	// Both primaries lag → 2 match. Admit when at least 2 lag.
 	eval := `(upstreams) => upstreams
-		.preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+		.excludeTag('tier:reserve')
 		.includeIf((p) => p.filter(blockNumberLagAbove(16)).length >= 2, { tag: 'tier:reserve' })`
 	engine, ups, tracker, cancel := mkReserveEngine(t, eval)
 	defer cancel()

--- a/internal/policy/stdlib/stdlib.js
+++ b/internal/policy/stdlib/stdlib.js
@@ -1037,17 +1037,22 @@
   //   condition: boolean OR (upstreams, ctx) => boolean. The function form
   //     receives the CURRENT chain array — the pool that survived earlier
   //     steps — so it can ask aggregate ("network-level") questions about
-  //     what is left. Pair with the quantifier factories below:
+  //     what is left, using native array methods over the existing
+  //     per-upstream predicate factories:
   //
-  //       .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
-  //       .includeIf(forAll(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
-  //       .includeIf(sizeBelow(2),                      { tag: 'tier:reserve' })
+  //       // admit when EVERY survivor is lagging (empty pool also admits —
+  //       // native `every` is true on []):
+  //       .includeIf(p => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+  //       // ...or when too few survive:
+  //       .includeIf(p => p.length < 2, { tag: 'tier:reserve' })
   //
-  //   opts.{ id, tag, vendor, where }: select which upstreams to pull from
-  //     `__policyAllUpstreams` when the condition holds. Facets AND together
-  //     (same semantics as `where`). At least one selector is required — with
-  //     none, includeIf is a no-op (it never pulls the whole universe by
-  //     accident). Already-present upstreams (by id) are not duplicated.
+  //   opts.{ id, tag, vendor, type, where }: select which upstreams to pull
+  //     from `__policyAllUpstreams` when the condition holds. Facets AND
+  //     together (same semantics as `where`). At least one facet must resolve
+  //     to a concrete value — otherwise includeIf is a no-op (it never pulls
+  //     the whole universe by accident, including for `where: {}` or a `where`
+  //     carrying only unsupported keys). Already-present upstreams (by id) are
+  //     not duplicated.
   //   opts.position: 'head' | 'tail' (default 'tail'). Added upstreams go to
   //     the tail by default so the surviving pool keeps priority and the
   //     reserve set is consulted only after — let `sortByScore` reorder if a
@@ -1072,21 +1077,25 @@
     }
     if (!pass) return this.slice();
 
-    // 2. Build the selector from opts facets. Require at least one facet —
-    //    a selector-less includeIf would otherwise admit the entire
-    //    universe, which is never the intent.
+    // 2. Resolve the selector facets (flat opts win over the `where` block),
+    //    then require at least one to be concrete. Gating on the RESOLVED
+    //    facets — not on `opts.where != null` — is what makes `where: {}` or
+    //    a `where` carrying only unsupported keys a no-op instead of a
+    //    match-all that admits the entire universe.
     opts = opts || {};
-    const hasSelector = opts.id != null || opts.tag != null ||
-      opts.vendor != null || opts.where != null;
-    if (!hasSelector) return this.slice();
     const where = opts.where || {};
     const idPat     = opts.id     != null ? opts.id     : where.id;
     const tagPat    = opts.tag    != null ? opts.tag    : where.tag;
     const vendorPat = opts.vendor != null ? opts.vendor : where.vendor;
+    const typePat   = opts.type   != null ? opts.type   : where.type;
+    if (idPat == null && tagPat == null && vendorPat == null && typePat == null) {
+      return this.slice();
+    }
     const matchFn = function (u) {
       if (idPat     != null && !matchAny(idPat, u.id)) return false;
       if (tagPat    != null && !hasMatchingTag(u, tagPat)) return false;
       if (vendorPat != null && !matchAny(vendorPat, u.vendor)) return false;
+      if (typePat   != null && !matchAny(typePat, u.type)) return false;
       return true;
     };
 
@@ -1546,87 +1555,6 @@
       // and pretending it caused the not.
       return [fn.policySlug];
     };
-    return fn;
-  };
-
-  // ─── 4.16 Quantifiers — lift a per-upstream predicate to a pool gate ────
-  //
-  // `all` / `any` / `not` above compose per-upstream predicates (`u =>
-  // bool`) into another per-upstream predicate, for `excludeIf`. The
-  // quantifiers below instead collapse a per-upstream predicate over a
-  // WHOLE array into a single boolean — an aggregate, "network-level"
-  // question about the surviving pool. They are the conditions `includeIf`
-  // consumes:
-  //
-  //   forAll(pred)        true iff the array is non-empty AND every element
-  //                       satisfies `pred`. ("every survivor is lagging")
-  //   forAny(pred)        true iff at least one element satisfies `pred`.
-  //   forNone(pred)       true iff no element satisfies `pred`.
-  //   atLeast(n, pred)    true iff at least `n` elements satisfy `pred`.
-  //   fewerThan(n, pred)  true iff fewer than `n` elements satisfy `pred`.
-  //                       ("fewer than 2 healthy survivors remain")
-  //   sizeBelow(n)        true iff the array has fewer than `n` elements.
-  //   sizeAtLeast(n)      true iff the array has at least `n` elements.
-  //
-  // Each returns `(upstreams) => boolean`. `forAll` is deliberately false
-  // on an empty array — "all of nothing are bad" should NOT trigger a
-  // break-glass inclusion; use `sizeBelow` for the empty/thin-pool case.
-  // The predicate is applied defensively (a throwing per-upstream predicate
-  // counts as "did not match") so a malformed leaf can't sink the eval.
-  function _safePred(pred, u) {
-    if (typeof pred !== 'function') return false;
-    try { return !!pred(u); } catch (_e) { return false; }
-  }
-  function _countMatching(arr, pred) {
-    let n = 0;
-    for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) n++;
-    return n;
-  }
-  globalThis.forAll = function (pred) {
-    const fn = function (arr) {
-      if (!arr || arr.length === 0) return false;
-      for (let i = 0; i < arr.length; i++) if (!_safePred(pred, arr[i])) return false;
-      return true;
-    };
-    fn.policyReason = 'forAll(' + _reasonFor(pred) + ')';
-    return fn;
-  };
-  globalThis.forAny = function (pred) {
-    const fn = function (arr) {
-      if (!arr) return false;
-      for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) return true;
-      return false;
-    };
-    fn.policyReason = 'forAny(' + _reasonFor(pred) + ')';
-    return fn;
-  };
-  globalThis.forNone = function (pred) {
-    const fn = function (arr) {
-      if (!arr) return true;
-      for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) return false;
-      return true;
-    };
-    fn.policyReason = 'forNone(' + _reasonFor(pred) + ')';
-    return fn;
-  };
-  globalThis.atLeast = function (n, pred) {
-    const fn = function (arr) { return arr ? _countMatching(arr, pred) >= n : false; };
-    fn.policyReason = 'atLeast(' + n + ',' + _reasonFor(pred) + ')';
-    return fn;
-  };
-  globalThis.fewerThan = function (n, pred) {
-    const fn = function (arr) { return arr ? _countMatching(arr, pred) < n : true; };
-    fn.policyReason = 'fewerThan(' + n + ',' + _reasonFor(pred) + ')';
-    return fn;
-  };
-  globalThis.sizeBelow = function (n) {
-    const fn = function (arr) { return (arr ? arr.length : 0) < n; };
-    fn.policyReason = 'sizeBelow(' + n + ')';
-    return fn;
-  };
-  globalThis.sizeAtLeast = function (n) {
-    const fn = function (arr) { return (arr ? arr.length : 0) >= n; };
-    fn.policyReason = 'sizeAtLeast(' + n + ')';
     return fn;
   };
 })();

--- a/internal/policy/stdlib/stdlib.js
+++ b/internal/policy/stdlib/stdlib.js
@@ -1027,12 +1027,12 @@
   // removes anyone.
   //
   // The intended use is a "break-glass" tier: keep a set of upstreams out
-  // of normal rotation (e.g. via `preferTag('!tier:<x>', { fallback })`)
-  // and bring them in ONLY when the upstreams that are currently serving
-  // become collectively unfit — too few left, all of them lagging, all of
-  // them slow. Because it adds rather than excludes, a single degraded
-  // primary is never evicted; the reserve set is offered alongside it and
-  // ranked by the subsequent `sortByScore`.
+  // of normal rotation (e.g. via `excludeTag('tier:<x>')`) and bring them
+  // in ONLY when the upstreams that are currently serving become
+  // collectively unfit — too few left, all of them lagging, all of them
+  // slow. Because it adds rather than excludes, a single degraded primary
+  // is never evicted; the reserve set is offered alongside it and ranked
+  // by the subsequent `sortByScore`.
   //
   //   condition: boolean OR (upstreams, ctx) => boolean. The function form
   //     receives the CURRENT chain array — the pool that survived earlier

--- a/internal/policy/stdlib/stdlib.js
+++ b/internal/policy/stdlib/stdlib.js
@@ -1034,6 +1034,21 @@
   // is never evicted; the reserve set is offered alongside it and ranked
   // by the subsequent `sortByScore`.
   //
+  //   target: WHAT to admit — placed first so the policy reads
+  //     "include <these> if <condition>" and is never ambiguous. Either:
+  //       * a tag pattern (string / array, `!negation` accepted) — the
+  //         common case: `includeIf('tier:reserve', cond)`; or
+  //       * a selector object `{ id, tag, vendor, type, position }` whose
+  //         facets AND together (same semantics as `where`). At least one
+  //         facet must resolve to a concrete value — otherwise includeIf is
+  //         a no-op (it never pulls the whole universe by accident, e.g. for
+  //         `{}` or `{ position: 'head' }`).
+  //     `position` ('head' | 'tail', default 'tail') only applies to the
+  //     object form; admitted upstreams go to the tail by default so the
+  //     surviving pool keeps priority — let `sortByScore` reorder if a
+  //     reserve upstream is genuinely better. Already-present upstreams (by
+  //     id) are not duplicated.
+  //
   //   condition: boolean OR (upstreams, ctx) => boolean. The function form
   //     receives the CURRENT chain array — the pool that survived earlier
   //     steps — so it can ask aggregate ("network-level") questions about
@@ -1042,27 +1057,34 @@
   //
   //       // admit when EVERY survivor is lagging (empty pool also admits —
   //       // native `every` is true on []):
-  //       .includeIf(p => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+  //       .includeIf('tier:reserve', p => p.every(blockSecondsLagAbove(30)))
   //       // ...or when too few survive:
-  //       .includeIf(p => p.length < 2, { tag: 'tier:reserve' })
-  //
-  //   opts.{ id, tag, vendor, type, where }: select which upstreams to pull
-  //     from `__policyAllUpstreams` when the condition holds. Facets AND
-  //     together (same semantics as `where`). At least one facet must resolve
-  //     to a concrete value — otherwise includeIf is a no-op (it never pulls
-  //     the whole universe by accident, including for `where: {}` or a `where`
-  //     carrying only unsupported keys). Already-present upstreams (by id) are
-  //     not duplicated.
-  //   opts.position: 'head' | 'tail' (default 'tail'). Added upstreams go to
-  //     the tail by default so the surviving pool keeps priority and the
-  //     reserve set is consulted only after — let `sortByScore` reorder if a
-  //     reserve upstream is genuinely better.
+  //       .includeIf('tier:reserve', p => p.length < 2)
   //
   // Defensive: any malformed argument degrades to a no-op (returns the
   // chain unchanged) rather than throwing — a throw mid-eval would drop the
   // whole network back to the engine's default policy.
-  define('includeIf', function (condition, opts) {
-    // 1. Evaluate the gate. Function form gets (upstreams, ctx); a thrown
+  define('includeIf', function (target, condition) {
+    // 1. Resolve the target into selector facets + position. A string/array
+    //    is the tag shorthand; an object carries explicit facets. Gating on
+    //    the RESOLVED facets (not on "an object was passed") is what keeps
+    //    `{}` / `{ position: 'head' }` a no-op instead of a match-all that
+    //    admits the entire universe.
+    let idPat, tagPat, vendorPat, typePat, position;
+    if (typeof target === 'string' || Array.isArray(target)) {
+      tagPat = target;
+    } else if (target != null && typeof target === 'object') {
+      idPat = target.id;
+      tagPat = target.tag;
+      vendorPat = target.vendor;
+      typePat = target.type;
+      position = target.position;
+    }
+    if (idPat == null && tagPat == null && vendorPat == null && typePat == null) {
+      return this.slice();
+    }
+
+    // 2. Evaluate the gate. Function form gets (upstreams, ctx); a thrown
     //    predicate is swallowed (treated as "do not include") so one bad
     //    custom condition can't sink the eval.
     let pass;
@@ -1077,20 +1099,7 @@
     }
     if (!pass) return this.slice();
 
-    // 2. Resolve the selector facets (flat opts win over the `where` block),
-    //    then require at least one to be concrete. Gating on the RESOLVED
-    //    facets — not on `opts.where != null` — is what makes `where: {}` or
-    //    a `where` carrying only unsupported keys a no-op instead of a
-    //    match-all that admits the entire universe.
-    opts = opts || {};
-    const where = opts.where || {};
-    const idPat     = opts.id     != null ? opts.id     : where.id;
-    const tagPat    = opts.tag    != null ? opts.tag    : where.tag;
-    const vendorPat = opts.vendor != null ? opts.vendor : where.vendor;
-    const typePat   = opts.type   != null ? opts.type   : where.type;
-    if (idPat == null && tagPat == null && vendorPat == null && typePat == null) {
-      return this.slice();
-    }
+    // 3. Union in matching upstreams from the universe, deduped by id.
     const matchFn = function (u) {
       if (idPat     != null && !matchAny(idPat, u.id)) return false;
       if (tagPat    != null && !hasMatchingTag(u, tagPat)) return false;
@@ -1098,13 +1107,11 @@
       if (typePat   != null && !matchAny(typePat, u.type)) return false;
       return true;
     };
-
-    // 3. Union in matching upstreams from the universe, deduped by id.
     const all = globalThis.__policyAllUpstreams || [];
     const haves = new Set(this.map(u => u.id));
     const adds = all.filter(u => !haves.has(u.id) && matchFn(u));
     if (adds.length === 0) return this.slice();
-    return (opts.position === 'head') ? adds.concat(this) : this.concat(adds);
+    return (position === 'head') ? adds.concat(this) : this.concat(adds);
   });
 
   // ─── 4.11 Combinators ───────────────────────────────────────────────────

--- a/internal/policy/stdlib/stdlib.js
+++ b/internal/policy/stdlib/stdlib.js
@@ -1020,6 +1020,84 @@
     return (position === 'head') ? adds.concat(this) : this.concat(adds);
   });
 
+  // includeIf — conditionally admit upstreams from the full universe back
+  // into the chain. The dual of `excludeIf`: where `excludeIf` DROPS a
+  // per-upstream offender, `includeIf` ADDS a selected set of upstreams
+  // when an aggregate condition over the surviving pool holds. It never
+  // removes anyone.
+  //
+  // The intended use is a "break-glass" tier: keep a set of upstreams out
+  // of normal rotation (e.g. via `preferTag('!tier:<x>', { fallback })`)
+  // and bring them in ONLY when the upstreams that are currently serving
+  // become collectively unfit — too few left, all of them lagging, all of
+  // them slow. Because it adds rather than excludes, a single degraded
+  // primary is never evicted; the reserve set is offered alongside it and
+  // ranked by the subsequent `sortByScore`.
+  //
+  //   condition: boolean OR (upstreams, ctx) => boolean. The function form
+  //     receives the CURRENT chain array — the pool that survived earlier
+  //     steps — so it can ask aggregate ("network-level") questions about
+  //     what is left. Pair with the quantifier factories below:
+  //
+  //       .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+  //       .includeIf(forAll(latencyAbove(2000, 99)),   { tag: 'tier:reserve' })
+  //       .includeIf(sizeBelow(2),                      { tag: 'tier:reserve' })
+  //
+  //   opts.{ id, tag, vendor, where }: select which upstreams to pull from
+  //     `__policyAllUpstreams` when the condition holds. Facets AND together
+  //     (same semantics as `where`). At least one selector is required — with
+  //     none, includeIf is a no-op (it never pulls the whole universe by
+  //     accident). Already-present upstreams (by id) are not duplicated.
+  //   opts.position: 'head' | 'tail' (default 'tail'). Added upstreams go to
+  //     the tail by default so the surviving pool keeps priority and the
+  //     reserve set is consulted only after — let `sortByScore` reorder if a
+  //     reserve upstream is genuinely better.
+  //
+  // Defensive: any malformed argument degrades to a no-op (returns the
+  // chain unchanged) rather than throwing — a throw mid-eval would drop the
+  // whole network back to the engine's default policy.
+  define('includeIf', function (condition, opts) {
+    // 1. Evaluate the gate. Function form gets (upstreams, ctx); a thrown
+    //    predicate is swallowed (treated as "do not include") so one bad
+    //    custom condition can't sink the eval.
+    let pass;
+    if (typeof condition === 'function') {
+      try {
+        pass = !!condition(this, globalThis.__policyCtx || {});
+      } catch (_e) {
+        pass = false;
+      }
+    } else {
+      pass = !!condition;
+    }
+    if (!pass) return this.slice();
+
+    // 2. Build the selector from opts facets. Require at least one facet —
+    //    a selector-less includeIf would otherwise admit the entire
+    //    universe, which is never the intent.
+    opts = opts || {};
+    const hasSelector = opts.id != null || opts.tag != null ||
+      opts.vendor != null || opts.where != null;
+    if (!hasSelector) return this.slice();
+    const where = opts.where || {};
+    const idPat     = opts.id     != null ? opts.id     : where.id;
+    const tagPat    = opts.tag    != null ? opts.tag    : where.tag;
+    const vendorPat = opts.vendor != null ? opts.vendor : where.vendor;
+    const matchFn = function (u) {
+      if (idPat     != null && !matchAny(idPat, u.id)) return false;
+      if (tagPat    != null && !hasMatchingTag(u, tagPat)) return false;
+      if (vendorPat != null && !matchAny(vendorPat, u.vendor)) return false;
+      return true;
+    };
+
+    // 3. Union in matching upstreams from the universe, deduped by id.
+    const all = globalThis.__policyAllUpstreams || [];
+    const haves = new Set(this.map(u => u.id));
+    const adds = all.filter(u => !haves.has(u.id) && matchFn(u));
+    if (adds.length === 0) return this.slice();
+    return (opts.position === 'head') ? adds.concat(this) : this.concat(adds);
+  });
+
   // ─── 4.11 Combinators ───────────────────────────────────────────────────
 
   define('if', function (cond, thenFn, elseFn) {
@@ -1468,6 +1546,87 @@
       // and pretending it caused the not.
       return [fn.policySlug];
     };
+    return fn;
+  };
+
+  // ─── 4.16 Quantifiers — lift a per-upstream predicate to a pool gate ────
+  //
+  // `all` / `any` / `not` above compose per-upstream predicates (`u =>
+  // bool`) into another per-upstream predicate, for `excludeIf`. The
+  // quantifiers below instead collapse a per-upstream predicate over a
+  // WHOLE array into a single boolean — an aggregate, "network-level"
+  // question about the surviving pool. They are the conditions `includeIf`
+  // consumes:
+  //
+  //   forAll(pred)        true iff the array is non-empty AND every element
+  //                       satisfies `pred`. ("every survivor is lagging")
+  //   forAny(pred)        true iff at least one element satisfies `pred`.
+  //   forNone(pred)       true iff no element satisfies `pred`.
+  //   atLeast(n, pred)    true iff at least `n` elements satisfy `pred`.
+  //   fewerThan(n, pred)  true iff fewer than `n` elements satisfy `pred`.
+  //                       ("fewer than 2 healthy survivors remain")
+  //   sizeBelow(n)        true iff the array has fewer than `n` elements.
+  //   sizeAtLeast(n)      true iff the array has at least `n` elements.
+  //
+  // Each returns `(upstreams) => boolean`. `forAll` is deliberately false
+  // on an empty array — "all of nothing are bad" should NOT trigger a
+  // break-glass inclusion; use `sizeBelow` for the empty/thin-pool case.
+  // The predicate is applied defensively (a throwing per-upstream predicate
+  // counts as "did not match") so a malformed leaf can't sink the eval.
+  function _safePred(pred, u) {
+    if (typeof pred !== 'function') return false;
+    try { return !!pred(u); } catch (_e) { return false; }
+  }
+  function _countMatching(arr, pred) {
+    let n = 0;
+    for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) n++;
+    return n;
+  }
+  globalThis.forAll = function (pred) {
+    const fn = function (arr) {
+      if (!arr || arr.length === 0) return false;
+      for (let i = 0; i < arr.length; i++) if (!_safePred(pred, arr[i])) return false;
+      return true;
+    };
+    fn.policyReason = 'forAll(' + _reasonFor(pred) + ')';
+    return fn;
+  };
+  globalThis.forAny = function (pred) {
+    const fn = function (arr) {
+      if (!arr) return false;
+      for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) return true;
+      return false;
+    };
+    fn.policyReason = 'forAny(' + _reasonFor(pred) + ')';
+    return fn;
+  };
+  globalThis.forNone = function (pred) {
+    const fn = function (arr) {
+      if (!arr) return true;
+      for (let i = 0; i < arr.length; i++) if (_safePred(pred, arr[i])) return false;
+      return true;
+    };
+    fn.policyReason = 'forNone(' + _reasonFor(pred) + ')';
+    return fn;
+  };
+  globalThis.atLeast = function (n, pred) {
+    const fn = function (arr) { return arr ? _countMatching(arr, pred) >= n : false; };
+    fn.policyReason = 'atLeast(' + n + ',' + _reasonFor(pred) + ')';
+    return fn;
+  };
+  globalThis.fewerThan = function (n, pred) {
+    const fn = function (arr) { return arr ? _countMatching(arr, pred) < n : true; };
+    fn.policyReason = 'fewerThan(' + n + ',' + _reasonFor(pred) + ')';
+    return fn;
+  };
+  globalThis.sizeBelow = function (n) {
+    const fn = function (arr) { return (arr ? arr.length : 0) < n; };
+    fn.policyReason = 'sizeBelow(' + n + ')';
+    return fn;
+  };
+  globalThis.sizeAtLeast = function (n) {
+    const fn = function (arr) { return (arr ? arr.length : 0) >= n; };
+    fn.policyReason = 'sizeAtLeast(' + n + ')';
     return fn;
   };
 })();

--- a/typescript/config/src/__tests__/erpc.test-d.ts
+++ b/typescript/config/src/__tests__/erpc.test-d.ts
@@ -204,7 +204,36 @@ const _upstreamHelpers: SelectionPolicyEvalFunction = (upstreams) =>
     return u.metrics.errorRate < 0.5;
   }) as unknown as PolicyEvalUpstreamArray;
 
+/* ─────────────── 6b. includeIf + quantifiers type-check ───────────────── */
+
+// Quantifiers lift a per-upstream predicate to a pool-level condition, and
+// includeIf consumes it with a tag/id/vendor/where selector + position.
+const _includeIfConditions: SelectionPolicyEvalFunction = (upstreams) =>
+  upstreams
+    .preferTag("!tier:reserve", { fallback: "tier:reserve" })
+    .includeIf(forAll(blockSecondsLagAbove(30)), { tag: "tier:reserve" })
+    .includeIf(forAny(errorRateAbove(0.5)), { id: "reserve-*" })
+    .includeIf(forNone(latencyAbove(100)), { vendor: "premium" })
+    .includeIf(atLeast(2, blockNumberLagAbove(16)), { tag: "tier:reserve" })
+    .includeIf(fewerThan(2, errorRateBelow(0.1)), { tag: "tier:reserve" })
+    .includeIf(sizeBelow(2), { tag: "tier:reserve", position: "tail" })
+    .includeIf(sizeAtLeast(1), { where: { tag: "tier:reserve" } })
+    .includeIf(true, { tag: "tier:reserve" })
+    .sortByScore(PREFER_FASTEST);
+
+// includeIf condition also accepts an inline array predicate.
+const _includeIfInlineCondition: SelectionPolicyEvalFunction = (upstreams) =>
+  upstreams.includeIf((pool) => pool.length < 2, { tag: "tier:reserve" });
+
 /* ───────────────────────── 7. Negative cases (must error) ─────────────── */
+
+const _includeIfBadCondition: SelectionPolicyEvalFunction = (upstreams) =>
+  // @ts-expect-error — sizeBelow takes a number, not a string
+  upstreams.includeIf(sizeBelow("two"), { tag: "tier:reserve" });
+
+const _includeIfMissingSelector: SelectionPolicyEvalFunction = (upstreams) =>
+  // @ts-expect-error — includeIf requires an opts selector argument
+  upstreams.includeIf(sizeBelow(2));
 
 createConfig({
   projects: [

--- a/typescript/config/src/__tests__/erpc.test-d.ts
+++ b/typescript/config/src/__tests__/erpc.test-d.ts
@@ -206,32 +206,31 @@ const _upstreamHelpers: SelectionPolicyEvalFunction = (upstreams) =>
 
 /* ─────────────── 6b. includeIf conditions type-check ──────────────────── */
 
-// Conditions are native array methods over the per-upstream predicate
-// factories; includeIf consumes them with a tag/id/vendor/type/where
-// selector + position.
+// Target comes first (tag shorthand or selector object); conditions are
+// native array methods over the per-upstream predicate factories.
 const _includeIfConditions: SelectionPolicyEvalFunction = (upstreams) =>
   upstreams
     .excludeTag("tier:reserve")
-    .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: "tier:reserve" })
-    .includeIf((p) => p.some(errorRateAbove(0.5)), { id: "reserve-*" })
-    .includeIf((p) => p.length < 2, { vendor: "premium" })
-    .includeIf((p) => p.filter(blockNumberLagAbove(16)).length >= 2, {
-      tag: "tier:reserve",
-      position: "tail",
-    })
-    .includeIf((p) => p.length === 0, { where: { tag: "tier:reserve" } })
-    .includeIf(true, { type: "evm" })
+    .includeIf("tier:reserve", (p) => p.every(blockSecondsLagAbove(30)))
+    .includeIf(["tier:reserve", "tier:overflow"], (p) => p.length < 2)
+    .includeIf({ id: "reserve-*" }, (p) => p.some(errorRateAbove(0.5)))
+    .includeIf({ vendor: "premium", position: "tail" }, (p) => p.length < 2)
+    .includeIf(
+      { tag: "tier:reserve" },
+      (p) => p.filter(blockNumberLagAbove(16)).length >= 2,
+    )
+    .includeIf({ type: "evm" }, true)
     .sortByScore(PREFER_FASTEST);
 
 /* ───────────────────────── 7. Negative cases (must error) ─────────────── */
 
 const _includeIfBadCondition: SelectionPolicyEvalFunction = (upstreams) =>
   // @ts-expect-error — condition must be a boolean or an array→boolean function
-  upstreams.includeIf(42, { tag: "tier:reserve" });
+  upstreams.includeIf("tier:reserve", 42);
 
-const _includeIfMissingSelector: SelectionPolicyEvalFunction = (upstreams) =>
-  // @ts-expect-error — includeIf requires an opts selector argument
-  upstreams.includeIf((p) => p.length < 2);
+const _includeIfMissingCondition: SelectionPolicyEvalFunction = (upstreams) =>
+  // @ts-expect-error — includeIf requires a condition argument
+  upstreams.includeIf("tier:reserve");
 
 createConfig({
   projects: [

--- a/typescript/config/src/__tests__/erpc.test-d.ts
+++ b/typescript/config/src/__tests__/erpc.test-d.ts
@@ -204,36 +204,34 @@ const _upstreamHelpers: SelectionPolicyEvalFunction = (upstreams) =>
     return u.metrics.errorRate < 0.5;
   }) as unknown as PolicyEvalUpstreamArray;
 
-/* ─────────────── 6b. includeIf + quantifiers type-check ───────────────── */
+/* ─────────────── 6b. includeIf conditions type-check ──────────────────── */
 
-// Quantifiers lift a per-upstream predicate to a pool-level condition, and
-// includeIf consumes it with a tag/id/vendor/where selector + position.
+// Conditions are native array methods over the per-upstream predicate
+// factories; includeIf consumes them with a tag/id/vendor/type/where
+// selector + position.
 const _includeIfConditions: SelectionPolicyEvalFunction = (upstreams) =>
   upstreams
-    .preferTag("!tier:reserve", { fallback: "tier:reserve" })
-    .includeIf(forAll(blockSecondsLagAbove(30)), { tag: "tier:reserve" })
-    .includeIf(forAny(errorRateAbove(0.5)), { id: "reserve-*" })
-    .includeIf(forNone(latencyAbove(100)), { vendor: "premium" })
-    .includeIf(atLeast(2, blockNumberLagAbove(16)), { tag: "tier:reserve" })
-    .includeIf(fewerThan(2, errorRateBelow(0.1)), { tag: "tier:reserve" })
-    .includeIf(sizeBelow(2), { tag: "tier:reserve", position: "tail" })
-    .includeIf(sizeAtLeast(1), { where: { tag: "tier:reserve" } })
-    .includeIf(true, { tag: "tier:reserve" })
+    .excludeTag("tier:reserve")
+    .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: "tier:reserve" })
+    .includeIf((p) => p.some(errorRateAbove(0.5)), { id: "reserve-*" })
+    .includeIf((p) => p.length < 2, { vendor: "premium" })
+    .includeIf((p) => p.filter(blockNumberLagAbove(16)).length >= 2, {
+      tag: "tier:reserve",
+      position: "tail",
+    })
+    .includeIf((p) => p.length === 0, { where: { tag: "tier:reserve" } })
+    .includeIf(true, { type: "evm" })
     .sortByScore(PREFER_FASTEST);
-
-// includeIf condition also accepts an inline array predicate.
-const _includeIfInlineCondition: SelectionPolicyEvalFunction = (upstreams) =>
-  upstreams.includeIf((pool) => pool.length < 2, { tag: "tier:reserve" });
 
 /* ───────────────────────── 7. Negative cases (must error) ─────────────── */
 
 const _includeIfBadCondition: SelectionPolicyEvalFunction = (upstreams) =>
-  // @ts-expect-error — sizeBelow takes a number, not a string
-  upstreams.includeIf(sizeBelow("two"), { tag: "tier:reserve" });
+  // @ts-expect-error — condition must be a boolean or an array→boolean function
+  upstreams.includeIf(42, { tag: "tier:reserve" });
 
 const _includeIfMissingSelector: SelectionPolicyEvalFunction = (upstreams) =>
   // @ts-expect-error — includeIf requires an opts selector argument
-  upstreams.includeIf(sizeBelow(2));
+  upstreams.includeIf((p) => p.length < 2);
 
 createConfig({
   projects: [

--- a/typescript/config/src/index.ts
+++ b/typescript/config/src/index.ts
@@ -30,7 +30,7 @@ export type {
   ByFinalityHandlers,
   WhereFilter,
   PolicyEvalArrayCondition,
-  IncludeIfOptions,
+  IncludeIfTarget,
   EvmNetworkConfigForDefaults,
 } from "./types";
 export {

--- a/typescript/config/src/index.ts
+++ b/typescript/config/src/index.ts
@@ -29,6 +29,8 @@ export type {
   LatencyDeviationOptions,
   ByFinalityHandlers,
   WhereFilter,
+  PolicyEvalArrayCondition,
+  IncludeIfOptions,
   EvmNetworkConfigForDefaults,
 } from "./types";
 export {

--- a/typescript/config/src/types/index.ts
+++ b/typescript/config/src/types/index.ts
@@ -34,5 +34,5 @@ export type {
     ByFinalityHandlers,
     WhereFilter,
     PolicyEvalArrayCondition,
-    IncludeIfOptions,
+    IncludeIfTarget,
   } from "./policyEval";

--- a/typescript/config/src/types/index.ts
+++ b/typescript/config/src/types/index.ts
@@ -33,4 +33,6 @@ export type {
     LatencyDeviationOptions,
     ByFinalityHandlers,
     WhereFilter,
+    PolicyEvalArrayCondition,
+    IncludeIfOptions,
   } from "./policyEval";

--- a/typescript/config/src/types/policyEval.ts
+++ b/typescript/config/src/types/policyEval.ts
@@ -380,25 +380,25 @@ export type WhereFilter = {
 
 /**
  * An aggregate condition over the whole surviving pool, returning a single
- * boolean. Produced by the quantifier factories (`forAll`, `forAny`,
- * `fewerThan`, `sizeBelow`, ...) and consumed by `includeIf`. Distinct from
- * `PolicyEvalPredicate`, which is per-upstream.
+ * boolean — consumed by `includeIf`. Distinct from `PolicyEvalPredicate`,
+ * which is per-upstream. Build one with native array methods over the
+ * per-upstream predicate factories, e.g.
+ * `(pool) => pool.every(blockSecondsLagAbove(30))` or `(pool) => pool.length < 2`.
  */
-export type PolicyEvalArrayCondition = ((
+export type PolicyEvalArrayCondition = (
   upstreams: PolicyEvalUpstreamArray,
-) => boolean) & {
-  readonly policyReason?: string;
-};
+) => boolean;
 
 /**
- * Selector for `includeIf`. At least one facet must be set — the facets AND
- * together (same semantics as `where`) to pick which upstreams are admitted
- * from the full universe when the condition holds.
+ * Selector for `includeIf`. At least one facet must resolve to a concrete
+ * value — the facets AND together (same semantics as `where`) to pick which
+ * upstreams are admitted from the full universe when the condition holds.
  */
 export type IncludeIfOptions = {
   id?: Pattern;
   tag?: TagPattern;
   vendor?: Pattern;
+  type?: Pattern;
   /** Alternative to the flat facets above; same AND semantics. */
   where?: WhereFilter;
   /**
@@ -564,19 +564,20 @@ export interface PolicyEvalUpstreamArray
    *
    * The function form of `condition` receives the CURRENT chain array (the
    * pool that survived earlier steps), so it can ask aggregate questions
-   * about what is left — pair it with the quantifier factories
-   * (`forAll`, `fewerThan`, `sizeBelow`, ...):
+   * about what is left using native array methods over the per-upstream
+   * predicate factories:
    *
-   *   .preferTag('!tier:reserve', { fallback: 'tier:reserve' })
-   *   .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
-   *   .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })
+   *   .excludeTag('tier:reserve')
+   *   .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+   *   .includeIf((p) => p.length < 2,                      { tag: 'tier:reserve' })
    *
    * Use it for a break-glass reserve tier: kept out of normal rotation, but
    * admitted alongside the survivors when the serving pool is collectively
    * unfit (too few left, all lagging, all slow). At least one selector facet
-   * is required; with none it is a no-op (it never admits the whole
-   * universe). Added upstreams default to the tail so the survivors keep
-   * priority; a later `sortByScore` reorders if a reserve upstream is better.
+   * must resolve to a concrete value; otherwise it is a no-op (it never
+   * admits the whole universe). Added upstreams default to the tail so the
+   * survivors keep priority; a later `sortByScore` reorders if a reserve
+   * upstream is better.
    */
   includeIf(
     condition: boolean | PolicyEvalArrayCondition,
@@ -755,35 +756,6 @@ declare global {
   function any(...preds: PolicyEvalPredicate[]): PolicyEvalPredicate;
   /** Negate a predicate. */
   function not(pred: PolicyEvalPredicate): PolicyEvalPredicate;
-
-  // Quantifiers — lift a per-upstream predicate to a pool-level condition
-  // for `includeIf`. Where `all` / `any` / `not` compose per-upstream
-  // predicates into another per-upstream predicate, these collapse a
-  // predicate over the WHOLE array into one boolean.
-  /**
-   * True iff the array is non-empty AND every upstream satisfies `pred`.
-   * Deliberately false on an empty array — "all of nothing are bad" should
-   * not trigger a break-glass inclusion; use `sizeBelow` for the empty case.
-   */
-  function forAll(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
-  /** True iff at least one upstream satisfies `pred`. */
-  function forAny(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
-  /** True iff no upstream satisfies `pred`. */
-  function forNone(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
-  /** True iff at least `n` upstreams satisfy `pred`. */
-  function atLeast(
-    n: number,
-    pred: PolicyEvalPredicate,
-  ): PolicyEvalArrayCondition;
-  /** True iff fewer than `n` upstreams satisfy `pred`. */
-  function fewerThan(
-    n: number,
-    pred: PolicyEvalPredicate,
-  ): PolicyEvalArrayCondition;
-  /** True iff the array has fewer than `n` upstreams. */
-  function sizeBelow(n: number): PolicyEvalArrayCondition;
-  /** True iff the array has at least `n` upstreams. */
-  function sizeAtLeast(n: number): PolicyEvalArrayCondition;
 
   // Module-level helpers ──────────────────────────────────────────────
   /** True iff `ctx.method` matches the glob/pattern. */

--- a/typescript/config/src/types/policyEval.ts
+++ b/typescript/config/src/types/policyEval.ts
@@ -379,6 +379,37 @@ export type WhereFilter = {
 };
 
 /**
+ * An aggregate condition over the whole surviving pool, returning a single
+ * boolean. Produced by the quantifier factories (`forAll`, `forAny`,
+ * `fewerThan`, `sizeBelow`, ...) and consumed by `includeIf`. Distinct from
+ * `PolicyEvalPredicate`, which is per-upstream.
+ */
+export type PolicyEvalArrayCondition = ((
+  upstreams: PolicyEvalUpstreamArray,
+) => boolean) & {
+  readonly policyReason?: string;
+};
+
+/**
+ * Selector for `includeIf`. At least one facet must be set — the facets AND
+ * together (same semantics as `where`) to pick which upstreams are admitted
+ * from the full universe when the condition holds.
+ */
+export type IncludeIfOptions = {
+  id?: Pattern;
+  tag?: TagPattern;
+  vendor?: Pattern;
+  /** Alternative to the flat facets above; same AND semantics. */
+  where?: WhereFilter;
+  /**
+   * Where admitted upstreams land relative to the survivors. `'tail'`
+   * (default) keeps the survivors as primaries; `'head'` puts the reserve
+   * set in front (rarely what you want — usually let `sortByScore` decide).
+   */
+  position?: "head" | "tail";
+};
+
+/**
  * The chainable upstream array passed into the eval. All methods return
  * a NEW array (immutable-style) so the chain is side-effect-free. Order
  * is meaningful: position 0 is the primary, position N is the Nth
@@ -524,6 +555,32 @@ export interface PolicyEvalUpstreamArray
   forceInclude(
     idOrFn: Pattern | ((u: PolicyEvalUpstream) => unknown),
     position?: "head" | "tail",
+  ): PolicyEvalUpstreamArray;
+  /**
+   * Conditionally admit upstreams from the full universe back into the
+   * chain — the dual of `excludeIf`. When `condition` holds, every upstream
+   * matching `opts` (and not already present) is unioned in; otherwise the
+   * chain is unchanged. It never removes an upstream.
+   *
+   * The function form of `condition` receives the CURRENT chain array (the
+   * pool that survived earlier steps), so it can ask aggregate questions
+   * about what is left — pair it with the quantifier factories
+   * (`forAll`, `fewerThan`, `sizeBelow`, ...):
+   *
+   *   .preferTag('!tier:reserve', { fallback: 'tier:reserve' })
+   *   .includeIf(forAll(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
+   *   .includeIf(sizeBelow(2),                     { tag: 'tier:reserve' })
+   *
+   * Use it for a break-glass reserve tier: kept out of normal rotation, but
+   * admitted alongside the survivors when the serving pool is collectively
+   * unfit (too few left, all lagging, all slow). At least one selector facet
+   * is required; with none it is a no-op (it never admits the whole
+   * universe). Added upstreams default to the tail so the survivors keep
+   * priority; a later `sortByScore` reorders if a reserve upstream is better.
+   */
+  includeIf(
+    condition: boolean | PolicyEvalArrayCondition,
+    opts: IncludeIfOptions,
   ): PolicyEvalUpstreamArray;
 
   // ─── 4.11 Combinators ─────────────────────────────────────────────────
@@ -698,6 +755,35 @@ declare global {
   function any(...preds: PolicyEvalPredicate[]): PolicyEvalPredicate;
   /** Negate a predicate. */
   function not(pred: PolicyEvalPredicate): PolicyEvalPredicate;
+
+  // Quantifiers — lift a per-upstream predicate to a pool-level condition
+  // for `includeIf`. Where `all` / `any` / `not` compose per-upstream
+  // predicates into another per-upstream predicate, these collapse a
+  // predicate over the WHOLE array into one boolean.
+  /**
+   * True iff the array is non-empty AND every upstream satisfies `pred`.
+   * Deliberately false on an empty array — "all of nothing are bad" should
+   * not trigger a break-glass inclusion; use `sizeBelow` for the empty case.
+   */
+  function forAll(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
+  /** True iff at least one upstream satisfies `pred`. */
+  function forAny(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
+  /** True iff no upstream satisfies `pred`. */
+  function forNone(pred: PolicyEvalPredicate): PolicyEvalArrayCondition;
+  /** True iff at least `n` upstreams satisfy `pred`. */
+  function atLeast(
+    n: number,
+    pred: PolicyEvalPredicate,
+  ): PolicyEvalArrayCondition;
+  /** True iff fewer than `n` upstreams satisfy `pred`. */
+  function fewerThan(
+    n: number,
+    pred: PolicyEvalPredicate,
+  ): PolicyEvalArrayCondition;
+  /** True iff the array has fewer than `n` upstreams. */
+  function sizeBelow(n: number): PolicyEvalArrayCondition;
+  /** True iff the array has at least `n` upstreams. */
+  function sizeAtLeast(n: number): PolicyEvalArrayCondition;
 
   // Module-level helpers ──────────────────────────────────────────────
   /** True iff `ctx.method` matches the glob/pattern. */

--- a/typescript/config/src/types/policyEval.ts
+++ b/typescript/config/src/types/policyEval.ts
@@ -390,17 +390,16 @@ export type PolicyEvalArrayCondition = (
 ) => boolean;
 
 /**
- * Selector for `includeIf`. At least one facet must resolve to a concrete
- * value — the facets AND together (same semantics as `where`) to pick which
- * upstreams are admitted from the full universe when the condition holds.
+ * The selector-object form of `includeIf`'s target. At least one facet must
+ * resolve to a concrete value — the facets AND together (same semantics as
+ * `where`) to pick which upstreams are admitted from the full universe when
+ * the condition holds.
  */
-export type IncludeIfOptions = {
+export type IncludeIfTarget = {
   id?: Pattern;
   tag?: TagPattern;
   vendor?: Pattern;
   type?: Pattern;
-  /** Alternative to the flat facets above; same AND semantics. */
-  where?: WhereFilter;
   /**
    * Where admitted upstreams land relative to the survivors. `'tail'`
    * (default) keeps the survivors as primaries; `'head'` puts the reserve
@@ -559,17 +558,19 @@ export interface PolicyEvalUpstreamArray
   /**
    * Conditionally admit upstreams from the full universe back into the
    * chain — the dual of `excludeIf`. When `condition` holds, every upstream
-   * matching `opts` (and not already present) is unioned in; otherwise the
+   * matching `target` (and not already present) is unioned in; otherwise the
    * chain is unchanged. It never removes an upstream.
    *
-   * The function form of `condition` receives the CURRENT chain array (the
-   * pool that survived earlier steps), so it can ask aggregate questions
-   * about what is left using native array methods over the per-upstream
-   * predicate factories:
+   * `target` comes first so the policy reads "include <these> if
+   * <condition>". It is a tag pattern for the common case, or a selector
+   * object (`{ id, tag, vendor, type, position }`) for the rest. The function
+   * form of `condition` receives the CURRENT chain array (the pool that
+   * survived earlier steps), so it can ask aggregate questions about what is
+   * left using native array methods over the per-upstream predicate factories:
    *
    *   .excludeTag('tier:reserve')
-   *   .includeIf((p) => p.every(blockSecondsLagAbove(30)), { tag: 'tier:reserve' })
-   *   .includeIf((p) => p.length < 2,                      { tag: 'tier:reserve' })
+   *   .includeIf('tier:reserve', (p) => p.every(blockSecondsLagAbove(30)))
+   *   .includeIf('tier:reserve', (p) => p.length < 2)
    *
    * Use it for a break-glass reserve tier: kept out of normal rotation, but
    * admitted alongside the survivors when the serving pool is collectively
@@ -580,8 +581,8 @@ export interface PolicyEvalUpstreamArray
    * upstream is better.
    */
   includeIf(
+    target: TagPattern | IncludeIfTarget,
     condition: boolean | PolicyEvalArrayCondition,
-    opts: IncludeIfOptions,
   ): PolicyEvalUpstreamArray;
 
   // ─── 4.11 Combinators ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds an `includeIf` primitive to the selection-policy stdlib — the dual of `excludeIf`. Where `excludeIf` **drops** a per-upstream offender, `includeIf` **admits** a selected set of upstreams from the full universe when an aggregate condition over the surviving pool holds. It never removes an upstream.

```js
upstreams
  .excludeTag('tier:reserve')                                            // reserve out of normal rotation
  .includeIf('tier:reserve', (p) => p.every(blockSecondsLagAbove(30)))   // admit if every survivor lags
  .includeIf('tier:reserve', (p) => p.length < 2)                        // ...or if too few remain
  .sortByScore(PREFER_FASTEST)
```

`includeIf(target, condition)` — the **target comes first** so the policy reads "include *these* if *condition*". The target is a tag pattern for the common case, or a selector object (`{ id, tag, vendor, type, position }`) whose facets AND together. The condition is a boolean or a function over the **current** chain array (the pool that survived earlier steps), written with native `every` / `some` / `length` / `filter` over the existing per-upstream predicate factories — no parallel quantifier vocabulary.

## Why

This enables a **break-glass reserve tier**: upstreams kept out of normal rotation and ranked in alongside the survivors only when the serving pool is collectively unfit — too few left, all lagging, all slow. Because it **adds** rather than excludes, a single slow primary is never evicted; the reserve is offered alongside the degraded pool and a later `sortByScore` decides the order.

The explicit `excludeTag` + `includeIf` pair is deliberate: `excludeTag` states "this tier is NOT in normal rotation", `includeIf` states "this is the only condition under which it comes back" — the policy documents its own intent (now also spelled out in the docs).

## Behavior details

- At least one selector facet must resolve, so a facet-less target (`{}`, `{ position: 'head' }`) is a no-op — it never admits the whole universe by accident.
- Already-present upstreams are not duplicated; admitted upstreams default to the tail so survivors keep priority.
- Malformed args and throwing conditions degrade to a no-op rather than failing the eval (which would drop the network back to the default policy).
- Native `every` is true on `[]`, so a bare `p.every(...)` admits on an empty pool; guard with `p.length > 0 &&` when that's not wanted.
- Pure JS over data already exposed to the eval — no engine or Go changes. Additive only.

## Tests

- Go unit tests (`internal/policy/stdlib/include_if_test.go`): admit / no-admit gating, tag and object targets, all selector facets, `position`, dedup, the surviving-pool view of the condition, `every`/`some`/`length`/`filter` conditions, empty-pool semantics, throwing-condition safety, and the end-to-end reserve-tier pattern.
- TS type-level tests (`erpc.test-d.ts`): the chained surface plus negative `@ts-expect-error` cases.
- Docs (`selection-policies.mdx`): reference entry, the "Reserve tier" worked pattern, and the rationale for keeping `excludeTag` explicit.
