### PR TITLE
feat(clients/bds): make gRPC connection pool size configurable

### DIFF
--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -53,12 +53,16 @@ type GenericGrpcBdsClient struct {
 	isLogLevelTrace bool
 }
 
+// NewGrpcBdsClient builds a BDS gRPC client backed by a round-robin connection
+// pool. poolSize sets the number of connections; <= 0 uses the built-in default
+// (bdsPoolSize).
 func NewGrpcBdsClient(
 	appCtx context.Context,
 	logger *zerolog.Logger,
 	projectId string,
 	upstream common.Upstream,
 	parsedUrl *url.URL,
+	poolSize int,
 ) (GrpcBdsClient, error) {
 	upsId := "n/a"
 	if upstream != nil {
@@ -123,7 +127,7 @@ func NewGrpcBdsClient(
 		}]
 	}`
 
-	pool, err := newBdsPool(logger, projectId, upsId, target, transportCredentials, serviceConfig)
+	pool, err := newBdsPool(logger, projectId, upsId, target, transportCredentials, serviceConfig, poolSize)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +141,7 @@ func NewGrpcBdsClient(
 
 	logger.Debug().
 		Str("target", target).
-		Int("pool_size", bdsPoolSize).
+		Int("pool_size", pool.Size()).
 		Dur("hard_call_timeout", bdsHardCallTimeout).
 		Msg("created gRPC BDS client")
 

--- a/clients/grpc_bds_client_test.go
+++ b/clients/grpc_bds_client_test.go
@@ -109,7 +109,7 @@ func TestGrpcBdsClientAppliesUpstreamGrpcHeaders(t *testing.T) {
 		},
 	}))
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL, 0)
 	require.NoError(t, err)
 
 	gc, ok := client.(*GenericGrpcBdsClient)
@@ -128,7 +128,7 @@ func TestGrpcBdsClientNilUpstreamNoHeaders(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 
 	gc, ok := client.(*GenericGrpcBdsClient)
@@ -143,7 +143,7 @@ func TestGrpcBdsClientQueryMethodsDoNotShortCircuit(t *testing.T) {
 	logger := zerolog.New(io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 
 	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_queryBlocks","params":[{"fromBlock":"0x1","toBlock":"0x2","limit":1}]}`))

--- a/clients/grpc_bds_pool_size_test.go
+++ b/clients/grpc_bds_pool_size_test.go
@@ -1,0 +1,120 @@
+package clients
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newTestPool builds a pool directly (no server needed — grpc.NewClient dials
+// lazily) so the sizing/round-robin behavior can be asserted in isolation.
+func newTestPool(t *testing.T, poolSize int) *bdsPool {
+	t.Helper()
+	logger := zerolog.New(io.Discard)
+	p, err := newBdsPool(
+		&logger,
+		"test-project",
+		"n/a",
+		"dns:///127.0.0.1:50051",
+		insecure.NewCredentials(),
+		"{}",
+		poolSize,
+	)
+	require.NoError(t, err)
+	t.Cleanup(p.Shutdown)
+	return p
+}
+
+// newClientWithPoolSize builds a client against a dummy (never-dialed) address.
+// NewGrpcBdsClient does not probe on construction, so no server is required to
+// assert how many connections the pool opened.
+func newClientWithPoolSize(t *testing.T, poolSize int) *GenericGrpcBdsClient {
+	t.Helper()
+	parsedURL, err := url.Parse("grpc://127.0.0.1:50051")
+	require.NoError(t, err)
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, poolSize)
+	require.NoError(t, err)
+	return client.(*GenericGrpcBdsClient)
+}
+
+// TestNewBdsPool_HonorsConfiguredSize verifies a configured poolSize maps 1:1
+// to the number of connection slots the pool opens.
+func TestNewBdsPool_HonorsConfiguredSize(t *testing.T) {
+	for _, size := range []int{1, 2, 5, 16, 32} {
+		size := size
+		t.Run("size="+strconv.Itoa(size), func(t *testing.T) {
+			p := newTestPool(t, size)
+			require.Equal(t, size, p.Size(),
+				"pool should open exactly the configured number of conns")
+			require.Len(t, p.conns, size)
+		})
+	}
+}
+
+// TestNewBdsPool_DefaultsWhenUnsetOrInvalid verifies that an unset (0) or
+// nonsensical (negative) poolSize falls back to the built-in default so legacy
+// configs and bad values both keep the historical behavior.
+func TestNewBdsPool_DefaultsWhenUnsetOrInvalid(t *testing.T) {
+	for _, size := range []int{0, -1, -100} {
+		size := size
+		t.Run("size="+strconv.Itoa(size), func(t *testing.T) {
+			p := newTestPool(t, size)
+			require.Equal(t, bdsPoolSize, p.Size(),
+				"non-positive poolSize must fall back to the default")
+		})
+	}
+}
+
+// TestBdsPool_PickRoundRobinsAcrossConfiguredSize verifies Pick() rotates
+// evenly across every slot of a custom-sized pool — the blast-radius guarantee
+// must scale with the configured size, not just the default.
+func TestBdsPool_PickRoundRobinsAcrossConfiguredSize(t *testing.T) {
+	const size = 5
+	p := newTestPool(t, size)
+
+	seen := make(map[*bdsConn]int)
+	for i := 0; i < size*3; i++ {
+		seen[p.Pick()]++
+	}
+	require.Len(t, seen, size, "Pick must rotate through every slot")
+	for c, n := range seen {
+		require.Equal(t, 3, n, "every slot should be picked exactly 3 times; %p got %d", c, n)
+	}
+}
+
+// TestBdsPool_SingleConnHasNoIsolation documents the degenerate poolSize=1
+// case: every Pick returns the same conn, so a wedge there chokes everyone.
+// This is the behavior an operator opts into by setting poolSize: 1.
+func TestBdsPool_SingleConnHasNoIsolation(t *testing.T) {
+	p := newTestPool(t, 1)
+	require.Equal(t, 1, p.Size())
+
+	first := p.Pick()
+	for i := 0; i < 5; i++ {
+		require.Same(t, first, p.Pick(),
+			"a single-conn pool must always return the same conn")
+	}
+}
+
+// TestNewGrpcBdsClient_ThreadsPoolSize verifies the poolSize argument is
+// threaded all the way from the client constructor into the underlying pool.
+func TestNewGrpcBdsClient_ThreadsPoolSize(t *testing.T) {
+	client := newClientWithPoolSize(t, 7)
+	require.Equal(t, 7, client.pool.Size())
+}
+
+// TestNewGrpcBdsClient_DefaultPoolSizeWhenZero verifies the client falls back
+// to the default pool size when none is configured (poolSize == 0).
+func TestNewGrpcBdsClient_DefaultPoolSizeWhenZero(t *testing.T) {
+	client := newClientWithPoolSize(t, 0)
+	require.Equal(t, bdsPoolSize, client.pool.Size())
+}

--- a/clients/grpc_bds_resilience.go
+++ b/clients/grpc_bds_resilience.go
@@ -34,9 +34,11 @@ var (
 	// enough that a wedged stream doesn't pile up callers.
 	bdsHardCallTimeout = 20 * time.Second
 
-	// bdsPoolSize is the number of independent grpc.ClientConn instances
-	// kept per upstream. Round-robin across them so a single wedged conn
-	// only chokes ~1/N of in-flight callers.
+	// bdsPoolSize is the DEFAULT number of independent grpc.ClientConn
+	// instances kept per upstream, used when the connector/upstream config
+	// leaves poolSize unset. Round-robin across them so a single wedged conn
+	// only chokes ~1/N of in-flight callers. Override per connector/upstream
+	// via the `poolSize` config knob (see newBdsPool / GrpcConnectorConfig).
 	bdsPoolSize = 3
 
 	// bdsStuckCallThreshold / bdsStuckCallWindow drive the per-conn
@@ -98,22 +100,29 @@ type bdsPool struct {
 	logger     *zerolog.Logger
 }
 
+// newBdsPool builds a round-robin pool of poolSize independent connections.
+// A poolSize <= 0 means "unconfigured" and falls back to bdsPoolSize, so an
+// absent/zero/negative config value preserves the historical default.
 func newBdsPool(
 	logger *zerolog.Logger,
 	projectId, upstreamId, target string,
 	creds credentials.TransportCredentials,
 	serviceConfig string,
+	poolSize int,
 ) (*bdsPool, error) {
+	if poolSize <= 0 {
+		poolSize = bdsPoolSize
+	}
 	p := &bdsPool{
 		target:        target,
 		creds:         creds,
 		serviceConfig: serviceConfig,
-		conns:         make([]*bdsConn, bdsPoolSize),
+		conns:         make([]*bdsConn, poolSize),
 		projectId:     projectId,
 		upstreamId:    upstreamId,
 		logger:        logger,
 	}
-	for i := 0; i < bdsPoolSize; i++ {
+	for i := 0; i < poolSize; i++ {
 		c, err := p.dial()
 		if err != nil {
 			for _, prev := range p.conns[:i] {
@@ -126,6 +135,13 @@ func newBdsPool(
 		p.conns[i] = c
 	}
 	return p, nil
+}
+
+// Size returns the number of connection slots in the pool.
+func (p *bdsPool) Size() int {
+	p.poolMu.RLock()
+	defer p.poolMu.RUnlock()
+	return len(p.conns)
 }
 
 func (p *bdsPool) dial() (*bdsConn, error) {

--- a/clients/grpc_bds_resilience_extras_test.go
+++ b/clients/grpc_bds_resilience_extras_test.go
@@ -121,7 +121,7 @@ func newTestClient(t *testing.T, addr string) *GenericGrpcBdsClient {
 	logger := zerolog.New(io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 	return client.(*GenericGrpcBdsClient)
 }
@@ -210,7 +210,7 @@ func TestSendRequest_ConfigHeadersReachWireAsMetadata(t *testing.T) {
 	ups := common.NewFakeUpstream("test-ups", common.WithGrpcConfig(&common.GrpcUpstreamConfig{
 		Headers: map[string]string{"authorization": "Bearer secret-token"},
 	}))
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", ups, parsedURL, 0)
 	require.NoError(t, err)
 
 	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}`))

--- a/clients/grpc_bds_resilience_test.go
+++ b/clients/grpc_bds_resilience_test.go
@@ -91,7 +91,7 @@ func TestGrpcBdsClient_HardTimeoutFreesGoroutineWithinCap(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 
 	// Use a tight caller-supplied deadline so the test runs fast — the
@@ -151,7 +151,7 @@ func TestGrpcBdsClient_WatchdogReplacesWedgedConn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 	gen := client.(*GenericGrpcBdsClient)
 
@@ -194,7 +194,7 @@ func TestGrpcBdsClient_WatchdogIgnoresCallerDeadline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 	gen := client.(*GenericGrpcBdsClient)
 	gen.pool.conns = gen.pool.conns[:1]
@@ -238,7 +238,7 @@ func TestGrpcBdsClient_WatchdogIgnoresCallerDynamicTimeoutCause(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL)
+	client, err := NewGrpcBdsClient(ctx, &logger, "test-project", nil, parsedURL, 0)
 	require.NoError(t, err)
 	gen := client.(*GenericGrpcBdsClient)
 	gen.pool.conns = gen.pool.conns[:1]

--- a/clients/registry.go
+++ b/clients/registry.go
@@ -100,12 +100,17 @@ func (manager *ClientRegistry) CreateClient(appCtx context.Context, ups common.U
 				} else if parsedUrl.Scheme == "ws" || parsedUrl.Scheme == "wss" {
 					clientErr = fmt.Errorf("websocket client not implemented yet")
 				} else if parsedUrl.Scheme == "grpc" || parsedUrl.Scheme == "grpc+bds" {
+					grpcPoolSize := 0
+					if cfg.Grpc != nil {
+						grpcPoolSize = cfg.Grpc.PoolSize
+					}
 					newClient, err = NewGrpcBdsClient(
 						appCtx,
 						&lg,
 						manager.projectId,
 						ups,
 						parsedUrl,
+						grpcPoolSize,
 					)
 					if err != nil {
 						clientErr = fmt.Errorf("failed to create gRPC BDS client for upstream: %v", cfg.Id)

--- a/common/config.go
+++ b/common/config.go
@@ -362,6 +362,13 @@ type GrpcConnectorConfig struct {
 	Servers    []string          `yaml:"servers,omitempty" json:"servers"`
 	Headers    map[string]string `yaml:"headers,omitempty" json:"headers"`
 	GetTimeout Duration          `yaml:"getTimeout,omitempty" json:"getTimeout" tstype:"Duration"`
+
+	// PoolSize is the number of independent gRPC connections opened to each
+	// backing server, selected round-robin per request. Larger values raise the
+	// concurrent-stream ceiling and shrink the blast radius of a single wedged
+	// connection, at the cost of more open connections per server. When unset
+	// (0) a built-in default is used.
+	PoolSize int `yaml:"poolSize,omitempty" json:"poolSize"`
 }
 
 type MemoryConnectorConfig struct {
@@ -1155,6 +1162,11 @@ func (c *JsonRpcUpstreamConfig) Copy() *JsonRpcUpstreamConfig {
 // every outbound request (e.g. an edge-api auth key: authorization: Bearer ...).
 type GrpcUpstreamConfig struct {
 	Headers map[string]string `yaml:"headers,omitempty" json:"headers"`
+
+	// PoolSize is the number of independent gRPC connections opened to this
+	// upstream, selected round-robin per request. See GrpcConnectorConfig.PoolSize.
+	// When unset (0) a built-in default is used.
+	PoolSize int `yaml:"poolSize,omitempty" json:"poolSize"`
 }
 
 func (c *GrpcUpstreamConfig) Copy() *GrpcUpstreamConfig {

--- a/common/grpc_pool_size_test.go
+++ b/common/grpc_pool_size_test.go
@@ -1,0 +1,124 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGrpcConnectorConfig_Validate_PoolSize(t *testing.T) {
+	t.Run("zero (unset) is valid", func(t *testing.T) {
+		require.NoError(t, (&GrpcConnectorConfig{PoolSize: 0}).Validate())
+	})
+	t.Run("positive is valid", func(t *testing.T) {
+		require.NoError(t, (&GrpcConnectorConfig{PoolSize: 8}).Validate())
+	})
+	t.Run("max boundary is valid", func(t *testing.T) {
+		require.NoError(t, (&GrpcConnectorConfig{PoolSize: MaxGrpcConnPoolSize}).Validate())
+	})
+	t.Run("negative is rejected", func(t *testing.T) {
+		err := (&GrpcConnectorConfig{PoolSize: -1}).Validate()
+		require.ErrorContains(t, err, "must not be negative")
+		require.ErrorContains(t, err, "database.*.connector.grpc.poolSize")
+	})
+	t.Run("above max is rejected", func(t *testing.T) {
+		err := (&GrpcConnectorConfig{PoolSize: MaxGrpcConnPoolSize + 1}).Validate()
+		require.ErrorContains(t, err, "must be <=")
+	})
+}
+
+func TestGrpcUpstreamConfig_Validate_PoolSize(t *testing.T) {
+	t.Run("zero (unset) is valid", func(t *testing.T) {
+		require.NoError(t, (&GrpcUpstreamConfig{PoolSize: 0}).Validate())
+	})
+	t.Run("positive is valid", func(t *testing.T) {
+		require.NoError(t, (&GrpcUpstreamConfig{PoolSize: 16}).Validate())
+	})
+	t.Run("negative is rejected with upstream scope", func(t *testing.T) {
+		err := (&GrpcUpstreamConfig{PoolSize: -5}).Validate()
+		require.ErrorContains(t, err, "must not be negative")
+		require.ErrorContains(t, err, "upstream.*.grpc.poolSize")
+	})
+	t.Run("above max is rejected", func(t *testing.T) {
+		require.ErrorContains(t,
+			(&GrpcUpstreamConfig{PoolSize: MaxGrpcConnPoolSize + 1}).Validate(), "must be <=")
+	})
+}
+
+// TestConnectorConfig_Validate_PropagatesGrpcPoolSize proves the connector-level
+// Validate() actually dispatches into the gRPC sub-config (i.e. the hook is
+// wired), not just that GrpcConnectorConfig.Validate() exists.
+func TestConnectorConfig_Validate_PropagatesGrpcPoolSize(t *testing.T) {
+	cfg := &ConnectorConfig{
+		Id:     "edge-cache",
+		Driver: DriverGrpc,
+		Grpc:   &GrpcConnectorConfig{PoolSize: -1},
+	}
+	require.ErrorContains(t, cfg.Validate(), "must not be negative")
+
+	cfg.Grpc.PoolSize = 8
+	require.NoError(t, cfg.Validate())
+}
+
+// TestUpstreamConfig_Validate_PropagatesGrpcPoolSize proves the upstream-level
+// Validate() dispatches into the gRPC sub-config.
+func TestUpstreamConfig_Validate_PropagatesGrpcPoolSize(t *testing.T) {
+	cfg := &UpstreamConfig{
+		Id:       "gcs-edge",
+		Endpoint: "grpc://example.internal:50051",
+		Grpc:     &GrpcUpstreamConfig{PoolSize: -1},
+	}
+	require.ErrorContains(t, cfg.Validate(&Config{}, false), "must not be negative")
+
+	cfg.Grpc.PoolSize = 16
+	require.NoError(t, cfg.Validate(&Config{}, false))
+}
+
+// TestGrpcUpstreamConfig_Copy_PreservesPoolSize guards the upstream-config copy
+// path (used when materializing per-upstream configs) against dropping the knob.
+func TestGrpcUpstreamConfig_Copy_PreservesPoolSize(t *testing.T) {
+	orig := &GrpcUpstreamConfig{
+		Headers:  map[string]string{"authorization": "Bearer x"},
+		PoolSize: 9,
+	}
+	cp := orig.Copy()
+	require.Equal(t, 9, cp.PoolSize)
+
+	// Mutating the copy must not affect the original (deep copy of headers,
+	// independent PoolSize value).
+	cp.PoolSize = 1
+	cp.Headers["authorization"] = "Bearer y"
+	require.Equal(t, 9, orig.PoolSize)
+	require.Equal(t, "Bearer x", orig.Headers["authorization"])
+}
+
+func TestGrpcConnectorConfig_PoolSize_YAMLRoundTrip(t *testing.T) {
+	t.Run("parses poolSize from yaml", func(t *testing.T) {
+		var cfg GrpcConnectorConfig
+		require.NoError(t, yaml.Unmarshal([]byte("poolSize: 12\n"), &cfg))
+		require.Equal(t, 12, cfg.PoolSize)
+	})
+	t.Run("omitempty drops zero poolSize", func(t *testing.T) {
+		out, err := yaml.Marshal(GrpcConnectorConfig{})
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "poolSize")
+	})
+	t.Run("marshals non-zero poolSize", func(t *testing.T) {
+		out, err := yaml.Marshal(GrpcConnectorConfig{PoolSize: 12})
+		require.NoError(t, err)
+		require.Contains(t, string(out), "poolSize: 12")
+	})
+}
+
+func TestGrpcUpstreamConfig_PoolSize_YAMLRoundTrip(t *testing.T) {
+	var cfg GrpcUpstreamConfig
+	require.NoError(t, yaml.Unmarshal([]byte("poolSize: 9\n"), &cfg))
+	require.Equal(t, 9, cfg.PoolSize)
+
+	out, err := yaml.Marshal(GrpcUpstreamConfig{})
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(out), "poolSize"),
+		"zero poolSize must be omitted, got: %q", string(out))
+}

--- a/common/validation.go
+++ b/common/validation.go
@@ -481,6 +481,11 @@ func (c *ConnectorConfig) Validate() error {
 			return err
 		}
 	}
+	if c.Grpc != nil {
+		if err := c.Grpc.Validate(); err != nil {
+			return err
+		}
+	}
 
 	for i, fsCfg := range c.FailsafeForGets {
 		if err := validateConnectorFailsafe(c.Id, "failsafeForGets", i, fsCfg); err != nil {
@@ -494,6 +499,33 @@ func (c *ConnectorConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// MaxGrpcConnPoolSize is the upper bound accepted for a gRPC connection-pool
+// size. It guards against a fat-fingered value opening an absurd number of
+// connections to each backing server; it is not a recommended operating point.
+const MaxGrpcConnPoolSize = 256
+
+func validateGrpcConnPoolSize(scope string, poolSize int) error {
+	if poolSize < 0 {
+		return fmt.Errorf("%s.poolSize must not be negative", scope)
+	}
+	if poolSize > MaxGrpcConnPoolSize {
+		return fmt.Errorf("%s.poolSize must be <= %d", scope, MaxGrpcConnPoolSize)
+	}
+	return nil
+}
+
+// Validate checks the gRPC cache-connector knobs. A zero PoolSize is valid and
+// means "use the built-in default".
+func (g *GrpcConnectorConfig) Validate() error {
+	return validateGrpcConnPoolSize("database.*.connector.grpc", g.PoolSize)
+}
+
+// Validate checks the gRPC upstream knobs. A zero PoolSize is valid and means
+// "use the built-in default".
+func (g *GrpcUpstreamConfig) Validate() error {
+	return validateGrpcConnPoolSize("upstream.*.grpc", g.PoolSize)
 }
 
 func validateConnectorFailsafe(connectorId, field string, index int, fsCfg *FailsafeConfig) error {
@@ -912,6 +944,11 @@ func (u *UpstreamConfig) Validate(c *Config, skipEndpointCheck bool) error {
 	}
 	if u.JsonRpc != nil {
 		if err := u.JsonRpc.Validate(c); err != nil {
+			return err
+		}
+	}
+	if u.Grpc != nil {
+		if err := u.Grpc.Validate(); err != nil {
 			return err
 		}
 	}

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -128,7 +128,7 @@ func NewGrpcConnector(
 					gc.logger.Error().Err(perr).Str("server", serverURL).Msg("invalid gRPC server URL")
 					return common.NewTaskFatal(perr)
 				}
-				cli, cerr := clients.NewGrpcBdsClient(gc.appCtx, &lg, "<cache>", nil, parsed)
+				cli, cerr := clients.NewGrpcBdsClient(gc.appCtx, &lg, "<cache>", nil, parsed, cfg.PoolSize)
 				if cerr != nil {
 					gc.logger.Warn().Err(cerr).Str("server", serverURL).Msg("failed to create gRPC client")
 					return cerr

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -398,6 +398,14 @@ export interface GrpcConnectorConfig {
   servers?: string[];
   headers?: { [key: string]: string};
   getTimeout?: Duration;
+  /**
+   * PoolSize is the number of independent gRPC connections opened to each
+   * backing server, selected round-robin per request. Larger values raise the
+   * concurrent-stream ceiling and shrink the blast radius of a single wedged
+   * connection, at the cost of more open connections per server. When unset
+   * (0) a built-in default is used.
+   */
+  poolSize?: number /* int */;
 }
 export interface MemoryConnectorConfig {
   maxItems: number /* int */;
@@ -769,6 +777,12 @@ export interface JsonRpcUpstreamConfig {
  */
 export interface GrpcUpstreamConfig {
   headers?: { [key: string]: string};
+  /**
+   * PoolSize is the number of independent gRPC connections opened to this
+   * upstream, selected round-robin per request. See GrpcConnectorConfig.PoolSize.
+   * When unset (0) a built-in default is used.
+   */
+  poolSize?: number /* int */;
 }
 export interface EvmUpstreamConfig {
   chainId: number /* int64 */;
@@ -1803,3 +1817,13 @@ export interface User {
   id: string;
   ratelimitbudget: string;
 }
+
+//////////
+// source: validation.go
+
+/**
+ * MaxGrpcConnPoolSize is the upper bound accepted for a gRPC connection-pool
+ * size. It guards against a fat-fingered value opening an absurd number of
+ * connections to each backing server; it is not a recommended operating point.
+ */
+export const MaxGrpcConnPoolSize = 256;


### PR DESCRIPTION
## What

The BDS gRPC client keeps a fixed round-robin pool of independent
`grpc.ClientConn`s per backing server (hard-coded to **3**) so that a single
wedged HTTP/2 connection only chokes ~1/N of in-flight callers. This PR makes
that pool size configurable via a new `poolSize` knob, exposed on **both** gRPC
config surfaces and defaulting to the existing value of 3 when unset:

- `database.*.connector.grpc.poolSize` — gRPC cache connectors
- `upstreams[].grpc.poolSize` — `grpc://` / `grpc+bds://` upstreams

Both feed the same client/pool, so the knob is wired symmetrically.

## Why

Under high concurrency a single HTTP/2 connection can become a bottleneck —
per-connection `MaxConcurrentStreams` limits, transport-level head-of-line
blocking, single-path load balancing. Today the only way to trade more open
connections for higher concurrent-stream headroom is to fork and rebuild. A
config knob lets operators tune (and A/B) this per connector/upstream without a
code change.

Default behavior is unchanged: an unset / zero / negative value falls back to
the built-in default (3), so existing configs are unaffected.

## Changes

- Add `PoolSize` to `GrpcConnectorConfig` and `GrpcUpstreamConfig` (`omitempty`).
- Thread it through `NewGrpcBdsClient` → `newBdsPool`; `<= 0` resolves to the
  default. Add `bdsPool.Size()`.
- Validate `poolSize` (`>= 0`, `<= 256`) and wire the checks into the existing
  connector- and upstream-level `Validate()`.
- Regenerate the TypeScript config types.

## Tests

- Pool opens exactly the configured number of connections; falls back to the
  default on unset/negative.
- `Pick()` round-robins across the configured size; `poolSize: 1` is a single,
  no-isolation connection.
- `poolSize` threads from `NewGrpcBdsClient` into the pool.
- Config: validation matrix (zero / positive / max / negative / over-max) on
  both surfaces; the connector- and upstream-level `Validate()` dispatch into
  the gRPC sub-config; `Copy()` preserves the value; YAML round-trips and
  `omitempty` drops a zero value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged when `poolSize` is unset; risk is mainly mis-tuning (e.g. `poolSize: 1` or very large values increasing connection load), bounded by validation and existing pool/watchdog logic.
> 
> **Overview**
> Adds a **`poolSize`** knob so operators can tune how many independent gRPC connections the BDS client opens per server, instead of always using the hard-coded default of **3**.
> 
> **Config:** `poolSize` is on `GrpcConnectorConfig` (`database.*.connector.grpc.poolSize`) and `GrpcUpstreamConfig` (`upstreams[].grpc.poolSize`), with YAML/JSON `omitempty`, validation (`0` = default, negative rejected, max **256**), and regenerated TypeScript types. **`GrpcUpstreamConfig.Copy()`** keeps the value when configs are cloned.
> 
> **Runtime:** `NewGrpcBdsClient` and `newBdsPool` take `poolSize`; values **≤ 0** still resolve to **`bdsPoolSize` (3)**. **`clients/registry.go`** and **`data/grpc.go`** pass connector/upstream config into the client. **`bdsPool.Size()`** exposes the effective size for logging.
> 
> **Tests:** New coverage for pool sizing, round-robin at custom N, default fallback, config validation/YAML, and existing call sites updated for the new constructor argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227abd39a9b9e73135ef102cae3b4a94711af175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->