### PR TITLE
feat(cache): serve eth_blockNumber from the gRPC cache connector

### DIFF
--- a/data/grpc.go
+++ b/data/grpc.go
@@ -63,6 +63,9 @@ var supportedMethods = map[string]struct{}{
 	"eth_getTransactionReceipt": {},
 	"eth_getBlockReceipts":      {},
 	"eth_chainId":               {},
+	// eth_blockNumber has no native BDS gRPC method; Get derives it from the
+	// latest block (see the translation in Get).
+	"eth_blockNumber": {},
 }
 
 func NewGrpcConnector(
@@ -258,6 +261,20 @@ func (g *GrpcConnector) Get(ctx context.Context, index, partitionKey, rangeKey s
 			callCtx, cancel = context.WithTimeout(ctx, g.getTimeout)
 			defer cancel()
 		}
+	}
+
+	// The backing reader has no eth_blockNumber RPC; derive it from the latest
+	// block. Read getBlockByNumber("latest") and return just its number in the
+	// eth_blockNumber result shape (a quoted hex string). Freshness is enforced
+	// by the cache layer's realtime gate via the connector's reported head.
+	if method == "eth_blockNumber" {
+		num, _, ok := g.fetchTaggedBlock(callCtx, cli, "latest")
+		if !ok {
+			span.SetAttributes(attribute.String("grpc.skip_reason", "latest_block_unavailable"))
+			return nil, common.NewErrRecordNotFound(partitionKey, rangeKey, GrpcDriverName)
+		}
+		span.SetAttributes(attribute.String("grpc.result", "success_block_number"))
+		return []byte(fmt.Sprintf("\"0x%x\"", num)), nil
 	}
 
 	resp, err := cli.SendRequest(callCtx, req)

--- a/data/grpc_blocknumber_test.go
+++ b/data/grpc_blocknumber_test.go
@@ -1,0 +1,121 @@
+package data
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/clients"
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBlockNumberNetwork satisfies common.Network but only implements Id; Get
+// touches nothing else on the network.
+type fakeBlockNumberNetwork struct{ common.Network }
+
+func (fakeBlockNumberNetwork) Id() string { return "evm:1" }
+
+// fakeBlockNumberClient satisfies clients.GrpcBdsClient but only implements
+// SendRequest; that is the sole client method Get/fetchTaggedBlock invoke.
+type fakeBlockNumberClient struct {
+	clients.GrpcBdsClient
+	resp *common.NormalizedResponse
+	err  error
+}
+
+func (f *fakeBlockNumberClient) SendRequest(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+	return f.resp, f.err
+}
+
+func newBlockNumberConnector(t *testing.T, cli clients.GrpcBdsClient) *GrpcConnector {
+	t.Helper()
+	lg := zerolog.Nop()
+	return &GrpcConnector{
+		id:                 "test-grpc",
+		logger:             &lg,
+		clientByNetwork:    map[string]clients.GrpcBdsClient{"evm:1": cli},
+		earliestByNetwork:  map[string]uint64{},
+		latestByNetwork:    map[string]uint64{},
+		finalizedByNetwork: map[string]uint64{},
+		latestTsByNetwork:  map[string]int64{},
+		initializer:        &util.Initializer{},
+	}
+}
+
+func blockNumberRequest(t *testing.T) *common.NormalizedRequest {
+	t.Helper()
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`))
+	req.SetNetwork(fakeBlockNumberNetwork{})
+	return req
+}
+
+func blockResponse(t *testing.T, resultJSON string) *common.NormalizedResponse {
+	t.Helper()
+	jrr, err := common.NewJsonRpcResponseFromBytes([]byte(`1`), []byte(resultJSON), nil)
+	require.NoError(t, err)
+	return common.NewNormalizedResponse().WithJsonRpcResponse(jrr)
+}
+
+// eth_blockNumber is translated to getBlockByNumber("latest") and returns just
+// the block number as a quoted, canonical (lowercase, no leading zeros) hex
+// string.
+func TestGrpcConnector_EthBlockNumber_TranslatesFromLatest(t *testing.T) {
+	cli := &fakeBlockNumberClient{
+		resp: blockResponse(t, `{"number":"0x1a2b3c","timestamp":"0x6500"}`),
+	}
+	g := newBlockNumberConnector(t, cli)
+
+	out, err := g.Get(context.Background(), "idx", "pk", "rk", blockNumberRequest(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, `"0x1a2b3c"`, string(out))
+}
+
+// A zero latest block must serialize as "0x0", not "0x" or "0x00".
+func TestGrpcConnector_EthBlockNumber_Zero(t *testing.T) {
+	cli := &fakeBlockNumberClient{resp: blockResponse(t, `{"number":"0x0"}`)}
+	g := newBlockNumberConnector(t, cli)
+
+	out, err := g.Get(context.Background(), "idx", "pk", "rk", blockNumberRequest(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, `"0x0"`, string(out))
+}
+
+// Hex with leading zeros from the reader is normalized through the uint64
+// round-trip, so the eth_blockNumber result is always canonical.
+func TestGrpcConnector_EthBlockNumber_NormalizesHex(t *testing.T) {
+	cli := &fakeBlockNumberClient{resp: blockResponse(t, `{"number":"0x00ff"}`)}
+	g := newBlockNumberConnector(t, cli)
+
+	out, err := g.Get(context.Background(), "idx", "pk", "rk", blockNumberRequest(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, `"0xff"`, string(out))
+}
+
+// When the latest block cannot be read, the connector reports a miss so the
+// request falls through to upstreams rather than surfacing a bogus number.
+func TestGrpcConnector_EthBlockNumber_LatestUnavailable(t *testing.T) {
+	cli := &fakeBlockNumberClient{err: assert.AnError}
+	g := newBlockNumberConnector(t, cli)
+
+	out, err := g.Get(context.Background(), "idx", "pk", "rk", blockNumberRequest(t))
+
+	assert.Nil(t, out)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeRecordNotFound), "expected record-not-found, got %v", err)
+}
+
+// A latest-block response with no parsable number is also treated as a miss.
+func TestGrpcConnector_EthBlockNumber_NoNumberField(t *testing.T) {
+	cli := &fakeBlockNumberClient{resp: blockResponse(t, `{"timestamp":"0x6500"}`)}
+	g := newBlockNumberConnector(t, cli)
+
+	out, err := g.Get(context.Background(), "idx", "pk", "rk", blockNumberRequest(t))
+
+	assert.Nil(t, out)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeRecordNotFound), "expected record-not-found, got %v", err)
+}


### PR DESCRIPTION
The backing reader exposes no eth_blockNumber RPC, so the gRPC cache connector skipped the method and it always fell through to upstreams. Translate it on read: fetch getBlockByNumber("latest") and return just the block number in the eth_blockNumber result shape (a quoted hex string). Reuses the existing latest-block fetch path; the result is canonical hex via a uint64 round-trip.

Freshness is enforced by the existing realtime cache gate, which falls back to the connector's reported head timestamp for response-less methods like this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-only cache path change with explicit miss behavior and tests; no auth or persistence changes.
> 
> **Overview**
> The gRPC read-through cache connector can now satisfy **`eth_blockNumber`** instead of skipping it and always falling through to upstreams.
> 
> **`GrpcConnector.Get`** allowlists the method and, when BDS has no native RPC, derives the answer by calling **`fetchTaggedBlock`** with **`latest`**, then returns a JSON-RPC-shaped quoted hex string (`"0x…"`) with canonical formatting via a uint64 round-trip. If the latest block cannot be read or has no parsable **`number`**, it returns a **record-not-found** miss so callers can retry upstream. Freshness for this response-less method still relies on the existing realtime cache gate and **`CacheLatestBlockTimestamp`**.
> 
> New unit tests in **`grpc_blocknumber_test.go`** cover happy path, zero block, leading-zero normalization, RPC errors, and missing **`number`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a0c5883ed2520b3f1b9f5291efd7e3a75c22ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->