### PR TITLE
feat(cache): gate cache connectors by tags + use-upstream directive

### DIFF
--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -41,12 +41,14 @@ func NewEvmJsonRpcCache(ctx context.Context, logger *zerolog.Logger, cfg *common
 
 	// Create connectors map
 	connectors := make(map[string]data.Connector)
+	connectorTags := make(map[string][]string)
 	for _, connCfg := range cfg.Connectors {
 		c, err := data.NewConnector(ctx, logger, connCfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create connector %s: %w", connCfg.Id, err)
 		}
 		connectors[connCfg.Id] = c
+		connectorTags[connCfg.Id] = connCfg.Tags
 	}
 
 	// Create policies
@@ -61,6 +63,8 @@ func NewEvmJsonRpcCache(ctx context.Context, logger *zerolog.Logger, cfg *common
 		if err != nil {
 			return nil, fmt.Errorf("failed to create policy: %w", err)
 		}
+		// Connector tags drive use-upstream gating of this policy's cache.
+		policy.SetConnectorTags(connectorTags[policyCfg.Connector])
 		policies = append(policies, policy)
 	}
 
@@ -230,10 +234,15 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 	results := make(chan fanResult, len(policies))
 	spawned := 0
 
+	useUpstream := useUpstreamSelector(req)
 	for _, p := range policies {
 		conn := p.GetConnector()
 		if req.ShouldSkipCacheRead(conn.Id()) {
 			c.logger.Debug().Str("connector", conn.Id()).Interface("id", req.ID()).Msg("skipping cache connector due to skip-cache-read directive pattern")
+			continue
+		}
+		if eligible, _ := p.MatchesUpstreamSelector(useUpstream); !eligible {
+			c.logger.Debug().Str("connector", conn.Id()).Str("useUpstream", useUpstream).Interface("id", req.ID()).Msg("skipping cache connector due to use-upstream directive selector")
 			continue
 		}
 		spawned++
@@ -714,7 +723,14 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 	wg := sync.WaitGroup{}
 	errs := []error{}
 	errsMu := sync.Mutex{}
+	useUpstream := useUpstreamSelector(req)
 	for _, policy := range policies {
+		// Don't write a response into a cache the request's use-upstream selector
+		// excludes, so a source-tagged connector only stores matching data.
+		if eligible, _ := policy.MatchesUpstreamSelector(useUpstream); !eligible {
+			lg.Debug().Str("connector", policy.GetConnector().Id()).Str("useUpstream", useUpstream).Msg("skipping cache write due to use-upstream directive selector")
+			continue
+		}
 		wg.Add(1)
 		go func(policy *data.CachePolicy) {
 			defer wg.Done()
@@ -1178,6 +1194,15 @@ func shouldCacheResponse(
 	default:
 		return false, fmt.Errorf("unknown cache empty behavior: %s", policy.EmptyState())
 	}
+}
+
+// useUpstreamSelector returns the request's use-upstream directive, used to gate
+// which cache connectors may serve/store it (empty = no gating).
+func useUpstreamSelector(req *common.NormalizedRequest) string {
+	if d := req.Directives(); d != nil {
+		return d.UseUpstream
+	}
+	return ""
 }
 
 func generateKeysForJsonRpcRequest(

--- a/common/config.go
+++ b/common/config.go
@@ -345,8 +345,15 @@ const (
 )
 
 type ConnectorConfig struct {
-	Id              string                     `yaml:"id,omitempty" json:"id"`
-	Driver          ConnectorDriverType        `yaml:"driver" json:"driver" tstype:"TsConnectorDriverType"`
+	Id     string              `yaml:"id,omitempty" json:"id"`
+	Driver ConnectorDriverType `yaml:"driver" json:"driver" tstype:"TsConnectorDriverType"`
+	// Tags label the data source a connector caches, so the `use-upstream`
+	// directive can gate which connector is read/written — e.g. a connector
+	// fed by a system-transaction node tagged `systx` is only used when the
+	// request's selector admits it. Same glob/`!negation` grammar as upstream
+	// tags. Untagged connectors are always eligible (a use-upstream pin meant
+	// for upstreams must not disable a normal cache).
+	Tags            []string                   `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Memory          *MemoryConnectorConfig     `yaml:"memory,omitempty" json:"memory"`
 	Redis           *RedisConnectorConfig      `yaml:"redis,omitempty" json:"redis"`
 	DynamoDB        *DynamoDBConnectorConfig   `yaml:"dynamodb,omitempty" json:"dynamodb"`

--- a/common/matcher.go
+++ b/common/matcher.go
@@ -117,6 +117,36 @@ func UpstreamMatchesSelector(pattern string, u Upstream) (bool, error) {
 	return MatchesSelector(pattern, u.Id(), tags)
 }
 
+// SelectorAdmits reports whether `pattern` permits an entity identified by `id`
+// and carrying `tags`. It extends MatchesSelector with tag-level exclusion so a
+// negated selector can filter by tag — MatchesSelector deliberately matches
+// negation against the id only (see its doc), but a source-tagged cache
+// connector must be excludable by tag (a `!systx*` request must skip a
+// `systx`-tagged cache even though the connector id is e.g. `prism`).
+//
+//   - Positive patterns (no `!`): identical to MatchesSelector — admitted if the
+//     id matches, else if any tag matches.
+//   - Patterns containing `!`: admitted only if the id AND every tag satisfy the
+//     expression; one excluded tag rejects the entity. The `!`-branch mirrors
+//     MatchesSelector's own negation guard.
+func SelectorAdmits(pattern, id string, tags []string) (bool, error) {
+	if pattern == "" {
+		return false, nil
+	}
+	if !strings.ContainsRune(pattern, '!') {
+		return MatchesSelector(pattern, id, tags)
+	}
+	if ok, err := WildcardMatch(pattern, id); err != nil || !ok {
+		return false, err
+	}
+	for _, t := range tags {
+		if ok, err := WildcardMatch(pattern, t); err != nil || !ok {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 // ValidatePattern checks if a pattern string is syntactically valid.
 // It returns an error if the pattern is invalid, nil otherwise.
 func ValidatePattern(pattern string) error {

--- a/common/matcher_test.go
+++ b/common/matcher_test.go
@@ -210,6 +210,43 @@ func TestMatchesSelector(t *testing.T) {
 	}
 }
 
+func TestSelectorAdmits(t *testing.T) {
+	// id "prism" carrying tag "systx" models a system-transaction cache connector.
+	tests := []struct {
+		name    string
+		pattern string
+		id      string
+		tags    []string
+		want    bool
+	}{
+		// --- positive patterns behave exactly like MatchesSelector ---
+		{name: "positive tag match", pattern: "systx*", id: "prism", tags: []string{"systx"}, want: true},
+		{name: "positive id match", pattern: "prism", id: "prism", tags: []string{"systx"}, want: true},
+		{name: "positive no match", pattern: "alchemy*", id: "prism", tags: []string{"systx"}, want: false},
+
+		// --- negation honors tag-level exclusion (the new capability) ---
+		{name: "negation excludes by tag despite id", pattern: "!systx*", id: "prism", tags: []string{"systx"}, want: false},
+		{name: "negation admits unrelated source", pattern: "!systx*", id: "redis", tags: []string{"clean"}, want: true},
+		{name: "negation: one excluded tag rejects", pattern: "!systx*", id: "prism", tags: []string{"region:us", "systx"}, want: false},
+
+		// --- edge cases ---
+		{name: "empty pattern admits nothing", pattern: "", id: "prism", tags: []string{"systx"}, want: false},
+		{name: "positive, no tags", pattern: "systx*", id: "prism", tags: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SelectorAdmits(tt.pattern, tt.id, tt.tags)
+			if err != nil {
+				t.Fatalf("SelectorAdmits() unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("SelectorAdmits(%q, %q, %v) = %v, want %v", tt.pattern, tt.id, tt.tags, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidatePattern(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/data/cache_policy.go
+++ b/data/cache_policy.go
@@ -10,11 +10,12 @@ import (
 )
 
 type CachePolicy struct {
-	config    *common.CachePolicyConfig
-	connector Connector
-	str       string
-	minSize   *int
-	maxSize   *int
+	config        *common.CachePolicyConfig
+	connector     Connector
+	connectorTags []string
+	str           string
+	minSize       *int
+	maxSize       *int
 }
 
 func NewCachePolicy(cfg *common.CachePolicyConfig, connector Connector) (*CachePolicy, error) {
@@ -53,6 +54,25 @@ func NewCachePolicy(cfg *common.CachePolicyConfig, connector Connector) (*CacheP
 		minSize:   minSize,
 		maxSize:   maxSize,
 	}, nil
+}
+
+// SetConnectorTags records the tags of the policy's connector so the policy can
+// be gated by the use-upstream directive. Tags live on the ConnectorConfig (one
+// connector backs many policies); the cache wires them in at construction.
+func (p *CachePolicy) SetConnectorTags(tags []string) {
+	p.connectorTags = tags
+}
+
+// MatchesUpstreamSelector reports whether this policy's connector is eligible to
+// serve (get) or store (set) a request carrying the given use-upstream selector.
+// An untagged connector — or an empty selector — is always eligible, so an
+// upstream pin never silently disables a normal cache; a tagged connector
+// participates only when the selector admits its id/tags. See SelectorAdmits.
+func (p *CachePolicy) MatchesUpstreamSelector(selector string) (bool, error) {
+	if selector == "" || len(p.connectorTags) == 0 {
+		return true, nil
+	}
+	return common.SelectorAdmits(selector, p.connector.Id(), p.connectorTags)
 }
 
 func (p *CachePolicy) MarshalJSON() ([]byte, error) {

--- a/data/cache_policy_test.go
+++ b/data/cache_policy_test.go
@@ -301,3 +301,40 @@ func TestCachePolicy_MatchParams(t *testing.T) {
 		})
 	}
 }
+
+func TestCachePolicy_MatchesUpstreamSelector(t *testing.T) {
+	// Connector "prism" stands in for a system-transaction cache.
+	cases := []struct {
+		name     string
+		tags     []string
+		selector string
+		want     bool
+	}{
+		// Untagged connector: never gated by an upstream pin.
+		{name: "untagged, no selector", tags: nil, selector: "", want: true},
+		{name: "untagged, selector present", tags: nil, selector: "systx*", want: true},
+		{name: "untagged, unrelated upstream pin", tags: nil, selector: "alchemy", want: true},
+
+		// Tagged connector: participates only when the selector admits it.
+		{name: "tagged, no selector", tags: []string{"systx"}, selector: "", want: true},
+		{name: "tagged, selector matches tag", tags: []string{"systx"}, selector: "systx*", want: true},
+		{name: "tagged, selector excludes tag", tags: []string{"systx"}, selector: "!systx*", want: false},
+		{name: "tagged, unrelated selector", tags: []string{"systx"}, selector: "alchemy", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy, err := NewCachePolicy(&common.CachePolicyConfig{
+				Network:  "*",
+				Method:   "*",
+				Finality: common.DataFinalityStateUnfinalized,
+			}, NewMockConnector("prism"))
+			assert.NoError(t, err)
+			policy.SetConnectorTags(tc.tags)
+
+			got, err := policy.MatchesUpstreamSelector(tc.selector)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -143,6 +143,46 @@ func createCacheTestFixtures(ctx context.Context, upstreamConfigs []upsTestCfg) 
 	return []*data.MockConnector{mockConnector1, mockConnector2}, mockNetwork, upstreams, cache
 }
 
+func TestEvmJsonRpcCache_Set_UseUpstreamGating(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockConnectors, mockNetwork, mockUpstreams, cache := createCacheTestFixtures(ctx, []upsTestCfg{{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15}})
+
+	// connector[0] caches system-transaction data (tagged systx); connector[1] is a neutral cache.
+	systxPolicy, err := data.NewCachePolicy(&common.CachePolicyConfig{
+		Network: "evm:123",
+		Method:  "eth_getBlockByNumber",
+	}, mockConnectors[0])
+	require.NoError(t, err)
+	systxPolicy.SetConnectorTags([]string{"systx"})
+
+	neutralPolicy, err := data.NewCachePolicy(&common.CachePolicyConfig{
+		Network: "evm:123",
+		Method:  "eth_getBlockByNumber",
+	}, mockConnectors[1])
+	require.NoError(t, err)
+
+	cache.SetPolicies([]*data.CachePolicy{systxPolicy, neutralPolicy})
+
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",false],"id":1}`))
+	req.SetNetwork(mockNetwork)
+	req.SetCacheDal(cache)
+	// Caller pinned away from systx sources, so the systx-tagged cache must be skipped.
+	req.SetDirectives(&common.RequestDirectives{UseUpstream: "!systx*"})
+	resp := common.NewNormalizedResponse().WithRequest(req).WithBody(stringToReaderCloser(`{"result":{"hash":"0xabc","number":"0x2"}}`))
+	resp.SetUpstream(mockUpstreams[0])
+	req.SetLastValidResponse(ctx, resp)
+
+	mockConnectors[0].On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockConnectors[1].On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	err = cache.Set(context.Background(), req, resp)
+	assert.NoError(t, err)
+
+	mockConnectors[0].AssertNotCalled(t, "Set")
+	mockConnectors[1].AssertCalled(t, "Set", mock.Anything, "evm:123:2", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestEvmJsonRpcCache_Set(t *testing.T) {
 	t.Run("DoNotCacheWhenEthGetTransactionByHashMissingBlockNumber", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -354,6 +354,15 @@ export declare const DriverGrpc: ConnectorDriverType;
 export interface ConnectorConfig {
     id?: string;
     driver: TsConnectorDriverType;
+    /**
+     * Tags label the data source a connector caches, so the `use-upstream`
+     * directive can gate which connector is read/written — e.g. a connector
+     * fed by a system-transaction node tagged `systx` is only used when the
+     * request's selector admits it. Same glob/`!negation` grammar as upstream
+     * tags. Untagged connectors are always eligible (a use-upstream pin meant
+     * for upstreams must not disable a normal cache).
+     */
+    tags?: string[];
     memory?: MemoryConnectorConfig;
     redis?: RedisConnectorConfig;
     dynamodb?: DynamoDBConnectorConfig;

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -385,6 +385,15 @@ export const DriverGrpc: ConnectorDriverType = "grpc";
 export interface ConnectorConfig {
   id?: string;
   driver: TsConnectorDriverType;
+  /**
+   * Tags label the data source a connector caches, so the `use-upstream`
+   * directive can gate which connector is read/written — e.g. a connector
+   * fed by a system-transaction node tagged `systx` is only used when the
+   * request's selector admits it. Same glob/`!negation` grammar as upstream
+   * tags. Untagged connectors are always eligible (a use-upstream pin meant
+   * for upstreams must not disable a normal cache).
+   */
+  tags?: string[];
   memory?: MemoryConnectorConfig;
   redis?: RedisConnectorConfig;
   dynamodb?: DynamoDBConnectorConfig;
@@ -544,6 +553,7 @@ export interface ProjectConfig {
    */
   userAgentMode?: UserAgentTrackingMode;
   forwardHeaders?: string[];
+  allowClientDirectives?: string;
   ignoreMethods?: string[];
   allowMethods?: string[];
   /**


### PR DESCRIPTION
## Summary

Lets a cache connector be **tagged** with the data source it caches, and makes the existing `use-upstream` request directive **gate which cache connectors may serve (get) or store (set)** a response — reusing the exact selector grammar already used for upstream selection (`MatchesSelector`: glob + `&`/`|`/`!`/parens, matched against id and tags).

Eligibility rule (per cache policy's connector):

| condition | eligible? |
|---|---|
| connector has **no tags** | ✅ always (neutral) |
| `use-upstream` absent | ✅ always |
| connector tagged, selector admits it | ✅ |
| connector tagged, selector excludes it | ❌ skipped (get and set) |

Untagged connectors stay neutral, so an upstream-only pin (e.g. `use-upstream=alchemy`) never silently disables a normal Redis/memory cache — **fully backward compatible**.

## Motivation

HyperEVM nodes that surface **system transactions** (`systx`) return extra txs that some consumers (e.g. ponder indexers) don't expect, so today such a cache can't be enabled safely — a request that wants clean data might be served `systx`-sourced data and vice-versa.

With this change you tag the `systx`-backed connector `tags: [systx]` and the behavior becomes predictable:

- `use-upstream=systx*` → reads/writes the systx cache ✅
- `use-upstream=!systx*` → **skips** the systx cache (clean-data consumers) ✅
- omitted → neutral caches still apply (no predictability expectation) ✅

## Implementation

- **`common`**: `Tags []string` on `ConnectorConfig`; new `SelectorAdmits(pattern,id,tags)` = `MatchesSelector` for positive patterns, plus tag-level exclusion for negated ones (a `!systx*` request must skip a `systx`-tagged connector even though its id is e.g. `prism`, which `MatchesSelector` intentionally won't do).
- **`data`**: `CachePolicy` records its connector's tags (`SetConnectorTags`) and exposes `MatchesUpstreamSelector`.
- **`architecture/evm`**: gate the Get fan-out loop and the Set write loop by the request's `use-upstream` directive.
- Regenerated `typescript/config` types.

## Tests

- `TestSelectorAdmits` — positive/negation/exclusion matrix
- `TestCachePolicy_MatchesUpstreamSelector` — neutral vs tagged gating
- `TestEvmJsonRpcCache_Set_UseUpstreamGating` — end-to-end: a `systx`-tagged connector is **not** written under `use-upstream=!systx*` while the neutral connector is

## Notes / scope

- This gates connector **selection**; it does not encode the source into the cache key. A *neutral* (untagged) connector shared by mixed sources still mixes — predictability comes from routing source-specific data to a *tagged* connector. Folding a source dimension into the cache key would be a separate, larger change.
- Negated selectors containing `!` use an "every facet must satisfy" rule (mirrors `MatchesSelector`'s own `!` guard); a single excluded tag rejects the connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which cache layer serves or stores responses for pinned requests; mis-tagged connectors could cause unexpected misses or skipped writes, but behavior is opt-in via tags and directives.
> 
> **Overview**
> Adds optional **`tags`** on cache **connectors** and reuses the request **`use-upstream`** selector to decide which connector-backed policies may **read** or **write** cache entries.
> 
> **`SelectorAdmits`** extends upstream-style matching so **negated** selectors (e.g. `!systx*`) can exclude connectors by **tag**, not only by connector id—needed when a systx-backed cache uses a neutral id like `prism`. **Untagged** connectors and requests **without** `use-upstream` stay eligible, so existing setups keep working.
> 
> Cache construction wires connector tags onto policies; the EVM JSON-RPC cache **skips** gated connectors in the **Get** fan-out and **Set** loop when the directive does not admit them. TypeScript config types are regenerated; tests cover selector logic, policy gating, and an end-to-end Set skip for a systx-tagged connector under `!systx*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38798e33526ce0e0b6d224306b2516e2e78d6e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->