### PR TITLE
fix(errors): correct severity + retry classification for client/transient errors

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -2559,6 +2559,16 @@ func ClassifySeverity(err error) Severity {
 	if HasErrorCode(err, ErrCodeUpstreamBlockUnavailable) {
 		return SeverityWarning
 	}
+	// ErrNetworkNotSupported is, like block-unavailable, intentionally retryable —
+	// upstream/registry.go returns it from the network-readiness wait loop so the
+	// auto-retry loop can re-attempt once lazily-registered upstreams warm up. (Do
+	// NOT move it into the no-retry list; that would break bootstrap recovery.)
+	// Whether it means "client requested an unconfigured network" or "upstreams
+	// aren't ready yet", it is a client/transient condition, not a critical infra
+	// failure — so it is a warning.
+	if HasErrorCode(err, ErrCodeNetworkNotSupported) {
+		return SeverityWarning
+	}
 	if !IsRetryableTowardsUpstream(err) {
 		return SeverityWarning
 	}

--- a/common/errors.go
+++ b/common/errors.go
@@ -444,13 +444,20 @@ type ErrInvalidRequest struct{ BaseError }
 const ErrCodeInvalidRequest ErrorCode = "ErrInvalidRequest"
 
 var NewErrInvalidRequest = func(cause error) error {
-	return &ErrInvalidRequest{
+	e := &ErrInvalidRequest{
 		BaseError{
 			Code:    ErrCodeInvalidRequest,
 			Message: "invalid request body or headers",
 			Cause:   cause,
 		},
 	}
+	// An invalid/malformed request is rejected identically by every upstream, so it
+	// must never be retried: not failed-over to another upstream (network scope, set
+	// here) and not re-tried on the same upstream (upstream scope, enforced via
+	// IsRetryableTowardsUpstream). IsClientError additionally makes it info severity
+	// (the caller's fault), not a critical infra error.
+	e.WithRetryableTowardNetwork(false)
+	return e
 }
 
 func (e *ErrInvalidRequest) ErrorStatusCode() int {
@@ -2471,6 +2478,11 @@ func IsRetryableTowardsUpstream(err error) bool {
 		// 400 / 404 / 405 / 413 -> No Retry
 		ErrCodeJsonRpcRequestUnmarshal,
 
+		// Invalid/malformed request (e.g. eth_getLogs fromBlock > toBlock, bad
+		// params, missing method) -> No Retry: no upstream will accept it, so
+		// retrying the same upstream is pointless.
+		ErrCodeInvalidRequest,
+
 		// Execution exceptions are not retryable
 		ErrCodeEndpointExecutionException,
 
@@ -2515,6 +2527,7 @@ func IsClientError(err error) bool {
 		err,
 		ErrCodeEndpointClientSideException,
 		ErrCodeJsonRpcRequestUnmarshal,
+		ErrCodeInvalidRequest,
 		ErrCodeGetLogsExceededMaxAllowedRange,
 		ErrCodeGetLogsExceededMaxAllowedAddresses,
 		ErrCodeGetLogsExceededMaxAllowedTopics,
@@ -2536,6 +2549,15 @@ func ClassifySeverity(err error) Severity {
 	}
 	if IsClientError(err) || HasErrorCode(err, ErrCodeEndpointExecutionException) {
 		return SeverityInfo
+	}
+	// ErrUpstreamBlockUnavailable is *intentionally* retryable toward the upstream:
+	// network_executor runs a block-time-aware catch-up retry keyed on this exact
+	// code, and that nuance must not change. But it only means an upstream hasn't
+	// synced the requested block yet — an expected, self-healing condition, not an
+	// infra failure an operator must urgently act on — so it is a warning. Classified
+	// explicitly here, ahead of the retryable->critical fall-through below.
+	if HasErrorCode(err, ErrCodeUpstreamBlockUnavailable) {
+		return SeverityWarning
 	}
 	if !IsRetryableTowardsUpstream(err) {
 		return SeverityWarning

--- a/common/errors_retry_test.go
+++ b/common/errors_retry_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -275,6 +276,48 @@ func TestHasErrorCode_NestedErrors(t *testing.T) {
 
 		assert.True(t, HasErrorCode(missingDataErr, ErrCodeEndpointMissingData))
 		assert.True(t, HasErrorCode(missingDataErr, ErrCodeJsonRpcExceptionInternal))
+	})
+}
+
+func TestClassifySeverity_InvalidRequest(t *testing.T) {
+	// An invalid/malformed request is the caller's fault, not an infra failure:
+	// it must be info severity and must never be retried at either scope.
+	err := NewErrInvalidRequest(errors.New("fromBlock (10) must be <= toBlock (5)"))
+
+	t.Run("IsInfoSeverity", func(t *testing.T) {
+		assert.Equal(t, SeverityInfo, ClassifySeverity(err),
+			"ErrInvalidRequest is a client error and must be info, not critical")
+	})
+	t.Run("IsClientError", func(t *testing.T) {
+		assert.True(t, IsClientError(err))
+	})
+	t.Run("NotRetryableTowardsUpstream", func(t *testing.T) {
+		assert.False(t, IsRetryableTowardsUpstream(err),
+			"no upstream will accept a malformed request — same-upstream retry is pointless")
+	})
+	t.Run("NotRetryableTowardNetwork", func(t *testing.T) {
+		assert.False(t, IsRetryableTowardNetwork(err),
+			"failing over a malformed request to another upstream is pointless")
+	})
+}
+
+func TestClassifySeverity_UpstreamBlockUnavailable(t *testing.T) {
+	// Block-unavailable means an upstream simply hasn't synced the requested block
+	// yet — a warning (self-healing), not a critical infra error. Crucially, its
+	// retry nuance (network_executor's block-time catch-up) must be UNCHANGED.
+	err := NewErrUpstreamBlockUnavailable("upstream1", 1000, 990, 980)
+
+	t.Run("IsWarningSeverity", func(t *testing.T) {
+		assert.Equal(t, SeverityWarning, ClassifySeverity(err),
+			"block-unavailable is an expected catch-up condition, not critical")
+	})
+	t.Run("StaysRetryableTowardsUpstream", func(t *testing.T) {
+		assert.True(t, IsRetryableTowardsUpstream(err),
+			"REGRESSION GUARD: network_executor block-time catch-up retry depends on this staying true")
+	})
+	t.Run("StaysRetryableTowardNetwork", func(t *testing.T) {
+		assert.True(t, IsRetryableTowardNetwork(err),
+			"REGRESSION GUARD: block-unavailable must still fail over across upstreams")
 	})
 }
 

--- a/common/errors_retry_test.go
+++ b/common/errors_retry_test.go
@@ -321,6 +321,22 @@ func TestClassifySeverity_UpstreamBlockUnavailable(t *testing.T) {
 	})
 }
 
+func TestClassifySeverity_NetworkNotSupported(t *testing.T) {
+	// Either "client requested an unconfigured network" or "upstreams not ready yet
+	// during bootstrap" — a client/transient condition, never a critical infra error.
+	err := NewErrNetworkNotSupported("myproject", "evm:99999")
+
+	t.Run("IsWarningSeverity", func(t *testing.T) {
+		assert.Equal(t, SeverityWarning, ClassifySeverity(err),
+			"network-not-supported is client/transient, not a critical infra error")
+	})
+	t.Run("StaysRetryableTowardsUpstream", func(t *testing.T) {
+		assert.True(t, IsRetryableTowardsUpstream(err),
+			"REGRESSION GUARD: registry.go's network-readiness wait loop returns this as "+
+				"retryable so bootstrap recovery works — it must stay retryable")
+	})
+}
+
 func BenchmarkIsRetryableTowardNetwork(b *testing.B) {
 	missingDataErr := NewErrEndpointMissingData(
 		NewErrJsonRpcExceptionInternal(-32000, -32014, "missing trie node", nil, nil),


### PR DESCRIPTION
## Problem

Several errors were reported as `severity="critical"` in the network/upstream error metrics (and the **Network-level Critical Errors** dashboard panel) even though they aren't infra failures. Root cause: `ClassifySeverity` derived severity from `IsRetryableTowardsUpstream` — a predicate that exists for **retry control-flow**, not alerting — so anything retryable-but-not-cancelled inherited `critical` by accident.

## Changes (all keyed on error code, so robust to every construction path)

### `ErrInvalidRequest` → info + never retried
HTTP-400 malformed request (e.g. `eth_getLogs` `fromBlock > toBlock`). No upstream will accept it, so retrying is waste. Mirrors the existing `ErrJsonRpcRequestUnmarshal` precedent:
- Added to `IsClientError` → **info** severity.
- Added to the `IsRetryableTowardsUpstream` no-retry list → no same-upstream retry; `NextUpstream`/`canReUse` stop cycling it across upstreams.
- Constructor sets `WithRetryableTowardNetwork(false)` → no network-level failover (the post-upstream validation variant returns straight out of `Forward()` and was previously retried network-wide).

### `ErrUpstreamBlockUnavailable` → warning, retry behavior untouched
Means an upstream hasn't synced the requested block yet — expected/self-healing. Its network retry is **nuanced** (block-time-aware delay, separate `EmptyResultMaxAttempts` cap, async state-poller refresh, pre-routing gating), keyed **explicitly on the error code** in `network_executor` and never consulting `IsRetryableTowardsUpstream`.
- No retry predicate touched. Severity → **warning** via one explicit clause in `ClassifySeverity`, ahead of the `retryable → critical` fall-through.

### `ErrNetworkNotSupported` → warning, retry behavior untouched
Either "client requested an unconfigured network" or "upstreams aren't ready yet during bootstrap" — client/transient, not critical. It is **deliberately retryable**: `upstream/registry.go`'s network-readiness wait loop returns it so the auto-retry loop can re-attempt once lazily-registered upstreams warm up.
- No retry predicate touched (moving it to the no-retry list would break bootstrap recovery). Severity → **warning** via an explicit clause.

## Not changed (deliberately)

- **`ErrEndpointRequestCanceled` / `ContextCanceled`** — already classified **warning** (client-driven cancellation / discarded hedges). This was the headline of the latest ops handoff; it's already correct, so the dashboard already shows these under Warnings, not Critical.
- **`ErrEndpointExecutionException`** (reverts, -32003) already **info**; **`ErrEndpointUnsupported`** (-32601) and **`ErrEndpointCapacityExceeded`** (-32005) already **warning** (non-retryable / capacity).
- **`ErrEndpointServerSideException`** (-32603) stays **critical**: the model has 3 tiers (info/warning/critical), no "medium"; at network scope a final -32603 is a genuinely unrecovered server error.
- **"unexpected EOF"** is a log message, not an error code — its severity follows the wrapping error (client-cancel → already warning; genuine upstream transport EOF → `ErrEndpointTransportFailure`, correctly critical). Reclassifying it wholesale would hide real failures.

## Tests

`common/errors_retry_test.go` — severity + both retry scopes for `ErrInvalidRequest`; severity for block-unavailable and network-not-supported; plus **regression guards** asserting block-unavailable and network-not-supported stay retryable (their catch-up / bootstrap-recovery behavior must not be broken).

Verified: `go build` + `go vet` clean; new tests pass; existing `common/` and `erpc/` availability + network-executor + request-processor suites, and EVM getLogs/trace_filter validation suites, all green.

## Dashboard effect

`ErrInvalidRequest` rows leave the Critical panel (now `info`); `ErrUpstreamBlockUnavailable` and `ErrNetworkNotSupported` move from Critical to **Warnings**. Note: there is no `severity="info"` panel today, so info-level errors aren't visualized — a small follow-up if a "notices" tier is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)