### PR TITLE
fix(evm): don't count cancelled cache fan-out reads as success_miss

### DIFF
--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -370,6 +370,7 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 		lastMiss   *fanResult
 		lastReject *fanResult
 		lastError  *fanResult
+		aborted    bool
 	)
 drain:
 	for received := 0; received < spawned && jrr == nil; {
@@ -408,6 +409,16 @@ drain:
 			// so the hit IS in the channel — Go's select just happened to
 			// pick the Done branch over the receive branch. Picking up
 			// that hit here avoids a phantom miss under the race.
+			//
+			// Mark the fan-out aborted: if no hit surfaces from the buffer
+			// below, we exited because of cancellation (a)/(b), not because
+			// every connector confirmed a genuine miss. The post-fan-out
+			// block uses this to avoid recording a cancelled read as a
+			// success_miss (which would inflate the miss count and attribute
+			// the cancellation latency — e.g. a request-level failsafe
+			// timeout ceiling — to the connector). Case (c) sets jrr below,
+			// so this flag is irrelevant there.
+			aborted = true
 		drainBuffer:
 			for {
 				select {
@@ -440,6 +451,22 @@ drain:
 	}
 
 	if jrr == nil {
+		// The fan-out was aborted by context cancellation (caller cancelled
+		// the parent ctx, or the 30s defensive backstop fired) rather than
+		// every connector confirming a genuine miss. This is NOT a cache
+		// miss: counting it inflates success_miss with cancelled reads and
+		// records the cancellation latency (often a fixed request-level
+		// failsafe/hedge timeout ceiling) against the connector. Fall through
+		// to the upstream layer without emitting a miss metric — mirroring the
+		// per-goroutine "cancelled" guard above.
+		if aborted {
+			span.SetAttributes(
+				attribute.Bool("cache.hit", false),
+				attribute.String("cache.miss_reason", "cancelled"),
+			)
+			return nil, nil
+		}
+
 		// All connectors confirmed miss / errored / age-rejected. Attribute the
 		// fall-through metric to the most informative outcome we observed,
 		// preferring rejections over plain misses over errors.

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -299,6 +299,46 @@ func TestEvmJsonRpcCache_FanOut_ParentContextDeadlineStopsAll(t *testing.T) {
 		"deadline-cancelled connector calls must not emit cache_get_error_total — they are external cancellations, not connector failures")
 }
 
+// CancelledFanOutIsNotAMiss covers ERPC-553: when the parent context is
+// cancelled before any connector confirms a genuine miss, the fan-out is
+// aborted. Such a cancelled read must NOT be recorded as a success_miss —
+// otherwise the miss count is inflated and the cancellation latency (e.g. a
+// request-level failsafe/hedge timeout ceiling) is attributed to the connector.
+func TestEvmJsonRpcCache_FanOut_CancelledFanOutIsNotAMiss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+		{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+	})
+	cache.SetPolicies(fanOutPolicies(t, conns))
+
+	// Both connectors hang until their call context is cancelled, simulating a
+	// slow read that never returns a genuine result before the parent deadline.
+	for _, c := range conns {
+		c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				callCtx := args.Get(0).(context.Context)
+				<-callCtx.Done()
+			}).
+			Return(nil, context.Canceled).Maybe()
+	}
+
+	beforeMiss := promUtil.CollectAndCount(telemetry.MetricCacheGetSuccessMissTotal)
+
+	getCtx, cancelGet := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelGet()
+	resp, err := cache.Get(getCtx, newGetBlockByNumberRequest(t, network, cache))
+
+	// Allow goroutines a brief moment to drain any (incorrect) metric emission.
+	time.Sleep(50 * time.Millisecond)
+	afterMiss := promUtil.CollectAndCount(telemetry.MetricCacheGetSuccessMissTotal)
+
+	require.NoError(t, err)
+	assert.Nil(t, resp, "a cancelled fan-out falls through to the upstream layer")
+	assert.Equal(t, beforeMiss, afterMiss,
+		"a context-cancelled fan-out must not emit cache_get_success_miss_total — it is an aborted read, not a genuine cache miss")
+}
+
 func TestEvmJsonRpcCache_FanOut_RespectsSkipCacheReadDirective(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## What this does

`EvmJsonRpcCache.Get` fans out cache reads across connectors and drains results until a hit lands, every connector reports a genuine miss, or the fan-out is aborted. The drain loop exits via `fanCtx.Done()` when the parent context is cancelled (e.g. a request-level failsafe/hedge timeout) or the 30s defensive backstop fires. In that case `jrr` stays nil and the post-fan-out block **unconditionally** recorded `cache_get_success_miss_total` plus duration, using `time.Since(start)` as the latency.

That counts a *cancelled* read as a slow cache miss — inflating the miss count and attributing the cancellation-timeout latency to the connector, rather than reflecting real cache-miss behavior.

This change mirrors the existing per-goroutine "cancelled" guard (`fanCtx.Err() != nil`) in the post-fan-out block: it tracks an `aborted` flag set when the drain loop bails on `fanCtx.Done()`, and skips the miss metric (falling through to upstream exactly as before) when no connector confirmed a genuine miss. Genuine all-connector misses are still recorded.

## Testing

- New regression test `TestEvmJsonRpcCache_FanOut_CancelledFanOutIsNotAMiss` asserts no `success_miss` increment when the parent context is cancelled. It fails without the fix (count 1) and passes with it (0).
- Full `architecture/evm` suite and all `erpc` cache tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change for aborted fan-outs; request path still falls through to upstream the same way, and real cache misses keep being recorded.
> 
> **Overview**
> When parallel cache reads exit because **`fanCtx`** is done (caller cancel/deadline or the 30s fan-out backstop) and no hit is found, **`EvmJsonRpcCache.Get`** no longer increments **`cache_get_success_miss_total`** or records miss duration. It sets trace **`cache.miss_reason=cancelled`** and still returns **`nil, nil`** so upstream handling is unchanged.
> 
> The drain loop sets an **`aborted`** flag on the **`fanCtx.Done()`** path (after the buffered winner race drain). Genuine all-connector misses still use the existing miss metrics.
> 
> Adds **`TestEvmJsonRpcCache_FanOut_CancelledFanOutIsNotAMiss`** (ERPC-553) to assert no **`success_miss`** increment when a short parent timeout cancels hanging connector reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3521309b599dbf2dac37e4ab68fd6fb9418ecc9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->