### PR TITLE
fix(initializer): gate request-path task re-runs behind retry backoff

### DIFF
--- a/erpc/networks_registry.go
+++ b/erpc/networks_registry.go
@@ -249,7 +249,13 @@ func (nr *NetworksRegistry) buildNetworkBootstrapTask(networkId string) *util.Bo
 			err = nr.upstreamsRegistry.PrepareUpstreamsForNetwork(ctx, networkId)
 			ups := nr.upstreamsRegistry.GetNetworkUpstreams(nr.appCtx, networkId)
 			if len(ups) == 0 {
-				nr.logger.Error().
+				// Warn, not Error: a network resolving to zero upstreams is
+				// usually a client requesting an unsupported/lazy network (e.g.
+				// an unknown chain id), which is expected and self-resolving —
+				// not an operator-actionable error. The initializer's per-task
+				// retry backoff (request path) already throttles how often this
+				// bootstrap re-runs, so this no longer fires once per request.
+				nr.logger.Warn().
 					Str("projectId", nr.project.Config.Id).
 					Str("networkId", networkId).
 					Err(err).

--- a/util/initializer.go
+++ b/util/initializer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -209,7 +210,7 @@ func (i *Initializer) ExecuteTasks(ctx context.Context, tasks ...*BootstrapTask)
 	i.tasksMu.Unlock()
 
 	i.ensureAutoRetryIfEnabled()
-	i.attemptRemainingTasks()
+	i.attemptRemainingTasks(true)
 
 	return i.waitForTasks(ctx, tasksToWait...)
 }
@@ -245,12 +246,56 @@ func (i *Initializer) waitForTasks(ctx context.Context, tasks ...*BootstrapTask)
 	return nil
 }
 
+// retryBackoff returns the minimum delay that must elapse after a task's last
+// attempt before it may run again. It mirrors the auto-retry loop's schedule
+// (RetryMinDelay growing by RetryFactor, capped at RetryMaxDelay) so the
+// request path and the background loop pace re-attempts identically.
+func (i *Initializer) retryBackoff(attempts int32) time.Duration {
+	minDelay := i.conf.RetryMinDelay
+	maxDelay := i.conf.RetryMaxDelay
+	factor := i.conf.RetryFactor
+	if minDelay <= 0 {
+		minDelay = 3 * time.Second
+	}
+	if maxDelay <= 0 {
+		maxDelay = 130 * time.Second
+	}
+	if factor < 1 {
+		factor = 1.5
+	}
+	if attempts < 1 {
+		return minDelay
+	}
+	d := float64(minDelay) * math.Pow(factor, float64(attempts-1))
+	if d >= float64(maxDelay) {
+		return maxDelay
+	}
+	return time.Duration(d)
+}
+
+// taskReadyForRetry reports whether a failed/timed-out task's backoff has
+// elapsed since its last attempt. A task with no recorded attempt is always
+// ready (it has effectively never run).
+func (i *Initializer) taskReadyForRetry(t *BootstrapTask) bool {
+	lastAttempt, ok := t.lastAttempt.Load().(time.Time)
+	if !ok || lastAttempt.IsZero() {
+		return true
+	}
+	return time.Since(lastAttempt) >= i.retryBackoff(t.attempts.Load())
+}
+
 // attemptRemainingTasks tries to run any tasks in Pending, Failed or TimedOut states again.
 // This function must use appContext to avoid premature cancellation of tasks when caller context is cancelled.
 // The correct way to enforce timeout is to pass appropriate context to "waitForTasks()" function.
 // To enforce timeout of task execution set proper TaskTimeout in InitializerConfig.
 // To cancel a running task, use MarkTaskAsFailed() function instead.
-func (i *Initializer) attemptRemainingTasks() {
+//
+// respectBackoff gates re-attempts of already-failed/timed-out tasks behind
+// their per-task retry backoff. The request path (ExecuteTasks) sets it true so
+// a flood of requests for a not-yet-ready network cannot re-execute a failing
+// task on every request. The auto-retry loop sets it false because it already
+// paces itself, so it remains the authoritative driver of retry cadence.
+func (i *Initializer) attemptRemainingTasks(respectBackoff bool) {
 	i.tasksMu.Lock()
 	defer i.tasksMu.Unlock()
 
@@ -262,6 +307,18 @@ func (i *Initializer) attemptRemainingTasks() {
 		t := value.(*BootstrapTask)
 		state := TaskState(t.state.Load())
 		if state == TaskPending || state == TaskFailed || state == TaskTimedOut {
+			// Gate re-attempts of already-failed/timed-out tasks behind their
+			// retry backoff. ExecuteTasks (hence this function) runs on every
+			// request for a not-yet-ready network, so without this gate a
+			// permanently-failing task (e.g. a lazy-loaded network that resolves
+			// to zero upstreams) is re-executed on every single request — burning
+			// CPU and flooding logs. Pending tasks have never run, so they always
+			// start immediately. The auto-retry loop passes respectBackoff=false
+			// because it already paces its own cadence.
+			if respectBackoff && (state == TaskFailed || state == TaskTimedOut) && !i.taskReadyForRetry(t) {
+				wg.Done()
+				return true
+			}
 			// Attempt to swap from [Pending|Failed|Timeout] -> Running
 			// #nosec G115 - We know TaskState is small enough that int->int32 won't overflow
 			if t.state.CompareAndSwap(int32(state), int32(TaskRunning)) {
@@ -578,7 +635,7 @@ func (i *Initializer) autoRetryLoop(ctx context.Context) {
 			return
 		}
 		i.attempts.Add(1)
-		i.attemptRemainingTasks()
+		i.attemptRemainingTasks(false)
 		err := i.WaitForTasks(ctx)
 		state := i.State()
 		if state == StateFatal {

--- a/util/initializer_test.go
+++ b/util/initializer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +18,86 @@ import (
 func setupInitializer(t *testing.T, ctx context.Context, conf *InitializerConfig) *Initializer {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 	return NewInitializer(ctx, &logger, conf)
+}
+
+// TestInitializer_FailedTaskBackoffGatesReRuns reproduces the production hot
+// path where NetworksRegistry.GetNetwork calls ExecuteTasks on every incoming
+// request for a network that never finishes initializing (e.g. a lazy-loaded
+// network that resolves to zero upstreams). Each request builds a fresh task
+// with the same name, so without a backoff gate the failing task is re-executed
+// on every single request — which is what flooded prod with ~900k/2h
+// "network initialization ended with zero upstreams" error logs.
+//
+// A just-failed task must NOT be re-executed again until its retry backoff has
+// elapsed; rapid requests inside that window should return the cached failure.
+func TestInitializer_FailedTaskBackoffGatesReRuns(t *testing.T) {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Auto-retry off isolates the request-path (ExecuteTasks) behavior; a large
+	// RetryMinDelay keeps every rapid re-execution inside the backoff window.
+	conf := &InitializerConfig{
+		TaskTimeout:   5 * time.Second,
+		AutoRetry:     false,
+		RetryFactor:   1.5,
+		RetryMinDelay: 10 * time.Second,
+		RetryMaxDelay: 130 * time.Second,
+	}
+	init := setupInitializer(t, appCtx, conf)
+
+	var runs atomic.Int32
+	fn := func(ctx context.Context) error {
+		runs.Add(1)
+		return errors.New("network initialization ended with zero upstreams")
+	}
+
+	const requests = 25
+	for i := 0; i < requests; i++ {
+		// Mirrors GetNetwork -> ExecuteTasks(buildNetworkBootstrapTask(id)):
+		// a fresh task object each time, keyed by the same name.
+		err := init.ExecuteTasks(appCtx, NewBootstrapTask("network/evm:999", fn))
+		require.Error(t, err, "every request must still surface the init failure")
+	}
+
+	assert.Equal(t, int32(1), runs.Load(),
+		"a failing task must not be re-executed on every request within its backoff window")
+}
+
+// TestInitializer_FailedTaskReRunsAfterBackoff is the complement: once the
+// backoff elapses, the task becomes eligible again so a subsequent request (or
+// the auto-retry loop) re-runs it — the gate delays re-execution, it does not
+// permanently pin a task to its first failure.
+func TestInitializer_FailedTaskReRunsAfterBackoff(t *testing.T) {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conf := &InitializerConfig{
+		TaskTimeout:   5 * time.Second,
+		AutoRetry:     false,
+		RetryFactor:   1.5,
+		RetryMinDelay: 50 * time.Millisecond,
+		RetryMaxDelay: 130 * time.Second,
+	}
+	init := setupInitializer(t, appCtx, conf)
+
+	var runs atomic.Int32
+	fn := func(ctx context.Context) error {
+		runs.Add(1)
+		return errors.New("still failing")
+	}
+
+	_ = init.ExecuteTasks(appCtx, NewBootstrapTask("network/evm:1000", fn))
+	require.Equal(t, int32(1), runs.Load(), "first request runs the task")
+
+	// Within the backoff window: no re-run.
+	_ = init.ExecuteTasks(appCtx, NewBootstrapTask("network/evm:1000", fn))
+	require.Equal(t, int32(1), runs.Load(), "request inside backoff window must not re-run")
+
+	// After the backoff elapses: the next request re-runs the task.
+	time.Sleep(80 * time.Millisecond)
+	_ = init.ExecuteTasks(appCtx, NewBootstrapTask("network/evm:1000", fn))
+	require.Equal(t, int32(2), runs.Load(),
+		"a failing task must become eligible for re-execution once its backoff elapses")
 }
 
 func TestInitializer_SingleTaskSuccess(t *testing.T) {


### PR DESCRIPTION
## Problem (found via prod telemetry)

In production, **~96% of all `erpc-proxy` error logs** were a single internal message — `"network initialization ended with zero upstreams"` — at **~880k / 2h**, dwarfing every real upstream error.

Root cause: `NetworksRegistry.GetNetwork` calls `Initializer.ExecuteTasks` on **every incoming request** for a network not yet in `preparedNetworks`, and `attemptRemainingTasks` re-ran any `Failed`/`TimedOut` task **unconditionally**. A network that can never initialize — most commonly a lazy-loaded network that resolves to **zero upstreams** (an unknown/unsupported chain id like `evm:3698193502869237`) — never enters `preparedNetworks`, so it was fully re-bootstrapped (resolve config + prepare upstreams) on **every request**, at request rate rather than the 130s retry cadence.

Confirmed in metrics: if the 130s auto-retry were the only driver, the volume would be ~4.6k/2h (84 dead networks × 55 cycles). The observed 880k is ~190× that — i.e. request-driven re-execution.

Impact:
- **Log flood** — 96% of error logs are this one self-inflicted line; real errors buried ~25:1.
- **Wasted CPU + latency** — every request to a dead network synchronously re-runs the full (failing) bootstrap.
- **Unbounded growth** — one permanent `TaskFailed` entry per unique bogus chain id, never evicted, each auto-retried forever (mild DoS vector for clients spraying chain ids).

## Fix

`attemptRemainingTasks` now takes `respectBackoff`:
- **Request path** (`ExecuteTasks`) passes `true` — a `Failed`/`TimedOut` task whose per-task backoff hasn't elapsed returns the **cached failure** instead of re-running. Re-execution is bounded to the retry cadence regardless of request rate.
- **Auto-retry loop** passes `false` — it already self-paces, so it stays the authoritative retry driver and its cadence is unchanged.
- **Pending** (never-run) tasks always start immediately, so first-touch latency is unaffected.
- Networks that bootstrap successfully are served from `preparedNetworks` and never touch this path.

The per-task backoff mirrors the auto-retry loop's existing schedule (`RetryMinDelay` × `RetryFactor`, capped at `RetryMaxDelay`).

Also downgrade the `"zero upstreams"` log **Error → Warn** (it's usually a client requesting an unsupported/lazy chain, and self-resolving — not operator-actionable). Combined with the gate, this message drops ~190× in frequency *and* in severity.

## Tests (TDD)

Added two regression tests that fail on `main` and pass with the fix:
- `TestInitializer_FailedTaskBackoffGatesReRuns` — 25 rapid requests for a failing task ⇒ **1 execution** (was 25).
- `TestInitializer_FailedTaskReRunsAfterBackoff` — no re-run inside the backoff window; re-runs once the backoff elapses (the gate delays, it doesn't pin).

## Verification

`go build ./...`, `go vet ./util/ ./erpc/`, and the full `./erpc/` (767s), `./util/`, `./upstream/` suites all pass. The existing `TestInitializer_ManualMarkAsFailedAfterSuccess` (auto-retry path) is unaffected because the auto-retry loop keeps `respectBackoff=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
