### PR TITLE
fix(evm): namespace shared-state counter keys by value schema version

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -94,6 +95,18 @@ type EvmStatePoller struct {
 	earliestMu                   sync.RWMutex
 }
 
+// sharedCounterKey builds a shared-state counter key namespaced by the counter
+// value's wire-format version (data.CounterValueSchemaVersion). Namespacing by
+// version keeps erpc instances running incompatible counter formats from
+// reading or writing the same key — mixing the pre-0.0.63 bare-integer format
+// with the current JSON CounterInt64State on one key surfaces as an
+// "expected integer" parse error and breaks block-tip coordination. Crossing a
+// version boundary cold-starts the counter once; it re-seeds within a poll
+// interval, so requests are unaffected.
+func sharedCounterKey(parts ...string) string {
+	return data.CounterValueSchemaVersion + "/" + strings.Join(parts, "/")
+}
+
 func NewEvmStatePoller(
 	projectId string,
 	appCtx context.Context,
@@ -105,8 +118,8 @@ func NewEvmStatePoller(
 	networkId := up.NetworkId()
 	lg := logger.With().Str("component", "evmStatePoller").Str("networkId", networkId).Logger()
 
-	lbs := sharedState.GetCounterInt64(fmt.Sprintf("latestBlock/%s", common.UniqueUpstreamKey(up)), DefaultToleratedBlockHeadRollback)
-	fbs := sharedState.GetCounterInt64(fmt.Sprintf("finalizedBlock/%s", common.UniqueUpstreamKey(up)), DefaultToleratedBlockHeadRollback)
+	lbs := sharedState.GetCounterInt64(sharedCounterKey("latestBlock", common.UniqueUpstreamKey(up)), DefaultToleratedBlockHeadRollback)
+	fbs := sharedState.GetCounterInt64(sharedCounterKey("finalizedBlock", common.UniqueUpstreamKey(up)), DefaultToleratedBlockHeadRollback)
 
 	e := &EvmStatePoller{
 		projectId:                    projectId,
@@ -737,7 +750,7 @@ func (e *EvmStatePoller) initializeEarliestBlockDetectionAndStartScheduler(ctx c
 
 		// Initialize shared var if missing
 		if _, ok := e.earliestByProbe[probe]; !ok {
-			key := fmt.Sprintf("earliestBlock/%s/%s", common.UniqueUpstreamKey(e.upstream), string(probe))
+			key := sharedCounterKey("earliestBlock", common.UniqueUpstreamKey(e.upstream), string(probe))
 			e.earliestByProbe[probe] = e.sharedStateRegistry.GetCounterInt64(key, 0)
 		}
 

--- a/data/shared_state_registry.go
+++ b/data/shared_state_registry.go
@@ -15,6 +15,26 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// CounterValueSchemaVersion identifies the on-the-wire format this registry uses
+// to persist (Set) and publish (PublishCounterInt64) counter values. Callers
+// embed it in the counter key namespace (see the evm state poller) so that erpc
+// instances running incompatible counter formats never read or write the same
+// key.
+//
+// History:
+//   - v1 (erpc <= 0.0.62): bare integer string, e.g. "12345", parsed via Sscanf/ParseInt.
+//   - v2 (erpc >= 0.0.63): JSON CounterInt64State {value, updatedAt, updatedBy}.
+//
+// The two formats collide on a shared key: a v1 reader hitting a v2 JSON value
+// fails with "expected integer" and never seeds the counter, breaking
+// cross-instance block-tip coordination (and a v1 pub/sub subscriber silently
+// drops v2 messages). Bump this whenever the persisted value or the pub/sub
+// payload changes incompatibly. Crossing a version boundary cold-starts each
+// counter once; it re-seeds within a poll interval and the foreground request
+// path is local-only (see CounterInt64.TryUpdateIfStale), so requests are
+// unaffected.
+const CounterValueSchemaVersion = "v2"
+
 type SharedStateRegistry interface {
 	GetCounterInt64(key string, ignoreRollbackOf int64) CounterInt64SharedVariable
 	GetLockTtl() time.Duration

--- a/erpc/networks_earliest_detection_test.go
+++ b/erpc/networks_earliest_detection_test.go
@@ -281,8 +281,8 @@ func TestEarliestDetection_InitialDetectionAlwaysRunsOnBootstrap(t *testing.T) {
 	ssr, _ := data.NewSharedStateRegistry(ctx, &log.Logger, sharedStateCfg)
 
 	// Pre-set a value in shared state (simulating another instance)
-	// The key format matches what evm_state_poller uses
-	presetKey := "earliestBlock/evm:123:rpc1/blockHeader"
+	// The key format matches what evm_state_poller uses (version-namespaced)
+	presetKey := data.CounterValueSchemaVersion + "/earliestBlock/evm:123:rpc1/blockHeader"
 	presetCounter := ssr.GetCounterInt64(presetKey, 0)
 	presetCounter.TryUpdate(ctx, 50) // Pre-set to 50
 
@@ -620,7 +620,7 @@ func TestEarliestDetection_StaleHighValueInSharedState(t *testing.T) {
 	sha.Write([]byte("http://rpc1.localhost")) // upCfg.Endpoint
 	sha.Write([]byte("evm:123"))               // networkId
 	uniqueKey := "rpc1/" + hex.EncodeToString(sha.Sum(nil))
-	presetKey := fmt.Sprintf("earliestBlock/%s/blockHeader", uniqueKey)
+	presetKey := fmt.Sprintf("%s/earliestBlock/%s/blockHeader", data.CounterValueSchemaVersion, uniqueKey)
 	t.Logf("Pre-computed key: %s", presetKey)
 
 	// PRE-SET STALE/WRONG VALUE BEFORE BOOTSTRAP:


### PR DESCRIPTION
## Problem

The shared-state counter wire format changed **incompatibly** between erpc `<=0.0.62` and `>=0.0.63`, but both versions write the **same Redis keys** (`clusterKey/latestBlock/<UniqueUpstreamKey>`, etc.):

| | `<=0.0.62` (v1) | `>=0.0.63` (v2) |
|---|---|---|
| Persisted `value` | bare int `"12345"` (`Set(fmt.Sprintf("%d"))`) | JSON `{"value":..,"updatedAt":..,"updatedBy":..}` (`Marshal`) |
| Read path | `Sscanf("%d")` / `ParseInt` | `Unmarshal` into `CounterInt64State` |
| Pub/sub payload | bare `int64` | `CounterInt64State` |

Because the formats collide on one key, a reader hitting a value written by the *other* version can't parse it. An old reader on a new JSON value fails with **`expected integer`** ([Go `fmt` scan](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/fmt/scan.go;l=592)), the counter **never seeds**, and cross-instance block-tip coordination breaks. A v1 pub/sub subscriber also silently drops v2 messages. The counter `value` key is written with no TTL, so stale cross-version values persist.

This bites on **any mixed-version rolling deploy or rollback** across that boundary, worst on high-rate chains (e.g. Arbitrum) where the block counters churn fastest and `enforceHighestBlock` leans on them. Observed in production as:

```
{"level":"error","component":"sharedState","error":"expected integer",
 "key":"erpc-prod/latestBlock/erpc-1-evm:42161/<hash>",
 "message":"failed to fetch initial value for counter"}
{"level":"warn","component":"sharedState","task":"initialValue/...",
 "error":"expected integer","message":"initialization task failed"}
```

## Fix

Namespace block-head counter keys by an explicit **value schema version** (`data.CounterValueSchemaVersion = "v2"`), co-located with the registry that owns the (de)serialization. Instances speaking different formats now use **disjoint keys** and never collide, in either direction (deploy *or* rollback).

- `data/shared_state_registry.go` — exported `CounterValueSchemaVersion` constant with the v1→v2 history and a "bump on any incompatible format change" contract. Referenced by callers, so a future format change is a one-line bump that auto-renamespaces every counter.
- `architecture/evm/evm_state_poller.go` — a `sharedCounterKey()` helper threads the version into all 4 counter call sites (`latestBlock`, `finalizedBlock`, `earliestBlock` ×2). Keys go `erpc-prod/latestBlock/<hash>` → `erpc-prod/v2/latestBlock/<hash>`.
- `erpc/networks_earliest_detection_test.go` — preset keys updated to match.

## Behavior / safety

- **Upgrade across the boundary** cold-starts each counter once (v2 keys start empty → `RecordNotFound`, no error). It re-seeds within one poll interval, and `TryUpdateIfStale`'s foreground path is local-only (`enforceHighestBlock` is permissive at tip=0), so **requests are unaffected**.
- **Rollback** reads the old un-prefixed keys in the old format — no collision. v2 keys are simply orphaned.
- Note: this also re-namespaces away from the current un-prefixed JSON keys (`0.0.63`–`0.1.1`), so any upgrade to this build cold-starts block counters once. Old un-prefixed keys become orphaned (harmless; optionally flushable).

## Testing

- `go build ./...`, `go vet ./architecture/evm/ ./data/` — clean
- `go test ./data/` (full), `./erpc/ -run Earliest`, `./architecture/evm/ -run 'StatePoller|Earliest|Block'` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)