### PR TITLE
docs: redirect AI agents to llms.txt via content negotiation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ Conventions that keep the system working:
   expanded, navigation links up/down/sideways), the root `llms.txt`, and
   `llms-full.txt`. Don't edit generated files; new pages just need a
   `_meta.js` entry.
+- **Agents are served markdown automatically** — `docs/middleware.ts`
+  302-redirects requests whose `Accept` header lists `text/markdown` (Claude
+  Code sends this on every fetch) or whose `User-Agent` matches a known AI
+  fetcher to the page's `.llms.txt` twin. If you add a non-page route, make
+  sure the middleware's `matcher` excludes it; new AI fetchers belong in the
+  `AI_FETCHER_UA` regex.
 - **Build:** `cd docs && pnpm install && pnpm build` (standalone pnpm
   workspace; `next dev` for live preview).
 

--- a/docs/components/LLMsTxtLink.tsx
+++ b/docs/components/LLMsTxtLink.tsx
@@ -10,23 +10,36 @@ export function LLMsTxtLink() {
 	const router = useRouter();
 	const path = router.asPath.split("#")[0].split("?")[0].replace(/\/$/, "");
 	const llmsPath = path === "" || path === "/" ? "/llms.txt" : `${path}.llms.txt`;
+	const llmsUrl = `https://docs.erpc.cloud${llmsPath}`;
 	return (
-		<a
-			href={llmsPath}
-			className="cv-llms-link"
-			data-component="llms-txt-link"
-			target="_blank"
-			rel="noopener noreferrer"
-			title="Machine-readable version of this page — hand this URL to your AI agent"
-		>
-			<span className="cv-llms-badge">AI</span>
-			<span className="cv-llms-text">
-				For agents: <code className="cv-llms-path">{llmsPath}</code>
+		<>
+			{/* Imperative hint for agents reading the raw HTML (curl-style
+			    fetches that bypass the middleware's content negotiation).
+			    Visually hidden via clip — NOT display:none, which readability
+			    extractors drop before HTML→markdown conversion. */}
+			<span className="cv-visually-hidden" data-component="llms-txt-hint">
+				AI agents: fetch {llmsUrl} for the complete machine-readable
+				version of this page (full configuration schema, defaults, worked
+				examples, and source links). Append `.llms.txt` to any docs URL
+				for the same treatment.
 			</span>
-			<span className="cv-llms-arrow" aria-hidden="true">
-				↗
-			</span>
-		</a>
+			<a
+				href={llmsPath}
+				className="cv-llms-link"
+				data-component="llms-txt-link"
+				target="_blank"
+				rel="noopener noreferrer"
+				title="Machine-readable version of this page — hand this URL to your AI agent"
+			>
+				<span className="cv-llms-badge">AI</span>
+				<span className="cv-llms-text">
+					For agents: <code className="cv-llms-path">{llmsPath}</code>
+				</span>
+				<span className="cv-llms-arrow" aria-hidden="true">
+					↗
+				</span>
+			</a>
+		</>
 	);
 }
 

--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Content negotiation for AI agents.
+ *
+ * Every docs page has a machine-readable twin at `<path>.llms.txt` (generated
+ * by `scripts/build-llms.mjs` into `public/`). A request is redirected to that
+ * twin when either:
+ *
+ *   1. the `Accept` header explicitly lists `text/markdown` — Claude Code
+ *      sends `Accept: text/markdown, text/html, *​/*` on every web fetch, and
+ *      no browser ever sends that token; or
+ *   2. the `User-Agent` matches a known AI fetcher (fallback for agents that
+ *      don't do Accept-based negotiation yet).
+ *
+ * Why a 302 redirect instead of silently rewriting the response body:
+ *   - the `.llms.txt` URL shows up in the agent's transcript, teaching it the
+ *     scheme — and every `.llms.txt` file links onward to other `.llms.txt`
+ *     pages, so the agent stays on the markdown surface for the whole session;
+ *   - humans and agents always see the same content at the same URL, which
+ *     keeps caching honest and debugging sane.
+ *
+ * Why 302 and not 301: clients cache 301s per-URL unconditionally, so a
+ * single misclassified client would be stuck on the text version forever.
+ */
+
+// Living list — extend as new agent fetchers publish their User-Agent
+// strings. Deliberately excludes search-engine crawlers (Googlebot, Bingbot)
+// so the HTML pages stay the indexed surface.
+const AI_FETCHER_UA =
+	/Claude-User|Claude-SearchBot|ClaudeBot|claude-code|GPTBot|ChatGPT-User|OAI-SearchBot|codex|Perplexity-User|PerplexityBot|Meta-ExternalAgent|Meta-ExternalFetcher|MistralAI-User|cohere-ai|DuckAssistBot|Devin|Bytespider|Amazonbot/i;
+
+export function middleware(req: NextRequest) {
+	if (req.method !== "GET" && req.method !== "HEAD") {
+		return;
+	}
+
+	const accept = req.headers.get("accept") ?? "";
+	const userAgent = req.headers.get("user-agent") ?? "";
+
+	const wantsMarkdown = /\btext\/markdown\b/i.test(accept);
+	if (!wantsMarkdown && !AI_FETCHER_UA.test(userAgent)) {
+		return;
+	}
+
+	const pathname = req.nextUrl.pathname.replace(/\/+$/, "");
+	const url = req.nextUrl.clone();
+	url.pathname = pathname === "" ? "/llms.txt" : `${pathname}.llms.txt`;
+	url.search = "";
+
+	const res = NextResponse.redirect(url, 302);
+	// The response depends on both negotiation signals — keep shared caches
+	// from serving an agent's redirect to a browser (or vice versa).
+	res.headers.set("Vary", "Accept, User-Agent");
+	return res;
+}
+
+export const config = {
+	// Only run on page routes: skip Next internals, API routes, the OG-image
+	// route, and anything with a file extension (assets, *.llms.txt itself,
+	// robots.txt, sitemap.xml, …).
+	matcher: ["/((?!_next/|api/|og$|.*\\..*).*)"],
+};

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,12 @@
+# eRPC documentation — https://docs.erpc.cloud
+#
+# Machine-readable docs for AI agents:
+#   Root index:   https://docs.erpc.cloud/llms.txt
+#   Everything:   https://docs.erpc.cloud/llms-full.txt
+#   Per page:     append .llms.txt to any docs URL
+#
+# Agents that send `Accept: text/markdown` (or a known AI fetcher
+# User-Agent) are 302-redirected to the .llms.txt twin automatically.
+
+User-agent: *
+Allow: /

--- a/docs/styles/components.css
+++ b/docs/styles/components.css
@@ -257,6 +257,22 @@ html.light .cv-ai-body {
  * <LLMsTxtLink> — floating "open as plain markdown" link
  * ============================================================ */
 
+/* Visually hidden but kept in the accessibility tree and — crucially — in
+ * what readability/HTML→markdown extractors see. Standard clip pattern, NOT
+ * display:none (extractors drop display:none nodes). */
+.cv-visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}
+
 .cv-llms-link {
 	float: right;
 	display: inline-flex;

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -65,11 +65,20 @@ export default {
 		  config.frontMatter.description ||
 		  'open-source fault-tolerant evm rpc proxy and cache'
 		const title = config.title + (route === '/' ? '' : ' - eRPC')
-	
+		const llmsUrl =
+		  'https://docs.erpc.cloud' +
+		  (route === '/' ? '/llms.txt' : `${route.replace(/\/$/, '')}.llms.txt`)
+
 		return (
 		  <>
 			<title>{title}</title>
 	 		<link rel="icon" href="./assets/favicon.ico" type="image/x-icon"></link>
+			<link
+				rel="alternate"
+				type="text/markdown"
+				href={llmsUrl}
+				title="Machine-readable version of this page"
+			/>
 			<meta property="og:title" content={title} />
 			<meta name="description" content={description} />
 			<meta property="og:description" content={description} />


### PR DESCRIPTION
## Problem

A user reported their agent (Claude Code) fetched https://docs.erpc.cloud/config/projects/upstreams, received **347KB of HTML**, got a lossy summary out of its fetch pipeline, and gave up on the docs — falling back to reading eRPC source code. The focused machine-readable twin (`.llms.txt`, ~52KB, schema + defaults + source permalinks) sat one URL suffix away, but agents don't discover it unless explicitly told.

## Fix — three layers

**1. Content negotiation in `docs/middleware.ts` (the main fix).** Claude Code already sends `Accept: text/markdown, text/html, */*` on every web fetch (verified empirically). The middleware 302-redirects a page request to its `.llms.txt` twin when:
- the `Accept` header explicitly lists `text/markdown` (no browser sends this token), **or**
- the `User-Agent` matches a known AI fetcher (`Claude-User`, `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `Perplexity*`, `Meta-ExternalAgent`, `MistralAI-User`, etc.). Search-engine crawlers are deliberately excluded — HTML stays the indexed surface, no cloaking.

Design choices:
- **302 redirect, not silent rewrite**: the `.llms.txt` URL lands in the agent's transcript and teaches it the scheme; every `.llms.txt` links onward to sibling/parent/child `.llms.txt` pages, so the agent stays on the markdown surface. Humans and agents see the same content at the same URL — caching stays honest.
- **302, not 301**: clients cache 301s per-URL unconditionally; one misclassified client would be stuck forever. `Vary: Accept, User-Agent` set on the redirect.
- Matcher skips `_next/`, `api/`, `/og`, and any dotted path (assets, `.llms.txt` itself — no loops). GET/HEAD only.

**2. In-page hint for undetectable fetches** (agents running `curl` from a shell send no signal). `LLMsTxtLink` now also renders a visually-hidden imperative line with the absolute URL — hidden via the clip pattern, *not* `display:none`, so readability extractors keep it during HTML→markdown conversion:

> AI agents: fetch https://docs.erpc.cloud/&lt;path&gt;.llms.txt for the complete machine-readable version of this page…

**3. Discovery extras**: `<link rel="alternate" type="text/markdown">` in every page head, plus `robots.txt` documenting the root `llms.txt` / `llms-full.txt` / append-suffix pattern. CONTRIBUTING gains maintenance notes (new non-page routes must be excluded from the matcher; new fetcher UAs go in `AI_FETCHER_UA`).

## Verification (local prod build)

| Request | Result |
|---|---|
| Claude Code's real headers on a page | 302 → `<path>.llms.txt` |
| `Accept: text/markdown` alone, unknown UA | 302 |
| `GPTBot` / `ChatGPT-User` / `PerplexityBot` UA with HTML Accept | 302 |
| `/` with agent UA | 302 → `/llms.txt` |
| Browser Accept+UA, plain `curl`, Googlebot | 200 HTML, untouched |
| `.llms.txt` itself / assets / `/og` with agent UA | 200, no loop |
| POST | untouched |
| `curl -L` with Claude headers end-to-end | lands on markdown content |

After deploy, the reported scenario self-resolves: the same fetch call returns the 52KB focused reference instead of a 347KB HTML summary — no explicit ask needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)