### PR TITLE
feat(postgres): add skipSchemaSetup for read-only replica connectors

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -460,31 +460,40 @@ type PostgreSQLConnectorConfig struct {
 	GetTimeout    Duration                 `yaml:"getTimeout,omitempty" json:"getTimeout" tstype:"Duration"`
 	SetTimeout    Duration                 `yaml:"setTimeout,omitempty" json:"setTimeout" tstype:"Duration"`
 	IAMAuth       *PostgreSQLIAMAuthConfig `yaml:"iamAuth,omitempty" json:"iamAuth,omitempty"`
+	// SkipSchemaSetup skips all startup DDL (CREATE TABLE/INDEX, column
+	// migrations, pg_cron) and the local expired-row cleanup DELETE loop. Set
+	// it for connectors whose ConnectionUri targets a read-only replica (e.g.
+	// an Aurora global-database secondary): DDL cannot execute there (SQLSTATE
+	// 25006) and is not write-forwarded, so the writer-region connector owns
+	// the schema and the replica receives it via storage replication.
+	SkipSchemaSetup bool `yaml:"skipSchemaSetup,omitempty" json:"skipSchemaSetup"`
 }
 
 func (p *PostgreSQLConnectorConfig) MarshalJSON() ([]byte, error) {
 	return sonic.Marshal(map[string]interface{}{
-		"connectionUri": util.RedactEndpoint(p.ConnectionUri),
-		"table":         p.Table,
-		"minConns":      fmt.Sprintf("%d", p.MinConns),
-		"maxConns":      fmt.Sprintf("%d", p.MaxConns),
-		"initTimeout":   p.InitTimeout.String(),
-		"getTimeout":    p.GetTimeout.String(),
-		"setTimeout":    p.SetTimeout.String(),
-		"iamAuth":       p.IAMAuth,
+		"connectionUri":   util.RedactEndpoint(p.ConnectionUri),
+		"table":           p.Table,
+		"minConns":        fmt.Sprintf("%d", p.MinConns),
+		"maxConns":        fmt.Sprintf("%d", p.MaxConns),
+		"initTimeout":     p.InitTimeout.String(),
+		"getTimeout":      p.GetTimeout.String(),
+		"setTimeout":      p.SetTimeout.String(),
+		"iamAuth":         p.IAMAuth,
+		"skipSchemaSetup": p.SkipSchemaSetup,
 	})
 }
 
 func (p *PostgreSQLConnectorConfig) MarshalYAML() (interface{}, error) {
 	return map[string]interface{}{
-		"connectionUri": util.RedactEndpoint(p.ConnectionUri),
-		"table":         p.Table,
-		"minConns":      p.MinConns,
-		"maxConns":      p.MaxConns,
-		"initTimeout":   p.InitTimeout.String(),
-		"getTimeout":    p.GetTimeout.String(),
-		"setTimeout":    p.SetTimeout.String(),
-		"iamAuth":       p.IAMAuth,
+		"connectionUri":   util.RedactEndpoint(p.ConnectionUri),
+		"table":           p.Table,
+		"minConns":        p.MinConns,
+		"maxConns":        p.MaxConns,
+		"initTimeout":     p.InitTimeout.String(),
+		"getTimeout":      p.GetTimeout.String(),
+		"setTimeout":      p.SetTimeout.String(),
+		"iamAuth":         p.IAMAuth,
+		"skipSchemaSetup": p.SkipSchemaSetup,
 	}, nil
 }
 

--- a/data/postgres_skip_schema_test.go
+++ b/data/postgres_skip_schema_test.go
@@ -1,0 +1,122 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostgreSQLConnector_SkipSchemaSetup_CleanupTicker verifies that the local
+// expired-row cleanup ticker is armed only when the connector owns the schema.
+// On a read-only replica (SkipSchemaSetup=true) the ticker must be nil so the
+// startCleanup goroutine never issues its periodic DELETE (a write that either
+// fails or gets needlessly cross-region write-forwarded). This is deterministic
+// and needs no database — the ticker is decided in the constructor before the
+// first connect attempt.
+func TestPostgreSQLConnector_SkipSchemaSetup_CleanupTicker(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Unreachable address so the initial connect fails fast (no server). The
+	// constructor still returns the connector and the cleanupTicker decision
+	// has already been made regardless of connectivity.
+	cfg := func(skip bool) *common.PostgreSQLConnectorConfig {
+		return &common.PostgreSQLConnectorConfig{
+			Table:           "test_skip_cleanup",
+			ConnectionUri:   "postgres://user:pass@127.0.0.1:9876/bogusdb?sslmode=disable",
+			InitTimeout:     common.Duration(500 * time.Millisecond),
+			GetTimeout:      common.Duration(500 * time.Millisecond),
+			SetTimeout:      common.Duration(500 * time.Millisecond),
+			MinConns:        1,
+			MaxConns:        1,
+			SkipSchemaSetup: skip,
+		}
+	}
+
+	t.Run("reader skips cleanup ticker", func(t *testing.T) {
+		conn, err := NewPostgreSQLConnector(ctx, &logger, "test-skip-true", cfg(true))
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		require.Nil(t, conn.cleanupTicker, "cleanupTicker must be nil when SkipSchemaSetup is true")
+	})
+
+	t.Run("writer arms cleanup ticker", func(t *testing.T) {
+		conn, err := NewPostgreSQLConnector(ctx, &logger, "test-skip-false", cfg(false))
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		require.NotNil(t, conn.cleanupTicker, "cleanupTicker must be set when SkipSchemaSetup is false")
+		conn.cleanupTicker.Stop()
+	})
+}
+
+// TestPostgreSQLConnector_SkipSchemaSetup_NoDDL proves that SkipSchemaSetup
+// prevents the connector from running any startup DDL: with it enabled the
+// connector connects but does NOT create its table, while the default (writer)
+// path does. Mirrors a read-only Aurora global secondary, where CREATE TABLE
+// fails with SQLSTATE 25006 and DDL is not write-forwarded.
+//
+// Requires a writable Postgres reachable via POSTGRES_TEST_URI; skipped
+// otherwise (same convention as the other PostgreSQL integration tests).
+func TestPostgreSQLConnector_SkipSchemaSetup_NoDDL(t *testing.T) {
+	uri := os.Getenv("POSTGRES_TEST_URI")
+	if uri == "" {
+		t.Skip("Skipping PostgreSQL test - POSTGRES_TEST_URI not set")
+	}
+
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	table := fmt.Sprintf("test_skip_schema_%d", time.Now().UnixNano())
+
+	cfg := func(skip bool, id string) *common.PostgreSQLConnectorConfig {
+		return &common.PostgreSQLConnectorConfig{
+			Table:           table,
+			ConnectionUri:   uri,
+			InitTimeout:     common.Duration(10 * time.Second),
+			GetTimeout:      common.Duration(5 * time.Second),
+			SetTimeout:      common.Duration(5 * time.Second),
+			MinConns:        1,
+			MaxConns:        5,
+			SkipSchemaSetup: skip,
+		}
+	}
+
+	tableExists := func(c *PostgreSQLConnector) bool {
+		var exists bool
+		err := c.conn.QueryRow(ctx,
+			`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)`,
+			table).Scan(&exists)
+		require.NoError(t, err)
+		return exists
+	}
+
+	// Reader: connects, but must not create the table.
+	reader, err := NewPostgreSQLConnector(ctx, &logger, "test-pg-skip", cfg(true, "test-pg-skip"))
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.NotNil(t, reader.conn, "connector should connect even with schema setup skipped")
+	require.False(t, tableExists(reader), "SkipSchemaSetup=true must not create the table")
+
+	// Writer: default path creates the table and is fully functional.
+	writer, err := NewPostgreSQLConnector(ctx, &logger, "test-pg-write", cfg(false, "test-pg-write"))
+	require.NoError(t, err)
+	require.NotNil(t, writer)
+	require.True(t, tableExists(writer), "SkipSchemaSetup=false must create the table")
+	t.Cleanup(func() {
+		_, _ = writer.conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+	})
+
+	require.NoError(t, writer.Set(ctx, "pk", "rk", []byte("v"), nil))
+	got, err := writer.Get(ctx, "", "pk", "rk", nil)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), got)
+}

--- a/data/postgresql.go
+++ b/data/postgresql.go
@@ -123,17 +123,24 @@ func NewPostgreSQLConnector(
 	lg.Debug().Interface("config", cfg).Msg("creating postgresql connector")
 
 	connector := &PostgreSQLConnector{
-		id:            id,
-		logger:        &lg,
-		appCtx:        ctx,
-		table:         cfg.Table,
-		minConns:      cfg.MinConns,
-		maxConns:      cfg.MaxConns,
-		initTimeout:   cfg.InitTimeout.Duration(),
-		getTimeout:    cfg.GetTimeout.Duration(),
-		setTimeout:    cfg.SetTimeout.Duration(),
-		cleanupTicker: time.NewTicker(5 * time.Minute),
-		connMu:        sync.RWMutex{},
+		id:          id,
+		logger:      &lg,
+		appCtx:      ctx,
+		table:       cfg.Table,
+		minConns:    cfg.MinConns,
+		maxConns:    cfg.MaxConns,
+		initTimeout: cfg.InitTimeout.Duration(),
+		getTimeout:  cfg.GetTimeout.Duration(),
+		setTimeout:  cfg.SetTimeout.Duration(),
+		connMu:      sync.RWMutex{},
+	}
+
+	// Only arm the local expired-row cleanup ticker when this connector owns
+	// the schema (writer region). On a read-only replica the periodic DELETE
+	// either fails or gets needlessly cross-region write-forwarded, so leave
+	// the ticker nil — startCleanup and the cleanupOnce gate both handle it.
+	if !cfg.SkipSchemaSetup {
+		connector.cleanupTicker = time.NewTicker(5 * time.Minute)
 	}
 
 	// create an Initializer to handle (re)connecting
@@ -213,12 +220,19 @@ func (p *PostgreSQLConnector) connectTask(ctx context.Context, cfg *common.Postg
 	// the `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` parts
 	// are safe under that race; the TEXT→BYTEA `DROP COLUMN` and
 	// `cron.schedule` steps are not.
-	if err := p.ensureSchema(connectCtx, newConn, cfg); err != nil {
-		// The pool we just opened is about to be discarded — close it
-		// synchronously so its connections are released back to the
-		// pooler rather than lingering until GC.
-		newConn.Close()
-		return err
+	// Schema setup issues DDL (CREATE TABLE/INDEX, ALTER, pg_cron) that a
+	// read-only replica cannot execute (SQLSTATE 25006) and that Aurora global
+	// write-forwarding does not forward. SkipSchemaSetup lets a reader-region
+	// connector come up without it; the writer-region connector owns the
+	// schema and it arrives via storage replication.
+	if !cfg.SkipSchemaSetup {
+		if err := p.ensureSchema(connectCtx, newConn, cfg); err != nil {
+			// The pool we just opened is about to be discarded — close it
+			// synchronously so its connections are released back to the
+			// pooler rather than lingering until GC.
+			newConn.Close()
+			return err
+		}
 	}
 
 	// Publish the new pool. This is the only critical section: readers see

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -456,6 +456,15 @@ export interface PostgreSQLConnectorConfig {
   getTimeout?: Duration;
   setTimeout?: Duration;
   iamAuth?: PostgreSQLIAMAuthConfig;
+  /**
+   * SkipSchemaSetup skips all startup DDL (CREATE TABLE/INDEX, column
+   * migrations, pg_cron) and the local expired-row cleanup DELETE loop. Set
+   * it for connectors whose ConnectionUri targets a read-only replica (e.g.
+   * an Aurora global-database secondary): DDL cannot execute there (SQLSTATE
+   * 25006) and is not write-forwarded, so the writer-region connector owns
+   * the schema and the replica receives it via storage replication.
+   */
+  skipSchemaSetup?: boolean;
 }
 export interface AwsAuthConfig {
   mode: 'file' | 'env' | 'secret'; // "file", "env", "secret"


### PR DESCRIPTION
## Summary

Adds an opt-in `skipSchemaSetup` flag to the PostgreSQL connector config. When set, the connector skips all startup schema management (`CREATE TABLE`/`CREATE INDEX`, the TEXT→BYTEA column migration, and the optional `pg_cron` job) and does not start the local expired-row cleanup loop.

Default is `false` — fully backward compatible.

## Motivation

When the connector's `connectionUri` points at a **read-only replica** (e.g. an Aurora PostgreSQL global-database secondary, or any hot standby), the connector never initializes — it fails on startup with:

```
ERROR: cannot execute CREATE TABLE in a read-only transaction (SQLSTATE 25006)
```

`applySchema` issues DDL (`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN`, `CREATE INDEX`). A read-only transaction rejects DDL at statement classification — **before** the `IF NOT EXISTS` existence check — so pre-creating the table does not help. On Aurora global databases, DDL is additionally **not write-forwarded**, so a secondary-region connector has no way to run it at all.

The intended topology for a multi-region deployment is: the writer-region connector owns the schema; replicas receive it via storage-level replication and only read. The periodic TTL-cleanup `DELETE` is likewise the writer's responsibility (on a replica it would fail, or with write-forwarding be needlessly forwarded cross-region), so `skipSchemaSetup` leaves the cleanup ticker disabled as well.

## Changes

- **`common`**: add `SkipSchemaSetup bool` (`yaml: skipSchemaSetup`) to `PostgreSQLConnectorConfig`; include it in the redacting `MarshalJSON`/`MarshalYAML`; regenerate the TypeScript config types (`typescript/config/src/generated.ts`).
- **`data`**: in `NewPostgreSQLConnector`, arm the cleanup ticker only when `!SkipSchemaSetup`; in `connectTask`, skip `ensureSchema` when set. The nil-ticker paths are already handled by `startCleanup` and the `cleanupOnce` gate.
- **tests**: a deterministic unit test for the cleanup-ticker gating (no DB), plus an integration test (gated on `POSTGRES_TEST_URI`) asserting that `skipSchemaSetup=true` connects without creating the table while the default path does.

## Testing

- `go build ./...`, `go vet ./data/`, and `go test ./data/ -run TestPostgreSQLConnector_SkipSchemaSetup` all pass (the DB-backed test skips when `POSTGRES_TEST_URI` is unset).
