### PR TITLE
fix(grafana): accurate legend Total for fixed-window cache + upstream count panels

### DIFF
--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -7997,7 +7997,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_upstream_request_errors_total{\n    cluster=~\"${cluster:regex}\",\n    namespace=~\"${namespace:regex}\",\n    region=~\"${region:regex}\",\n    finality=~\"${finality:regex}\",\n    severity=\"info\",\n    network=~\"${network:regex}\",\n    upstream=~\"${upstream:regex}\",\n    category=~\"${category:regex}\",\n    user=~\"${user:regex}\",\n    composite=\"none\",\n    vendor=~\"${vendor:regex}\",\n    vendor!~\"${ignore_vendor:regex}\",\n    project=~\"${project:regex}\"\n}[1m])) by (project, network, upstream, category, error) > 0",
+              "expr": "sum(increase(erpc_upstream_request_errors_total{\n    cluster=~\"${cluster:regex}\",\n    namespace=~\"${namespace:regex}\",\n    region=~\"${region:regex}\",\n    finality=~\"${finality:regex}\",\n    severity=\"info\",\n    network=~\"${network:regex}\",\n    upstream=~\"${upstream:regex}\",\n    category=~\"${category:regex}\",\n    user=~\"${user:regex}\",\n    composite=\"none\",\n    vendor=~\"${vendor:regex}\",\n    vendor!~\"${ignore_vendor:regex}\",\n    project=~\"${project:regex}\"\n}[$__interval])) by (project, network, upstream, category, error) > 0",
               "interval": "",
               "legendFormat": "{{project}}, {{network}}, {{category}}, {{upstream}}, {{error}}",
               "range": true,

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -11412,7 +11412,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_set_success_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[1m])) by (project, network, category, connector)",
+              "expr": "sum(increase(erpc_cache_set_success_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[$__interval])) by (project, network, category, connector)",
               "legendFormat": "{{project}}, {{network}}, {{category}}, {{connector}}",
               "range": true,
               "refId": "A"
@@ -11627,7 +11627,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_set_error_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[1m])) by (project, network, category, connector, policy, error, ttl)",
+              "expr": "sum(increase(erpc_cache_set_error_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[$__interval])) by (project, network, category, connector, policy, error, ttl)",
               "legendFormat": "{{project}}, {{network}}, {{category}}, {{connector}}, {{error}}, {{policy}}, TTL={{ttl}}",
               "range": true,
               "refId": "A"
@@ -11843,7 +11843,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_get_success_hit_total{namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\", cluster=~\"${cluster:regex}\"}[30s])) by (project, network, category, connector)",
+              "expr": "sum(increase(erpc_cache_get_success_hit_total{namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\", cluster=~\"${cluster:regex}\"}[$__interval])) by (project, network, category, connector)",
               "legendFormat": "{{project}}, {{network}}, {{category}}, {{connector}}",
               "range": true,
               "refId": "A"
@@ -12065,7 +12065,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_get_success_miss_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[1m])) by (project, network, category, connector)",
+              "expr": "sum(increase(erpc_cache_get_success_miss_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", project=~\"${project:regex}\"}[$__interval])) by (project, network, category, connector)",
               "legendFormat": "{{project}}, {{network}}, {{category}}, {{connector}}",
               "range": true,
               "refId": "A"
@@ -12282,7 +12282,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_get_error_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", error!~\".*(ErrRecordNotFound|MissingData).*\", project=~\"${project:regex}\"}[1m])) by (region, project, network, category, connector, error) > 0",
+              "expr": "sum(increase(erpc_cache_get_error_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", category=~\"${category:regex}\", error!~\".*(ErrRecordNotFound|MissingData).*\", project=~\"${project:regex}\"}[$__interval])) by (region, project, network, category, connector, error) > 0",
               "legendFormat": "{{region}} {{project}}, {{network}}, {{category}}, {{connector}}, {{error}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
## Problem

The Grafana cache **count** panels — *Cache SET success total*, *Cache SET error total*, *Cache GET success-hit total*, *Cache GET success-miss total*, and *Cache GET error total* — render `sum(increase(..._total[<fixed>]))` as a time series and depend on the legend **Total** reduction for the per-series count.

With a **fixed** range window (`[1m]`, and `[30s]` on the hit panel) evaluated at a finer step, adjacent windows **overlap**, so summing the points over-counts. At a ~15s step a `[1m]` window counts each event ~**4×** — the legend "Total" then disagrees with the actual served counts (e.g. the vendor/cache-share pies), which is what makes the numbers look like they "don't add up."

## Fix

Switch these five panels to **`[$__interval]`** so each bucket's `increase()` tiles the selected range with no overlap:

- the bar shape and any spikes are preserved (still a time series), and
- the legend **Total** now equals the true number of events over the selected range.

## Not changed

Latency/quantile panels (`histogram_quantile(sum(rate(..._duration_seconds_bucket[...])))`) keep their fixed `rate()` windows — `rate()` over a window is the correct construct there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only dashboard JSON; no runtime or application behavior changes.
> 
> **Overview**
> Updates six **eRPC** Grafana time-series panels in `erpc.json` so `sum(increase(...))` uses **`[$__interval]`** instead of fixed **`[1m]`** or **`[30s]`** windows.
> 
> Affected panels: **Upstream-level notices** (info-severity upstream errors) and the five **cache count** panels (SET success/error, GET hit/miss/error). The goal is non-overlapping buckets that match the dashboard query step, so legend **Total** matches real event counts over the selected range (and aligns with other cache/share views). **Histogram/rate** latency panels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db93c10a6aecdad2dfac2445f84e1edbec314f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->