### PR TITLE
fix(tracing): add SpanKindClient and peer.service to upstream HTTP spans

### DIFF
--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -673,9 +674,11 @@ func getJsonRpcResponseFromNode(rootNode ast.Node) (*common.JsonRpcResponse, err
 
 func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error) {
 	ctx, span := common.StartSpan(ctx, "HttpJsonRpcClient.sendSingleRequest",
+		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("network.id", req.NetworkId()),
 			attribute.String("upstream.id", c.upstream.Id()),
+			semconv.PeerServiceKey.String(c.Url.Hostname()),
 		),
 	)
 	defer span.End()

--- a/clients/tracing_test.go
+++ b/clients/tracing_test.go
@@ -1,0 +1,73 @@
+package clients
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSendSingleRequest_SpanAttributes(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	common.SetTracerProviderForTest(tp)
+	t.Cleanup(func() { common.IsTracingEnabled = false })
+
+	util.ResetGock()
+	defer util.ResetGock()
+	gock.New("http://rpc1.localhost:8545").
+		Post("/").
+		Reply(200).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": "0x1"})
+
+	logger := zerolog.Nop()
+	ups := common.NewFakeUpstream("quicknode-mainnet")
+	ups.Config().Type = common.UpstreamTypeEvm
+
+	client, err := NewGenericHttpJsonRpcClient(
+		context.Background(),
+		&logger,
+		"prj1",
+		ups,
+		&url.URL{Scheme: "http", Host: "rpc1.localhost:8545"},
+		ups.Config().JsonRpc,
+		nil,
+		&noopErrorExtractor{},
+	)
+	require.NoError(t, err)
+
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`))
+	_, _ = client.SendRequest(context.Background(), req)
+
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	var found *tracetest.SpanStub
+	for _, s := range exp.GetSpans() {
+		if s.Name == "HttpJsonRpcClient.sendSingleRequest" {
+			s := s
+			found = &s
+			break
+		}
+	}
+	require.NotNil(t, found, "HttpJsonRpcClient.sendSingleRequest span not emitted")
+
+	assert.Equal(t, trace.SpanKindClient, found.SpanKind, "span.kind must be client for Datadog dependency edges")
+
+	attrMap := make(map[string]string, len(found.Attributes))
+	for _, a := range found.Attributes {
+		attrMap[string(a.Key)] = a.Value.AsString()
+	}
+	assert.Equal(t, "rpc1.localhost", attrMap["peer.service"], "peer.service must be the upstream hostname")
+}

--- a/common/tracing_testing.go
+++ b/common/tracing_testing.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SetTracerProviderForTest installs tp as the active tracer provider and enables tracing.
+// Intended for unit tests that need to inspect emitted spans without a real OTLP collector.
+// Consumes initOnce so that InitializeTracing is a no-op for the rest of the process.
+func SetTracerProviderForTest(tp *sdktrace.TracerProvider) {
+	otel.SetTracerProvider(tp)
+	tracer = otel.Tracer(instrumentationName)
+	IsTracingEnabled = true
+	IsTracingDetailed = false
+	initOnce.Do(func() {})
+}


### PR DESCRIPTION
## Problem

The `HttpJsonRpcClient.sendSingleRequest` span is created without an explicit span kind or a `peer.service` attribute. As a result, APM backends (Datadog, Jaeger, etc.) cannot infer the downstream service edges from eRPC to its upstream RPC providers, so the service dependency graph for upstream calls appears empty.

## Change

On the `HttpJsonRpcClient.sendSingleRequest` span:

- Set `trace.SpanKindClient`. Datadog (and others) only synthesize downstream/outbound edges from client-kind spans; an unspecified/internal kind is not treated as an outbound call. See Datadog's [service entry spans mapping](https://docs.datadoghq.com/opentelemetry/mapping/service_entry_spans/).
- Set `semconv.PeerServiceKey` (`peer.service`) to the upstream endpoint hostname. This makes each provider show up as a distinct downstream node per chain (e.g. `arbitrum-mainnet.quiknode.pro` vs `opt-mainnet.quiknode.pro`) instead of collapsing into a single vendor-level bucket. `peer.service` is consumed by Datadog's inferred-services / peer-tags feature, which only applies to client-kind spans, hence both changes together.

## Testing

Adds a unit test using an in-memory OTEL exporter (`tracetest.NewInMemoryExporter`) that asserts the span kind is `client` and `peer.service` is the upstream hostname, without requiring a live collector. Also adds a small `SetTracerProviderForTest` helper in `common`.