### PR TITLE
feat: add Satelink decentralized Polygon RPC as example upstream

### DIFF
--- a/erpc.dist.yaml
+++ b/erpc.dist.yaml
@@ -220,6 +220,21 @@ projects:
             backoffMaxDelay: 10s
             backoffFactor: 0.3
             jitter: 500ms
+      - id: satelink-polygon
+        type: evm
+        endpoint: https://rpc.satelink.network/rpc/polygon
+        rateLimitBudget: default-budget
+        evm:
+          chainId: 137
+        failsafe:
+          timeout:
+            duration: 15s
+          retry:
+            maxAttempts: 2
+            delay: 1000ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
 rateLimiters:
   budgets:
     - id: global-tenderly


### PR DESCRIPTION
Adds [Satelink](https://satelink.network) as an example Polygon mainnet upstream in the sample configuration.

Satelink is a decentralized RPC network (DePIN) that routes Polygon JSON-RPC traffic through distributed node operators.

**Public endpoint:** https://rpc.satelink.network/rpc/polygon
- No API key required
- 500 calls/day free tier
- Paid tier via USDT prepaid credits
- Privacy-preserving (no logs sold)

This gives erpc users a decentralized alternative to centralized RPC providers.