### PR TITLE
fix: consensus wait caps armed by skipped participants resolve rounds before any real attempt

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -1431,10 +1431,12 @@ var NewErrUpstreamShadowing = func(upstreamId string) error {
 
 type ErrUpstreamNotAllowed struct{ BaseError }
 
+const ErrCodeUpstreamNotAllowed ErrorCode = "ErrUpstreamNotAllowed"
+
 var NewErrUpstreamNotAllowed = func(required, upstreamId string) error {
 	return &ErrUpstreamNotAllowed{
 		BaseError{
-			Code:    "ErrUpstreamNotAllowed",
+			Code:    ErrCodeUpstreamNotAllowed,
 			Message: "upstream not allowed based on use-upstream directive",
 			Details: map[string]interface{}{
 				"required":   required,

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -450,8 +450,22 @@ func (e *executor) runAnalyzer(
 		if maxWaitOnEmpty <= 0 && maxWaitOnResult <= 0 {
 			return
 		}
+		// Results that never reached an upstream (config-static skips like
+		// ignored methods or shadow upstreams, and empty-cursor outcomes —
+		// see isNoAttemptResult) are produced locally in microseconds and
+		// carry no signal about how long the round's real participants
+		// need. Arming the caps off them would start the countdown before
+		// any live attempt exists: under fan-out configs where some
+		// upstreams statically skip the method, the round would resolve
+		// with only non-votable infrastructure errors while the real
+		// participants are still in flight. The collection loop still
+		// counts these results toward maxToSpawn, so rounds where every
+		// participant skips terminate immediately without any cap.
+		if isNoAttemptResult(resp) {
+			return
+		}
 		now := time.Now()
-		// First response of any kind arms maxWaitOnEmpty.
+		// First response from an actual upstream attempt arms maxWaitOnEmpty.
 		if maxWaitOnEmpty > 0 && waitDeadline.IsZero() {
 			armTimer(now.Add(maxWaitOnEmpty))
 		}
@@ -627,6 +641,83 @@ func (e *executor) releaseNonWinningResponses(
 			}
 		}
 	}
+}
+
+// isNoAttemptResult reports whether a participant's result was produced
+// without any network call to an upstream: config-static skips (method
+// ignored/not allowed, shadow upstreams, syncing nodes, use-upstream
+// directive mismatch) and empty-cursor outcomes (no upstreams left to
+// select, exhausted lists where every recorded error is itself a skip).
+// Such results are decided locally in microseconds, so they say nothing
+// about how long the round's real participants need — the wait caps must
+// not be armed off them. Genuine attempt failures (timeouts, 5xx,
+// connection resets) are NOT no-attempt: they prove the round is live and
+// should keep arming the caps.
+func isNoAttemptResult(r *execResult) bool {
+	if r == nil {
+		return true
+	}
+	if r.Err == nil {
+		return false
+	}
+	return isNoAttemptError(r.Err)
+}
+
+func isNoAttemptError(err error) bool {
+	se, ok := err.(common.StandardError)
+	if !ok {
+		return false
+	}
+	base := se.Base()
+	if base == nil {
+		return false
+	}
+	switch base.Code {
+	case common.ErrCodeUpstreamRequestSkipped,
+		common.ErrCodeUpstreamMethodIgnored,
+		common.ErrCodeUpstreamShadowing,
+		common.ErrCodeUpstreamSyncing,
+		common.ErrCodeUpstreamNotAllowed,
+		common.ErrCodeNoUpstreamsLeftToSelect:
+		return true
+	case common.ErrCodeUpstreamsExhausted:
+		// Wrapper: the verdict follows the recorded child errors. No
+		// children at all means no upstream was ever tried.
+		cause := se.GetCause()
+		if cause == nil {
+			return true
+		}
+		return isNoAttemptCause(cause)
+	case common.ErrCodeFailsafeRetryExceeded:
+		// Wrapper: retry-exceeded always carries the last attempt's error;
+		// the verdict follows it.
+		cause := se.GetCause()
+		if cause == nil {
+			return false
+		}
+		return isNoAttemptCause(cause)
+	}
+	return false
+}
+
+// isNoAttemptCause unwraps a wrapper's cause, which may be an errors.Join
+// multi-error (e.g. ErrUpstreamsExhausted joining ErrorsByUpstream): ALL
+// children must be no-attempt for the wrapper to count as no-attempt — a
+// single real attempt failure means the round is live.
+func isNoAttemptCause(cause error) bool {
+	if multi, ok := cause.(interface{ Unwrap() []error }); ok {
+		children := multi.Unwrap()
+		if len(children) == 0 {
+			return true
+		}
+		for _, child := range children {
+			if !isNoAttemptError(child) {
+				return false
+			}
+		}
+		return true
+	}
+	return isNoAttemptError(cause)
 }
 
 // executeParticipant runs a single upstream request within a goroutine.

--- a/consensus/wait_cap_test.go
+++ b/consensus/wait_cap_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -127,4 +128,176 @@ func TestWaitCap_NoCap_WaitsForEveryone(t *testing.T) {
 
 	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond,
 		"with no wait cap, consensus must wait for the slower participant")
+}
+
+// skippedParticipantErr builds the error a participant slot produces when its
+// drawn upstream statically skips the method (e.g. ignoreMethods).
+func skippedParticipantErr(method, upstreamId string) error {
+	return common.NewErrUpstreamRequestSkipped(
+		common.NewErrUpstreamMethodIgnored(method, upstreamId), upstreamId)
+}
+
+// TestWaitCap_NotArmedBySkippedParticipants verifies that participants which
+// never reached an upstream (config-static skips, exhausted cursors whose
+// recorded errors are all skips) do NOT arm the wait caps: the round must
+// keep waiting for the only real participant even though it is far slower
+// than both caps.
+func TestWaitCap_NotArmedBySkippedParticipants(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := newBuilder().
+		WithLogger(&logger).
+		WithMaxParticipants(3).
+		WithAgreementThreshold(3). // disable short-circuit; the collection loop must decide
+		WithLowParticipantsBehavior(common.ConsensusLowParticipantsBehaviorAcceptMostCommonValidResult).
+		WithMaxWaitOnEmpty(common.NewStaticDuration(30 * time.Millisecond)).
+		WithMaxWaitOnResult(common.NewStaticDuration(30 * time.Millisecond)).
+		Build()
+
+	req := newTestRequest()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var slot atomic.Int32
+	start := time.Now()
+	resp, err := pol.Run(ctx, req, func(_ context.Context, _ *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+		idx := slot.Add(1)
+		switch idx {
+		case 1:
+			// Config-static skip — produced locally in microseconds.
+			return nil, skippedParticipantErr("eth_getLogs", "archive-1")
+		case 2:
+			// A slot that exhausted the shared cursor after burning its
+			// retries on skipped upstreams — also produced in microseconds.
+			return nil, common.NewErrFailsafeRetryExceeded(common.ScopeNetwork,
+				common.NewErrUpstreamsExhaustedWithCause(errors.Join(
+					skippedParticipantErr("eth_getLogs", "archive-1"),
+					skippedParticipantErr("eth_getLogs", "archive-2"),
+				)), nil)
+		default:
+			// The only real participant — far beyond both caps.
+			time.Sleep(150 * time.Millisecond)
+			return validResponseWithValue("0xreal"), nil
+		}
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err,
+		"instant skips must not resolve the round with only infrastructure errors")
+	require.NotNil(t, resp)
+	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond,
+		"round must wait for the real participant; skips must not start the countdown")
+}
+
+// TestWaitCap_AllParticipantsSkipped_ResolvesImmediately verifies that when
+// every participant skips, the round still terminates promptly: the loop
+// collects all (instant) responses and resolves without ever needing a cap.
+func TestWaitCap_AllParticipantsSkipped_ResolvesImmediately(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := newBuilder().
+		WithLogger(&logger).
+		WithMaxParticipants(3).
+		WithAgreementThreshold(1).
+		// Deliberately long caps: termination must come from collecting all
+		// responses, not from any timer.
+		WithMaxWaitOnEmpty(common.NewStaticDuration(10 * time.Second)).
+		WithMaxWaitOnResult(common.NewStaticDuration(10 * time.Second)).
+		Build()
+
+	req := newTestRequest()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var slot atomic.Int32
+	start := time.Now()
+	_, err := pol.Run(ctx, req, func(_ context.Context, _ *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+		idx := slot.Add(1)
+		return nil, skippedParticipantErr("eth_getLogs", "archive-"+string(rune('0'+idx)))
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "an all-skips round has no result to return")
+	assert.Less(t, elapsed, 2*time.Second,
+		"all-skips round must resolve as soon as every participant has responded")
+}
+
+// TestWaitCap_ArmedByRealAttemptFailures pins the intended cap semantics:
+// a genuine attempt failure (connection reset, 5xx, timeout) proves the round
+// is live and MUST still arm maxWaitOnEmpty, bounding a slow straggler.
+func TestWaitCap_ArmedByRealAttemptFailures(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	pol := newBuilder().
+		WithLogger(&logger).
+		WithMaxParticipants(2).
+		WithAgreementThreshold(2).
+		WithLowParticipantsBehavior(common.ConsensusLowParticipantsBehaviorAcceptMostCommonValidResult).
+		WithMaxWaitOnEmpty(common.NewStaticDuration(50 * time.Millisecond)).
+		Build()
+
+	req := newTestRequest()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var slot atomic.Int32
+	start := time.Now()
+	_, _ = pol.Run(ctx, req, func(_ context.Context, _ *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+		idx := slot.Add(1)
+		if idx == 1 {
+			// Real attempt failure: a plain transport error, not a skip.
+			return nil, errors.New("connection reset by peer")
+		}
+		time.Sleep(2 * time.Second)
+		return validResponseWithValue("0xslow"), nil
+	})
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 800*time.Millisecond,
+		"a real attempt failure must arm maxWaitOnEmpty and bound the straggler")
+}
+
+// TestIsNoAttemptError pins the classification used by considerWaitCap.
+func TestIsNoAttemptError(t *testing.T) {
+	req := newTestRequest()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"method ignored", common.NewErrUpstreamMethodIgnored("eth_call", "u1"), true},
+		{"request skipped wrapping method ignored", skippedParticipantErr("eth_call", "u1"), true},
+		{"shadow upstream", common.NewErrUpstreamShadowing("u1"), true},
+		{"syncing upstream", common.NewErrUpstreamSyncing("u1"), true},
+		{"use-upstream directive mismatch", common.NewErrUpstreamNotAllowed("u9*", "u1"), true},
+		{"no upstreams left to select", common.NewErrNoUpstreamsLeftToSelect(req, "all consumed"), true},
+		{"exhausted with no recorded errors", common.NewErrUpstreamsExhaustedWithCause(nil), true},
+		{"exhausted joining only skips", common.NewErrUpstreamsExhaustedWithCause(errors.Join(
+			skippedParticipantErr("eth_call", "u1"),
+			skippedParticipantErr("eth_call", "u2"),
+		)), true},
+		{"exhausted joining a skip and a real failure", common.NewErrUpstreamsExhaustedWithCause(errors.Join(
+			skippedParticipantErr("eth_call", "u1"),
+			errors.New("connection reset by peer"),
+		)), false},
+		{"retry-exceeded wrapping exhausted skips", common.NewErrFailsafeRetryExceeded(common.ScopeNetwork,
+			common.NewErrUpstreamsExhaustedWithCause(errors.Join(
+				skippedParticipantErr("eth_call", "u1"),
+			)), nil), true},
+		{"retry-exceeded wrapping a real failure", common.NewErrFailsafeRetryExceeded(common.ScopeNetwork,
+			errors.New("boom"), nil), false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isNoAttemptError(tc.err))
+		})
+	}
+
+	t.Run("successful result is an attempt", func(t *testing.T) {
+		assert.False(t, isNoAttemptResult(&execResult{Result: validResponseWithValue("0x1")}))
+	})
+	t.Run("nil result is not an attempt", func(t *testing.T) {
+		assert.True(t, isNoAttemptResult(nil))
+	})
 }

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -955,6 +955,20 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			upsList = append(upsList, u)
 		}
 	}
+	// Enforce method eligibility at selection time: an upstream whose
+	// ignoreMethods/allowMethods config (including entries added by
+	// autoIgnoreUnsupportedMethods) excludes this method would only be
+	// skipped at forward time anyway — but letting it into the request's
+	// upstream list makes it consume retry/hedge/consensus attempts and
+	// emit instant "method ignored" skips; under consensus fan-out those
+	// skips become phantom participants. When EVERY upstream ignores the
+	// method, keep the full list so the request fails with the descriptive
+	// per-upstream "method ignored" error instead of a generic
+	// "no upstreams found".
+	if eligible, dropped := filterMethodEligible(upsList, method); dropped > 0 && len(eligible) > 0 {
+		upstreamSpan.SetAttributes(attribute.Int("upstreams.method_ineligible", dropped))
+		upsList = eligible
+	}
 	upstreamSpan.SetAttributes(attribute.Int("upstreams.count", len(upsList)))
 	if common.IsTracingDetailed {
 		ids := make([]string, len(upsList))
@@ -2059,6 +2073,34 @@ func (n *Network) shouldHandleMethod(req *common.NormalizedRequest, method strin
 	}
 
 	return nil
+}
+
+// filterMethodEligible returns the upstreams expected to serve `method` per
+// their ignoreMethods/allowMethods config (Upstream.ShouldHandleMethod, which
+// is memoized per method), plus the number dropped. The input slice is never
+// mutated — selection-policy slots hand out their cached backing array as
+// read-only — and is returned as-is when nothing is dropped. Matcher errors
+// fail open (the upstream stays in) so a malformed pattern degrades to the
+// forward-time skip rather than silently shrinking the pool.
+func filterMethodEligible(ups []common.Upstream, method string) ([]common.Upstream, int) {
+	eligible := ups
+	dropped := 0
+	for i, u := range ups {
+		ok, err := u.ShouldHandleMethod(method)
+		if err == nil && !ok {
+			if dropped == 0 {
+				// First drop: materialize a fresh slice with the survivors so far.
+				eligible = make([]common.Upstream, i, len(ups))
+				copy(eligible, ups[:i])
+			}
+			dropped++
+			continue
+		}
+		if dropped > 0 {
+			eligible = append(eligible, u)
+		}
+	}
+	return eligible, dropped
 }
 
 func (n *Network) enrichStatePoller(ctx context.Context, method string, req *common.NormalizedRequest, resp *common.NormalizedResponse) {

--- a/erpc/networks_method_eligibility_test.go
+++ b/erpc/networks_method_eligibility_test.go
@@ -2,8 +2,10 @@ package erpc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/erpc/erpc/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,5 +55,117 @@ func TestFilterMethodEligible(t *testing.T) {
 		assert.Equal(t, "full-1", ups[0].Id())
 		assert.Equal(t, "archive-1", ups[1].Id())
 		assert.Equal(t, "full-2", ups[2].Id())
+	})
+}
+
+// sumCounterFamily returns the sum of every series in a counter family from
+// the default prometheus registry. Reading the family sum (rather than exact
+// label values) keeps the assertion robust to label changes; callers compare
+// before/after deltas around the code under test.
+func sumCounterFamily(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var sum float64
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			sum += m.GetCounter().GetValue()
+		}
+	}
+	return sum
+}
+
+// TestNetworkConsensus_MethodIgnoredUpstreams_EndToEnd exercises the full
+// network path (real Network, real upstream registry, per-upstream HTTP
+// servers) for consensus over a mixed pool where some upstreams statically
+// ignore the requested method. End goals verified:
+//
+//  1. method-ignored upstreams receive ZERO traffic and never become
+//     participants (strict per-upstream call counts);
+//  2. their instant exclusions do NOT arm maxWaitOnResult/maxWaitOnEmpty —
+//     the round waits for the real participants even when they are far
+//     slower than both caps (duration check + wait-capped metric delta);
+//  3. surplus participant slots (maxParticipants > eligible upstreams)
+//     resolve as no-attempt and do not arm the caps either;
+//  4. when EVERY upstream ignores the method, the request still fails fast
+//     with the descriptive per-upstream "method ignored" error and no
+//     upstream traffic.
+func TestNetworkConsensus_MethodIgnoredUpstreams_EndToEnd(t *testing.T) {
+	t.Run("ignored upstreams excluded and wait caps not armed by exclusions", func(t *testing.T) {
+		upstreams := createTestUpstreams(4)
+		// Archive-style nodes: statically ignore broadcast methods.
+		upstreams[0].IgnoreMethods = []string{"eth_send*"}
+		upstreams[1].IgnoreMethods = []string{"eth_send*"}
+
+		waitCappedBefore := sumCounterFamily(t, "erpc_consensus_wait_capped_total")
+
+		runConsensusTest(t, consensusTestCase{
+			name:          "ignored_upstreams_excluded_wait_caps_not_armed",
+			upstreams:     upstreams,
+			requestMethod: "eth_sendRawTransaction",
+			requestParams: []interface{}{"0x02f870018203e8843b9aca00847735940082520894aabbccddeeff00112233445566778899aabbccdd8080c0"},
+			consensusConfig: &common.ConsensusPolicyConfig{
+				// More participants than eligible upstreams: the surplus
+				// slots resolve instantly with no-upstreams-left and must
+				// not arm the wait caps.
+				MaxParticipants: 4,
+				// Unreachable threshold: the round must rely on response
+				// collection (and the method's first-success rule), not on
+				// an agreement short-circuit, so premature wait-cap firing
+				// would be visible as a failure.
+				AgreementThreshold:      4,
+				LowParticipantsBehavior: common.ConsensusLowParticipantsBehaviorAcceptMostCommonValidResult,
+				// Far smaller than the real upstreams' response time: if
+				// the instant exclusions armed these, the round would
+				// resolve before any tx hash arrives.
+				MaxWaitOnResult: common.NewStaticDuration(30 * time.Millisecond),
+				MaxWaitOnEmpty:  common.NewStaticDuration(30 * time.Millisecond),
+			},
+			mockResponses: []mockResponse{
+				{}, // ignored upstream: must never be called (placeholder keeps indexes aligned)
+				{}, // ignored upstream: must never be called
+				{status: 200, body: jsonRpcSuccess("0x1111111111111111111111111111111111111111111111111111111111111111"), delay: 150 * time.Millisecond},
+				{status: 200, body: jsonRpcSuccess("0x1111111111111111111111111111111111111111111111111111111111111111"), delay: 150 * time.Millisecond},
+			},
+			expectedCalls: []int{0, 0, 1, 1},
+			expectedResult: &expectedResult{
+				contains: "0x1111111111111111111111111111111111111111111111111111111111111111",
+				check: func(t *testing.T, resp *common.NormalizedResponse, duration time.Duration) {
+					assert.GreaterOrEqual(t, duration, 140*time.Millisecond,
+						"round must wait for the real (slow) participants; instant exclusions must not start the wait-cap countdown")
+				},
+			},
+		})
+
+		assert.Equal(t, waitCappedBefore, sumCounterFamily(t, "erpc_consensus_wait_capped_total"),
+			"wait caps must not fire when the only instant responses are method-ignored exclusions")
+	})
+
+	t.Run("all upstreams ignore the method: descriptive error, zero traffic", func(t *testing.T) {
+		upstreams := createTestUpstreams(3)
+		for _, u := range upstreams {
+			u.IgnoreMethods = []string{"eth_send*"}
+		}
+
+		runConsensusTest(t, consensusTestCase{
+			name:          "all_upstreams_ignore_method",
+			upstreams:     upstreams,
+			requestMethod: "eth_sendRawTransaction",
+			requestParams: []interface{}{"0x02f870018203e8843b9aca00847735940082520894aabbccddeeff00112233445566778899aabbccdd8080c0"},
+			consensusConfig: &common.ConsensusPolicyConfig{
+				MaxParticipants:    3,
+				AgreementThreshold: 3,
+				MaxWaitOnResult:    common.NewStaticDuration(30 * time.Millisecond),
+				MaxWaitOnEmpty:     common.NewStaticDuration(30 * time.Millisecond),
+			},
+			mockResponses: []mockResponse{},
+			expectedCalls: []int{0, 0, 0},
+			expectedError: &expectedError{
+				code: common.ErrCodeUpstreamMethodIgnored,
+			},
+		})
 	})
 }

--- a/erpc/networks_method_eligibility_test.go
+++ b/erpc/networks_method_eligibility_test.go
@@ -1,0 +1,57 @@
+package erpc
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterMethodEligible(t *testing.T) {
+	full1 := common.NewFakeUpstream("full-1")
+	full2 := common.NewFakeUpstream("full-2")
+	archive1 := common.NewFakeUpstream("archive-1")
+	archive1.Config().IgnoreMethods = []string{"eth_send*"}
+	archive2 := common.NewFakeUpstream("archive-2")
+	archive2.Config().IgnoreMethods = []string{"*"}
+
+	t.Run("drops ineligible upstreams preserving order", func(t *testing.T) {
+		ups := []common.Upstream{archive1, full1, archive2, full2}
+		eligible, dropped := filterMethodEligible(ups, "eth_sendRawTransaction")
+		require.Equal(t, 2, dropped)
+		require.Len(t, eligible, 2)
+		assert.Equal(t, "full-1", eligible[0].Id())
+		assert.Equal(t, "full-2", eligible[1].Id())
+	})
+
+	t.Run("returns input slice untouched when all are eligible", func(t *testing.T) {
+		ups := []common.Upstream{full1, archive1, full2}
+		eligible, dropped := filterMethodEligible(ups, "eth_getLogs")
+		assert.Equal(t, 0, dropped)
+		// Same backing array, no copy: the selection-policy cache slice is
+		// passed through as-is on the hot path.
+		assert.Equal(t, &ups[0], &eligible[0])
+		assert.Len(t, eligible, 3)
+	})
+
+	t.Run("all ineligible reports full drop", func(t *testing.T) {
+		ups := []common.Upstream{archive1, archive2}
+		eligible, dropped := filterMethodEligible(ups, "eth_sendRawTransaction")
+		assert.Equal(t, 2, dropped)
+		assert.Empty(t, eligible)
+		// The Forward call-site keeps the original list in this case so the
+		// request still fails with the descriptive per-upstream
+		// "method ignored" error rather than "no upstreams found".
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		ups := []common.Upstream{full1, archive1, full2}
+		eligible, dropped := filterMethodEligible(ups, "eth_sendRawTransaction")
+		require.Equal(t, 1, dropped)
+		require.Len(t, eligible, 2)
+		assert.Equal(t, "full-1", ups[0].Id())
+		assert.Equal(t, "archive-1", ups[1].Id())
+		assert.Equal(t, "full-2", ups[2].Id())
+	})
+}


### PR DESCRIPTION
## Problem

Two compounding issues affect consensus fan-out when some upstreams statically skip the matched method — a common setup being archive nodes configured with `ignoreMethods: ["eth_send*"]` alongside full nodes that handle broadcasts:

1. **`ignoreMethods` is enforced too late.** Upstream selection installs the full policy-ordered list on the request; method-ineligible upstreams are only rejected at forward time (`ErrUpstreamMethodIgnored` via `shouldSkip`). Until then they consume consensus participant slots and retry/hedge attempts just to produce instant skips.

2. **Wait caps are armed by responses that never reached an upstream.** Since 0.1.0, `maxWaitOnResult`/`maxWaitOnEmpty` default to adaptive values whenever consensus is configured. `considerWaitCap` arms `maxWaitOnEmpty` on the *first response of any kind* — including skip results that resolve locally in microseconds and that the analyzer itself classifies as non-votable infrastructure errors (`ResponseTypeInfrastructureError`).

The failing sequence:

- consensus spawns `maxParticipants` slots; each slot is `retry(hedge(tryOneUpstream))` over a shared cursor
- slots that draw skip-configured upstreams (or find the cursor exhausted) burn their entire network retry budget on skips in microseconds (`gave up retrying on network-level after 84µs`) and return instantly
- the first such result arms `maxWaitOnEmpty`; the cap fires before any real participant has answered
- the round resolves with only infrastructure errors → the client receives a "method ignored" flavored error (`-32601`)

With `fireAndForget: true` the detached broadcasts still complete in the background, so a transaction can land on chain while the submitter is told the request failed — the worst possible outcome for `eth_sendRawTransaction` (clients rebroadcast, bump nonces, etc.).

## Fix

Two complementary changes:

1. **Selection-time eligibility** (`erpc/networks.go`): filter the candidate list through the (memoized) `ShouldHandleMethod` before `SetUpstreams`, so method-ineligible upstreams never become attempts or consensus participants. When *every* upstream ignores the method, the unfiltered list is kept so the request still fails with the descriptive per-upstream "method ignored" error instead of a generic "no upstreams found" (existing behavior, still covered by `TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping`).

2. **Skip-aware wait-cap arming** (`consensus/executor.go`): `considerWaitCap` now ignores results that represent no actual upstream attempt — config-static skips (method ignored, shadow upstream, syncing, `use-upstream` mismatch) and empty-cursor outcomes (`ErrNoUpstreamsLeftToSelect`, exhausted/retry-exceeded wrappers whose leaf causes are all skips). This also covers what selection filtering alone cannot: when `maxParticipants` exceeds the number of eligible upstreams, the surplus slots still return instant exhausted-cursor errors that would otherwise arm the cap. Genuine attempt failures (timeouts, 5xx, connection resets) still arm the caps, and all-skip rounds still terminate immediately because every response counts toward the spawn total.

Also adds the previously missing `ErrCodeUpstreamNotAllowed` constant.

## Tests

- `TestWaitCap_NotArmedBySkippedParticipants` — reproduces the failure (30ms caps, one skip + one exhausted-cursor result + one 150ms real participant). Fails on the previous logic — the round resolved at ~30ms with only infrastructure errors — and passes now by waiting for the real participant.
- `TestWaitCap_AllParticipantsSkipped_ResolvesImmediately` — all-skip rounds terminate promptly without relying on any cap.
- `TestWaitCap_ArmedByRealAttemptFailures` — pins that genuine failures still arm `maxWaitOnEmpty`.
- `TestIsNoAttemptError` — classification table including mixed skip+real exhausted causes and wrapper recursion.
- `TestFilterMethodEligible` — order preservation, zero-copy pass-through when nothing is dropped, all-ineligible fallback, input immutability (selection-cache slices are read-only).
- Full `consensus` suite passes with `-race`; `erpc` forward/skip/consensus suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus timing and upstream selection for fan-out requests; misclassification of skip vs real errors could affect when rounds resolve, but behavior is heavily tested including end-to-end consensus paths.
> 
> **Overview**
> Fixes consensus rounds that could end early with only “method ignored” / infrastructure errors when **instant skip** participant results armed `maxWaitOnEmpty` / `maxWaitOnResult` before any real upstream attempt completed.
> 
> **Upstream selection** (`erpc/networks.go`): before binding the request’s upstream list, drops upstreams that `ShouldHandleMethod` would reject (`ignoreMethods` / `allowMethods`), so they no longer consume consensus/retry slots or emit phantom skips. If every upstream is ineligible, the unfiltered list is kept so clients still get per-upstream “method ignored” errors.
> 
> **Wait-cap arming** (`consensus/executor.go`): `considerWaitCap` ignores **no-attempt** results (static skips, shadow/syncing/`use-upstream` mismatches, empty-cursor / all-skip exhausted wrappers) via `isNoAttemptResult` / `isNoAttemptError`; real transport failures still arm caps. Adds `ErrCodeUpstreamNotAllowed` in `common/errors.go`.
> 
> Tests cover wait-cap behavior, error classification, `filterMethodEligible`, and an end-to-end network consensus path for ignored methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439f5392a816563940f17acedb0f0e64d7f60e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->