### PR TITLE
fix(evm): enforce highest block on eth_blockNumber across cache hits, directives, and selector-scoped tips

### DIFF
--- a/architecture/evm/eth_blockNumber.go
+++ b/architecture/evm/eth_blockNumber.go
@@ -10,52 +10,51 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// projectPreForward_eth_blockNumber calls the normal forward, then compares the returned block number,
-// to all EVM upstreams' StatePoller for this network and returns the highest block number across them.
-func projectPreForward_eth_blockNumber(ctx context.Context, network common.Network, nq *common.NormalizedRequest) (handled bool, resp *common.NormalizedResponse, err error) {
-	ctx, span := common.StartDetailSpan(ctx, "Project.PreForwardHook.eth_blockNumber", trace.WithAttributes(
+// networkPostForward_eth_blockNumber enforces the highest-known block on every
+// eth_blockNumber response regardless of its source — a live upstream OR the
+// cache. It compares the returned block number against the network's served
+// tip and, when the response is behind, replaces it with the tip. The
+// correction is a pure in-memory synthesis (poller state), never an extra
+// upstream call.
+//
+// Positioning this at the network post-forward layer (it used to be a project
+// pre-forward wrapper that explicitly skipped FromCache responses) is what
+// guarantees cache hits are corrected too: a stale value planted in the
+// (possibly shared) cache must not be served below the tip this instance
+// already advertises, otherwise clients observe the block number moving
+// backwards by the full upstream lag for an entire TTL window.
+//
+// Gating on the request directives (instead of the deprecated
+// evm.integrity config) matches eth_getBlockByNumber enforcement: the
+// config-level default still applies via directive defaults, and per-request
+// overrides (enforce-highest-block=false) are honored.
+func networkPostForward_eth_blockNumber(ctx context.Context, network common.Network, nq *common.NormalizedRequest, nr *common.NormalizedResponse, re error) (*common.NormalizedResponse, error) {
+	if re != nil || nr == nil {
+		return nr, re
+	}
+
+	dirs := nq.Directives()
+	if dirs == nil || !dirs.EnforceHighestBlock {
+		return nr, re
+	}
+
+	ctx, span := common.StartDetailSpan(ctx, "Network.PostForward.eth_blockNumber", trace.WithAttributes(
 		attribute.String("request.id", fmt.Sprintf("%v", nq.ID())),
 		attribute.String("network.id", network.Id()),
 	))
 	defer span.End()
 
-	ncfg := network.Config()
-	if ncfg == nil ||
-		ncfg.Evm == nil ||
-		ncfg.Evm.Integrity == nil ||
-		ncfg.Evm.Integrity.EnforceHighestBlock == nil ||
-		!*ncfg.Evm.Integrity.EnforceHighestBlock {
-		// If integrity check for highest block is disabled, skip this hook.
-		return false, nil, nil
-	}
-
-	// Step 1: forward the request normally
-	resp, err = network.Forward(ctx, nq)
+	blockRef, blockNumber, err := ExtractBlockReferenceFromResponse(ctx, nr)
 	if err != nil {
 		common.SetTraceSpanError(span, err)
-		return true, nil, err
+		return nil, err
 	}
 
-	// If response is from cache, skip enforcement otherwise there's no point in caching.
-	// As we'll definetely have higher latest block number vs what we have in cache.
-	// The correct way to deal with this situation is to set proper TTL for "realtime" cache policy.
-	if resp != nil && resp.FromCache() {
-		network.Logger().Trace().
-			Object("request", nq).
-			Object("response", resp).
-			Msg("skipping enforcement of highest block number as response is from cache")
-		return true, resp, nil
-	}
-
-	// Step 2: parse the block number from the existing response
-	blockRef, blockNumber, err := ExtractBlockReferenceFromResponse(ctx, resp)
-	if err != nil {
-		common.SetTraceSpanError(span, err)
-		return true, nil, err
-	}
-
-	// Step 3: collect the highest block from all EVM upstream pollers for this network
-	highestBlock := network.EvmHighestLatestBlockNumber(ctx)
+	// Resolve the tip with the request bound to the context so a
+	// use-upstream selector scopes the tip to the targeted subset (the
+	// selector-scoped served-tip semantics): a request pinned to a lagging
+	// group must not be promised a block that group cannot serve.
+	highestBlock := network.EvmHighestLatestBlockNumber(context.WithValue(ctx, common.RequestContextKey, nq))
 	if common.IsTracingDetailed {
 		blockNumberLag := highestBlock - blockNumber
 		if blockNumberLag < 0 {
@@ -69,53 +68,56 @@ func projectPreForward_eth_blockNumber(ctx context.Context, network common.Netwo
 		)
 	}
 
-	// Step 4: if maxBlock is larger than forwardBlock, write that in the response
-	if highestBlock > blockNumber {
-		ups := resp.Upstream()
-		if ups != nil {
-			telemetry.MetricUpstreamStaleLatestBlock.WithLabelValues(
-				network.ProjectId(),
-				ups.VendorName(),
-				network.Label(),
-				ups.Id(),
-				"eth_blockNumber",
-			).Inc()
-			network.Logger().Debug().
-				Str("method", "eth_blockNumber").
-				Int64("knownHighestBlock", highestBlock).
-				Int64("responseBlockNumber", blockNumber).
-				Str("upstreamId", ups.Id()).
-				Msg("upstream returned older block than we known, falling back to highest known block")
-		} else {
-			// This usually shouldn't happen except when reading from cache which is already ignored above.
-			network.Logger().Debug().
-				Str("method", "eth_blockNumber").
-				Int64("knownHighestBlock", highestBlock).
-				Int64("responseBlockNumber", blockNumber).
-				Object("request", nq).
-				Object("response", resp).
-				Msg("upstream returned older block than we known, falling back to highest known block")
-		}
-		hbk, err := common.NormalizeHex(highestBlock)
-		if err != nil {
-			common.SetTraceSpanError(span, err)
-			return true, nil, err
-		}
-		jrr, err := common.NewJsonRpcResponse(nq.ID(), hbk, nil)
-		if err != nil {
-			common.SetTraceSpanError(span, err)
-			return true, nil, err
-		}
-		// We are replacing the original response, so release it to avoid retaining buffers
-		if resp != nil {
-			resp.Release()
-		}
-		resp := common.NewNormalizedResponse().
-			WithRequest(nq).
-			WithJsonRpcResponse(jrr)
-
-		return true, resp, nil
+	if highestBlock <= blockNumber {
+		return nr, re
 	}
 
-	return true, resp, nil
+	ups := nr.Upstream()
+	if ups != nil {
+		telemetry.MetricUpstreamStaleLatestBlock.WithLabelValues(
+			network.ProjectId(),
+			ups.VendorName(),
+			network.Label(),
+			ups.Id(),
+			"eth_blockNumber",
+		).Inc()
+		network.Logger().Debug().
+			Str("method", "eth_blockNumber").
+			Int64("knownHighestBlock", highestBlock).
+			Int64("responseBlockNumber", blockNumber).
+			Str("upstreamId", ups.Id()).
+			Msg("upstream returned older block than we know, falling back to highest known block")
+	} else {
+		// No upstream attribution — typically a cache hit carrying a value
+		// below the tip (e.g. written before the tip advanced, or by another
+		// instance reading from a lagging upstream).
+		network.Logger().Debug().
+			Str("method", "eth_blockNumber").
+			Int64("knownHighestBlock", highestBlock).
+			Int64("responseBlockNumber", blockNumber).
+			Bool("fromCache", nr.FromCache()).
+			Msg("response contains older block than we know, falling back to highest known block")
+	}
+
+	hbk, err := common.NormalizeHex(highestBlock)
+	if err != nil {
+		common.SetTraceSpanError(span, err)
+		return nil, err
+	}
+	jrr, err := common.NewJsonRpcResponse(nq.ID(), hbk, nil)
+	if err != nil {
+		common.SetTraceSpanError(span, err)
+		return nil, err
+	}
+	corrected := common.NewNormalizedResponse().
+		WithRequest(nq).
+		WithJsonRpcResponse(jrr)
+	if nr.FromCache() {
+		// Preserve cache attribution: the value was upgraded in-memory and no
+		// upstream call was made to produce this response.
+		corrected.WithFromCache(true)
+	}
+	// We are replacing the original response, so release it to avoid retaining buffers
+	nr.Release()
+	return corrected, nil
 }

--- a/architecture/evm/eth_getBlockByNumber.go
+++ b/architecture/evm/eth_getBlockByNumber.go
@@ -150,9 +150,15 @@ func enforceHighestBlock(ctx context.Context, network common.Network, nq *common
 		return nr, re
 	}
 
+	// Resolve tips with the request bound to the context so a use-upstream
+	// selector scopes the tip to the targeted subset (the selector-scoped
+	// served-tip semantics): a request pinned to a lagging group must not be
+	// re-forwarded towards a block that group cannot serve.
+	tipCtx := context.WithValue(ctx, common.RequestContextKey, nq)
+
 	switch bnp {
 	case "latest":
-		highestBlockNumber := network.EvmHighestLatestBlockNumber(ctx)
+		highestBlockNumber := network.EvmHighestLatestBlockNumber(tipCtx)
 		_, respBlockNumber, err := ExtractBlockReferenceFromResponse(ctx, nr)
 		if err != nil {
 			return nil, err
@@ -213,7 +219,7 @@ func enforceHighestBlock(ctx context.Context, network common.Network, nq *common
 			return nr, re
 		}
 	case "finalized":
-		highestBlockNumber := network.EvmHighestFinalizedBlockNumber(ctx)
+		highestBlockNumber := network.EvmHighestFinalizedBlockNumber(tipCtx)
 		_, respBlockNumber, err := ExtractBlockReferenceFromResponse(ctx, nr)
 		if err != nil {
 			return nil, err

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -20,8 +20,6 @@ func HandleProjectPreForward(ctx context.Context, network common.Network, nq *co
 	}
 
 	switch strings.ToLower(method) {
-	case "eth_blocknumber":
-		return projectPreForward_eth_blockNumber(ctx, network, nq)
 	case "eth_call":
 		return projectPreForward_eth_call(ctx, network, nq)
 	case "eth_chainid":
@@ -70,6 +68,8 @@ func HandleNetworkPostForward(ctx context.Context, network common.Network, nq *c
 	}
 
 	switch strings.ToLower(method) {
+	case "eth_blocknumber":
+		return networkPostForward_eth_blockNumber(ctx, network, nq, nr, re)
 	case "eth_getblockbynumber":
 		return networkPostForward_eth_getBlockByNumber(ctx, network, nq, nr, re)
 	case "eth_getlogs":

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -694,7 +694,7 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 			connector := policy.GetConnector()
 			ttl := policy.GetTTL()
 
-			shouldCache, err := shouldCacheResponse(ctx, lg, resp, rpcResp, policy)
+			shouldCache, err := shouldCacheResponse(ctx, lg, resp, rpcResp, policy, finState)
 			if !shouldCache {
 				if err != nil {
 					telemetry.MetricCacheSetErrorTotal.WithLabelValues(
@@ -1057,6 +1057,7 @@ func shouldCacheResponse(
 	resp *common.NormalizedResponse,
 	rpcResp *common.JsonRpcResponse,
 	policy *data.CachePolicy,
+	finality common.DataFinalityState,
 ) (bool, error) {
 	// Never cache responses with errors
 	if rpcResp != nil && rpcResp.Error != nil {
@@ -1069,6 +1070,32 @@ func shouldCacheResponse(
 	if !policy.MatchesSizeLimits(size) {
 		lg.Debug().Int("size", size).Msg("skip caching because response size does not match policy limits")
 		return false, nil
+	}
+
+	// Never persist a realtime response that is already behind the network
+	// tip while the request runs under enforceHighestBlock: enforcement will
+	// never serve such a value as-is, so caching it can only poison future
+	// reads (e.g. the eth_blockNumber sawtooth: a lagging upstream's value
+	// lands in the cache and is then served for a full TTL window). The tip
+	// is resolved network-wide on purpose — the cache entry is shared by all
+	// requests regardless of any use-upstream selector — and the guard fails
+	// open when pollers don't know a tip yet.
+	if finality == common.DataFinalityStateRealtime && resp != nil {
+		if req := resp.Request(); req != nil {
+			if dirs := req.Directives(); dirs != nil && dirs.EnforceHighestBlock {
+				if ntw := req.Network(); ntw != nil {
+					if _, respBlock, err := ExtractBlockReferenceFromResponse(ctx, resp); err == nil && respBlock > 0 {
+						if tip := ntw.EvmHighestLatestBlockNumber(ctx); tip > respBlock {
+							lg.Debug().
+								Int64("responseBlockNumber", respBlock).
+								Int64("knownHighestBlock", tip).
+								Msg("skip caching realtime response older than the known highest block")
+							return false, nil
+						}
+					}
+				}
+			}
+		}
 	}
 	result := rpcResp.GetResultBytes()
 	// Check if we should cache empty results

--- a/docs/pages/config/failsafe/integrity.mdx
+++ b/docs/pages/config/failsafe/integrity.mdx
@@ -96,12 +96,12 @@ https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
 
 <PromptExample
 	n={4}
-	title="debug why eth_blockNumber enforcement won't turn off"
-	prompt={`I set directiveDefaults.enforceHighestBlock: false in my network config but
-eth_blockNumber responses are still being replaced with a synthetic highest-known
-block. Why doesn't the directive control that hook, and what do I actually need to
-set to disable it? Work with my existing eRPC config. Reference:
-https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
+	title="debug one upstream's raw view of the chain tip"
+	prompt={`I need to see what one specific upstream actually answers for eth_blockNumber,
+without eRPC upgrading the response to the network-wide highest block and without
+cache interference. Show me the per-request headers (use-upstream, enforce-highest-block,
+skip-cache-read) to send for a one-off debugging request, leaving the network config
+untouched. Reference: https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
 />
 
 <PromptExample
@@ -124,7 +124,7 @@ https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
 
 **Hook architecture.** Checks live in EVM-specific pre/post-forward hooks registered in an `EvmHookRegistry`. Network-level hooks run before or after the entire failsafe execution; upstream-level hooks run per attempt. Key hooks:
 
-- `projectPreForward_eth_blockNumber` — replaces a stale block number with a synthetic highest-known result (reads legacy `EvmIntegrityConfig`, not directive).
+- `networkPostForward_eth_blockNumber` — replaces a stale block number, including on cache hits, with a synthetic highest-known result (reads directive).
 - `networkPostForward_eth_getBlockByNumber` — enforces highest-block then non-null after the full failsafe round (reads directive).
 - `upstreamPreForward_eth_getLogs` / `upstreamPreForward_trace_filter` — checks block-range availability before each upstream attempt (read legacy `EvmIntegrityConfig`).
 - `upstreamPostForward_eth_getLogs` — normalizes empty arrays in `eth_getLogs` upstream responses. <SourceLink file="architecture/evm/eth_getLogs.go" lines="349-362" />
@@ -132,9 +132,11 @@ https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
 - `upstreamPostForward_eth_getBlockByNumber` — validates block header and transaction fields.
 - `upstreamPostForward_eth_getBlockReceipts` — validates receipt/log structure including Bloom.
 
-**Highest-block enforcement — `eth_blockNumber`.** Reads `ncfg.Evm.Integrity.EnforceHighestBlock` directly (not the directive). If the response block is below the network-known highest, eRPC replaces the response with a synthetic JSON-RPC result containing the highest hex block number — no re-request is made. Cache responses bypass enforcement entirely. <SourceLink file="architecture/evm/eth_blockNumber.go" lines="15-121" />
+**Highest-block enforcement — `eth_blockNumber`.** Reads `dirs.EnforceHighestBlock`. If the response block is below the network-known highest, eRPC replaces the response with a synthetic JSON-RPC result containing the highest hex block number — no re-request is made. Applies to EVERY response source, including cache hits (the synthetic upgrade preserves cache attribution), so a stale value planted in a shared cache can never be served below the tip this instance knows. The tip is resolved request-aware: a `use-upstream` selector scopes it to the targeted subset so a pinned request is never promised a block its upstreams don't have. <SourceLink file="architecture/evm/eth_blockNumber.go" lines="31-123" />
 
-**Highest-block enforcement — `eth_getBlockByNumber[latest/finalized]`.** Reads `dirs.EnforceHighestBlock`. If the returned block is behind the network-known highest, eRPC constructs a new request for that block, sets `SkipCacheRead=true`, excludes the lagging upstream (`UseUpstream=!<id>`), and forwards again. If the re-request also returns a lower block, `pickHighestBlock` picks whichever response has the higher block number — protecting against a corrupted state pointer. Cache responses skip enforcement. <SourceLink file="architecture/evm/eth_getBlockByNumber.go" lines="111-277" />
+**Highest-block enforcement — `eth_getBlockByNumber[latest/finalized]`.** Reads `dirs.EnforceHighestBlock`. If the returned block is behind the network-known highest (resolved request-aware, selector-scoped like above), eRPC constructs a new request for that block, sets `SkipCacheRead=true`, excludes the lagging upstream (`UseUpstream=!<id>`), and forwards again. If the re-request also returns a lower block, `pickHighestBlock` picks whichever response has the higher block number — protecting against a corrupted state pointer. Cache responses skip the re-fetch (the read-side realtime age guard rejects too-old cached blocks instead). <SourceLink file="architecture/evm/eth_getBlockByNumber.go" lines="111-283" />
+
+**Stale-tip cache write guard.** When a request runs under `enforceHighestBlock`, a realtime-finality response whose block number is already behind the network-wide tip is never written to the cache: enforcement would never serve that value as-is, so persisting it could only poison future reads (the classic symptom: `eth_blockNumber` sawtoothing backwards on `x-erpc-cache: HIT` while one upstream lags). Fails open when pollers don't know a tip yet. <SourceLink file="architecture/evm/json_rpc_cache.go" lines="1075-1098" />
 
 **Block-range availability.** Before forwarding `eth_getLogs`, `trace_filter`, or `arbtrace_filter` to a specific upstream, `CheckBlockRangeAvailability` is called: `toBlock` first with `forceFreshIfStale=true`, `fromBlock` second with `forceFreshIfStale=false`. If either block is outside the upstream's available range, `ErrUpstreamBlockUnavailable` (retryable) is returned so the network-level retry routes to a different upstream. Block tags are resolved to hex numbers via the state poller; unresolvable tags (`pending`, `safe`, `earliest`) skip the check entirely. <SourceLink file="architecture/evm/block_range.go" />
 
@@ -150,7 +152,7 @@ All boolean fields under this path set the default `RequestDirectives` value for
 
 | Field | Type | Default | Behavior / footguns |
 |---|---|---|---|
-| `enforceHighestBlock` | `*bool` | `true` | Re-fetches `eth_getBlockByNumber[latest/finalized]` against a different upstream when the result is behind the known tip. **Does NOT disable `eth_blockNumber` enforcement** — that hook reads the deprecated `evm.integrity.enforceHighestBlock` field. Header: `X-ERPC-Enforce-Highest-Block`. <SourceLink file="common/defaults.go" lines="1458-1460" /> |
+| `enforceHighestBlock` | `*bool` | `true` | Controls highest-block enforcement for both `eth_blockNumber` (synthetic in-memory upgrade, applied to cache hits too) and `eth_getBlockByNumber[latest/finalized]` (re-fetch against a different upstream). Also gates the stale-tip cache write guard. Header: `X-ERPC-Enforce-Highest-Block`. <SourceLink file="common/defaults.go" lines="1458-1460" /> |
 | `enforceGetLogsBlockRange` | `*bool` | `true` | Before forwarding `eth_getLogs`/`trace_filter`/`arbtrace_filter`, checks both `fromBlock` and `toBlock` are within the upstream's available range. **Does NOT control the actual hooks** — those read `evm.integrity.enforceGetLogsBlockRange` directly. Header: `X-ERPC-Enforce-GetLogs-Range`. <SourceLink file="common/defaults.go" lines="1461-1463" /> |
 | `enforceNonNullTaggedBlocks` | `*bool` | `true` | Converts null `eth_getBlockByNumber` responses for tag-based requests into `ErrEndpointMissingData`. Numeric block requests always error on null regardless. Disable for chains that return null for some tags (e.g. ZKSync Era). Header: `X-ERPC-Enforce-Non-Null-Tagged-Blocks`. <SourceLink file="common/defaults.go" lines="1464-1466" /> |
 | `validateTransactionsRoot` | `*bool` | `true` | Checks `transactionsRoot` is consistent with the transaction count. Has a phantom-transaction special case for Polygon PoS and BSC. Header: `X-ERPC-Validate-Transactions-Root`. <SourceLink file="common/defaults.go" lines="1467-1469" /> |
@@ -200,7 +202,7 @@ All directives can be overridden per-request without redeploying. Booleans accep
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `enforceHighestBlock` | `*bool` | `nil` → `true` via `EvmIntegrityConfig.SetDefaults` | **@deprecated** — use `directiveDefaults.enforceHighestBlock`. Still read directly by `projectPreForward_eth_blockNumber` at runtime. Setting `directiveDefaults.enforceHighestBlock: false` without also setting this to `false` leaves `eth_blockNumber` enforcement active. <SourceLink file="common/config.go" lines="2310" /> <SourceLink file="common/defaults.go" lines="2117-2120" /> |
+| `enforceHighestBlock` | `*bool` | `nil` → `true` via `EvmIntegrityConfig.SetDefaults` | **@deprecated** — use `directiveDefaults.enforceHighestBlock`. Only acts as migration source; not read at runtime. <SourceLink file="common/config.go" lines="2310" /> <SourceLink file="common/defaults.go" lines="2117-2120" /> |
 | `enforceGetLogsBlockRange` | `*bool` | `nil` → `true` via `EvmIntegrityConfig.SetDefaults` | **@deprecated** — use `directiveDefaults.enforceGetLogsBlockRange`. Still read by `eth_getLogs` and `trace_filter` hooks at runtime. <SourceLink file="common/config.go" lines="2312" /> <SourceLink file="common/defaults.go" lines="2121-2123" /> |
 | `enforceNonNullTaggedBlocks` | `*bool` | `nil` → `true` via `EvmIntegrityConfig.SetDefaults` | **@deprecated** — use `directiveDefaults.enforceNonNullTaggedBlocks`. Only acts as migration source; not read at runtime. <SourceLink file="common/config.go" lines="2314" /> <SourceLink file="common/defaults.go" lines="2124-2126" /> |
 
@@ -225,31 +227,26 @@ Migration: `NetworkConfig.SetDefaults` performs the migration in this order: (1)
 All patterns below are distilled from real production fleets; comments explain the
 non-obvious choices.
 
-**1. Mainnet Ethereum — baseline defaults with `evm.integrity` for full coverage.** Production uses
-`evm.integrity` in networkDefaults so both the `eth_blockNumber` hook (which reads the deprecated
-field directly) and `eth_getBlockByNumber` enforcement (which reads the directive) are both active.
-Setting only `directiveDefaults` would leave `eth_blockNumber` enforcement silently active via the
-legacy path — explicitly setting both closes the gap:
+**1. Mainnet Ethereum — baseline defaults, stated explicitly.** Both enforcement defaults are
+already on; listing them in `directiveDefaults` keeps the intent reviewable. `enforceHighestBlock`
+covers `eth_blockNumber` and `eth_getBlockByNumber[latest/finalized]` through the same directive
+(the deprecated `evm.integrity` block is auto-migrated into these fields — no need to set both).
+Note one exception: the `eth_getLogs`/`trace_filter` range hooks still read
+`evm.integrity.enforceGetLogsBlockRange` directly, so to fully control that one set the legacy
+field too:
 
 <ConfigTabs
-  path="projects[].networks[].evm"
-  yaml={`evm:
-  chainId: 1
-  # enforceHighestBlock here feeds the eth_blockNumber pre-forward hook,
-  # which reads the deprecated EvmIntegrityConfig field directly at runtime.
-  # directiveDefaults.enforceHighestBlock controls eth_getBlockByNumber only.
-  integrity:
-    enforceHighestBlock: true
-    enforceGetLogsBlockRange: true`}
-  ts={`evm: {
-  chainId: 1,
-  // enforceHighestBlock here feeds the eth_blockNumber pre-forward hook,
-  // which reads the deprecated EvmIntegrityConfig field directly at runtime.
-  // directiveDefaults.enforceHighestBlock controls eth_getBlockByNumber only.
-  integrity: {
-    enforceHighestBlock: true,
-    enforceGetLogsBlockRange: true,
-  },
+  path="projects[].networks[].directiveDefaults"
+  yaml={`directiveDefaults:
+  # one directive covers eth_blockNumber (synthetic upgrade, incl. cache hits)
+  # and eth_getBlockByNumber[latest/finalized] (re-fetch on another upstream)
+  enforceHighestBlock: true
+  enforceGetLogsBlockRange: true`}
+  ts={`directiveDefaults: {
+  // one directive covers eth_blockNumber (synthetic upgrade, incl. cache hits)
+  // and eth_getBlockByNumber[latest/finalized] (re-fetch on another upstream)
+  enforceHighestBlock: true,
+  enforceGetLogsBlockRange: true,
 }`}
 />
 
@@ -263,23 +260,19 @@ defaults remain active:
   yaml={`networks:
   - evm:
       chainId: 324
-    # ZKSync Era returns null for 'finalized'/'safe' tags intermittently —
-    # enforcing non-null would cause infinite retries on a correct response.
-    evm:
-      integrity:
-        enforceNonNullTaggedBlocks: false
     directiveDefaults:
+      # ZKSync Era returns null for 'finalized'/'safe' tags intermittently —
+      # enforcing non-null would cause infinite retries on a correct response.
+      enforceNonNullTaggedBlocks: false
       # ZKSync Era uses a non-standard txRoot (ZK proof root, not trie root) —
       # the default validateTransactionsRoot check would reject every block.
       validateTransactionsRoot: false`}
   ts={`networks: [{
   evm: { chainId: 324 },
-  // ZKSync Era returns null for 'finalized'/'safe' tags intermittently —
-  // enforcing non-null would cause infinite retries on a correct response.
-  evm: {
-    integrity: { enforceNonNullTaggedBlocks: false },
-  },
   directiveDefaults: {
+    // ZKSync Era returns null for 'finalized'/'safe' tags intermittently —
+    // enforcing non-null would cause infinite retries on a correct response.
+    enforceNonNullTaggedBlocks: false,
     // ZKSync Era uses a non-standard txRoot (ZK proof root, not trie root) —
     // the default validateTransactionsRoot check would reject every block.
     validateTransactionsRoot: false,
@@ -360,14 +353,15 @@ checks without paying the CPU cost on every request.
 - Integrity violations produce `ErrEndpointContentValidation` — HTTP 200 with JSON-RPC error body `{"code": -32603, "message": "..."}`. `ErrorStatusCode()` returns 502 but is dead code with zero call sites. <SourceLink file="erpc/http_server.go" lines="1473-1491" />
 - `ErrEndpointContentValidation` is retryable at network scope (try another upstream) but NOT retryable at the same upstream. <SourceLink file="common/errors.go" lines="2719-2747" />
 - `ErrUpstreamBlockUnavailable` (block-range failure) is retryable — the network-level retry routes to a different upstream.
-- Cache responses bypass all highest-block enforcement — a cached `eth_getBlockByNumber[latest]` will not be re-fetched even if a newer block is known.
+- `eth_blockNumber` enforcement applies to cache hits too: a cached value behind the tip is upgraded in-memory (the response keeps its `x-erpc-cache: HIT` attribution). A cached `eth_getBlockByNumber[latest]` is not re-fetched — the read-side realtime age guard rejects too-old cached blocks instead.
 - The `eth_blockNumber` enforcement response is synthetic: eRPC returns the highest-known hex block number directly; no upstream re-request is made.
+- Realtime responses behind the network tip are not written to the cache while `enforceHighestBlock` is on — enforcement would never serve them as-is, so persisting them could only poison future reads.
 - Always-on checks for `eth_getBlockReceipts` (no directive required): duplicate `transactionHash` across receipts; all receipts sharing the same `blockHash` if present. <SourceLink file="architecture/evm/eth_getBlockReceipts.go" lines="55-460" />
 
 ### Best practices
 
-- **Do not try to disable `eth_blockNumber` enforcement via `directiveDefaults` alone.** That hook reads the deprecated `evm.integrity.enforceHighestBlock` field. To disable it you must also set `evm.integrity.enforceHighestBlock: false`.
-- **Same split for `eth_getLogs` and `trace_filter`.** Setting `directiveDefaults.enforceGetLogsBlockRange: false` has no effect on those hooks. Set `evm.integrity.enforceGetLogsBlockRange: false` to actually disable range checks.
+- **Disable highest-block enforcement via `directiveDefaults.enforceHighestBlock: false`** — it controls both the `eth_blockNumber` and `eth_getBlockByNumber` paths, and can also be turned off per-request with `X-ERPC-Enforce-Highest-Block: false` (e.g. when debugging one upstream's raw view together with `X-ERPC-Use-Upstream`).
+- **`eth_getLogs` and `trace_filter` still read the legacy field.** Setting `directiveDefaults.enforceGetLogsBlockRange: false` has no effect on those hooks. Set `evm.integrity.enforceGetLogsBlockRange: false` to actually disable range checks.
 - **Set `emptyResultConfidence: finalizedBlock` for archive workloads.** The default `blockHead` retries empty results for any block at/below the latest tip — this causes retry storms when archive nodes legitimately return empty for unfinalized blocks.
 - **Prefer per-request headers for expensive validators.** `validateLogsBloomMatch` (full Bloom recompute) and `validateHeaderFieldLengths` add CPU cost per response. Enable globally only on networks where upstream data quality warrants it; use `X-ERPC-Validate-Logs-Bloom-Match: true` headers for critical-path requests only.
 - **`validateTransactionsRoot` is on by default** but can be disabled per-request via `X-ERPC-Validate-Transactions-Root: false`. Useful for Polygon PoS / BSC if phantom-transaction detection isn't firing correctly.
@@ -376,11 +370,11 @@ checks without paying the CPU cost on every request.
 
 ### Edge cases & gotchas
 
-1. **`eth_blockNumber` dual-path.** `projectPreForward_eth_blockNumber` reads `ncfg.Evm.Integrity.EnforceHighestBlock` (deprecated field), while `eth_getBlockByNumber` reads `dirs.EnforceHighestBlock` (directive). Setting `directiveDefaults.enforceHighestBlock: false` disables the `eth_getBlockByNumber` path but leaves `eth_blockNumber` enforcement active. To disable both, also set `evm.integrity.enforceHighestBlock: false`. <SourceLink file="architecture/evm/eth_blockNumber.go" lines="23-29" />
+1. **`eth_blockNumber` cache hits ARE corrected; `eth_getBlockByNumber` cache hits are not.** The `eth_blockNumber` hook upgrades any response (fresh or cached) behind the tip in-memory. The `eth_getBlockByNumber` hook still skips `resp.FromCache()` responses because its correction is a real re-fetch — there the read-side realtime age guard plus the stale-tip write guard limit cache staleness instead. <SourceLink file="architecture/evm/eth_blockNumber.go" lines="31-123" />
 
 2. **`eth_getLogs` / `trace_filter` dual-path.** Both `upstreamPreForward_eth_getLogs` and `upstreamPreForward_trace_filter` read `ncfg.Evm.Integrity.EnforceGetLogsBlockRange` directly. Setting only `directiveDefaults.enforceGetLogsBlockRange: false` has no effect on those hooks. <SourceLink file="architecture/evm/eth_getLogs.go" lines="283-285" />
 
-3. **Cache responses bypass enforcement.** Both `eth_blockNumber` and `eth_getBlockByNumber` hooks skip when `resp.FromCache()` is true. A cached `eth_getBlockByNumber[latest]` will not be upgraded even if a newer block is known. Tune realtime cache TTLs to limit the staleness window.
+3. **Pinned requests use the pinned subset's tip.** Highest-block enforcement resolves the tip request-aware: with a `use-upstream` selector, "highest known" is computed among the matching upstreams only, so a request pinned to a lagging group is corrected against that group's tip rather than being promised a network-wide block those upstreams can't serve. Cache writes use the network-wide tip on purpose (the cache entry is shared by all requests), so a pinned-to-laggard response below the global tip is served but not persisted.
 
 4. **`emptyResultBeyondConfidence` fail-open.** If the network's head is unknown (≤ 0) or the request uses a block tag (`latest`, `finalized`, etc.) rather than a concrete number, the guard always treats the empty as missing data and retries — regardless of `emptyResultConfidence`.
 
@@ -416,7 +410,7 @@ checks without paying the CPU cost on every request.
 | `erpc_network_retry_attempt_total` | counter | project, network, category, reason, finality | `reason=block_unavailable` on block-range retry; `reason=missing_data` on null-response retry. |
 
 **OTel trace spans:**
-- `Project.PreForwardHook.eth_blockNumber` — spans `eth_blockNumber` highest-block enforcement; attributes include `block.number_lag` in detailed tracing mode.
+- `Network.PostForward.eth_blockNumber` — spans `eth_blockNumber` highest-block enforcement; attributes include `block.number_lag` in detailed tracing mode.
 - `Network.PostForward.eth_getBlockByNumber` — spans block enforcement and null check.
 - `Upstream.PreForwardHook.eth_getLogs` / `Upstream.PreForwardHook.trace_filter` — spans block-range availability checks.
 - `Upstream.PostForwardHook.eth_getBlockByNumber` — spans upstream block structure validation.
@@ -424,14 +418,15 @@ checks without paying the CPU cost on every request.
 - `Evm.PickHighestBlock` — spans the `pickHighestBlock` comparison.
 
 **Notable log messages:**
-- `DEBUG "upstream returned older block than we known, falling back to highest known block"` — `eth_blockNumber` stale detection.
+- `DEBUG "upstream returned older block than we know, falling back to highest known block"` — `eth_blockNumber` stale detection (fresh response); the `"response contains older block…"` variant fires for cache hits.
 - `DEBUG "enforcing highest latest block"` / `"enforcing highest finalized block"` — `eth_getBlockByNumber` stale detection.
-- `TRACE "skipping enforcement of highest block number as response is from cache"` — cache bypass.
+- `TRACE "skipping enforcement of highest block number as response is from cache"` — `eth_getBlockByNumber` cache bypass.
+- `DEBUG "skip caching realtime response older than the known highest block"` — stale-tip cache write guard.
 - `WARN "passed upstream is not a common.EvmUpstream"` — emitted in `eth_getLogs` and `trace_filter` pre-forward hooks when the upstream type assertion fails; the range check is skipped.
 
 ### Source code entry points
 
-- [`architecture/evm/eth_blockNumber.go:L15-L121`](https://github.com/erpc/erpc/blob/main/architecture/evm/eth_blockNumber.go#L15-L121) — `projectPreForward_eth_blockNumber`: reads legacy `EvmIntegrityConfig.EnforceHighestBlock`; replaces stale responses with synthetic highest-block result.
+- [`architecture/evm/eth_blockNumber.go:L31-L123`](https://github.com/erpc/erpc/blob/main/architecture/evm/eth_blockNumber.go#L31-L123) — `networkPostForward_eth_blockNumber`: directive-gated; replaces stale responses (including cache hits) with synthetic highest-block result.
 - [`architecture/evm/eth_getBlockByNumber.go:L43-L109`](https://github.com/erpc/erpc/blob/main/architecture/evm/eth_getBlockByNumber.go#L43-L109) — `networkPostForward_eth_getBlockByNumber`: entry point for highest-block + non-null network-level enforcement.
 - [`architecture/evm/eth_getBlockByNumber.go:L489-L756`](https://github.com/erpc/erpc/blob/main/architecture/evm/eth_getBlockByNumber.go#L489-L756) — `validateBlock`: upstream-level block structure validation (`validateHeaderFieldLengths`, `validateBlockTransactions`).
 - [`architecture/evm/eth_getLogs.go:L273-L347`](https://github.com/erpc/erpc/blob/main/architecture/evm/eth_getLogs.go#L273-L347) — `upstreamPreForward_eth_getLogs`: block-range availability guard; tag resolution.

--- a/erpc/http_server_blocknumber_integrity_test.go
+++ b/erpc/http_server_blocknumber_integrity_test.go
@@ -185,7 +185,7 @@ func bniConfig(withCache bool, integrity *common.EvmIntegrityConfig) *common.Con
 						Method:    "eth_blockNumber",
 						Finality:  common.DataFinalityStateRealtime,
 						Connector: "memory-cache",
-						TTL:       common.Duration(10 * time.Second),
+						TTL:       common.FixedDuration(10 * time.Second),
 					},
 				},
 			},

--- a/erpc/http_server_blocknumber_integrity_test.go
+++ b/erpc/http_server_blocknumber_integrity_test.go
@@ -1,0 +1,481 @@
+package erpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This suite reproduces the "ineffective integrity mode enforceHighestBlock on
+// eth_blockNumber" incident (customer report, 2026-05-13): with a realtime
+// cache policy on eth_blockNumber and at least one lagging upstream, clients
+// observe a sawtooth of backwards-moving block numbers (thousands of blocks),
+// with the largest swings on `x-erpc-cache: HIT` responses.
+//
+// Topology in every sub-test (full HTTP server, real cache, real pollers,
+// only upstream HTTP responses are mocked):
+//
+//	rpc1 (lagging): head 0x800
+//	rpc2 (healthy): head 0x1000  →  network tip (default max mode) = 0x1000
+//
+// The selection order is pinned to [rpc1, rpc2] so user traffic lands on the
+// lagging upstream first, mirroring the customer's "a small amount of volume
+// is handled by lagging nodes" condition.
+//
+// Bug inventory exercised here (hook: architecture/evm/eth_blockNumber.go):
+//
+//	B1 write-side poisoning: network.Forward async-caches the ORIGINAL stale
+//	   response (erpc/networks.go cache-set goroutine) while the hook's
+//	   corrected response is only returned to the client — the corrected
+//	   value never reaches the cache.
+//	B2 read-side bypass: responses with FromCache()==true skip enforcement
+//	   entirely, so a poisoned (or otherwise stale) cache entry is served
+//	   verbatim for a full TTL window. The realtime age guard cannot save
+//	   eth_blockNumber either: its responses carry no block timestamp and
+//	   non-head-aware connectors (memory/redis) fail open.
+//	B3 selector scope: the hook resolves the tip with a context that does not
+//	   carry the request (common.RequestContextKey is only set inside
+//	   network.Forward), so X-ERPC-Use-Upstream-pinned requests are corrected
+//	   against the NETWORK-WIDE tip instead of the pinned subset's tip,
+//	   contradicting the selector-scoped served-tip semantics (#912).
+//	B4 directive gating: the hook is gated on the network config
+//	   (evm.integrity.enforceHighestBlock, deprecated but auto-defaulted to
+//	   true) instead of the request directives that eth_getBlockByNumber
+//	   honors — so per-request overrides (enforce-highest-block=false) are
+//	   silently ignored for eth_blockNumber.
+const (
+	bniLaggingHead = int64(0x800)  // rpc1's head
+	bniHealthyHead = int64(0x1000) // rpc2's head == expected network tip
+)
+
+// setupBniPollerMocks registers persistent state-poller bootstrap mocks for
+// both upstreams (chainId / syncing / latest / finalized), giving rpc1 a
+// lagging head and rpc2 a healthy head. The state pollers fetch heads via
+// eth_getBlockByNumber, so these never collide with user eth_blockNumber
+// traffic.
+func setupBniPollerMocks() {
+	for _, h := range []struct {
+		host      string
+		latest    string
+		finalized string
+	}{
+		{"http://rpc1.localhost", "0x800", "0x700"},
+		{"http://rpc2.localhost", "0x1000", "0x900"},
+	} {
+		gock.New(h.host).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_chainId")
+			}).
+			Reply(200).
+			JSON([]byte(`{"result":"0x7b"}`))
+		gock.New(h.host).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_syncing")
+			}).
+			Reply(200).
+			JSON([]byte(`{"result":false}`))
+		gock.New(h.host).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				b := util.SafeReadBody(r)
+				return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, "latest")
+			}).
+			Reply(200).
+			JSON([]byte(fmt.Sprintf(`{"result":{"number":"%s","timestamp":"0x6702a8f0"}}`, h.latest)))
+		gock.New(h.host).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				b := util.SafeReadBody(r)
+				return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, "finalized")
+			}).
+			Reply(200).
+			JSON([]byte(fmt.Sprintf(`{"result":{"number":"%s","timestamp":"0x6702a8e0"}}`, h.finalized)))
+	}
+}
+
+// setupBniBlockNumberMocks registers persistent user-facing eth_blockNumber
+// mocks: the lagging upstream answers with its stale head, the healthy one
+// with the tip. Persist (rather than Times(1)) keeps every sub-test
+// deterministic regardless of how many forwards the implementation performs.
+func setupBniBlockNumberMocks() {
+	gock.New("http://rpc1.localhost").Post("").Persist().
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_blockNumber")
+		}).
+		Reply(200).
+		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x800"}`))
+	gock.New("http://rpc2.localhost").Post("").Persist().
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_blockNumber")
+		}).
+		Reply(200).
+		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1000"}`))
+}
+
+// bniConfig builds a 2-upstream EVM project. integrity==nil exercises the
+// modern config path (only DirectiveDefaults, which default enforcement to
+// true). withCache adds a realtime cache policy on eth_blockNumber backed by
+// a real in-memory connector — the customer's setup (theirs had a 2s TTL; we
+// use 10s so entries cannot expire mid-test).
+func bniConfig(withCache bool, integrity *common.EvmIntegrityConfig) *common.Config {
+	cfg := &common.Config{
+		Server: &common.ServerConfig{
+			MaxTimeout: common.Duration(10 * time.Second).Ptr(),
+		},
+		Projects: []*common.ProjectConfig{
+			{
+				Id: "test_project",
+				Networks: []*common.NetworkConfig{
+					{
+						Architecture: "evm",
+						Evm: &common.EvmNetworkConfig{
+							ChainId:   123,
+							Integrity: integrity,
+						},
+					},
+				},
+				Upstreams: []*common.UpstreamConfig{
+					{
+						Id:       "rpc1",
+						Endpoint: "http://rpc1.localhost",
+						Type:     common.UpstreamTypeEvm,
+						Evm: &common.EvmUpstreamConfig{
+							ChainId:             123,
+							StatePollerInterval: common.Duration(10 * time.Second),
+						},
+					},
+					{
+						Id:       "rpc2",
+						Endpoint: "http://rpc2.localhost",
+						Type:     common.UpstreamTypeEvm,
+						Evm: &common.EvmUpstreamConfig{
+							ChainId:             123,
+							StatePollerInterval: common.Duration(10 * time.Second),
+						},
+					},
+				},
+			},
+		},
+	}
+	if withCache {
+		cfg.Database = &common.DatabaseConfig{
+			EvmJsonRpcCache: &common.CacheConfig{
+				Connectors: []*common.ConnectorConfig{
+					{
+						Id:     "memory-cache",
+						Driver: common.DriverMemory,
+						Memory: &common.MemoryConnectorConfig{
+							MaxItems: 100_000, MaxTotalSize: "1GB",
+						},
+					},
+				},
+				Policies: []*common.CachePolicyConfig{
+					{
+						Network:   "*",
+						Method:    "eth_blockNumber",
+						Finality:  common.DataFinalityStateRealtime,
+						Connector: "memory-cache",
+						TTL:       common.Duration(10 * time.Second),
+					},
+				},
+			},
+		}
+	}
+	return cfg
+}
+
+// bniBoot spins up the server, pins upstream order to [rpc1(lagging),
+// rpc2(healthy)] and waits until the pollers have learned the healthy head so
+// the network tip is deterministic before any assertion runs.
+func bniBoot(t *testing.T, cfg *common.Config) (
+	func(body string, headers map[string]string, queryParams map[string]string) (int, map[string]string, string),
+	*Network,
+	func(),
+) {
+	t.Helper()
+	sendRequest, _, _, shutdown, erpcInstance := createServerTestFixtures(cfg, t)
+
+	prj, err := erpcInstance.GetProject("test_project")
+	require.NoError(t, err)
+	policy.OverrideAllForTest(prj.policyEngine, "rpc1", "rpc2")
+
+	ntw, err := prj.GetNetwork(context.Background(), util.EvmNetworkId(123))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return ntw.EvmHighestLatestBlockNumber(context.Background()) == bniHealthyHead
+	}, 5*time.Second, 50*time.Millisecond,
+		"pollers must learn the healthy head (tip=0x1000) before the scenario starts")
+
+	return sendRequest, ntw, shutdown
+}
+
+// bniSend performs one eth_blockNumber request and returns the decoded block
+// number plus response headers.
+func bniSend(
+	t *testing.T,
+	send func(body string, headers map[string]string, queryParams map[string]string) (int, map[string]string, string),
+	headers map[string]string,
+	queryParams map[string]string,
+) (int64, map[string]string) {
+	t.Helper()
+	status, respHeaders, body := send(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`, headers, queryParams)
+	require.Equal(t, http.StatusOK, status, "body: %s", body)
+	var parsed map[string]interface{}
+	require.NoError(t, sonic.UnmarshalString(body, &parsed), "body: %s", body)
+	resStr, ok := parsed["result"].(string)
+	require.True(t, ok, "expected hex string result, body: %s", body)
+	n, err := strconv.ParseInt(strings.TrimPrefix(resStr, "0x"), 16, 64)
+	require.NoError(t, err, "body: %s", body)
+	return n, respHeaders
+}
+
+// bniProbeCache reads the eth_blockNumber cache entry (if any) through the
+// network's real cache DAL — the same key the HTTP path reads/writes.
+func bniProbeCache(ntw *Network) (int64, bool) {
+	probe := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":99,"method":"eth_blockNumber","params":[]}`))
+	probe.SetNetwork(ntw)
+	resp, err := ntw.cacheDal.Get(context.Background(), probe)
+	if err != nil || resp == nil || resp.IsObjectNull() {
+		return 0, false
+	}
+	jrr, err := resp.JsonRpcResponse()
+	if err != nil || jrr == nil {
+		return 0, false
+	}
+	s := strings.Trim(strings.TrimSpace(jrr.GetResultString()), `"`)
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimPrefix(s, "0x"), 16, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// bniWaitForCachedValue polls the cache until an eth_blockNumber entry
+// appears (the forward path writes it asynchronously) or the timeout lapses.
+func bniWaitForCachedValue(ntw *Network, timeout time.Duration) (int64, bool) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if v, ok := bniProbeCache(ntw); ok {
+			return v, true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return 0, false
+}
+
+// bniSeedCache plants an eth_blockNumber entry directly through the cache
+// DAL, simulating a value written by another pod sharing the same cache (or
+// by this pod moments earlier).
+func bniSeedCache(t *testing.T, ntw *Network, hexValue string) {
+	t.Helper()
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`))
+	req.SetNetwork(ntw)
+	jrr, err := common.NewJsonRpcResponse(1, hexValue, nil)
+	require.NoError(t, err)
+	resp := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+	require.NoError(t, ntw.cacheDal.Set(context.Background(), req, resp))
+	v, ok := bniProbeCache(ntw)
+	require.True(t, ok, "seeded cache entry must be readable back")
+	require.Equal(t, hexValue, fmt.Sprintf("0x%x", v))
+}
+
+func TestHttpServer_EthBlockNumberIntegrity(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	integrityOn := func() *common.EvmIntegrityConfig {
+		return &common.EvmIntegrityConfig{EnforceHighestBlock: util.BoolPtr(true)}
+	}
+	integrityOff := func() *common.EvmIntegrityConfig {
+		return &common.EvmIntegrityConfig{EnforceHighestBlock: util.BoolPtr(false)}
+	}
+
+	// ── Baselines: pin the behavior that already works ──────────────────────
+
+	t.Run("Baseline_FreshStaleResponseIsCorrectedForClient", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, _, shutdown := bniBoot(t, bniConfig(false, integrityOn()))
+		defer shutdown()
+
+		got, _ := bniSend(t, send, nil, nil)
+		assert.Equal(t, bniHealthyHead, got,
+			"a fresh (non-cached) stale response from the lagging upstream must be corrected to the network tip")
+	})
+
+	t.Run("Baseline_EnforcementExplicitlyDisabledServesRawValue", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, _, shutdown := bniBoot(t, bniConfig(false, integrityOff()))
+		defer shutdown()
+
+		got, _ := bniSend(t, send, nil, nil)
+		assert.Equal(t, bniLaggingHead, got,
+			"with enforcement explicitly disabled the raw upstream value must pass through untouched")
+	})
+
+	// ── B1+B2: the customer-visible sawtooth ────────────────────────────────
+
+	t.Run("Bug_CacheHitMustNotServeBlockBelowAlreadyServedTip", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, ntw, shutdown := bniBoot(t, bniConfig(true, integrityOn()))
+		defer shutdown()
+
+		// Request #1: cache miss → lagging upstream answers 0x800 → the hook
+		// corrects the client-bound response to the tip (0x1000)...
+		first, _ := bniSend(t, send, nil, nil)
+		require.Equal(t, bniHealthyHead, first,
+			"precondition: fresh-path correction must work (otherwise this test is proving a different bug)")
+
+		// ...meanwhile the forward path persisted SOMETHING for this method
+		// (today: the stale 0x800 — bug B1). Wait for the async write so
+		// request #2 deterministically exercises the cache-hit path.
+		if v, ok := bniWaitForCachedValue(ntw, 2*time.Second); ok {
+			t.Logf("cache now holds eth_blockNumber=0x%x", v)
+		}
+
+		// Request #2: the client already saw 0x1000; whatever source serves
+		// this response (cache hit today — bug B2), the served block number
+		// must never fall below the tip already served.
+		second, hdrs := bniSend(t, send, nil, nil)
+		t.Logf("second response: block=0x%x cacheHeader=%q", second, hdrs["X-Erpc-Cache"])
+		assert.GreaterOrEqual(t, second, first,
+			"sawtooth: served block number went BACKWARDS by %d blocks vs the tip already served to this client "+
+				"(stale upstream value was cached by the forward path and the cache-hit response skipped enforcement)",
+			first-second)
+	})
+
+	t.Run("Bug_StaleUpstreamValueMustNotPoisonCache", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, ntw, shutdown := bniBoot(t, bniConfig(true, integrityOn()))
+		defer shutdown()
+
+		first, _ := bniSend(t, send, nil, nil)
+		require.Equal(t, bniHealthyHead, first, "precondition: fresh-path correction must work")
+
+		// The fix may either write the corrected value back (entry >= tip) or
+		// skip caching the stale original (no entry). Both satisfy the
+		// invariant; today the stale 0x800 lands in the cache (bug B1).
+		v, ok := bniWaitForCachedValue(ntw, 2*time.Second)
+		if !ok {
+			t.Log("no eth_blockNumber cache entry written — acceptable (stale value skipped)")
+			return
+		}
+		assert.GreaterOrEqual(t, v, bniHealthyHead,
+			"cache poisoned: the forward path persisted the stale upstream value (0x%x) instead of the corrected value it served to the client (0x%x)",
+			v, first)
+	})
+
+	// ── B2 isolated: a stale entry already in the (possibly shared) cache ───
+
+	t.Run("Bug_StaleCacheEntryMustBeEnforcedOnRead", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, ntw, shutdown := bniBoot(t, bniConfig(true, integrityOn()))
+		defer shutdown()
+
+		// Simulate a stale value present in the cache regardless of how it
+		// got there (another pod, an earlier window, a race). Note the
+		// realtime age guard cannot reject it: eth_blockNumber responses
+		// carry no block timestamp and the memory connector is not
+		// head-aware, so the guard fails open.
+		bniSeedCache(t, ntw, "0x800")
+
+		got, hdrs := bniSend(t, send, nil, nil)
+		t.Logf("response: block=0x%x cacheHeader=%q", got, hdrs["X-Erpc-Cache"])
+		assert.GreaterOrEqual(t, got, bniHealthyHead,
+			"a cache-hit response below the known tip must be corrected just like a fresh response (FromCache responses currently skip enforcement entirely)")
+	})
+
+	// ── B3: use-upstream pinned requests must use the subset's tip ──────────
+
+	t.Run("Bug_UseUpstreamPinnedRequestMustUseSelectorScopedTip", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, _, shutdown := bniBoot(t, bniConfig(false, integrityOn()))
+		defer shutdown()
+
+		// The request is explicitly pinned to the lagging upstream. Per the
+		// selector-scoped served-tip semantics (#912, honored by max-mode
+		// tipCandidateUpstreams when the ctx carries the request), "latest"
+		// must be decided AMONG the pinned subset — advertising the
+		// network-wide tip promises a block rpc1 cannot serve.
+		got, _ := bniSend(t, send, map[string]string{"X-ERPC-Use-Upstream": "rpc1"}, nil)
+		assert.Equal(t, bniLaggingHead, got,
+			"request pinned to the lagging upstream must be corrected against the pinned subset's tip (0x%x), not the network-wide tip (0x%x)",
+			bniLaggingHead, bniHealthyHead)
+	})
+
+	// ── B4: directive gating parity with eth_getBlockByNumber ───────────────
+
+	t.Run("Baseline_EnforcementEnabledByDefaultOnModernConfig", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		// No integrity block in config: both the deprecated
+		// evm.integrity.enforceHighestBlock (which the eth_blockNumber hook
+		// reads) and DirectiveDefaults.EnforceHighestBlock (which
+		// eth_getBlockByNumber reads) are auto-defaulted to true, so
+		// enforcement must run out of the box.
+		send, _, shutdown := bniBoot(t, bniConfig(false, nil))
+		defer shutdown()
+
+		got, _ := bniSend(t, send, nil, nil)
+		assert.Equal(t, bniHealthyHead, got,
+			"enforcement must be active by default (no explicit integrity config)")
+	})
+
+	t.Run("Bug_PerRequestDirectiveOverrideMustBeHonored", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, _, shutdown := bniBoot(t, bniConfig(false, integrityOn()))
+		defer shutdown()
+
+		// eth_getBlockByNumber honors ?enforce-highest-block=false per
+		// request (see HonorsEnforceHighestBlockFalseQueryOverride); the
+		// eth_blockNumber hook must behave the same instead of reading only
+		// the network config.
+		got, _ := bniSend(t, send, nil, map[string]string{"enforce-highest-block": "false"})
+		assert.Equal(t, bniLaggingHead, got,
+			"per-request enforce-highest-block=false must disable correction for eth_blockNumber (it already does for eth_getBlockByNumber)")
+	})
+}

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/auth"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
@@ -7803,7 +7804,15 @@ func createServerTestFixtures(cfg *common.Config, t *testing.T) (
 		}
 	}
 
-	erpcInstance, err := NewERPC(ctx, &logger, ssr, nil, cfg)
+	// Wire the EVM JSON-RPC cache from config like production init does, so
+	// caching-related tests exercise the real cache layer.
+	var evmJsonRpcCache *evm.EvmJsonRpcCache
+	if cfg != nil && cfg.Database != nil && cfg.Database.EvmJsonRpcCache != nil {
+		evmJsonRpcCache, err = evm.NewEvmJsonRpcCache(ctx, &logger, cfg.Database.EvmJsonRpcCache)
+		require.NoError(t, err)
+	}
+
+	erpcInstance, err := NewERPC(ctx, &logger, ssr, evmJsonRpcCache, cfg)
 	require.NoError(t, err)
 
 	// Callback now set at construction; do not mutate in tests


### PR DESCRIPTION
## Problem

With `enforceHighestBlock` enabled and a realtime cache policy covering `eth_blockNumber`, clients behind a partially-lagging upstream fleet observe the served block number **sawtoothing backwards** by the full upstream lag (potentially thousands of blocks), with the largest swings on `x-erpc-cache: HIT` responses.

Root cause: `eth_blockNumber` enforcement was a project pre-forward wrapper around `network.Forward` that corrected only the client-bound copy of a fresh response. Four compounding gaps:

1. **Write-side poisoning** — `network.Forward` async-caches the *original* stale response; the synthesized correction never reached the cache. One response from a lagging upstream poisons the entry for the whole TTL window.
2. **Read-side bypass** — `FromCache()` responses skipped enforcement entirely, so the poisoned entry was served verbatim. The realtime age guard (#908) cannot catch this for `eth_blockNumber`: its responses carry no block timestamp, and non-head-aware connectors (memory/redis) fail open — and the guard measures *time* freshness, not block staleness anyway.
3. **Selector scope** — the hook resolved the tip with a context that does not carry the request (`RequestContextKey` is only set inside `Network.Forward`), so `use-upstream`-pinned requests were corrected against the *network-wide* tip, contradicting the selector-scoped served-tip semantics (#912).
4. **Directive gating** — the hook read the deprecated `evm.integrity.enforceHighestBlock` config instead of the request directives that `eth_getBlockByNumber` honors, so per-request `enforce-highest-block=false` was silently ignored and `directiveDefaults.enforceHighestBlock: false` alone could not disable it.

## Fix — one invariant instead of four patches

> A tip-bearing realtime response is never **served** below the tip visible to the request, regardless of source (upstream or cache), and never **persisted** below the network-wide tip.

- **Move enforcement to the network post-forward hook** (where the `eth_getBlockByNumber` sibling already lives), gated on request directives, applied to cache hits too. The correction is a pure in-memory synthesis from poller state — no extra upstream call — so the old "no point caching otherwise" rationale for skipping `FromCache` responses does not apply. Cache attribution (`x-erpc-cache: HIT`) is preserved on upgraded hits.
- **Stale-tip write guard in `shouldCacheResponse`** — skip persisting realtime responses already behind the network tip when enforcement is on. Race-free against the async cache-set goroutine (the guard runs inside the Set path itself), and it also closes the same write-side hole for `eth_getBlockByNumber(latest)`, which was previously only masked by the read-side block-timestamp age guard. Fails open when pollers don't know a tip yet.
- **Request-aware tip resolution in both hooks** — bind the request to the context before resolving the tip, so a `use-upstream` selector scopes "highest known" to the targeted subset (a pinned request must not be promised a block its upstreams can't serve). Cache writes deliberately keep the network-wide tip since the cache entry is shared by all requests.

## Tests

New http-server-level suite (`erpc/http_server_blocknumber_integrity_test.go`): full server, real cache (memory connector), real state pollers, real policy engine — only upstream HTTP responses are mocked. One lagging upstream (0x800) + one healthy (0x1000), traffic pinned to land on the laggard:

- 5 bug-proof sub-tests that were red before the fix and are green after: cache-hit sawtooth (exact reported signature, HIT + backwards jump), write-side poisoning, seeded stale entry bypass (simulates another pod sharing the cache), selector-scope bypass, ignored per-request override
- 3 baselines pinning what already worked: fresh-path correction, explicit disable, enforcement-on-by-default on modern configs

Also wires `cfg.Database.EvmJsonRpcCache` into `createServerTestFixtures` like production init does — it was silently dropped, so no http-server test could exercise the real cache layer before.

`./architecture/evm`, `./data`, `./common` and the full `./erpc` package pass. (`TestNetwork_HedgeAttemptsExcludedFromTrackerCounters` fails on `main` before this PR too — verified at 98dacaa7, unrelated, will be addressed separately.)

## Behavior changes

- `eth_blockNumber` cache hits below the tip are upgraded in-memory (still reported as `HIT`).
- Realtime responses below the network tip are no longer written to the cache while `enforceHighestBlock` is on.
- `enforce-highest-block=false` is now honored per-request for `eth_blockNumber`, and `directiveDefaults.enforceHighestBlock: false` alone disables both paths (the deprecated `evm.integrity` field still migrates as before).
- `use-upstream`-pinned requests are corrected against the pinned subset's tip instead of the network-wide tip (both `eth_blockNumber` and `eth_getBlockByNumber`).
- Docs (`docs/pages/config/failsafe/integrity.mdx`) updated: hook names, directive semantics, worked examples, gotchas, log/span names — the "dual-path" footgun documentation is gone because the footgun is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
