### PR TITLE
fix(consensus): exclude info-severity outcomes from consensus_errors_total

### DIFF
--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -1350,8 +1350,11 @@ func (e *executor) recordMetricsAndTracing(req *common.NormalizedRequest, startT
 			WithLabelValues(labels.projectId, labels.networkId, labels.category, labels.finalityStr).
 			Observe(float64(best.Count))
 	}
-	// Record categorized error counters for failure modes
-	if result.Error != nil {
+	// Record categorized error counters for failure modes. Deterministic
+	// client/execution errors (severity info) are the caller's failure that
+	// upstreams merely agreed on (e.g. nonce-too-low on eth_sendRawTransaction
+	// broadcast), not a consensus failure — keep them out of the error counter.
+	if result.Error != nil && common.ClassifySeverity(result.Error) != common.SeverityInfo {
 		errLabel := "generic_error"
 		if hasConsensus {
 			errLabel = "consensus_on_error"

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -1350,11 +1350,13 @@ func (e *executor) recordMetricsAndTracing(req *common.NormalizedRequest, startT
 			WithLabelValues(labels.projectId, labels.networkId, labels.category, labels.finalityStr).
 			Observe(float64(best.Count))
 	}
-	// Record categorized error counters for failure modes. Deterministic
-	// client/execution errors (severity info) are the caller's failure that
-	// upstreams merely agreed on (e.g. nonce-too-low on eth_sendRawTransaction
-	// broadcast), not a consensus failure — keep them out of the error counter.
-	if result.Error != nil && common.ClassifySeverity(result.Error) != common.SeverityInfo {
+	// Record categorized error counters for failure modes, but only for
+	// alert-worthy severities (warning/critical). Deterministic client/execution
+	// errors (severity info) are the caller's failure that upstreams merely
+	// agreed on (e.g. nonce-too-low on eth_sendRawTransaction broadcast), not a
+	// consensus failure — keep them out of the error counter.
+	severity := common.ClassifySeverity(result.Error)
+	if result.Error != nil && (severity == common.SeverityWarning || severity == common.SeverityCritical) {
 		errLabel := "generic_error"
 		if hasConsensus {
 			errLabel = "consensus_on_error"

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -654,5 +655,105 @@ func TestRecordMetricsAndTracing_NilAnalysis_DoesNotPanic(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		e.recordMetricsAndTracing(req, time.Now(), result, nil /* analysis */, labels, span)
+	})
+}
+
+// TestRecordMetricsAndTracing_InfoSeverityNotCountedAsConsensusError verifies
+// that rounds settling on a deterministic client/execution error (severity
+// info — e.g. all upstreams reject an eth_sendRawTransaction broadcast with
+// nonce-too-low) do not increment consensus_errors_total: consensus itself
+// succeeded, the error belongs to the caller. Non-info errors on the same
+// path must still be counted.
+func TestRecordMetricsAndTracing_InfoSeverityNotCountedAsConsensusError(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	cfg := &config{agreementThreshold: 2}
+	e := &executor{
+		consensusPolicy: &consensusPolicy{
+			config: cfg,
+			logger: &logger,
+		},
+	}
+
+	revertErr := common.NewErrEndpointExecutionException(
+		common.NewErrJsonRpcExceptionInternal(3, 3, "execution reverted", nil, nil),
+	)
+
+	// Two participants agreeing on the same execution error → hasConsensus,
+	// outcome "consensus_on_error".
+	buildAgreedErrorAnalysis := func() *consensusAnalysis {
+		responses := []*execResult{
+			{Err: revertErr, Index: 0},
+			{Err: revertErr, Index: 1},
+		}
+		analysis := &consensusAnalysis{
+			config:            cfg,
+			groups:            make(map[string]*responseGroup),
+			totalParticipants: len(responses),
+			method:            "eth_sendRawTransaction",
+		}
+		for _, r := range responses {
+			classifyAndHashResponse(r, nil, cfg)
+			analysis.validParticipants++
+			group, exists := analysis.groups[r.CachedHash]
+			if !exists {
+				group = &responseGroup{
+					Hash:         r.CachedHash,
+					ResponseType: r.CachedResponseType,
+				}
+				analysis.groups[r.CachedHash] = group
+			}
+			group.Count++
+			group.Results = append(group.Results, r)
+			if group.FirstError == nil {
+				group.FirstError = r.Err
+			}
+		}
+		return analysis
+	}
+
+	span := trace.SpanFromContext(context.Background()) // noop span
+
+	t.Run("info severity skips consensus_errors_total", func(t *testing.T) {
+		labels := metricsLabels{
+			projectId:   "test-proj-info-sev",
+			networkId:   "test-net",
+			category:    "eth_sendRawTransaction",
+			finalityStr: "latest",
+			method:      "eth_sendRawTransaction",
+		}
+		errCounter := telemetry.MetricConsensusErrors.WithLabelValues(
+			labels.projectId, labels.networkId, labels.category, "consensus_on_error", labels.finalityStr)
+		totalCounter := telemetry.MetricConsensusTotal.WithLabelValues(
+			labels.projectId, labels.networkId, labels.category, "consensus_on_error", labels.finalityStr)
+		errBefore := testutil.ToFloat64(errCounter)
+		totalBefore := testutil.ToFloat64(totalCounter)
+
+		e.recordMetricsAndTracing(newTestRequest(), time.Now(),
+			&slotResult{Error: revertErr}, buildAgreedErrorAnalysis(), labels, span)
+
+		assert.Equal(t, totalBefore+1, testutil.ToFloat64(totalCounter),
+			"round must still be counted in consensus_total with consensus_on_error outcome")
+		assert.Equal(t, errBefore, testutil.ToFloat64(errCounter),
+			"info-severity agreed error must not count as a consensus error")
+	})
+
+	t.Run("non-info severity still increments consensus_errors_total", func(t *testing.T) {
+		labels := metricsLabels{
+			projectId:   "test-proj-warn-sev",
+			networkId:   "test-net",
+			category:    "eth_sendRawTransaction",
+			finalityStr: "latest",
+			method:      "eth_sendRawTransaction",
+		}
+		serverErr := common.NewErrEndpointServerSideException(errors.New("boom"), nil, 500)
+		errCounter := telemetry.MetricConsensusErrors.WithLabelValues(
+			labels.projectId, labels.networkId, labels.category, "consensus_on_error", labels.finalityStr)
+		errBefore := testutil.ToFloat64(errCounter)
+
+		e.recordMetricsAndTracing(newTestRequest(), time.Now(),
+			&slotResult{Error: serverErr}, buildAgreedErrorAnalysis(), labels, span)
+
+		assert.Equal(t, errBefore+1, testutil.ToFloat64(errCounter),
+			"non-info errors must still be counted as consensus errors")
 	})
 }


### PR DESCRIPTION
## Problem

On `eth_sendRawTransaction` broadcast, when all upstreams return the same deterministic client/execution error (`ErrEndpointExecutionException`, severity `info` — e.g. nonce-too-low, already-known), the round still increments `consensus_errors_total{error="consensus_on_error"}`. This inflates the consensus error rate metric even though consensus actually succeeded — the upstreams unanimously agreed; the error belongs to the caller, not the consensus pipeline.

## Change

- `recordMetricsAndTracing` now increments `consensus_errors_total` only when `common.ClassifySeverity(result.Error)` returns `warning` or `critical` (explicit allow-list, so a future low-severity class cannot silently re-inflate the counter). Deterministic client/execution errors classify as `info` and are excluded.
- The guard applies to all outcome labels, not just `consensus_on_error` — e.g. a single-upstream round returning a revert under `low_participants` is also excluded, consistent with the "caller's error, not a consensus failure" rationale.
- The catastrophic `analysis == nil` panic-recovery path still always increments, since that is genuine consensus-machinery failure.
- These rounds remain fully visible via `consensus_total{outcome="consensus_on_error"}`; only the error counter is cleaned up.

## Testing

- New `TestRecordMetricsAndTracing_InfoSeverityNotCountedAsConsensusError`: an agreed execution revert leaves `consensus_errors_total` untouched while still incrementing `consensus_total`; a non-info server error on the same path still increments the error counter.
- Full `./consensus/` suite, erpc-package consensus tests, and `go build ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)