### PR TITLE
docs: add docstring for User struct

### DIFF
--- a/common/user.go
+++ b/common/user.go
@@ -1,5 +1,6 @@
 package common
 
+// User 表示系统中的用户，包含 ID 和速率限制预算信息。
 type User struct {
 	Id              string
 	RateLimitBudget string


### PR DESCRIPTION
### 问题背景

公共结构体 `User` 是代码中的一个核心数据类型，但缺少文档注释。在 Go 语言中，良好的文档注释（docstring）是代码可读性和可维护性的重要保障，有助于其他开发者快速理解类型的用途和设计意图。

### 修改内容

- **修改了什么**：在 `common/user.go` 文件中为 `User` 结构体添加了文档注释。
- **为什么这样改**：明确标识 `User` 类型在系统中的角色，说明其包含的 `Id` 和 `RateLimitBudget` 字段的意义，遵循 Go 语言的文档惯例，提升代码的可读性。
- **对代码质量的提升**：提高了代码的自文档化程度，降低了新贡献者或维护者的理解成本，是良好的开源实践的一部分。

### 验证方式

- 本次修改仅为添加注释，不涉及任何逻辑或行为变更。
- 项目所有现有测试应继续通过。
- 可以通过 `go vet` 等工具检查代码，确保没有引入格式或编译问题。

### 其他信息

- **Breaking Changes**: 无。
- **文档更新**: 本次修改即为代码文档的更新，无需同步更新项目 README 或其他外部文档。
- **已知限制**: 无。