### PR TITLE
feat(thirdparty): add Goldsky Edge as a built-in provider/vendor

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1242,6 +1242,27 @@ func convertUpstreamToProvider(upstream *UpstreamConfig) (*ProviderConfig, error
 
 func buildProviderSettings(vendorName string, endpoint *url.URL) (VendorSettings, error) {
 	switch vendorName {
+	case "goldsky", "evm+goldsky":
+		// goldsky://<secret>[?tier=<tier>] — the authority segment is the Edge
+		// secret token (the host is always edge.goldsky.com). Falls back to a
+		// ?secret= query param when the authority is empty.
+		settings := VendorSettings{}
+		if endpoint.Host != "" {
+			settings["secret"] = endpoint.Host
+		}
+		if endpoint.RawQuery != "" {
+			params, err := url.ParseQuery(endpoint.RawQuery)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse goldsky query parameters: %w", err)
+			}
+			if secret := params.Get("secret"); secret != "" {
+				settings["secret"] = secret
+			}
+			if tier := params.Get("tier"); tier != "" {
+				settings["tier"] = tier
+			}
+		}
+		return settings, nil
 	case "alchemy", "evm+alchemy":
 		return VendorSettings{
 			"apiKey": endpoint.Host,

--- a/common/defaults_test.go
+++ b/common/defaults_test.go
@@ -1142,6 +1142,30 @@ func TestSetDefaults_NetworkConfig_FailsafeMatchMethod(t *testing.T) {
 }
 
 func TestBuildProviderSettings(t *testing.T) {
+	// Goldsky shorthand: authority is the Edge secret token.
+	t.Run("goldsky with secret in authority", func(t *testing.T) {
+		endpoint, _ := url.Parse("goldsky://my-edge-secret")
+		settings, err := buildProviderSettings("goldsky", endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-edge-secret", settings["secret"])
+		assert.Nil(t, settings["tier"])
+	})
+
+	t.Run("goldsky with tier query param", func(t *testing.T) {
+		endpoint, _ := url.Parse("goldsky://my-edge-secret?tier=custom")
+		settings, err := buildProviderSettings("goldsky", endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-edge-secret", settings["secret"])
+		assert.Equal(t, "custom", settings["tier"])
+	})
+
+	t.Run("goldsky with secret query param fallback", func(t *testing.T) {
+		endpoint, _ := url.Parse("goldsky://?secret=query-secret")
+		settings, err := buildProviderSettings("goldsky", endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, "query-secret", settings["secret"])
+	})
+
 	// Test case for Chainstack with query parameters
 	t.Run("chainstack with filters", func(t *testing.T) {
 		endpoint, _ := url.Parse("chainstack://test-api-key?project=proj-123&organization=org-456&region=us-east-1&provider=aws&type=dedicated")

--- a/docs/pages/config/projects/providers.mdx
+++ b/docs/pages/config/projects/providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Providers & vendors
-description: One API key, every chain — declare a single provider entry and eRPC auto-generates upstreams for each network on first request, with 22 built-in vendor integrations.
+description: One API key, every chain — declare a single provider entry and eRPC auto-generates upstreams for each network on first request, with 23 built-in vendor integrations.
 ---
 
 import {
@@ -17,7 +17,7 @@ import {
 
 One API key, every chain. Instead of wiring one upstream per (vendor, network) pair, you
 declare a single provider and eRPC lazy-generates concrete upstreams the moment a new
-network is first requested. 22 vendor integrations are built in — from general-purpose node
+network is first requested. 23 vendor integrations are built in — from general-purpose node
 providers to ERC-4337 bundlers to public-endpoint catalogs — and a project with no config
 at all gets a sensible zero-cost default automatically.
 
@@ -109,7 +109,7 @@ https://docs.erpc.cloud/config/projects/providers.llms.txt`}
 
 ### How it works
 
-**Two distinct concepts.** A *vendor* (`common.Vendor` interface) is stateless integration logic: `Name()`, `OwnsUpstream(cfg)`, `SupportsNetwork(ctx, logger, settings, networkId)`, `GenerateConfigs(...)`, and `GetVendorSpecificErrorIfAny(...)`. A *provider* is a configured instance of a vendor: `ProviderConfig{Id, Vendor, Settings, OnlyNetworks, IgnoreNetworks, UpstreamIdTemplate, Overrides}`. All 22 vendors are registered in a global `VendorsRegistry` at startup; a per-project `ProvidersRegistry` resolves each `providers[].vendor` string and fails startup if the name is unknown. <SourceLink file="thirdparty/vendors_registry.go" lines="9-35" /> <SourceLink file="thirdparty/providers_registry.go" lines="15-34" />
+**Two distinct concepts.** A *vendor* (`common.Vendor` interface) is stateless integration logic: `Name()`, `OwnsUpstream(cfg)`, `SupportsNetwork(ctx, logger, settings, networkId)`, `GenerateConfigs(...)`, and `GetVendorSpecificErrorIfAny(...)`. A *provider* is a configured instance of a vendor: `ProviderConfig{Id, Vendor, Settings, OnlyNetworks, IgnoreNetworks, UpstreamIdTemplate, Overrides}`. All 23 vendors are registered in a global `VendorsRegistry` at startup; a per-project `ProvidersRegistry` resolves each `providers[].vendor` string and fails startup if the name is unknown. <SourceLink file="thirdparty/vendors_registry.go" lines="9-36" /> <SourceLink file="thirdparty/providers_registry.go" lines="15-34" />
 
 **Lazy upstream generation.** When a request arrives for a network with no prepared upstreams, `UpstreamsRegistry.PrepareUpstreamsForNetwork` schedules — exactly once per network via `sync.Once` — one bootstrap task per declared provider named `network/<networkId>/provider/<providerId>`. Each task: (1) calls `Provider.SupportsNetwork`, applying `ignoreNetworks` deny-list first, then `onlyNetworks` allow-list, then delegating to the vendor; (2) calls `Provider.GenerateUpstreamConfigs`, which copies the first wildcard-matching `overrides` entry (or creates a fresh defaults-filled config), stamps `VendorName`, renders the upstream id from `upstreamIdTemplate`, and runs `os.ExpandEnv` over every generated endpoint; (3) registers the resulting configs as ordinary upstream bootstrap tasks. The caller waits up to 30 seconds (polling every 200 ms) for at least one upstream to become ready. While tasks run, clients receive the retryable `ErrNetworkInitializing`; if all tasks finish without producing any upstreams, the error becomes the retryable `ErrNetworkNotSupported`. Failed tasks auto-retry with exponential backoff (factor 1.5, 3 s → 130 s). <SourceLink file="upstream/registry.go" lines="155-293" />
 
@@ -135,7 +135,7 @@ https://docs.erpc.cloud/config/projects/providers.llms.txt`}
 | field | type | default | behavior / footguns |
 |---|---|---|---|
 | `id` | string | vendor name (`p.Id = p.Vendor`) | Unique handle; appears in `<PROVIDER>` placeholder and bootstrap task names `network/<networkId>/provider/<id>`. Shorthand-converted providers get `<vendor>-<n>` (process-wide counter). No duplicate-id check — two providers with the same default id both run and may produce upstream-id collisions. <SourceLink file="common/defaults.go" lines="1474-1476" /> <SourceLink file="util/ids.go" lines="32-41" /> |
-| `vendor` | string | — (required) | Must exactly match one of 22 registered `Name()` strings: `alchemy, blastapi, conduit, drpc, dwellir, envio, etherspot, infura, pimlico, quicknode, llama, thirdweb, repository, superchain, tenderly, chainstack, onfinality, erpc, blockpi, ankr, routemesh, blockdaemon`. Unknown vendor → startup error. <SourceLink file="thirdparty/vendors_registry.go" lines="12-33" /> |
+| `vendor` | string | — (required) | Must exactly match one of 23 registered `Name()` strings: `goldsky, alchemy, blastapi, conduit, drpc, dwellir, envio, etherspot, infura, pimlico, quicknode, llama, thirdweb, repository, superchain, tenderly, chainstack, onfinality, erpc, blockpi, ankr, routemesh, blockdaemon`. Unknown vendor → startup error. <SourceLink file="thirdparty/vendors_registry.go" lines="12-34" /> |
 | `settings` | `map[string]any` (VendorSettings) | `nil` | Free-form, vendor-interpreted. Redacted in JSON/YAML marshaling (never echoed in admin dump). See per-vendor tables below. <SourceLink file="common/config.go" lines="667-700" /> |
 | `onlyNetworks` | `[]string` | `nil` | Exhaustive allow-list (`evm:<positiveInt>` format, validated). If set, vendor's own `SupportsNetwork` is **not** called. Mutually exclusive with `ignoreNetworks` (validation error). <SourceLink file="thirdparty/provider.go" lines="42-49" /> |
 | `ignoreNetworks` | `[]string` | `nil` | Exact-match deny-list checked **before** `onlyNetworks` and before vendor. Same `evm:<positiveInt>` validation. Omitted from `MarshalJSON` (present in YAML marshal). <SourceLink file="thirdparty/provider.go" lines="34-40" /> |
@@ -146,6 +146,7 @@ https://docs.erpc.cloud/config/projects/providers.llms.txt`}
 
 | shorthand | derived settings |
 |---|---|
+| `goldsky://<secret>[?tier=&secret=]` | `{secret: authority}` + `tier`/`secret` from query (host is always `edge.goldsky.com`) |
 | `alchemy://<key>` | `{apiKey: key}` |
 | `ankr://<key>` | `{apiKey: key}` |
 | `blastapi://<key>` | `{apiKey: key}` |
@@ -171,6 +172,18 @@ https://docs.erpc.cloud/config/projects/providers.llms.txt`}
 | unknown scheme | config-load error: `unsupported vendor name in vendor.settings: <scheme>` |
 
 ### Vendor catalog
+
+#### goldsky
+
+[Goldsky Edge](https://docs.goldsky.com/edge-rpc/introduction) — a multi-region public RPC service built on eRPC. One secret token covers every chain Goldsky serves; upstreams are lazy-generated per network. SupportsNetwork probes live `eth_chainId` against `https://edge.goldsky.com/{tier}/evm/{chainId}?secret={secret}` (10 s timeout) and confirms the returned chain id matches — so the secret's plan authoritatively decides chain support. A missing `secret` makes SupportsNetwork return `(false, nil)` (silent skip, no retry storm). `tier` defaults to `standard`; `endpoint` defaults to `https://edge.goldsky.com` and may be overridden for enterprise/custom deployments (an explicit path on the base URL is respected verbatim and the tier route is not injected). The secret can also be supplied out-of-band via the `X-ERPC-Secret-Token` header on a preset endpoint. Probe clients are cached per `"{url}-{chainId}"`. OwnsUpstream: `goldsky://`/`evm+goldsky://` prefix, `vendorName=="goldsky"`, or endpoint contains `edge.goldsky.com`.
+
+| key | required | default |
+|---|---|---|
+| `secret` | yes (auth fails without it) | — |
+| `tier` | no | `standard` |
+| `endpoint` | no | `https://edge.goldsky.com` |
+
+<SourceLink file="thirdparty/goldsky.go" lines="31-249" />
 
 #### alchemy
 
@@ -696,7 +709,7 @@ export default createConfig({
 17. **dwellir `OwnsUpstream` only matches `dwellir://` prefix** (not `evm+dwellir://`) or `.dwellir.com` domain; the `evm+` shorthand still works because shorthand conversion runs before vendor lookup. <SourceLink file="thirdparty/dwellir.go" lines="173-180" />
 18. **Live-probe vendors dial out during routing decisions**: envio/erpc/pimlico/routemesh/thirdweb perform a real `eth_chainId` HTTP call (10 s timeout) on the provider bootstrap path. Probe clients are cached forever in `sync.Map`s keyed by chain id or `"{url}-{chainId}"`.
 19. **`PrepareUpstreamsForNetwork` succeeds as soon as one upstream registers** (`minReady=1`). Slow providers continue adding upstreams in the background without blocking the first request. If all provider tasks finish with zero upstreams, there is a 100 ms grace re-check before the retryable `ErrNetworkNotSupported` is returned; if tasks are still running, the caller receives `ErrNetworkInitializing`. <SourceLink file="upstream/registry.go" lines="188-293" />
-20. **`LookupByUpstream` with an explicit but non-existent `vendorName` returns nil** — it does not fall through to `OwnsUpstream` matching. If `upstream.vendorName` is set to an unregistered name, vendor error-mapping is silently lost. Registration order of the 22 vendors determines which vendor wins when multiple `OwnsUpstream` checks return true for the same endpoint. <SourceLink file="thirdparty/vendors_registry.go" lines="54-71" />
+20. **`LookupByUpstream` with an explicit but non-existent `vendorName` returns nil** — it does not fall through to `OwnsUpstream` matching. If `upstream.vendorName` is set to an unregistered name, vendor error-mapping is silently lost. Registration order of the 23 vendors determines which vendor wins when multiple `OwnsUpstream` checks return true for the same endpoint. <SourceLink file="thirdparty/vendors_registry.go" lines="54-71" />
 21. **`llama` and `routemesh` `OwnsUpstream` do not check their own scheme prefixes**: `llama.OwnsUpstream` only matches `.llamarpc.com`; `routemesh.OwnsUpstream` only matches `vendorName=="routemesh"` or endpoint containing `routemes.sh`. Both shorthands (`llama://`, `routemesh://`) work only because shorthand conversion in `common/defaults.go` runs before vendor lookup. <SourceLink file="thirdparty/llama.go" lines="95-97" /> <SourceLink file="thirdparty/routemesh.go" lines="135-140" />
 22. **dwellir `SupportsNetwork` returns `(false, nil)` for an unparseable chain id** — unlike every other static-map vendor which propagates the parse error. <SourceLink file="thirdparty/dwellir.go" lines="109-113" />
 
@@ -727,7 +740,7 @@ Notable log messages:
 
 ### Source code entry points
 
-- <SourceLink file="thirdparty/vendors_registry.go" lines="9-35" /> — global 22-vendor registry; `LookupByName` / `LookupByUpstream` / `SupportedVendors`
+- <SourceLink file="thirdparty/vendors_registry.go" lines="9-36" /> — global 23-vendor registry; `LookupByName` / `LookupByUpstream` / `SupportedVendors`
 - <SourceLink file="thirdparty/providers_registry.go" lines="15-34" /> — per-project ProviderConfig → Provider binding; unknown-vendor startup error
 - <SourceLink file="thirdparty/provider.go" lines="13-162" /> — `SupportsNetwork` gating, `GenerateUpstreamConfigs`, id templating, env expansion
 - <SourceLink file="thirdparty/remote_cache.go" lines="13-78" /> — `RemoteDataCache[T]` algorithm; request-path safety rationale; `ErrRemoteCacheCold`

--- a/thirdparty/goldsky.go
+++ b/thirdparty/goldsky.go
@@ -1,0 +1,271 @@
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	archEvm "github.com/erpc/erpc/architecture/evm"
+	"github.com/erpc/erpc/clients"
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/rs/zerolog"
+)
+
+// Goldsky Edge is a multi-region public RPC service built on eRPC. A single
+// secret token covers every chain Goldsky serves; the vendor lazy-generates a
+// concrete upstream per network the moment it is first requested.
+//
+// Endpoint shape: https://edge.goldsky.com/<tier>/evm/<chainId>?secret=<secret>
+// (the secret may also be passed via the X-ERPC-Secret-Token header).
+const (
+	defaultGoldskyEndpoint = "https://edge.goldsky.com"
+	defaultGoldskyTier     = "standard"
+)
+
+type GoldskyVendor struct {
+	common.Vendor
+	headlessClients sync.Map
+}
+
+func CreateGoldskyVendor() common.Vendor {
+	return &GoldskyVendor{
+		headlessClients: sync.Map{},
+	}
+}
+
+func (v *GoldskyVendor) Name() string {
+	return "goldsky"
+}
+
+func (v *GoldskyVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger, settings common.VendorSettings, networkId string) (bool, error) {
+	if !strings.HasPrefix(networkId, "evm:") {
+		return false, nil
+	}
+
+	chainId, err := strconv.ParseInt(strings.TrimPrefix(networkId, "evm:"), 10, 64)
+	if err != nil {
+		return false, err
+	}
+
+	endpoint, _ := settings["endpoint"].(string)
+	tier, _ := settings["tier"].(string)
+	secret, _ := settings["secret"].(string)
+
+	// buildEndpointURL also derives a secret embedded in the endpoint
+	// (goldsky://<secret> authority or a ?secret= on an https base), matching
+	// what GenerateConfigs does.
+	parsedURL, err := v.buildEndpointURL(endpoint, tier, secret, chainId)
+	if err != nil {
+		return false, err
+	}
+
+	// Every Goldsky Edge endpoint requires a secret token; if none was supplied
+	// via settings or embedded in the endpoint, there is nothing to probe — skip
+	// silently rather than hammering an endpoint that will only 401.
+	if parsedURL.Query().Get("secret") == "" {
+		return false, nil
+	}
+
+	client, err := v.getOrCreateClient(ctx, logger, chainId, parsedURL)
+	if err != nil {
+		return false, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	pr := common.NewNormalizedRequest([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_chainId","params":[]}`, util.RandomID())))
+	resp, err := client.SendRequest(ctx, pr)
+	if resp != nil {
+		defer resp.Release()
+	}
+	if err != nil {
+		return false, err
+	}
+
+	jrr, err := resp.JsonRpcResponse()
+	if err != nil {
+		return false, err
+	}
+
+	cids, err := jrr.PeekStringByPath(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	cidh, err := common.NormalizeHex(cids)
+	if err != nil {
+		return false, err
+	}
+
+	cid, err := common.HexToInt64(cidh)
+	if err != nil {
+		return false, err
+	}
+
+	// Confirm the secret's plan actually serves this chain.
+	return cid == chainId, nil
+}
+
+func (v *GoldskyVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger, upstream *common.UpstreamConfig, settings common.VendorSettings) ([]*common.UpstreamConfig, error) {
+	if upstream.JsonRpc == nil {
+		upstream.JsonRpc = &common.JsonRpcUpstreamConfig{}
+	}
+
+	// If a concrete endpoint is already set (e.g. a statically-configured
+	// upstream pointing directly at edge.goldsky.com), use it as-is. The
+	// goldsky:// shorthand is converted to provider settings in
+	// common/defaults.go, so it normally never reaches here.
+	if upstream.Endpoint != "" {
+		if strings.HasPrefix(upstream.Endpoint, "goldsky://") || strings.HasPrefix(upstream.Endpoint, "evm+goldsky://") {
+			if upstream.Evm == nil {
+				return nil, fmt.Errorf("goldsky vendor requires upstream.evm to be defined")
+			}
+			// buildEndpointURL extracts the secret/tier from the goldsky://
+			// authority and targets the default Goldsky Edge host.
+			parsedURL, err := v.buildEndpointURL(upstream.Endpoint, "", "", upstream.Evm.ChainId)
+			if err != nil {
+				return nil, err
+			}
+			upstream.Endpoint = parsedURL.String()
+		}
+
+		upstream.Type = common.UpstreamTypeEvm
+		return []*common.UpstreamConfig{upstream}, nil
+	}
+
+	if upstream.Evm == nil {
+		return nil, fmt.Errorf("goldsky vendor requires upstream.evm to be defined")
+	}
+	chainId := upstream.Evm.ChainId
+	if chainId == 0 {
+		return nil, fmt.Errorf("goldsky vendor requires upstream.evm.chainId to be defined")
+	}
+
+	endpoint, _ := settings["endpoint"].(string)
+	tier, _ := settings["tier"].(string)
+	secret, _ := settings["secret"].(string)
+
+	parsedURL, err := v.buildEndpointURL(endpoint, tier, secret, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	upstream.Endpoint = parsedURL.String()
+	upstream.Type = common.UpstreamTypeEvm
+
+	return []*common.UpstreamConfig{upstream}, nil
+}
+
+func (v *GoldskyVendor) GetVendorSpecificErrorIfAny(req *common.NormalizedRequest, resp *http.Response, jrr interface{}, details map[string]interface{}) error {
+	bodyMap, ok := jrr.(*common.JsonRpcResponse)
+	if !ok {
+		return nil
+	}
+
+	err := bodyMap.Error
+	if err.Data != "" {
+		details["data"] = err.Data
+	}
+
+	return nil
+}
+
+func (v *GoldskyVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
+	if strings.HasPrefix(ups.Endpoint, "goldsky://") || strings.HasPrefix(ups.Endpoint, "evm+goldsky://") {
+		return true
+	}
+
+	if ups.VendorName == v.Name() {
+		return true
+	}
+
+	return strings.Contains(ups.Endpoint, "edge.goldsky.com")
+}
+
+// buildEndpointURL assembles a concrete Goldsky Edge URL of the form
+// <base>/<tier>/evm/<chainId>?secret=<secret>. The base defaults to
+// edge.goldsky.com and the tier to "standard". A base that already carries an
+// explicit path is respected verbatim (the tier route is not injected).
+func (v *GoldskyVendor) buildEndpointURL(endpoint string, tier string, secret string, chainId int64) (*url.URL, error) {
+	// A goldsky:// base is the config shorthand: its authority is the Edge secret
+	// token (not a host), with optional ?tier=/?secret= query params. Pull those
+	// out and fall back to the default host so the result still targets
+	// edge.goldsky.com instead of dialing the secret as a hostname.
+	if strings.HasPrefix(endpoint, "goldsky://") || strings.HasPrefix(endpoint, "evm+goldsky://") {
+		shorthand := strings.TrimPrefix(strings.TrimPrefix(endpoint, "evm+"), "goldsky://")
+		if u, err := url.Parse("//" + shorthand); err == nil {
+			if secret == "" && u.Host != "" {
+				secret = u.Host
+			}
+			if u.RawQuery != "" {
+				q := u.Query()
+				if s := q.Get("secret"); s != "" {
+					secret = s
+				}
+				if t := q.Get("tier"); tier == "" && t != "" {
+					tier = t
+				}
+			}
+		}
+		endpoint = "" // fall back to the default Goldsky Edge host
+	}
+
+	if endpoint == "" {
+		endpoint = defaultGoldskyEndpoint
+	}
+	if tier == "" {
+		tier = defaultGoldskyTier
+	}
+
+	// Normalize to something url.Parse can handle: a full http(s) URL or a bare host.
+	rawURL := endpoint
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		rawURL = "https://" + endpoint
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default to the tier route only when the base carries no explicit path.
+	basePath := strings.TrimSuffix(parsedURL.Path, "/")
+	if basePath == "" {
+		basePath = "/" + strings.Trim(tier, "/") + "/evm"
+	}
+	parsedURL.Path = basePath + "/" + strconv.FormatInt(chainId, 10)
+
+	// Attach the secret unless the base URL already carries one.
+	if secret != "" {
+		q := parsedURL.Query()
+		if q.Get("secret") == "" {
+			q.Set("secret", secret)
+			parsedURL.RawQuery = q.Encode()
+		}
+	}
+
+	return parsedURL, nil
+}
+
+func (v *GoldskyVendor) getOrCreateClient(ctx context.Context, logger *zerolog.Logger, chainId int64, parsedURL *url.URL) (clients.HttpJsonRpcClient, error) {
+	clientKey := fmt.Sprintf("%s-%d", parsedURL.String(), chainId)
+
+	if client, ok := v.headlessClients.Load(clientKey); ok {
+		return client.(clients.HttpJsonRpcClient), nil
+	}
+
+	u := &phonyUpstream{id: fmt.Sprintf("temp-goldsky-%d", chainId)}
+	client, err := clients.NewGenericHttpJsonRpcClient(ctx, logger, "n/a", u, parsedURL, nil, nil, archEvm.NewJsonRpcErrorExtractor())
+	if err != nil {
+		return nil, err
+	}
+
+	v.headlessClients.Store(clientKey, client)
+	return client, nil
+}

--- a/thirdparty/goldsky_test.go
+++ b/thirdparty/goldsky_test.go
@@ -1,0 +1,168 @@
+package thirdparty
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoldskyVendor_buildEndpointURL(t *testing.T) {
+	v := &GoldskyVendor{}
+	chainId := int64(1)
+
+	testCases := []struct {
+		name           string
+		endpoint       string
+		tier           string
+		secret         string
+		expectedScheme string
+		expectedHost   string
+		expectedPath   string
+		expectedQuery  string
+	}{
+		{
+			name:           "defaults to edge.goldsky.com standard tier",
+			endpoint:       "",
+			tier:           "",
+			secret:         "sec123",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "secret=sec123",
+		},
+		{
+			name:           "no secret omits the secret query param",
+			endpoint:       "",
+			tier:           "",
+			secret:         "",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "",
+		},
+		{
+			name:           "custom tier is used in the path",
+			endpoint:       "",
+			tier:           "custom",
+			secret:         "sec123",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/custom/evm/1",
+			expectedQuery:  "secret=sec123",
+		},
+		{
+			name:           "bare host override defaults to https and standard tier",
+			endpoint:       "gateway.example.com",
+			tier:           "",
+			secret:         "sec123",
+			expectedScheme: "https",
+			expectedHost:   "gateway.example.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "secret=sec123",
+		},
+		{
+			name:           "full https endpoint with explicit path is respected",
+			endpoint:       "https://edge.goldsky.com/custom/route",
+			tier:           "",
+			secret:         "sec123",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/custom/route/1",
+			expectedQuery:  "secret=sec123",
+		},
+		{
+			name:           "goldsky:// authority is the secret, host defaults to edge",
+			endpoint:       "goldsky://shorthand-secret",
+			tier:           "",
+			secret:         "",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "secret=shorthand-secret",
+		},
+		{
+			name:           "goldsky:// authority secret with tier query",
+			endpoint:       "goldsky://shorthand-secret?tier=custom",
+			tier:           "",
+			secret:         "",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/custom/evm/1",
+			expectedQuery:  "secret=shorthand-secret",
+		},
+		{
+			name:           "evm+goldsky:// authority is the secret",
+			endpoint:       "evm+goldsky://shorthand-secret",
+			tier:           "",
+			secret:         "",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "secret=shorthand-secret",
+		},
+		{
+			name:           "existing secret in base URL is not overwritten",
+			endpoint:       "https://edge.goldsky.com/standard/evm?secret=existing",
+			tier:           "",
+			secret:         "override",
+			expectedScheme: "https",
+			expectedHost:   "edge.goldsky.com",
+			expectedPath:   "/standard/evm/1",
+			expectedQuery:  "secret=existing",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedURL, err := v.buildEndpointURL(tc.endpoint, tc.tier, tc.secret, chainId)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedScheme, parsedURL.Scheme)
+			assert.Equal(t, tc.expectedHost, parsedURL.Host)
+			assert.Equal(t, tc.expectedPath, parsedURL.Path)
+			assert.Equal(t, tc.expectedQuery, parsedURL.RawQuery)
+		})
+	}
+}
+
+func TestGoldskyVendor_SupportsNetwork_SkipsWithoutProbe(t *testing.T) {
+	v := CreateGoldskyVendor()
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	// Non-evm networks short-circuit before any secret/probe logic.
+	ok, err := v.SupportsNetwork(ctx, &logger, common.VendorSettings{"secret": "x"}, "solana:mainnet")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// No secret anywhere (settings or endpoint) → silent skip, no network probe.
+	ok, err = v.SupportsNetwork(ctx, &logger, common.VendorSettings{}, "evm:1")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// A custom endpoint with no derivable secret also skips rather than probing.
+	ok, err = v.SupportsNetwork(ctx, &logger, common.VendorSettings{"endpoint": "https://gateway.example.com"}, "evm:1")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestGoldskyVendor_OwnsUpstream(t *testing.T) {
+	vendor := CreateGoldskyVendor()
+	cases := []struct {
+		endpoint string
+		owned    bool
+	}{
+		{"goldsky://sec123", true},
+		{"evm+goldsky://sec123", true},
+		{"https://edge.goldsky.com/standard/evm/1", true},
+		{"https://example.com/rpc", false},
+	}
+	for _, c := range cases {
+		t.Run(c.endpoint, func(t *testing.T) {
+			got := vendor.OwnsUpstream(&common.UpstreamConfig{Endpoint: c.endpoint})
+			assert.Equal(t, c.owned, got)
+		})
+	}
+}

--- a/thirdparty/vendors_registry.go
+++ b/thirdparty/vendors_registry.go
@@ -9,6 +9,7 @@ type VendorsRegistry struct {
 func NewVendorsRegistry() *VendorsRegistry {
 	r := &VendorsRegistry{}
 
+	r.Register(CreateGoldskyVendor())
 	r.Register(CreateAlchemyVendor())
 	r.Register(CreateBlastApiVendor())
 	r.Register(CreateConduitVendor())

--- a/typescript/config/lib/types/generic.d.ts
+++ b/typescript/config/lib/types/generic.d.ts
@@ -43,7 +43,7 @@ export type ConnectorConfig = {
 /**
  * Supported upstream type
  */
-export type UpstreamType = "evm" | "evm+alchemy" | "evm+blastapi" | "evm+conduit" | "evm+drpc" | "evm+dwellir" | "evm+envio" | "evm+etherspot" | "evm+infura" | "evm+pimlico" | "evm+quicknode" | "evm+llama" | "evm+thirdweb" | "evm+repository" | "evm+superchain" | "evm+chainstack" | "evm+tenderly" | "evm+onfinality" | "evm+erpc" | "evm+blockpi" | "evm+ankr" | "evm+routemesh";
+export type UpstreamType = "evm" | "evm+goldsky" | "evm+alchemy" | "evm+blastapi" | "evm+conduit" | "evm+drpc" | "evm+dwellir" | "evm+envio" | "evm+etherspot" | "evm+infura" | "evm+pimlico" | "evm+quicknode" | "evm+llama" | "evm+thirdweb" | "evm+repository" | "evm+superchain" | "evm+chainstack" | "evm+tenderly" | "evm+onfinality" | "evm+erpc" | "evm+blockpi" | "evm+ankr" | "evm+routemesh";
 /**
  * Supported auth type
  */

--- a/typescript/config/src/types/generic.ts
+++ b/typescript/config/src/types/generic.ts
@@ -87,6 +87,7 @@ import type {
    */
   export type UpstreamType =
     | "evm"
+    | "evm+goldsky"
     | "evm+alchemy"
     | "evm+blastapi"
     | "evm+conduit"


### PR DESCRIPTION
## What

Adds **Goldsky Edge** as a built-in vendor, so it can be configured with a single entry like the other built-in providers instead of going through the generic `erpc` provider.

[Goldsky Edge](https://docs.goldsky.com/edge-rpc/introduction) is a multi-region public RPC service built on eRPC. A single Edge secret token covers every chain it serves, and eRPC lazy-generates one upstream per network on first request.

## Usage

URL shorthand:

```yaml
projects:
  - id: main
    upstreams:
      - endpoint: goldsky://${GOLDSKY_EDGE_SECRET}
```

Or as an explicit provider:

```yaml
projects:
  - id: main
    providers:
      - vendor: goldsky
        settings:
          secret: ${GOLDSKY_EDGE_SECRET}
```

## How it works

- Generates `https://edge.goldsky.com/<tier>/evm/<chainId>?secret=<secret>` (`tier` defaults to `standard`). The secret may also be supplied via the `X-ERPC-Secret-Token` header on a preset endpoint.
- `SupportsNetwork` probes live `eth_chainId` (10s timeout) and confirms the returned chain id matches, so the configured secret authoritatively decides which chains are supported. Probe clients are cached per `"{url}-{chainId}"`.
- A missing `secret` makes `SupportsNetwork` return `(false, nil)` — a silent skip rather than a retrying error.
- `OwnsUpstream` matches the `goldsky://` / `evm+goldsky://` scheme, `vendorName == "goldsky"`, or any endpoint on `edge.goldsky.com`.

## Settings

| key | required | default |
|---|---|---|
| `secret` | yes (auth fails without it) | — |
| `tier` | no | `standard` |
| `endpoint` | no | `https://edge.goldsky.com` |

## Changes

- `thirdparty/goldsky.go` — new vendor, modeled on the existing `erpc` vendor.
- `thirdparty/vendors_registry.go` — register the vendor.
- `common/defaults.go` — `goldsky://<secret>[?tier=&secret=]` URL shorthand.
- `typescript/config` — add `evm+goldsky` to `UpstreamType` (source + generated `.d.ts`).
- `docs/.../providers.mdx` — catalog entry, shorthand row, and built-in vendor count.
- Tests for the URL builder, `OwnsUpstream`, and shorthand parsing.

The existing `erpc` vendor is left unchanged (chaining to arbitrary eRPC instances stays useful).

## Testing

```
go test ./thirdparty/ ./common/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New provider bootstrap path performs outbound `eth_chainId` probes (10s) and handles secrets in URLs; misconfiguration is mostly a silent skip, but probe latency affects first-request routing for new networks.
> 
> **Overview**
> Adds **Goldsky Edge** as a first-class vendor so one Edge secret can lazy-generate per-network upstreams (same pattern as Alchemy/dRPC), instead of routing through the generic `erpc` provider.
> 
> The new `GoldskyVendor` builds `https://edge.goldsky.com/<tier>/evm/<chainId>?secret=…` (defaults: `standard` tier, configurable `endpoint`), discovers chain support via a cached live `eth_chainId` probe (10s), and **silently skips** networks when no `secret` is configured. Config accepts `goldsky://<secret>[?tier=]` / `evm+goldsky://` shorthands via `buildProviderSettings`, registers the vendor in `VendorsRegistry`, and extends TypeScript `UpstreamType` with `evm+goldsky`. Docs bump the built-in vendor count to 23 and document settings and behavior. Unit tests cover URL building, shorthand parsing, `OwnsUpstream`, and no-probe skip paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38d5ca0fb88334c3431d022a73aaa6b818fc799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->