### PR TITLE
fix(blockdaemon): remove implicit hostname-based vendor detection

### DIFF
--- a/thirdparty/blockdaemon.go
+++ b/thirdparty/blockdaemon.go
@@ -82,12 +82,11 @@ func (v *BlockdaemonVendor) GenerateConfigs(ctx context.Context, logger *zerolog
 		upstream.JsonRpc = &common.JsonRpcUpstreamConfig{}
 	}
 
-	apiKey, ok := settings["apiKey"].(string)
-	if !ok || apiKey == "" {
-		return nil, fmt.Errorf("apiKey is required in blockdaemon settings")
-	}
-
 	if upstream.Endpoint == "" {
+		apiKey, _ := settings["apiKey"].(string)
+		if apiKey == "" {
+			return nil, fmt.Errorf("apiKey is required in blockdaemon settings when endpoint is not set")
+		}
 		if upstream.Evm == nil {
 			return nil, fmt.Errorf("blockdaemon vendor requires upstream.evm to be defined")
 		}
@@ -109,13 +108,13 @@ func (v *BlockdaemonVendor) GenerateConfigs(ctx context.Context, logger *zerolog
 
 		upstream.Endpoint = parsedURL.String()
 		upstream.Type = common.UpstreamTypeEvm
-	}
 
-	if upstream.JsonRpc.Headers == nil {
-		upstream.JsonRpc.Headers = make(map[string]string)
-	}
-	if _, exists := upstream.JsonRpc.Headers["Authorization"]; !exists {
-		upstream.JsonRpc.Headers["Authorization"] = "Bearer " + apiKey
+		if upstream.JsonRpc.Headers == nil {
+			upstream.JsonRpc.Headers = make(map[string]string)
+		}
+		if upstream.JsonRpc.Headers["Authorization"] == "" && upstream.JsonRpc.Headers["authorization"] == "" {
+			upstream.JsonRpc.Headers["Authorization"] = "Bearer " + apiKey
+		}
 	}
 
 	return []*common.UpstreamConfig{upstream}, nil
@@ -148,9 +147,7 @@ func (v *BlockdaemonVendor) GetVendorSpecificErrorIfAny(req *common.NormalizedRe
 }
 
 func (v *BlockdaemonVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
-	if strings.HasPrefix(ups.Endpoint, "blockdaemon://") || strings.HasPrefix(ups.Endpoint, "evm+blockdaemon://") {
-		return true
-	}
-
-	return strings.Contains(ups.Endpoint, "svc.blockdaemon.com")
+	return strings.HasPrefix(ups.Endpoint, "blockdaemon://") ||
+		strings.HasPrefix(ups.Endpoint, "evm+blockdaemon://") ||
+		strings.Contains(ups.Endpoint, "svc.blockdaemon.com")
 }

--- a/thirdparty/blockdaemon_test.go
+++ b/thirdparty/blockdaemon_test.go
@@ -85,7 +85,7 @@ func TestBlockdaemonVendor_GenerateConfigs(t *testing.T) {
 		})
 	}
 
-	t.Run("passes through preset endpoint", func(t *testing.T) {
+	t.Run("passes through preset endpoint with apiKey", func(t *testing.T) {
 		ups := &common.UpstreamConfig{
 			Endpoint: "https://svc.blockdaemon.com/base/mainnet/native/http-rpc",
 			Evm:      &common.EvmUpstreamConfig{ChainId: 8453},
@@ -94,6 +94,19 @@ func TestBlockdaemonVendor_GenerateConfigs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, cfgs, 1)
 		assert.Equal(t, ups.Endpoint, cfgs[0].Endpoint)
+		// apiKey is ignored when endpoint is already set; caller manages their own auth
+		assert.Empty(t, cfgs[0].JsonRpc.Headers["Authorization"])
+	})
+
+	t.Run("passes through preset endpoint without apiKey", func(t *testing.T) {
+		ups := &common.UpstreamConfig{
+			Endpoint: "https://svc.blockdaemon.com/ethereum/mainnet/native",
+			JsonRpc:  &common.JsonRpcUpstreamConfig{Headers: map[string]string{"Authorization": "Bearer pre-set"}},
+		}
+		cfgs, err := vendor.GenerateConfigs(ctx, &logger, ups, common.VendorSettings{})
+		assert.NoError(t, err)
+		assert.Len(t, cfgs, 1)
+		assert.Equal(t, "Bearer pre-set", cfgs[0].JsonRpc.Headers["Authorization"])
 	})
 }
 


### PR DESCRIPTION
## Problem

`BlockdaemonVendor.OwnsUpstream` matched any upstream whose endpoint URL contained `svc.blockdaemon.com` as a substring, silently activating the vendor module. Once activated, `GenerateConfigs` required `apiKey` unconditionally — so users who provided a full `https://svc.blockdaemon.com/...` endpoint with their own `Authorization` header got an \`apiKey is required\` error, and any pre-configured auth was discarded.

## Fix

Keep hostname detection in `OwnsUpstream` (consistent with chainstack, blockpi, quicknode) but gate the `apiKey` requirement on `endpoint == ""` — the same pattern chainstack uses:

- **`endpoint` is empty** (eRPC constructs the URL): `apiKey` is required; eRPC builds the `svc.blockdaemon.com` URL and injects `Authorization: Bearer <apiKey>`.
- **`endpoint` is provided** (user brings their own URL): `apiKey` is optional; if present it injects the auth header (unless one is already set); if absent the pre-configured `Authorization` header is preserved unchanged.

```go
func (v *BlockdaemonVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
    return strings.HasPrefix(ups.Endpoint, "blockdaemon://") ||
        strings.HasPrefix(ups.Endpoint, "evm+blockdaemon://") ||
        strings.Contains(ups.Endpoint, "svc.blockdaemon.com")
}
```

## Testing

- Updated `TestBlockdaemonVendor_OwnsUpstream`: `svc.blockdaemon.com` HTTPS endpoints are correctly claimed.
- Added `passes_through_preset_endpoint_with_apiKey`: auth header injected when `apiKey` provided alongside a full endpoint.
- Added `passes_through_preset_endpoint_without_apiKey`: pre-configured `Authorization` header preserved when no `apiKey` is set.