### PR TITLE
chore(config): bump @erpc-cloud/config to 0.0.65 to publish gRPC config types

### DIFF
--- a/typescript/config/package.json
+++ b/typescript/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erpc-cloud/config",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Library of types for IDE autocompletion of erpc config in Typescript",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Bumps `@erpc-cloud/config` from `0.0.64` → `0.0.65` (version-only change).

## Why

The gRPC upstream/connector config types are already generated on `main` —

- `UpstreamConfig.grpc?: GrpcUpstreamConfig` and `GrpcUpstreamConfig` (used by `clients/grpc_bds_client.go` → `cfg.Grpc.Headers`)
- `GrpcConnectorConfig.headers`

— but the latest version published to npm is `0.0.64`, which predates them. Downstream TypeScript configs that target a gRPC upstream/connector therefore can't reference the `grpc` block without an `as any` cast. Cutting a release at `0.0.65` publishes the already-merged types so consumers can drop the cast.

No code or type changes — `src/generated.ts` already contains the types (via `tygo generate` from `common/config.go`). This only moves the version so the next release publishes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version field change in package.json with no logic or type edits in this diff.
> 
> **Overview**
> Bumps **`@erpc-cloud/config`** from **`0.0.64`** to **`0.0.65`** in `typescript/config/package.json` so the next npm release ships types that are already on `main` (including **`UpstreamConfig.grpc`** / **`GrpcUpstreamConfig`** and **`GrpcConnectorConfig`** with **`headers`**).
> 
> There are **no** changes to generated sources or runtime code—only the package version for publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e62a597bb74e05146c6df0bb020043ed0a927e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->