### PR TITLE
feat(thirdparty): add XDC Apothem testnet (51) to Ankr and Envio

### DIFF
--- a/thirdparty/ankr.go
+++ b/thirdparty/ankr.go
@@ -18,6 +18,7 @@ var ankrNetworkNames = map[int64]string{
 	14:     "flare",
 	40:     "telos",
 	50:     "xdc",
+	51:     "xdc_testnet",
 	56:     "bsc",
 	57:     "syscoin",
 	88:     "velas",

--- a/thirdparty/envio.go
+++ b/thirdparty/envio.go
@@ -71,6 +71,7 @@ var envioKnownSupportedChains = map[int64]struct{}{
 	324:        {}, // ZKsync
 	7777777:    {}, // Zora
 	50:         {}, // Xdc
+	51:         {}, // Xdc Testnet (Apothem)
 	2741:       {}, // Abstract
 	5115:       {}, // Citrea Testnet
 	7560:       {}, // Cyber


### PR DESCRIPTION
XDC **mainnet (50)** is already supported across `ankr`, `dwellir`, and `envio`. This adds the **XDC Apothem testnet (chainId 51)** to the providers that serve it:

- **Ankr** (`ankr.go`): `51: "xdc_testnet"` — verified: `rpc.ankr.com/xdc_testnet` returns `eth_chainId` = `0x33` (51).
- **Envio** (`envio.go`): `51` — verified: Envio HyperSync supported-networks lists "Xdc Testnet".

(Left Dwellir out: its XDC page shows mainnet only, no Apothem subdomain.) `gofmt` clean, `go build ./thirdparty/` passes.