### PR TITLE
fix(evm): block availability gating enforces only configured bounds (#934)

### DIFF
--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1697,20 +1697,18 @@ func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req 
 	return evm.HandleUpstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
 }
 
-// upstreamHasBlockAvailabilityBounds reports whether the upstream has any
-// BlockAvailability bounds (lower or upper) configured. Presence of explicit
-// bounds is treated as the user's intent to enforce them when no higher-priority
-// explicit override has been set.
-func upstreamHasBlockAvailabilityBounds(u common.Upstream) bool {
-	if u == nil {
+// methodHasDedicatedRangeAvailabilityHook reports whether a method enforces its own
+// block availability via a dedicated pre-forward hook (CheckBlockRangeAvailability),
+// rather than the single-block path in checkUpstreamBlockAvailability. These are
+// range methods (fromBlock/toBlock) where gating on a single extracted block number
+// would be wrong and would conflict with the range-aware hook.
+func methodHasDedicatedRangeAvailabilityHook(method string) bool {
+	switch strings.ToLower(method) {
+	case "eth_getlogs", "trace_filter", "arbtrace_filter":
+		return true
+	default:
 		return false
 	}
-	cfg := u.Config()
-	if cfg == nil || cfg.Evm == nil || cfg.Evm.BlockAvailability == nil {
-		return false
-	}
-	ba := cfg.Evm.BlockAvailability
-	return ba.Lower != nil || ba.Upper != nil
 }
 
 // systemDefaultEnforceBlockAvailability returns the global system default for
@@ -1725,51 +1723,37 @@ func systemDefaultEnforceBlockAvailability(method string) *bool {
 	return nil
 }
 
-// resolveEnforceBlockAvailability resolves the effective enforcement flag for block availability.
-// Precedence (highest to lowest):
-//  1. Explicit method-level user override that differs from the system default
-//     (system defaults get merged into n.cfg.Methods.Definitions during config
-//     loading, so a method-level value that matches the system default is
-//     treated as not-an-override).
-//  2. Explicit network-level user override (network.cfg.Evm.EnforceBlockAvailability).
-//  3. Per-upstream BlockAvailability bounds — configured bounds are themselves
-//     an opt-in signal that overrides the method common default.
-//  4. System default for this method (DefaultWithBlockCacheMethods).
-//  5. Fallback: enabled.
-func (n *Network) resolveEnforceBlockAvailability(method string, u common.Upstream) bool {
+// blockAvailabilityExplicitlyDisabled reports whether the user explicitly turned
+// OFF block availability enforcement for this method, via a method-level or
+// network-level enforceBlockAvailability:false. It is the escape hatch that lets an
+// operator disable bound enforcement even on an upstream that has bounds configured.
+//
+// The method-level value is only treated as an override when it differs from the
+// system default, because MethodsConfig.SetDefaults() merges DefaultWithBlockCacheMethods
+// into Methods.Definitions at config load — so a value that matches the merged-in
+// default is not a real user override.
+func (n *Network) blockAvailabilityExplicitlyDisabled(method string) bool {
 	sysDefault := systemDefaultEnforceBlockAvailability(method)
-
-	// 1. Method-level user override (only when it differs from the system default).
-	//    The defaults loader merges DefaultWithBlockCacheMethods into Methods.Definitions,
-	//    so we cannot tell apart a user's explicit value from a merged-in default by
-	//    presence alone. Comparing values is the cleanest way to distinguish — and is
-	//    semantically harmless because a user explicitly setting the same value as the
-	//    default has the same intent as not setting it.
 	if n.cfg != nil && n.cfg.Methods != nil && n.cfg.Methods.Definitions != nil {
 		if mc, ok := n.cfg.Methods.Definitions[method]; ok && mc != nil && mc.EnforceBlockAvailability != nil {
 			if sysDefault == nil || *mc.EnforceBlockAvailability != *sysDefault {
-				return *mc.EnforceBlockAvailability
+				return !*mc.EnforceBlockAvailability
 			}
-			// Matches the system default — treat as not-an-override and fall through.
 		}
 	}
-	// 2. Explicit network-level user override
 	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.EnforceBlockAvailability != nil {
-		return *n.cfg.Evm.EnforceBlockAvailability
+		return !*n.cfg.Evm.EnforceBlockAvailability
 	}
-	// 3. Configured per-upstream bounds opt-in to enforcement, regardless of
-	//    method common defaults. This ensures that users who configure
-	//    BlockAvailability on an upstream actually get their bounds enforced
-	//    even for methods whose system default has it off (e.g. eth_getBlockByNumber).
-	if upstreamHasBlockAvailabilityBounds(u) {
-		return true
+	return false
+}
+
+// upstreamHeads returns the upstream's last-known latest and finalized block numbers,
+// or (0, 0) when the state poller is unavailable.
+func (n *Network) upstreamHeads(eu common.EvmUpstream) (latest int64, finalized int64) {
+	if sp := eu.EvmStatePoller(); sp != nil && !sp.IsObjectNull() {
+		return sp.LatestBlock(), sp.FinalizedBlock()
 	}
-	// 4. System default for this method
-	if sysDefault != nil {
-		return *sysDefault
-	}
-	// 5. Fallback: enabled
-	return true
+	return 0, 0
 }
 
 // handleBlockSkip records telemetry when a block availability check causes an upstream to be skipped,
@@ -1844,27 +1828,58 @@ func (n *Network) recordHedgeDiscard(
 	common.SetTraceSpanError(span, common.NewErrUpstreamHedgeCancelled(u.Id(), err))
 }
 
-// checkUpstreamBlockAvailability performs per-upstream gating for the request based on block availability.
-// It is invoked just before forwarding to an upstream to avoid copying/filtering the list.
-// Returns (nil, false) if upstream has the block available.
-// Returns (error, isRetryable) if block is not available:
-//   - isRetryable=true: block is just slightly ahead (within MaxRetryableBlockDistance), upstream may catch up
-//   - isRetryable=false: block is too far ahead or below lower bound, not worth retrying this upstream
+// checkUpstreamBlockAvailability performs per-upstream gating for the request based on
+// the upstream's configured block availability bounds. It is invoked just before
+// forwarding to an upstream to avoid copying/filtering the list.
 //
-// This is the single point of block-availability enforcement. It runs whenever
-// EnforceBlockAvailability resolves to true OR the upstream has explicit
-// BlockAvailability bounds configured (the user's signal that they want bounds
-// enforced regardless of per-method defaults).
+// Returns (nil, false) if the upstream is allowed to serve the block.
+// Returns (error, isRetryable) if the block is outside the configured range:
+//   - below the lower bound (pruned/historical) → not retryable
+//   - above the upper bound AND ahead of the live head within MaxRetryableBlockDistance → retryable
+//   - above the upper bound otherwise → not retryable
 //
-// FAIL-OPEN BEHAVIOR: If we cannot determine block availability (e.g., state poller issues),
-// we allow the request to proceed rather than blocking traffic.
+// SCOPE: this enforces ONLY the upstream's structural serving range — the configured
+// blockAvailability lower/upper bounds (which also cover the legacy
+// maxAvailableRecentBlocks via EvmBlockAvailabilityBounds). It deliberately does NOT
+// apply any implicit "blockNumber > latestBlock" head check. Tip-awareness — i.e.
+// "is this block past the chain head?" — is owned elsewhere:
+//   - served-tip short-circuits concrete future blocks beyond the network tip, and
+//   - integrity.enforceHighestBlock keeps "latest"/"finalized" tag responses honest.
+//
+// Coupling an implicit head check to this path raced with the state poller on fast
+// block-time chains and falsely rejected fresh blocks an upstream already had
+// (https://github.com/erpc/erpc/issues/934). Operators who want a node to serve only
+// blocks it has actually synced can express that explicitly as
+// blockAvailability.upper.latestBlockMinus: 0.
+//
+// FAIL-OPEN BEHAVIOR: If we cannot determine the bounds or block number (e.g. state
+// poller not ready), we allow the request to proceed rather than blocking traffic.
 func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool) {
 	if n.cfg.Architecture != common.ArchitectureEvm {
 		return nil, false
 	}
-	if !n.resolveEnforceBlockAvailability(method, u) {
+	// Range methods (eth_getLogs, trace_filter, arbtrace_filter) enforce block
+	// availability via their own range-aware pre-forward hooks; gating them here on a
+	// single extracted block number would conflict with that.
+	if methodHasDedicatedRangeAvailabilityHook(method) {
 		return nil, false
 	}
+	// Explicit method/network enforceBlockAvailability:false is an operator opt-out.
+	if n.blockAvailabilityExplicitlyDisabled(method) {
+		return nil, false
+	}
+	eu, ok := u.(common.EvmUpstream)
+	if !ok {
+		return nil, false
+	}
+	// Resolve the upstream's configured serving range (explicit blockAvailability
+	// lower/upper, or the legacy maxAvailableRecentBlocks lower bound). Unbounded on
+	// both sides means the upstream advertises no restriction → nothing to enforce.
+	minBound, maxBound := eu.EvmBlockAvailabilityBounds()
+	if minBound == math.MinInt64 && maxBound == math.MaxInt64 {
+		return nil, false
+	}
+
 	// Prefer the cached block number from normalization. Fall back to extracting
 	// from the request (defensive: handles paths that bypass json_rpc.go's
 	// normalization, and methods whose params haven't been pre-cached yet).
@@ -1883,48 +1898,36 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 		// If still unknown, skip gating (fail-open)
 		return nil, false
 	}
-	eu, ok := u.(common.EvmUpstream)
-	if !ok {
-		return nil, false
-	}
-	available, err := eu.EvmAssertBlockAvailability(ctx, method, common.AvailbilityConfidenceBlockHead, true, bn)
-	if err != nil {
-		// FAIL-OPEN: Error during availability check - allow the request to proceed
-		// This prevents blocking traffic due to state poller or detection issues
-		n.logger.Debug().
-			Err(err).
-			Str("upstreamId", u.Id()).
-			Int64("blockNumber", bn).
-			Str("method", method).
-			Msg("block availability check failed; failing open to allow request")
-		return nil, false
-	}
-	if !available {
-		// Get poller state for detailed error
-		var latestBlock, finalizedBlock int64
-		if sp := eu.EvmStatePoller(); sp != nil && !sp.IsObjectNull() {
-			latestBlock = sp.LatestBlock()
-			finalizedBlock = sp.FinalizedBlock()
-		}
 
-		blockErr := common.NewErrUpstreamBlockUnavailable(u.Id(), bn, latestBlock, finalizedBlock)
+	// Below the configured lower bound: the upstream genuinely cannot serve this
+	// historical block (e.g. pruned). Not retryable on this upstream.
+	if minBound != math.MinInt64 && bn < minBound {
+		telemetry.MetricUpstreamStaleLowerBound.WithLabelValues(
+			n.projectId, eu.VendorName(), n.Label(), eu.Id(), method, common.AvailbilityConfidenceBlockHead.String(),
+		).Inc()
+		latestBlock, finalizedBlock := n.upstreamHeads(eu)
+		return common.NewErrUpstreamBlockUnavailable(eu.Id(), bn, latestBlock, finalizedBlock), false
+	}
 
-		// Determine if this is retryable based on distance
-		// Upper bound issue (block ahead of latest): retryable if within max distance
-		// Lower bound issue (block too old): not retryable
+	// Above the configured upper bound. Classify retryability by distance to the live
+	// head: a block just ahead of the head (e.g. upper=latestBlockMinus:0) may become
+	// serveable shortly, so it is retryable within MaxRetryableBlockDistance.
+	if maxBound != math.MaxInt64 && bn > maxBound {
+		telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
+			n.projectId, eu.VendorName(), n.Label(), eu.Id(), method, common.AvailbilityConfidenceBlockHead.String(),
+		).Inc()
+		latestBlock, finalizedBlock := n.upstreamHeads(eu)
+		blockErr := common.NewErrUpstreamBlockUnavailable(eu.Id(), bn, latestBlock, finalizedBlock)
 		if bn > latestBlock && latestBlock > 0 {
-			distance := bn - latestBlock
 			maxDistance := int64(128) // default
 			if n.cfg.Evm != nil && n.cfg.Evm.MaxRetryableBlockDistance != nil {
 				maxDistance = *n.cfg.Evm.MaxRetryableBlockDistance
 			}
-			isRetryable := distance <= maxDistance
-			return blockErr, isRetryable
+			return blockErr, bn-latestBlock <= maxDistance
 		}
-
-		// Lower bound issue or unknown state - not retryable
 		return blockErr, false
 	}
+
 	return nil, false
 }
 

--- a/erpc/networks_availability_test.go
+++ b/erpc/networks_availability_test.go
@@ -1010,11 +1010,11 @@ func TestNetworkAvailability_Enforce_ConfiguredBounds_Override_DefaultFalse(t *t
 
 // Regression: MethodsConfig.SetDefaults() merges DefaultWithBlockCacheMethods
 // into the network's Methods.Definitions map at config load time. Before the
-// fix, resolveEnforceBlockAvailability treated any presence in that map as an
-// explicit user override and short-circuited the configured-bounds opt-in tier.
-// This test sets up the realistic shape (where the merged-in default for
-// eth_getBlockByNumber has EnforceBlockAvailability=false) and asserts that
-// configured per-upstream bounds still take effect.
+// fix, the enforcement resolver (resolveBlockAvailabilityEnforcement) treated any
+// presence in that map as an explicit user override and short-circuited the
+// configured-bounds opt-in tier. This test sets up the realistic shape (where the
+// merged-in default for eth_getBlockByNumber has EnforceBlockAvailability=false)
+// and asserts that configured per-upstream bounds still take effect.
 func TestNetworkAvailability_Enforce_MergedDefaults_DoNotMaskConfiguredBounds(t *testing.T) {
 	util.ResetGock()
 	defer util.ResetGock()
@@ -1156,7 +1156,10 @@ func TestNetworkAvailability_Enforce_NetworkFalse_Disables(t *testing.T) {
 	require.NoError(t, skipErr, "expected no skip error (allowed)")
 }
 
-// Test that ErrUpstreamBlockUnavailable is returned when block is beyond upstream's latest
+// Test that ErrUpstreamBlockUnavailable is returned when block is beyond upstream's latest.
+// Head-gating ("only serve blocks the node has actually synced") is now expressed
+// explicitly as blockAvailability.upper.latestBlockMinus:0 rather than being implied
+// by enforceBlockAvailability (issue #934).
 func TestCheckUpstreamBlockAvailability_BlockBeyondLatest_ReturnsRetryableError(t *testing.T) {
 	util.ResetGock()
 	defer util.ResetGock()
@@ -1173,6 +1176,10 @@ func TestCheckUpstreamBlockAvailability_BlockBeyondLatest_ReturnsRetryableError(
 			ChainId:             123,
 			StatePollerInterval: common.Duration(200 * time.Millisecond),
 			StatePollerDebounce: common.Duration(50 * time.Millisecond),
+			// Upper = latest: an explicit "serve only blocks up to the head" bound.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1241,6 +1248,11 @@ func TestCheckUpstreamBlockAvailability_SmallDistance_IsRetryable(t *testing.T) 
 			ChainId:             123,
 			StatePollerInterval: common.Duration(200 * time.Millisecond),
 			StatePollerDebounce: common.Duration(50 * time.Millisecond),
+			// Upper = latest: a block just ahead of the head is above this bound but
+			// within MaxRetryableBlockDistance, so the skip is retryable.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1333,6 +1345,11 @@ func TestCheckUpstreamBlockAvailability_ErrorHasCorrectDetails(t *testing.T) {
 			ChainId:             123,
 			StatePollerInterval: common.Duration(200 * time.Millisecond),
 			StatePollerDebounce: common.Duration(50 * time.Millisecond),
+			// Upper = latest, so a block beyond the head is rejected and the error
+			// carries the upstream's latest/finalized for diagnostics.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1415,6 +1432,11 @@ func TestRetryableBlockUnavailability_NoInfiniteLoop(t *testing.T) {
 			ChainId:             123,
 			StatePollerInterval: common.Duration(200 * time.Millisecond),
 			StatePollerDebounce: common.Duration(50 * time.Millisecond),
+			// Upper = latest makes a block just ahead of the head a retryable skip,
+			// which is the condition this test exercises for the no-spin guarantee.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1525,11 +1547,11 @@ func TestHandleBlockSkip_RetryableTriggersStatePollerRefresh(t *testing.T) {
 			count := latestPollCount.Add(1)
 			bl := pollBaseline.Load()
 			sinceBaseline := count - bl
-			// Before baseline is set (bl==0) or the first poll after baseline
-			// (EvmAssertBlockAvailability): return old block 0x11118888.
-			// Subsequent polls (handleBlockSkip async): return new block 0x11118889.
+			// Bounds-only gating no longer force-polls synchronously, so the first
+			// poll after baseline is handleBlockSkip's async refresh — it must observe
+			// the newer block so we can prove the refresh fired.
 			bn := "0x11118888"
-			if bl > 0 && sinceBaseline > 1 {
+			if bl > 0 && sinceBaseline >= 1 {
 				bn = "0x11118889"
 			}
 			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":{"number":"%s","timestamp":"0x6702a8f0"}}`, bn)
@@ -1560,6 +1582,10 @@ func TestHandleBlockSkip_RetryableTriggersStatePollerRefresh(t *testing.T) {
 			ChainId:             123,
 			StatePollerInterval: common.Duration(120 * time.Second),
 			StatePollerDebounce: common.Duration(1 * time.Nanosecond), // Near-zero debounce so every PollLatestBlockNumber fires (0 is overridden to 5s by defaults)
+			// Upper = latest turns "block just ahead of the head" into a retryable skip.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1614,9 +1640,10 @@ func TestHandleBlockSkip_RetryableTriggersStatePollerRefresh(t *testing.T) {
 
 	afterPolls := latestPollCount.Load()
 	delta := afterPolls - pollBaseline.Load()
-	// EvmAssertBlockAvailability fires 1 synchronous poll + handleBlockSkip fires 1 async poll = 2
-	require.GreaterOrEqual(t, delta, int64(2),
-		"retryable block skip should trigger at least 2 polls after baseline (availability check + async refresh); delta=%d", delta)
+	// Bounds-only gating no longer force-polls synchronously; handleBlockSkip fires
+	// at least the async refresh poll for a retryable skip.
+	require.GreaterOrEqual(t, delta, int64(1),
+		"retryable block skip should trigger at least 1 async refresh poll after baseline; delta=%d", delta)
 
 	// The async poll returned 0x11118889 → state poller should have updated
 	ups, upsErr := upr.GetSortedUpstreams(ctx, util.EvmNetworkId(123), "eth_getBalance")
@@ -1690,6 +1717,10 @@ func TestHandleBlockSkip_NonRetryableDoesNotTriggerRefresh(t *testing.T) {
 			ChainId:             123,
 			StatePollerInterval: common.Duration(120 * time.Second),
 			StatePollerDebounce: common.Duration(1 * time.Nanosecond),
+			// Upper = latest; a block far beyond the head is a non-retryable skip.
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)},
+			},
 		},
 	}
 
@@ -1745,9 +1776,10 @@ func TestHandleBlockSkip_NonRetryableDoesNotTriggerRefresh(t *testing.T) {
 
 	afterPolls := latestPollCount.Load()
 	delta := afterPolls - pollBaseline.Load()
-	// Without handleBlockSkip's async poll: only EvmAssertBlockAvailability fires 1 poll
-	require.Equal(t, int64(1), delta,
-		"non-retryable block skip should trigger exactly 1 poll after baseline (availability check only); delta=%d", delta)
+	// Bounds-only gating does not force-poll, and a non-retryable skip fires no async
+	// refresh, so no poll happens after baseline.
+	require.Equal(t, int64(0), delta,
+		"non-retryable block skip should trigger no polls after baseline; delta=%d", delta)
 
 	// The state poller should still report the old block (no async refresh happened)
 	ups, upsErr := upr.GetSortedUpstreams(ctx, util.EvmNetworkId(123), "eth_getBalance")

--- a/erpc/networks_availability_upper_race_test.go
+++ b/erpc/networks_availability_upper_race_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/erpc/erpc/util"
 	"github.com/h2non/gock"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -544,4 +545,152 @@ func TestNetworkAvailability_Issue934_RangeMethod_DeferredToHook(t *testing.T) {
 	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getLogs")
 	require.NoError(t, skipErr,
 		"eth_getLogs is gated by its dedicated range hook, not by checkUpstreamBlockAvailability")
+}
+
+// mockIssue934Node mocks the EVM state-poller endpoints for one node plus the
+// concrete fresh block. The poller's "latest" reflects a STALE tip, while the node
+// would happily serve the fresh block if the request reaches it.
+func mockIssue934Node(endpoint, chainIDHex, staleTipHex, finalizedHex, freshBlockHex string) {
+	gock.New(endpoint).Post("").Persist().
+		Filter(func(r *http.Request) bool { return strings.Contains(util.SafeReadBody(r), "eth_chainId") }).
+		Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"` + chainIDHex + `"}`))
+	gock.New(endpoint).Post("").Persist().
+		Filter(func(r *http.Request) bool { return strings.Contains(util.SafeReadBody(r), "eth_syncing") }).
+		Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":false}`))
+	gock.New(endpoint).Post("").Persist().
+		Filter(func(r *http.Request) bool {
+			b := util.SafeReadBody(r)
+			return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, "latest")
+		}).
+		Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + staleTipHex + `","hash":"0xaaa","timestamp":"0x6702a8f0"}}`))
+	gock.New(endpoint).Post("").Persist().
+		Filter(func(r *http.Request) bool {
+			b := util.SafeReadBody(r)
+			return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, "finalized")
+		}).
+		Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + finalizedHex + `","hash":"0xbbb","timestamp":"0x6702a8e0"}}`))
+	gock.New(endpoint).Post("").Persist().
+		Filter(func(r *http.Request) bool {
+			b := util.SafeReadBody(r)
+			return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, freshBlockHex)
+		}).
+		Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + freshBlockHex + `","hash":"0xfresh","timestamp":"0x6702a900"}}`))
+}
+
+// TestNetworkAvailability_Issue934_ExactConfigFromYAML_ServesFreshBlock is the
+// definitive end-to-end check: it loads the issue's LITERAL erpc.yaml through the
+// real config pipeline (LoadConfig → SetDefaults, which merges upstreamDefaults),
+// asserts the resolved upstream config is lower-only (no synthesized upper), then
+// builds a real Network from the resolved configs and verifies that a block one
+// ahead of the stale poller tip — the exact scenario in the report — is SERVED
+// rather than rejected with ErrUpstreamBlockUnavailable.
+func TestNetworkAvailability_Issue934_ExactConfigFromYAML_ServesFreshBlock(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The exact config from https://github.com/erpc/erpc/issues/934
+	const yamlCfg = `
+logLevel: debug
+projects:
+  - id: my-chain
+    upstreamDefaults:
+      evm:
+        chainId: 5042002
+        statePollerDebounce: 250ms
+    upstreams:
+      - endpoint: http://node-1:8545
+        id: node-1
+        evm:
+          blockAvailability:
+            lower:
+              latestBlockMinus: 237600
+      - endpoint: http://node-2:8545
+        id: node-2
+        evm:
+          blockAvailability:
+            lower:
+              latestBlockMinus: 237600
+`
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "erpc.yaml", []byte(yamlCfg), 0644))
+	cfg, err := common.LoadConfig(fs, "erpc.yaml", &common.DefaultOptions{})
+	require.NoError(t, err, "issue #934 config must load and validate")
+
+	// --- Config-side: the literal YAML must resolve to a lower-only bound ---
+	require.Len(t, cfg.Projects, 1)
+	upCfgs := cfg.Projects[0].Upstreams
+	require.Len(t, upCfgs, 2)
+	for _, u := range upCfgs {
+		require.NotNil(t, u.Evm.BlockAvailability, "blockAvailability must be parsed for %s", u.Id)
+		require.NotNil(t, u.Evm.BlockAvailability.Lower, "lower bound must be present for %s", u.Id)
+		require.NotNil(t, u.Evm.BlockAvailability.Lower.LatestBlockMinus)
+		require.Equal(t, int64(237600), *u.Evm.BlockAvailability.Lower.LatestBlockMinus)
+		require.Nil(t, u.Evm.BlockAvailability.Upper,
+			"a lower-only config must NOT synthesize an upper bound (issue #934)")
+	}
+
+	// --- Behavioral: build a real network from the resolved configs and serve ---
+	const chainID = int64(5042002)
+	const chainIDHex = "0x4cef52" // 5042002
+	const staleTip = int64(0x4c4b40) // 5,000,000
+	const finalizedHex = "0x4c4b30"  // staleTip - 16
+	const freshBlockHex = "0x4c4b41" // staleTip + 1 (the block the client saw via newHeads)
+	staleTipHex := fmt.Sprintf("0x%x", staleTip)
+	for _, u := range upCfgs {
+		mockIssue934Node(u.Endpoint, chainIDHex, staleTipHex, finalizedHex, freshBlockHex)
+	}
+
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	mt := health.NewTracker(&log.Logger, "my-chain", 2*time.Second)
+	vr := thirdparty.NewVendorsRegistry()
+	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
+	sharedStateCfg := &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+		LockMaxWait:     common.Duration(200 * time.Millisecond),
+		UpdateMaxWait:   common.Duration(200 * time.Millisecond),
+		FallbackTimeout: common.Duration(3 * time.Second),
+		LockTtl:         common.Duration(4 * time.Second),
+	}
+	sharedStateCfg.SetDefaults("test")
+	ssr, _ := data.NewSharedStateRegistry(ctx, &log.Logger, sharedStateCfg)
+	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "my-chain", upCfgs, ssr, rlr, vr, pr, nil, mt, nil)
+	upr.Bootstrap(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: chainID}}
+	network, err := NewNetwork(ctx, &log.Logger, "my-chain", ntwCfg, rlr, upr, mt, nil)
+	require.NoError(t, err)
+	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(chainID)))
+	require.NoError(t, network.Bootstrap(ctx))
+	network.PinUpstreamOrderForTest()
+
+	// Wait for both pollers to settle on the stale tip via real HTTP polling.
+	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(chainID))
+	require.Len(t, ups, 2)
+	for _, u := range ups {
+		uu := u
+		require.Eventually(t, func() bool { return uu.EvmStatePoller().LatestBlock() == staleTip }, 3*time.Second, 25*time.Millisecond,
+			"poller for %s should settle on stale tip", u.Id())
+	}
+
+	// The client already saw freshBlock via newHeads; request it through eRPC while the
+	// poller is still a block behind. It must be served, not rejected.
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["` + freshBlockHex + `",false]}`))
+	req.SetNetwork(network)
+
+	resp, err := network.Forward(ctx, req)
+	require.NoError(t, err,
+		"issue #934: with the literal config, a block one ahead of the stale poller tip must be served (the upstream has it)")
+	require.NotNil(t, resp)
+	jrr, jerr := resp.JsonRpcResponse(ctx)
+	require.NoError(t, jerr)
+	require.Contains(t, jrr.GetResultString(), "0xfresh", "the fresh block must be served from the upstream")
+	resp.Release()
 }

--- a/erpc/networks_availability_upper_race_test.go
+++ b/erpc/networks_availability_upper_race_test.go
@@ -1,0 +1,547 @@
+package erpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/thirdparty"
+	"github.com/erpc/erpc/upstream"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// Reproduction for https://github.com/erpc/erpc/issues/934
+//
+// Block availability gating used to apply an implicit upper-bound check
+// (blockNumber > latestBlock) for ANY upstream that had block availability
+// bounds configured — so configuring only `blockAvailability.lower` (for
+// pruned-node protection) silently also enabled an upper/head check.
+//
+// On fast block-time chains a client that learned about block N via a direct
+// `eth_subscribe newHeads` subscription requests block N through eRPC before
+// the per-upstream state poller (HTTP `eth_getBlockByNumber("latest")`) has
+// caught up. The poller still reports latestBlock = N-1, so the implicit
+// upper-bound check rejected the request with ErrUpstreamBlockUnavailable even
+// though the upstream actually has block N — and even though the user only
+// configured a lower bound, never an upper bound.
+//
+// The fix makes block availability gating enforce ONLY the upstream's
+// explicitly-configured bounds (lower/upper). Tip-awareness ("is this block
+// past the chain head?") is owned by served-tip and integrity.enforceHighestBlock,
+// not by this path. Operators who want head gating can opt in explicitly with
+// `blockAvailability.upper.latestBlockMinus: 0`.
+//
+// These tests use real Network / Upstream / EvmStatePoller objects; only the
+// upstream HTTP endpoint is mocked (via gock). The state poller settles on the
+// stale tip through real HTTP polling — SuggestLatestBlock is deliberately NOT
+// used so the race is reproduced faithfully.
+// ----------------------------------------------------------------------------
+
+// lowerOnlyRaceFixture configures one upstream for the reproduction.
+type lowerOnlyRaceFixture struct {
+	id       string // also used as the host: http://<id>.localhost
+	staleTip int64  // what the poller's eth_getBlockByNumber("latest") returns
+}
+
+// setupLowerOnlyRaceNetwork builds a Network whose upstreams:
+//   - are configured with ONLY blockAvailability.lower (latestBlockMinus), like
+//     the issue's config — no upper bound;
+//   - have their state poller settle on `staleTip` via real HTTP polling;
+//   - will happily serve eth_getBlockByNumber(freshBlock) if the request ever
+//     reaches them (freshBlock = staleTip+1, the block the client already saw
+//     via newHeads).
+//
+// freshBlockHex is the lowercase hex of the block the client requests.
+func setupLowerOnlyRaceNetwork(t *testing.T, ctx context.Context, fixtures []lowerOnlyRaceFixture, freshBlockHex string) (*Network, []*upstream.Upstream) {
+	t.Helper()
+
+	const latestMinus = int64(237600) // mirrors the issue config
+
+	upCfgs := make([]*common.UpstreamConfig, 0, len(fixtures))
+	for _, f := range fixtures {
+		endpoint := "http://" + f.id + ".localhost"
+		staleTipHex := fmt.Sprintf("0x%x", f.staleTip)
+		finalizedHex := fmt.Sprintf("0x%x", f.staleTip-16)
+
+		// eth_chainId
+		gock.New(endpoint).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_chainId")
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x7b"}`))
+
+		// eth_syncing
+		gock.New(endpoint).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "eth_syncing")
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":false}`))
+
+		// eth_getBlockByNumber("latest") -> STALE tip (the poller is behind the
+		// real chain head, exactly like a node that just produced N but whose
+		// HTTP "latest" hasn't reflected it within the debounce window yet).
+		gock.New(endpoint).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBlockByNumber") && strings.Contains(body, "latest")
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + staleTipHex + `","hash":"0xaaa","timestamp":"0x6702a8f0"}}`))
+
+		// eth_getBlockByNumber("finalized")
+		gock.New(endpoint).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBlockByNumber") && strings.Contains(body, "finalized")
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + finalizedHex + `","hash":"0xbbb","timestamp":"0x6702a8e0"}}`))
+
+		// eth_getBlockByNumber(freshBlock) -> the upstream DOES have it. If the
+		// implicit upper-bound check wrongly rejects the request, this mock is
+		// never consumed.
+		gock.New(endpoint).Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				body := util.SafeReadBody(r)
+				return strings.Contains(body, "eth_getBlockByNumber") && strings.Contains(body, freshBlockHex)
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"` + freshBlockHex + `","hash":"0xfresh","timestamp":"0x6702a900"}}`))
+
+		upCfgs = append(upCfgs, &common.UpstreamConfig{
+			Id:       f.id,
+			Type:     common.UpstreamTypeEvm,
+			Endpoint: endpoint,
+			Evm: &common.EvmUpstreamConfig{
+				ChainId:             123,
+				StatePollerInterval: common.Duration(200 * time.Millisecond),
+				StatePollerDebounce: common.Duration(250 * time.Millisecond), // mirrors the issue config
+				BlockAvailability: &common.EvmBlockAvailabilityConfig{
+					// ONLY a lower bound — no upper bound, like the issue config.
+					Lower: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(latestMinus)},
+				},
+			},
+		})
+	}
+
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
+	vr := thirdparty.NewVendorsRegistry()
+	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
+
+	sharedStateCfg := &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+		LockMaxWait:     common.Duration(200 * time.Millisecond),
+		UpdateMaxWait:   common.Duration(200 * time.Millisecond),
+		FallbackTimeout: common.Duration(3 * time.Second),
+		LockTtl:         common.Duration(4 * time.Second),
+	}
+	sharedStateCfg.SetDefaults("test")
+	ssr, _ := data.NewSharedStateRegistry(ctx, &log.Logger, sharedStateCfg)
+	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "prjA", upCfgs, ssr, rlr, vr, pr, nil, mt, nil)
+	upr.Bootstrap(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	// Network has NO enforceBlockAvailability override and NO served-tip config:
+	// enforcement is opted into solely by the per-upstream lower bound, exactly
+	// like the issue's config.
+	ntwCfg := &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
+	network, err := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt, nil)
+	require.NoError(t, err)
+	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
+	require.NoError(t, network.Bootstrap(ctx))
+	network.PinUpstreamOrderForTest()
+
+	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))
+	require.Len(t, ups, len(fixtures))
+
+	// Wait for each poller to settle on the stale tip via REAL HTTP polling.
+	for _, f := range fixtures {
+		var u *upstream.Upstream
+		for _, candidate := range ups {
+			if candidate.Id() == f.id {
+				u = candidate
+				break
+			}
+		}
+		require.NotNil(t, u, "fixture %q not found", f.id)
+		require.Eventually(t, func() bool {
+			return u.EvmStatePoller().LatestBlock() == f.staleTip
+		}, 3*time.Second, 25*time.Millisecond,
+			"poller for %q should settle on stale tip %d (got %d)", f.id, f.staleTip, u.EvmStatePoller().LatestBlock())
+	}
+
+	return network, ups
+}
+
+// TestNetworkAvailability_Issue934_LowerOnly_FreshBlockAboveStaleTip_Forward is
+// the end-to-end reproduction: a request for the block the client just saw via
+// newHeads (one block above the poller's stale tip) must be served, because the
+// upstream has it and the user configured ONLY a lower bound.
+//
+// On current (buggy) code the implicit upper-bound check rejects the request on
+// every upstream and Forward returns ErrUpstreamsExhausted (wrapping
+// ErrUpstreamBlockUnavailable) without ever querying the upstream for the block.
+func TestNetworkAvailability_Issue934_LowerOnly_FreshBlockAboveStaleTip_Forward(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const staleTip = int64(0x1e8480) // 2,000,000
+	const freshBlockHex = "0x1e8481" // 2,000,001 == staleTip + 1
+	network, _ := setupLowerOnlyRaceNetwork(t, ctx, []lowerOnlyRaceFixture{
+		{id: "rpc1", staleTip: staleTip},
+		{id: "rpc2", staleTip: staleTip},
+	}, freshBlockHex)
+
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["` + freshBlockHex + `",false]}`))
+	req.SetNetwork(network)
+
+	resp, err := network.Forward(ctx, req)
+
+	require.NoError(t, err,
+		"issue #934: a lower-only blockAvailability config must not enable the implicit "+
+			"upper-bound check; block %s is within the lower bound and the co-located upstream "+
+			"already has it (client saw it via newHeads), so it must be served instead of rejected", freshBlockHex)
+	require.NotNil(t, resp)
+	jrr, jerr := resp.JsonRpcResponse(ctx)
+	require.NoError(t, jerr)
+	require.Contains(t, jrr.GetResultString(), "0xfresh",
+		"expected the upstream to actually serve the fresh block")
+	resp.Release()
+}
+
+// TestNetworkAvailability_Issue934_LowerOnly_DoesNotTriggerImplicitUpperBound_Direct
+// pins the exact gating decision in isolation (no retries/hedging), mirroring the
+// style of the existing direct checkUpstreamBlockAvailability tests.
+func TestNetworkAvailability_Issue934_LowerOnly_DoesNotTriggerImplicitUpperBound_Direct(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const staleTip = int64(0x1e8480)
+	const freshBlock = int64(0x1e8481)
+	const freshBlockHex = "0x1e8481"
+	network, ups := setupLowerOnlyRaceNetwork(t, ctx, []lowerOnlyRaceFixture{
+		{id: "rpc1", staleTip: staleTip},
+	}, freshBlockHex)
+
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["` + freshBlockHex + `",false]}`))
+	req.SetNetwork(network)
+	req.SetEvmBlockNumber(freshBlock)
+
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups[0], req, "eth_getBlockByNumber")
+	require.NoError(t, skipErr,
+		"issue #934: lower-only config must not reject block %d (one above the stale poller tip %d) "+
+			"via the implicit upper-bound check", freshBlock, staleTip)
+}
+
+// TestNetworkAvailability_Issue934_LowerBound_StillEnforced is the guardrail:
+// the fix must NOT throw away pruned-node protection. A request for a block
+// below the configured lower bound must still be skipped (non-retryable).
+func TestNetworkAvailability_Issue934_LowerBound_StillEnforced(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const staleTip = int64(0x1e8480) // 2,000,000
+	const freshBlockHex = "0x1e8481"
+	network, ups := setupLowerOnlyRaceNetwork(t, ctx, []lowerOnlyRaceFixture{
+		{id: "rpc1", staleTip: staleTip},
+	}, freshBlockHex)
+
+	// lower bound = staleTip - 237600 = 1,762,400. Request a much older block.
+	const oldBlock = int64(1000)
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x3e8",false]}`))
+	req.SetNetwork(network)
+	req.SetEvmBlockNumber(oldBlock)
+
+	skipErr, isRetryable := network.checkUpstreamBlockAvailability(ctx, ups[0], req, "eth_getBlockByNumber")
+	require.Error(t, skipErr, "block below the configured lower bound must still be skipped (pruned-node protection)")
+	require.True(t, common.HasErrorCode(skipErr, common.ErrCodeUpstreamBlockUnavailable),
+		"expected ErrUpstreamBlockUnavailable, got: %v", skipErr)
+	require.False(t, isRetryable, "below lower bound is not retryable")
+}
+
+// ----------------------------------------------------------------------------
+// Direct coverage of the bounds-only gating semantics introduced for issue #934.
+//
+// These call checkUpstreamBlockAvailability directly (no Forward/retry/hedging) and
+// rely on SetupMocksForEvmStatePoller, which makes rpc1 settle on latest tip
+// 0x11118888. Block numbers below are expressed relative to that tip.
+// ----------------------------------------------------------------------------
+
+const issue934MockTip = int64(0x11118888) // latest tip from SetupMocksForEvmStatePoller (rpc1)
+
+// setupDirectAvailabilityNetwork builds a single "rpc1" EVM upstream with the given
+// per-upstream EVM config and network config, then waits for its state poller to
+// settle on the SetupMocksForEvmStatePoller tip. The caller must have already called
+// util.SetupMocksForEvmStatePoller(). chainId and sane poller intervals are filled in
+// when unset.
+func setupDirectAvailabilityNetwork(t *testing.T, ctx context.Context, upEvm *common.EvmUpstreamConfig, ntwCfg *common.NetworkConfig) (*Network, *upstream.Upstream) {
+	t.Helper()
+
+	upEvm.ChainId = 123
+	if upEvm.StatePollerInterval == 0 {
+		upEvm.StatePollerInterval = common.Duration(200 * time.Millisecond)
+	}
+	if upEvm.StatePollerDebounce == 0 {
+		upEvm.StatePollerDebounce = common.Duration(50 * time.Millisecond)
+	}
+	upCfg := &common.UpstreamConfig{
+		Id:       "rpc1",
+		Type:     common.UpstreamTypeEvm,
+		Endpoint: "http://rpc1.localhost",
+		Evm:      upEvm,
+	}
+
+	rlr, _ := upstream.NewRateLimitersRegistry(context.Background(), &common.RateLimiterConfig{}, &log.Logger)
+	mt := health.NewTracker(&log.Logger, "prjA", 2*time.Second)
+	vr := thirdparty.NewVendorsRegistry()
+	pr, _ := thirdparty.NewProvidersRegistry(&log.Logger, vr, nil, nil)
+	sharedStateCfg := &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+		LockMaxWait:     common.Duration(200 * time.Millisecond),
+		UpdateMaxWait:   common.Duration(200 * time.Millisecond),
+		FallbackTimeout: common.Duration(3 * time.Second),
+		LockTtl:         common.Duration(4 * time.Second),
+	}
+	sharedStateCfg.SetDefaults("test")
+	ssr, _ := data.NewSharedStateRegistry(ctx, &log.Logger, sharedStateCfg)
+	upr := upstream.NewUpstreamsRegistry(ctx, &log.Logger, "prjA", []*common.UpstreamConfig{upCfg}, ssr, rlr, vr, pr, nil, mt, nil)
+	upr.Bootstrap(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	if ntwCfg == nil {
+		ntwCfg = &common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123}}
+	}
+	network, err := NewNetwork(ctx, &log.Logger, "prjA", ntwCfg, rlr, upr, mt, nil)
+	require.NoError(t, err)
+	require.NoError(t, upr.PrepareUpstreamsForNetwork(ctx, util.EvmNetworkId(123)))
+	require.NoError(t, network.Bootstrap(ctx))
+	network.PinUpstreamOrderForTest()
+
+	ups := upr.GetNetworkUpstreams(ctx, util.EvmNetworkId(123))[0]
+	require.Eventually(t, func() bool {
+		return ups.EvmStatePoller().LatestBlock() == issue934MockTip
+	}, 3*time.Second, 25*time.Millisecond, "poller should settle on the mock tip")
+	return network, ups
+}
+
+// balanceReqAt builds an eth_getBalance request pinned to a concrete block number.
+func balanceReqAt(network *Network, blockHex string, bn int64) *common.NormalizedRequest {
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x0000000000000000000000000000000000000000","` + blockHex + `"]}`))
+	req.SetNetwork(network)
+	req.SetEvmBlockNumber(bn)
+	return req
+}
+
+// (1) The core behavior change: an upstream with NO configured bounds must NOT be
+// gated by an implicit head check, even when enforceBlockAvailability is true at the
+// network level. The block being ahead of the poller tip is irrelevant — head/tip
+// awareness is owned by served-tip + enforceHighestBlock, not this path.
+func TestNetworkAvailability_Issue934_NoBounds_EnforceTrue_AboveTip_Allowed(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{}, // no blockAvailability bounds at all
+		&common.NetworkConfig{Architecture: common.ArchitectureEvm, Evm: &common.EvmNetworkConfig{ChainId: 123, EnforceBlockAvailability: b(true)}},
+	)
+
+	req := balanceReqAt(network, "0x111188ba", issue934MockTip+50) // 50 blocks ahead of tip
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBalance")
+	require.NoError(t, skipErr,
+		"an upstream with no configured bounds must not be head-gated, even with enforceBlockAvailability:true (issue #934)")
+}
+
+// (2) An explicit upper cap (latestBlockMinus:5) is a real structural bound: a block
+// above the cap but still at/below the live head must be rejected (non-retryable,
+// since waiting will not help), while a block at/below the cap is served.
+func TestNetworkAvailability_Issue934_ExplicitUpperCap_BelowHead_Enforced(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(5)}, // cap = tip-5
+			},
+		}, nil,
+	)
+
+	// tip-2 (0x11118886) is above the cap (tip-5) but at/below the head → reject, not retryable.
+	above := balanceReqAt(network, "0x11118886", issue934MockTip-2)
+	skipErr, retryable := network.checkUpstreamBlockAvailability(ctx, ups, above, "eth_getBalance")
+	require.Error(t, skipErr, "block above the configured upper cap must be skipped")
+	require.True(t, common.HasErrorCode(skipErr, common.ErrCodeUpstreamBlockUnavailable))
+	require.False(t, retryable, "above the cap but not ahead of the live head → not retryable")
+
+	// tip-8 (0x11118880) is at/below the cap → served.
+	below := balanceReqAt(network, "0x11118880", issue934MockTip-8)
+	skipErr2, _ := network.checkUpstreamBlockAvailability(ctx, ups, below, "eth_getBalance")
+	require.NoError(t, skipErr2, "block within the configured upper cap must be served")
+}
+
+// (3) The migration path / opt-in head gating: blockAvailability.upper.latestBlockMinus:0
+// reproduces the old "serve only blocks the node has actually synced" behavior. At the
+// head is allowed; one block ahead is a retryable skip; far ahead is non-retryable.
+func TestNetworkAvailability_Issue934_UpperLatestMinusZero_OptInHeadGating(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(0)}, // cap = tip
+			},
+		}, nil,
+	)
+
+	// at the head → allowed
+	atHead := balanceReqAt(network, "0x11118888", issue934MockTip)
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, atHead, "eth_getBalance")
+	require.NoError(t, skipErr, "a block at the head is within upper=latestBlockMinus:0 and must be served")
+
+	// one block ahead → retryable skip
+	ahead := balanceReqAt(network, "0x11118889", issue934MockTip+1)
+	skipErr2, retryable2 := network.checkUpstreamBlockAvailability(ctx, ups, ahead, "eth_getBalance")
+	require.Error(t, skipErr2)
+	require.True(t, common.HasErrorCode(skipErr2, common.ErrCodeUpstreamBlockUnavailable))
+	require.True(t, retryable2, "one block ahead of the head is retryable (node may catch up)")
+
+	// far ahead (> MaxRetryableBlockDistance) → non-retryable
+	farAhead := balanceReqAt(network, "0x11119999", issue934MockTip+0x1111)
+	skipErr3, retryable3 := network.checkUpstreamBlockAvailability(ctx, ups, farAhead, "eth_getBalance")
+	require.Error(t, skipErr3)
+	require.False(t, retryable3, "far ahead of the head (> MaxRetryableBlockDistance) is not retryable")
+}
+
+// (4) An explicit method-level enforceBlockAvailability:false is an operator opt-out
+// that disables bound enforcement even on an upstream that has bounds configured.
+func TestNetworkAvailability_Issue934_MethodLevelEnforceFalse_DisablesBounds(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// eth_getBalance has no system default for EnforceBlockAvailability, so a
+	// method-level false is a genuine user override (disables enforcement).
+	ntwCfg := &common.NetworkConfig{
+		Architecture: common.ArchitectureEvm,
+		Evm:          &common.EvmNetworkConfig{ChainId: 123},
+		Methods: &common.MethodsConfig{Definitions: map[string]*common.CacheMethodConfig{
+			"eth_getBalance": {EnforceBlockAvailability: b(false)},
+		}},
+	}
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Lower: &common.EvmAvailabilityBoundConfig{ExactBlock: i64(100)},
+			},
+		}, ntwCfg,
+	)
+
+	// Block 50 is below the configured lower bound, but the method-level opt-out
+	// disables enforcement → allowed.
+	req := balanceReqAt(network, "0x32", 50)
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBalance")
+	require.NoError(t, skipErr,
+		"method-level enforceBlockAvailability:false must disable bound enforcement even with bounds configured")
+}
+
+// (5) A configured upper bound that sits ABOVE the head must not reactivate the head
+// race: a block just ahead of the stale poller tip but inside the [lower, upper]
+// window is served. This is the issue #934 scenario with a window rather than
+// lower-only.
+func TestNetworkAvailability_Issue934_Window_AboveTipWithinWindow_Allowed(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Lower: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: i64(237600)},
+				Upper: &common.EvmAvailabilityBoundConfig{ExactBlock: i64(issue934MockTip + 1000)}, // upper well above the head
+			},
+		}, nil,
+	)
+
+	// tip+1 is above the stale poller tip but well within [tip-237600, tip+1000].
+	req := balanceReqAt(network, "0x11118889", issue934MockTip+1)
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getBalance")
+	require.NoError(t, skipErr,
+		"a configured upper bound above the head must not reintroduce the implicit head race (issue #934)")
+}
+
+// (6) Range methods (eth_getLogs, trace_filter, arbtrace_filter) are gated by their
+// dedicated range-aware pre-forward hooks, not by checkUpstreamBlockAvailability's
+// single-block path. Even with bounds configured and a clearly out-of-range block,
+// this path must defer to the hook (return no skip).
+func TestNetworkAvailability_Issue934_RangeMethod_DeferredToHook(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupDirectAvailabilityNetwork(t, ctx,
+		&common.EvmUpstreamConfig{
+			BlockAvailability: &common.EvmBlockAvailabilityConfig{
+				Lower: &common.EvmAvailabilityBoundConfig{ExactBlock: i64(1_000_000)},
+			},
+		}, nil,
+	)
+
+	// fromBlock 0x1 is far below the lower bound; a single-block gate would skip it,
+	// but eth_getLogs must be deferred to the block-range hook here.
+	req := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0x2","address":"0x0000000000000000000000000000000000000000"}]}`))
+	req.SetNetwork(network)
+
+	skipErr, _ := network.checkUpstreamBlockAvailability(ctx, ups, req, "eth_getLogs")
+	require.NoError(t, skipErr,
+		"eth_getLogs is gated by its dedicated range hook, not by checkUpstreamBlockAvailability")
+}

--- a/erpc/networks_availability_upper_race_test.go
+++ b/erpc/networks_availability_upper_race_test.go
@@ -694,3 +694,67 @@ projects:
 	require.Contains(t, jrr.GetResultString(), "0xfresh", "the fresh block must be served from the upstream")
 	resp.Release()
 }
+
+// TestNetworkAvailability_Issue934_ArcSyncFlow_CustomMethodAndFreshBlock mirrors the
+// real Arc rpc-sync use case (from the issue discussion): on each new head the client
+// immediately calls eth_getBlockByNumber(N) AND a custom consensus method,
+// arc_getCertificate, for the just-produced block — through eRPC, against upstreams
+// configured lower-only while the state poller is still a block behind.
+//
+// eth_getBlockByNumber(N) must be served (issue #934). arc_getCertificate is a custom
+// method: eRPC cannot extract a block reference for it (it is in none of the cache-method
+// maps), so block-availability gating fails open and the request is forwarded — i.e. it
+// is never constrained by the state poller. This test grounds both in reality.
+//
+// Note: eRPC does not provide the newHeads websocket subscription itself (the ws upstream
+// client is unimplemented and the server is request/response only), so — as in the issue
+// — the client subscribes to newHeads directly on a node and uses eRPC for the follow-up
+// JSON-RPC calls.
+func TestNetworkAvailability_Issue934_ArcSyncFlow_CustomMethodAndFreshBlock(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const staleTip = int64(0x1e8480) // 2,000,000
+	const freshBlockHex = "0x1e8481" // staleTip + 1 (the head the client just saw)
+	network, _ := setupLowerOnlyRaceNetwork(t, ctx, []lowerOnlyRaceFixture{
+		{id: "rpc1", staleTip: staleTip},
+		{id: "rpc2", staleTip: staleTip},
+	}, freshBlockHex)
+
+	// The Arc consensus custom method, served by the node for the fresh block.
+	for _, id := range []string{"rpc1", "rpc2"} {
+		gock.New("http://" + id + ".localhost").Post("").Persist().
+			Filter(func(r *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(r), "arc_getCertificate")
+			}).
+			Reply(200).JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":{"certificate":"0xcert"}}`))
+	}
+
+	// 1) eth_getBlockByNumber(N) for the fresh head → served (issue #934 fix).
+	reqBlock := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["` + freshBlockHex + `",false]}`))
+	reqBlock.SetNetwork(network)
+	respBlock, err := network.Forward(ctx, reqBlock)
+	require.NoError(t, err, "fresh head block must be served, not rejected by the stale poller")
+	jrrBlock, jerr := respBlock.JsonRpcResponse(ctx)
+	require.NoError(t, jerr)
+	require.Contains(t, jrrBlock.GetResultString(), "0xfresh")
+	respBlock.Release()
+
+	// 2) arc_getCertificate(N) — custom method for the same fresh block. eRPC cannot
+	// extract a block reference, so gating fails open and it is forwarded regardless of
+	// the lower-only bounds or the lagging state poller.
+	reqCert := common.NewNormalizedRequest([]byte(
+		`{"jsonrpc":"2.0","id":2,"method":"arc_getCertificate","params":["` + freshBlockHex + `"]}`))
+	reqCert.SetNetwork(network)
+	respCert, err := network.Forward(ctx, reqCert)
+	require.NoError(t, err,
+		"a custom method (arc_getCertificate) must be forwarded, never constrained by the state poller")
+	jrrCert, jerr := respCert.JsonRpcResponse(ctx)
+	require.NoError(t, jerr)
+	require.Contains(t, jrrCert.GetResultString(), "0xcert", "the custom method response must be served from the upstream")
+	respCert.Release()
+}


### PR DESCRIPTION
Fixes #934

## Problem

The per-upstream block availability check applied an implicit upper-bound check (`blockNumber > latestBlock`) for **any** upstream that had bounds configured, because the mere presence of `blockAvailability` opted into full enforcement.

On fast block-time chains this races the state poller. A client subscribed to `eth_subscribe newHeads` on a node receives block N and immediately requests `eth_getBlockByNumber(N)` through eRPC — before eRPC's poller (HTTP `eth_getBlockByNumber("latest")`) has caught up. The poller still reports `latestBlock = N-1`, so the check rejects the request with `ErrUpstreamBlockUnavailable` even though the upstream has the block and the operator only configured a **lower** bound (for pruned-node protection), never an upper bound. Reported symptoms on a 500ms-block chain: ~40% upstream error rate, p90/p99 latency 60ms → 140ms, 100% hedge utilization, `erpc_upstream_stale_upper_bound_total` climbing continuously.

## Fix

`checkUpstreamBlockAvailability` now enforces **only** the upstream's configured serving range — `blockAvailability.lower`/`.upper` (including the legacy `maxAvailableRecentBlocks` lower bound). The implicit head check is removed entirely. Tip-awareness is left to the mechanisms that own it:

- **served-tip** short-circuits concrete future blocks beyond the network tip, and
- **`integrity.enforceHighestBlock`** keeps `"latest"`/`"finalized"` tag responses honest.

Range methods (`eth_getLogs`, `trace_filter`, `arbtrace_filter`) continue to enforce availability via their own range-aware pre-forward hooks (`CheckBlockRangeAvailability`) and are skipped by this single-block path.

### Behavior matrix

| Config | Before | After |
| --- | --- | --- |
| `lower` only, block above stale tip | ❌ rejected (race) | ✅ served |
| `lower` only, block below lower | ✅ skipped | ✅ skipped (unchanged) |
| `upper` configured | ✅ enforced | ✅ enforced (unchanged) |
| no bounds + `enforceBlockAvailability:true`, block above tip | ❌ rejected (implicit head check) | ✅ served |
| `enforceBlockAvailability:false` | disabled | disabled (unchanged) |

**Opt back into head gating**, explicitly: set `blockAvailability.upper.latestBlockMinus: 0` ("serve only blocks this node has actually synced"). This also removes the synchronous force-poll the old path did on every gated request.

## Tests

- **Reproduction** at the highest level — real `Network` / `Upstream` / `EvmStatePoller`, only the HTTP endpoint mocked via gock; the poller settles on a stale tip through real HTTP polling (no `SuggestLatestBlock` injection). Fails on the old code with the exact issue error, passes now.
- **New coverage** for the bounds-only semantics: no-bounds + enforce-true above tip; explicit upper cap below head; opt-in head gating (`upper.latestBlockMinus:0`); method-level `enforceBlockAvailability:false`; lower+upper window above stale tip; range-method deferral.
- Head-gating tests that asserted the old implicit check were migrated to the explicit `upper.latestBlockMinus:0` bound.

All `erpc`, `upstream`, and `architecture/evm` suites pass (the only failures in a full run are the Docker-dependent `TestEvmJsonRpcCache_Redis`/`_DynamoDB`, which need testcontainers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)