### PR TITLE
fix(release): publish bare erpc npm package and fail loudly on publish errors

### DIFF
--- a/.github/scripts/publish-npm.sh
+++ b/.github/scripts/publish-npm.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publishes the npm package in the current directory, optionally under an
+# alias name (e.g. "erpc", "start-rpc", "start-erpc").
+#
+# Exits 0 when this exact version is already on the registry, so release
+# re-runs stay idempotent. Any other failure (expired token shows up as
+# E404 on the PUT, network errors, etc.) fails the step — do NOT swallow
+# errors here, that is how the 0.1.0 npm release silently went missing.
+
+ALIAS_NAME="${1:-}"
+
+if [[ -n "$ALIAS_NAME" ]]; then
+  cp package.json package.json.bak
+  trap 'mv package.json.bak package.json' EXIT
+  npm pkg set name="$ALIAS_NAME"
+fi
+
+set +e
+OUTPUT=$(pnpm publish --access public --no-git-checks 2>&1)
+CODE=$?
+set -e
+
+echo "$OUTPUT"
+
+if [[ $CODE -ne 0 ]]; then
+  if grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT" <<<"$OUTPUT"; then
+    echo "Version already on the registry; nothing to publish."
+    exit 0
+  fi
+  echo "::error::npm publish failed for ${ALIAS_NAME:-$(npm pkg get name | tr -d '\"')}"
+  exit "$CODE"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,42 +203,35 @@ jobs:
         env:
           CI: true
 
-      # Publish packages
+      # Publish packages. publish-npm.sh tolerates already-published versions
+      # (idempotent re-runs) but fails the job on any other error, e.g. an
+      # expired NPM_TOKEN (npm reports rejected auth as E404 on the PUT).
       - name: Build and publish CLI package
         working-directory: typescript/cli
         run: |
           pnpm run build
-          pnpm publish --access public --no-git-checks || true
+          ../../.github/scripts/publish-npm.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Publish the same package under the "erpc" name
+      - name: Publish erpc alias package
+        working-directory: typescript/cli
+        run: ../../.github/scripts/publish-npm.sh erpc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Publish the same package under the "start-rpc" name
       - name: Publish start-rpc alias package
         working-directory: typescript/cli
-        run: |
-          # Backup the original package.json
-          cp package.json package.json.bak
-          # Modify the package.json name from "@erpc-cloud/cli" to "start-rpc"
-          sed -i 's/"@erpc-cloud\/cli"/"start-rpc"/' package.json
-          # Publish under the new name
-          pnpm publish --access public --no-git-checks || true
-          # Restore the original package.json
-          mv package.json.bak package.json
+        run: ../../.github/scripts/publish-npm.sh start-rpc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Publish the same package under the "start-erpc" name
       - name: Publish start-erpc alias package
         working-directory: typescript/cli
-        run: |
-          # Backup the original package.json
-          cp package.json package.json.bak
-          # Modify the package.json name from "@erpc-cloud/cli" to "start-erpc"
-          sed -i 's/"@erpc-cloud\/cli"/"start-erpc"/' package.json
-          # Publish under the new name
-          pnpm publish --access public --no-git-checks || true
-          # Restore the original package.json
-          mv package.json.bak package.json
+        run: ../../.github/scripts/publish-npm.sh start-erpc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -246,9 +239,31 @@ jobs:
         working-directory: typescript/config
         run: |
           pnpm run build
-          pnpm publish --access public --no-git-checks || true
+          ../../.github/scripts/publish-npm.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Hard guarantee that every package name actually serves this version,
+      # so a swallowed or half-failed publish can never go unnoticed again.
+      # NODE_AUTH_TOKEN is needed because setup-node's .npmrc references it
+      # for every npm invocation, not just publishes.
+      - name: Verify packages are live on npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          for pkg in @erpc-cloud/cli erpc start-rpc start-erpc @erpc-cloud/config; do
+            for attempt in 1 2 3 4 5; do
+              if [ -n "$(npm view "${pkg}@${VERSION}" version 2>/dev/null)" ]; then
+                echo "OK: ${pkg}@${VERSION} is live"
+                continue 2
+              fi
+              echo "Waiting for ${pkg}@${VERSION} (attempt ${attempt}/5)..."
+              sleep 10
+            done
+            echo "::error::${pkg}@${VERSION} is not on the registry after publishing"
+            exit 1
+          done
 
   # Native single-arch builds on matching runners; then compose a multi-arch manifest
   docker-build-amd64:


### PR DESCRIPTION
## Why 0.1.0 never reached npmjs

The release run for `chore: release 0.1.0` ([run 27333084715](https://github.com/erpc/erpc/actions/runs/27333084715)) shows green, but every npm publish in it actually failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@erpc-cloud%2fcli - Not found
```

Three things stacked up:

1. **Expired token.** `NPM_TOKEN` was created 2026-02-23; npm caps write tokens at 90 days, so it died ~May 24. Last successful publish (`0.0.64`, April 23) was inside the window; the June 11 release was not.
2. **npm masks auth failures as 404** on PUT (to avoid leaking package existence), which makes the log look like a registry problem instead of credentials.
3. **`|| true` on every publish step** swallowed the non-zero exit, so the job — and the release — looked successful. All four packages (`@erpc-cloud/cli`, `start-rpc`, `start-erpc`, `@erpc-cloud/config`) are still at 0.0.64.

GoReleaser, the GitHub release, and the Docker images for 0.1.0 all shipped fine — only npm is missing.

## Changes

- **New `.github/scripts/publish-npm.sh`** used by all publish steps: exits 0 only when the exact version is already on the registry (keeps re-runs idempotent — the reason `|| true` existed), fails the job on anything else (auth, network, …), and restores `package.json` via trap even when an alias publish fails mid-way.
- **Publish the CLI under the bare `erpc` name** (https://www.npmjs.com/package/erpc) alongside `start-rpc`/`start-erpc`. The npm transfer is complete — `aramalipoor` is the sole maintainer per the registry packument — it was just never wired into the flow.
- **Post-publish verification step** that polls the registry until all five names serve the released version (with retries for propagation lag), so a half-failed publish can never go unnoticed again.

Alias renames now use `npm pkg set name=…` instead of `sed` on the raw JSON.

## Follow-ups required before the next release (not in this PR)

- Rotate `NPM_TOKEN` with access to the `@erpc-cloud` scope plus `erpc`, `start-rpc`, `start-erpc` — or better, configure npm **trusted publishing** (OIDC) for the five packages to get off the 90-day rotation treadmill.
- Re-publish: dispatching a release (e.g. `0.1.1`) after token rotation publishes all five names, including `erpc`, in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)