### PR TITLE
fix(tests): pin hedge-loser quantile exclusion and close the CI shard gap that hid the stale test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,17 +76,25 @@ test-fast:
 	@# of TestNetwork_* was skipped while SHARD_NETWORK only ran an enumerated
 	@# subset — so any test under a skipped prefix but outside a shard ran
 	@# NOWHERE in CI (which is how a deterministically-failing test merged).
+	@# SHARD_CONTAINER_CACHE isolates the testcontainers-backed cache tests:
+	@# their duration is dominated by docker (image pull + dynamodb-local JVM
+	@# startup) and swings from ~15s to 9m+ on degraded runners. In the serial
+	@# catch-all that variance ate the entire 10m process budget and starved
+	@# every test scheduled after them; in a dedicated shard with extra
+	@# headroom it can't take anyone else down.
 	@bash -c '\
 	  SHARD_CONSENSUS="^(TestConsensusPolicy$$|TestConsensusGoroutine|TestConsensusSelectsLargest|TestInterpolation_)"; \
 	  SHARD_NETWORK="^(TestNetwork_Forward$$|TestNetwork_(SelectionScenarios|InFlightRequests|SkippingUpstreams|EvmGetLogs|ThunderingHerd|HighestFinalizedBlockNumber|HighestLatestBlockNumber|CacheEmptyBehavior|BatchRequests|SingleRequestErrors|CapacityExceededErrors|TraceExecutionTimeout|Multiplexer|SendRawTransaction))"; \
 	  SHARD_HTTPSERVER="^TestHttpServer_"; \
 	  SHARD_INTEGRITY="^(TestNetworkRetry_|TestNetworkForward_|TestNetworkIntegrity_|TestHedgeConsensus_|TestEmptyResultAcceptShortCircuit$$|TestNetworkFailsafe_|TestNetworksBootstrap_|TestNetworkAvailability_|TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping$$|TestNetwork_HedgePolicy)"; \
-	  SKIP_ALL="$$SHARD_CONSENSUS|$$SHARD_NETWORK|$$SHARD_HTTPSERVER|$$SHARD_INTEGRITY|^TestConsensusPolicy_DSL|^TestHttp_"; \
+	  SHARD_CONTAINER_CACHE="^TestEvmJsonRpcCache_(DynamoDB|Redis)$$"; \
+	  SKIP_ALL="$$SHARD_CONSENSUS|$$SHARD_NETWORK|$$SHARD_HTTPSERVER|$$SHARD_INTEGRITY|$$SHARD_CONTAINER_CACHE|^TestConsensusPolicy_DSL|^TestHttp_"; \
 	  pids=(); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_CONSENSUS" -test.parallel 4 & pids+=($$!); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_NETWORK" & pids+=($$!); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_HTTPSERVER" & pids+=($$!); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_INTEGRITY" & pids+=($$!); \
+	  /tmp/erpc.test -test.v -test.timeout 15m -test.run "$$SHARD_CONTAINER_CACHE" & pids+=($$!); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.skip "$$SKIP_ALL" & pids+=($$!); \
 	  fail=0; for pid in "$${pids[@]}"; do wait "$$pid" || fail=1; done; \
 	  exit $$fail'

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,19 @@ test-fast:
 	@/tmp/erpc.test -test.v -test.timeout 5m -test.run "^TestConsensusPolicy_DSL" || true &
 	@# Named shards run in parallel (each process has isolated gock state)
 	@# Shard definitions are only for the known-slow test groups.
-	@# The catch-all shard automatically picks up any new/unassigned tests.
+	@# The catch-all shard picks up any new/unassigned tests: its skip list is
+	@# composed from the shard regexes themselves (plus the two standalone
+	@# phases) so the shards and the skip can never drift apart. A previous
+	@# hand-maintained prefix list skipped MORE than the shards ran — e.g. all
+	@# of TestNetwork_* was skipped while SHARD_NETWORK only ran an enumerated
+	@# subset — so any test under a skipped prefix but outside a shard ran
+	@# NOWHERE in CI (which is how a deterministically-failing test merged).
 	@bash -c '\
 	  SHARD_CONSENSUS="^(TestConsensusPolicy$$|TestConsensusGoroutine|TestConsensusSelectsLargest|TestInterpolation_)"; \
 	  SHARD_NETWORK="^(TestNetwork_Forward$$|TestNetwork_(SelectionScenarios|InFlightRequests|SkippingUpstreams|EvmGetLogs|ThunderingHerd|HighestFinalizedBlockNumber|HighestLatestBlockNumber|CacheEmptyBehavior|BatchRequests|SingleRequestErrors|CapacityExceededErrors|TraceExecutionTimeout|Multiplexer|SendRawTransaction))"; \
 	  SHARD_HTTPSERVER="^TestHttpServer_"; \
 	  SHARD_INTEGRITY="^(TestNetworkRetry_|TestNetworkForward_|TestNetworkIntegrity_|TestHedgeConsensus_|TestEmptyResultAcceptShortCircuit$$|TestNetworkFailsafe_|TestNetworksBootstrap_|TestNetworkAvailability_|TestNetwork_Forward_InfiniteLoopWithAllUpstreamsSkipping$$|TestNetwork_HedgePolicy)"; \
-	  SKIP_ALL="TestConsensusPolicy|TestConsensusGoroutine|TestConsensusSelectsLargest|TestInterpolation_|TestNetwork_|TestHttpServer_|TestHttp_|TestNetworkRetry_|TestNetworkForward_|TestNetworkIntegrity_|TestHedgeConsensus_|TestEmptyResultAcceptShortCircuit|TestNetworkFailsafe_|TestNetworksBootstrap_|TestNetworkAvailability_"; \
+	  SKIP_ALL="$$SHARD_CONSENSUS|$$SHARD_NETWORK|$$SHARD_HTTPSERVER|$$SHARD_INTEGRITY|^TestConsensusPolicy_DSL|^TestHttp_"; \
 	  pids=(); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_CONSENSUS" -test.parallel 4 & pids+=($$!); \
 	  /tmp/erpc.test -test.v -test.timeout 10m -test.run "$$SHARD_NETWORK" & pids+=($$!); \

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -1931,6 +1931,14 @@ func TestEvmJsonRpcCache_ItemSizeLimits(t *testing.T) {
 }
 
 func TestEvmJsonRpcCache_DynamoDB(t *testing.T) {
+	// createMockUpstream bootstraps a real upstream against rpc1.localhost
+	// (chainId detection + state poller); register the standard poller mocks
+	// so this test is self-contained instead of freeloading on persist mocks
+	// leaked by whichever test happens to run before it in the same process.
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -2308,6 +2316,13 @@ func TestEvmJsonRpcCache_DynamoDB(t *testing.T) {
 }
 
 func TestEvmJsonRpcCache_Redis(t *testing.T) {
+	// Same hygiene as TestEvmJsonRpcCache_DynamoDB: createMockUpstream
+	// bootstraps against rpc1.localhost, so this test must register its own
+	// poller mocks rather than depend on leftovers from earlier tests.
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/erpc/networks_hedge_test.go
+++ b/erpc/networks_hedge_test.go
@@ -1204,21 +1204,28 @@ func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
 		}
 	})
 
-	// HedgeLoser_ElapsedRecordedAsLowerBoundLatency pins the fix for
-	// "slow upstream stays top-ranked because every hedge it loses is
-	// invisible to scoring". Before this, a canceled hedge fed
-	// `ObserveDuration(false)` and never reached `ResponseQuantiles` —
-	// so an upstream that consistently lost the race had only its rare
-	// wins in the quantile, and `sortByScore` saw a fast-looking p70
-	// even when the upstream was actually slow. Now the elapsed-by-
-	// cancel time IS recorded (as a lower-bound sample); slow primary
-	// gets penalized; sortByScore eventually rotates it off position 0.
+	// HedgeLoser_ElapsedExcludedFromQuantiles pins the deliberate design
+	// for hedge-loser latency accounting (see the ObserveDuration
+	// rationale in upstream/upstream.go): a canceled attempt must NOT
+	// feed its elapsed-by-cancel time into `ResponseQuantiles`.
+	// Elapsed-by-cancel is "however long the race winner took", not this
+	// upstream's latency — an upstream that mostly loses hedge races
+	// would otherwise accumulate a quantile full of artificial samples,
+	// and cross-upstream comparisons (`latencyDeviationAbove`) would trip
+	// even when per-method latencies are identical. Chronically-canceled
+	// upstreams are kept honest by `probeExcluded` shadow traffic
+	// instead, which records real successful samples.
+	//
+	// (An earlier iteration of the scoring rework recorded
+	// elapsed-by-cancel as a "lower bound" latency sample; that approach
+	// was replaced by `probeExcluded` before merge. This test pins the
+	// replacement design.)
 	//
 	// Setup: rpc1 is the slow primary (1s response). rpc2 is the fast
 	// hedge (40ms). The hedge fires at 80ms, wins; rpc1 is canceled
-	// somewhere around 80ms elapsed. After several requests we expect
-	// rpc1's quantile to contain ~80ms samples — not stay at zero.
-	t.Run("HedgeLoser_ElapsedRecordedAsLowerBoundLatency", func(t *testing.T) {
+	// somewhere around 80ms elapsed. No matter how many hedges rpc1
+	// loses, its quantile stays empty and its error counter stays clean.
+	t.Run("HedgeLoser_ElapsedExcludedFromQuantiles", func(t *testing.T) {
 		util.ResetGock()
 		defer util.ResetGock()
 		util.SetupMocksForEvmStatePoller()
@@ -1255,7 +1262,7 @@ func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
 			MaxCount: 1,
 		})
 
-		// Multiple requests so the quantile estimator has enough samples.
+		// Multiple requests: repeated losses must still record nothing.
 		for i := 0; i < 5; i++ {
 			resp, err := network.Forward(ctx, common.NewNormalizedRequest(requestBytes))
 			require.NoError(t, err)
@@ -1272,20 +1279,14 @@ func TestNetwork_HedgeAttemptsExcludedFromTrackerCounters(t *testing.T) {
 		assert.Equal(t, int64(0), m1.ErrorsTotal.Load(),
 			"canceled primary attempts must NOT pollute ErrorsTotal")
 
-		// The crux: rpc1's quantile MUST have samples now. Without the
-		// fix this stays at 0.0 and sortByScore can't see that rpc1 is
-		// chronically slow.
+		// The crux: elapsed-by-cancel is not a latency sample. rpc1's
+		// quantile stays empty no matter how many hedge races it loses;
+		// real samples for excluded/slow upstreams come from probeExcluded
+		// shadow traffic, not from cancellations.
 		p70 := m1.GetResponseQuantiles().GetQuantile(0.70).Seconds()
-		assert.Greater(t, p70, 0.0,
-			"slow primary's canceled-elapsed time must populate ResponseQuantiles; "+
-				"otherwise scoring sees zero latency and rotation never happens")
-		// Sanity: the sample is at-or-above the hedge delay (80ms) since
-		// that's when cancellation fires. We allow a generous upper
-		// bound to absorb gock + scheduling jitter.
-		assert.Greater(t, p70, 0.05,
-			"recorded latency should reflect the elapsed-by-cancel time (~hedge delay)")
-		assert.Less(t, p70, 0.5,
-			"recorded latency should be a lower bound, not the upstream's full 1s response time")
+		assert.Equal(t, 0.0, p70,
+			"hedge-loser cancellations must NOT feed ResponseQuantiles — "+
+				"elapsed-by-cancel reflects the race winner's speed, not this upstream's latency")
 	})
 
 	// MaxCount > 1 spawns multiple hedge attempts. Every one of them must


### PR DESCRIPTION
## Verdict: stale test, not a scoring regression — plus the CI hole that hid it

`TestNetwork_HedgeAttemptsExcludedFromTrackerCounters/HedgeLoser_ElapsedRecordedAsLowerBoundLatency` fails deterministically (`p70 == 0`), in isolation and in the full suite, on every commit since it merged — verified at #888's own merge commit (70a1f178).

### Why it fails

PR #888 evolved during development and shipped two contradictory artifacts in one commit:

- **Production code** (`upstream/upstream.go`, `ObserveDuration` call sites) deliberately **excludes** canceled attempts from `ResponseQuantiles`, with an explicit rationale: elapsed-by-cancel is "however long the race winner took", not the loser's latency; recording it would bias cross-upstream comparisons (`latencyDeviationAbove`) even when per-method latencies are identical. The "hedge-loser stays optimistic forever" problem is instead handled by `probeExcluded` shadow traffic, which feeds real successful samples.
- **The test** pins the earlier in-development iteration (record elapsed-by-cancel as a "lower bound" sample) that this design replaced before merge.

So the scoring/rotation behavior is working as designed; the test is the leftover. Rewritten as `HedgeLoser_ElapsedExcludedFromQuantiles`, pinning the shipped design: clean `ErrorsTotal` and an **empty** quantile no matter how many hedge races the upstream loses, with a comment trail pointing at the `upstream.go` rationale and the `probeExcluded` mechanism.

### How a deterministically-failing test merged: the CI shard gap

CI runs `make test-fast`, which shards the `erpc` package by regex. The catch-all shard's hand-maintained `SKIP_ALL` list was **broader than what the named shards actually run** — e.g. it skipped all of `TestNetwork_*` while `SHARD_NETWORK` only runs an enumerated subset. Result: six tests ran in **no shard at all**, despite the comment claiming "the catch-all automatically picks up any new/unassigned tests":

```
TestConsensusPolicy_RequiredParticipants
TestNetwork_Forward_UseUpstreamTagSelector
TestNetwork_HedgeAttemptsExcludedFromTrackerCounters   ← the broken one
TestNetwork_LatePrimaryResponseAfterHedgeWin_NoDoubleCounting
TestNetwork_LongTermHedgingDynamics_PromotesFasterUpstream
TestNetwork_TimeoutPolicy
```

Fix: compose `SKIP_ALL` from the shard regexes themselves (plus the two standalone phases, `^TestConsensusPolicy_DSL` and `^TestHttp_`), so the shards and the skip can never drift apart again.

### Verification

- Partition simulation over all **347** `erpc`-package test functions: every test now runs in exactly one place (zero orphans, zero double-runs).
- All six formerly-gapped tests pass at current `main` with the rewritten hedge test (`go test -run '^(…six names…)$'` → ok, 32.5s).
- `make -n test-fast` parses and expands the composed skip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
