### PR TITLE
feat(selection-policy): per-boundary eval axis (block-availability lanes)

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -2440,7 +2440,19 @@ type SelectionPolicyConfig struct {
 	EvalPerMethod *bool `yaml:"evalPerMethod,omitempty" json:"evalPerMethod,omitempty" tstype:"-"`
 	// EvalPerFinality — same shape and translation behavior as
 	// EvalPerMethod, for the finality axis.
-	EvalPerFinality *bool    `yaml:"evalPerFinality,omitempty" json:"evalPerFinality,omitempty" tstype:"-"`
+	EvalPerFinality *bool `yaml:"evalPerFinality,omitempty" json:"evalPerFinality,omitempty" tstype:"-"`
+	// EvalPerBoundary scopes selection-policy evaluation by block-availability
+	// "lane" — the set of upstreams whose configured block range can actually
+	// serve the request's block. Unlike EvalPerMethod / EvalPerFinality this is
+	// deliberately NOT folded into EvalScope: it must not change the
+	// health-tracker grain (boundary is a decision/pool axis, not a metrics
+	// axis), so the engine reads it directly as an orthogonal slot dimension.
+	// When on, a request whose block excludes some upstream is evaluated
+	// against a lane-scoped pool — an upstream that cannot serve the range is
+	// absent from the pool (a capability fact), distinct from the policy's
+	// soft health-based deprioritization. Default off. Pointer-typed so a
+	// future SetDefaults can distinguish "absent" from "explicitly false".
+	EvalPerBoundary *bool    `yaml:"evalPerBoundary,omitempty" json:"evalPerBoundary,omitempty" tstype:"boolean"`
 	EvalTimeout     Duration `yaml:"evalTimeout,omitempty" json:"evalTimeout" tstype:"Duration"`
 	// EvalFunc is the per-tick evaluation function. In YAML it's a JS
 	// source string; in TS configs it's a real arrow function compiled

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -955,7 +955,20 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		// (when EvalPerFinality is on) resolve to the bucket-specific
 		// ordering. Networks not configured per-finality see "*" and
 		// resolve to the wildcard slot regardless.
-		upsList = n.policyEngine.GetOrdered(n.networkId, method, req.Finality(ctx).String())
+		finality := req.Finality(ctx).String()
+		// When the boundary axis (EvalPerBoundary) is on, scope selection to
+		// the request's block-availability lane — the set of upstreams whose
+		// configured bounds can serve this block. laneIDs stays nil when the
+		// axis is off or the request has no resolvable block number, in which
+		// case GetOrderedInLane behaves exactly like GetOrdered.
+		var laneIDs []string
+		if n.policyEngine.PerBoundaryEnabled(n.networkId) {
+			laneIDs = n.eligibleUpstreamIDsForBoundary(ctx, method, req)
+			if common.IsTracingDetailed && len(laneIDs) > 0 {
+				upstreamSpan.SetAttributes(attribute.Int("upstreams.lane_size", len(laneIDs)))
+			}
+		}
+		upsList = n.policyEngine.GetOrderedInLane(n.networkId, method, finality, laneIDs)
 	}
 	if len(upsList) == 0 {
 		// Cold-start fallback: serve the raw registration order until the
@@ -1929,6 +1942,97 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 	}
 
 	return nil, false
+}
+
+// eligibleUpstreamIDsForBoundary derives the block-availability "lane" for a
+// single-block request: the IDs of upstreams whose configured availability
+// bounds can serve the request's block. It feeds the selection policy's
+// per-boundary axis (EvalPerBoundary) so the policy evaluates against — and
+// keeps health/exclusion state for — only the upstreams that can actually
+// answer this block.
+//
+// It returns nil ("no lane scoping → use the full-pool wildcard slot") when:
+//   - the network isn't EVM, or the method has a dedicated range-availability
+//     hook (eth_getLogs / trace_filter, gated by CheckBlockRangeAvailability),
+//   - the block number can't be resolved (e.g. eth_getBlockByHash carries a
+//     hash, not a number) — same fail-open as checkUpstreamBlockAvailability,
+//   - no upstream advertises any bound (a single implicit lane = everything), or
+//   - every upstream is eligible (the lane equals the full pool, so the caller
+//     reuses the wildcard slot instead of spawning an identical duplicate).
+//
+// The eligibility predicate mirrors checkUpstreamBlockAvailability's use of
+// EvmBlockAvailabilityBounds so the lane membership and the per-upstream
+// availability gate never disagree about which upstreams can serve a block.
+func (n *Network) eligibleUpstreamIDsForBoundary(ctx context.Context, method string, req *common.NormalizedRequest) []string {
+	if n.cfg == nil || n.cfg.Architecture != common.ArchitectureEvm {
+		return nil
+	}
+	if methodHasDedicatedRangeAvailabilityHook(method) {
+		return nil
+	}
+	// Resolve the request's block number (cached at normalization, with a
+	// defensive extraction fallback) — mirrors checkUpstreamBlockAvailability.
+	var bn int64
+	if v := req.EvmBlockNumber(); v != nil {
+		if n64, ok := v.(int64); ok {
+			bn = n64
+		}
+	}
+	if bn <= 0 {
+		if _, x, ebn := evm.ExtractBlockReferenceFromRequest(ctx, req); ebn == nil && x > 0 {
+			bn = x
+		}
+	}
+	if bn <= 0 {
+		return nil
+	}
+
+	ups := n.upstreamsRegistry.GetNetworkUpstreams(ctx, n.networkId)
+	if len(ups) == 0 {
+		return nil
+	}
+	bounds := make([]upstreamBlockBounds, len(ups))
+	for i, u := range ups {
+		// EvmBlockAvailabilityBounds returns (MinInt64, MaxInt64) — i.e.
+		// unbounded, hence always-eligible — for non-EVM or boundless
+		// upstreams, so no special-casing is needed here.
+		minBound, maxBound := u.EvmBlockAvailabilityBounds()
+		bounds[i] = upstreamBlockBounds{id: u.Id(), min: minBound, max: maxBound}
+	}
+	return eligibleLane(bounds, bn)
+}
+
+// upstreamBlockBounds is an upstream's resolved [min,max] availability range.
+type upstreamBlockBounds struct {
+	id       string
+	min, max int64
+}
+
+// eligibleLane returns the IDs of upstreams whose [min,max] range covers block
+// bn — the block-availability "lane" for that block. It returns nil ("no lane
+// scoping") when no upstream advertises any bound (a single implicit lane) or
+// when every upstream is eligible (the lane equals the full pool, so callers
+// reuse the wildcard slot rather than spawning a redundant duplicate). Split
+// out from eligibleUpstreamIDsForBoundary so the lane decision is unit-testable
+// without a live upstream registry.
+func eligibleLane(bounds []upstreamBlockBounds, bn int64) []string {
+	eligible := make([]string, 0, len(bounds))
+	anyBounded := false
+	for _, b := range bounds {
+		if b.min != math.MinInt64 || b.max != math.MaxInt64 {
+			anyBounded = true
+		}
+		if (b.min == math.MinInt64 || bn >= b.min) && (b.max == math.MaxInt64 || bn <= b.max) {
+			eligible = append(eligible, b.id)
+		}
+	}
+	// No bounds anywhere, or every upstream eligible → a single lane that
+	// equals the full pool. Returning nil routes to the wildcard slot and
+	// avoids spawning a redundant lane identical to it.
+	if !anyBounded || len(eligible) == len(bounds) {
+		return nil
+	}
+	return eligible
 }
 
 func (n *Network) handleMultiplexing(ctx context.Context, lg *zerolog.Logger, req *common.NormalizedRequest, startTime time.Time) (*Multiplexer, *common.NormalizedResponse, error) {

--- a/erpc/networks_boundary_test.go
+++ b/erpc/networks_boundary_test.go
@@ -1,0 +1,85 @@
+package erpc
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEligibleLane covers the block-availability "lane" decision that feeds
+// the selection policy's per-boundary axis. The interesting cases are the two
+// "no scoping → nil" collapses (no bounds anywhere; every upstream eligible),
+// which keep the engine from spawning a lane slot identical to the wildcard.
+func TestEligibleLane(t *testing.T) {
+	const (
+		lo = math.MinInt64
+		hi = math.MaxInt64
+	)
+	// archive: fully unbounded. recent: only blocks >= 100 (lower.exactBlock).
+	// capped: only blocks <= 200 (an upper bound). window: [100,200].
+	archive := upstreamBlockBounds{id: "archive", min: lo, max: hi}
+	recent := upstreamBlockBounds{id: "recent", min: 100, max: hi}
+	capped := upstreamBlockBounds{id: "capped", min: lo, max: 200}
+	window := upstreamBlockBounds{id: "window", min: 100, max: 200}
+
+	cases := []struct {
+		name   string
+		bounds []upstreamBlockBounds
+		bn     int64
+		want   []string // nil means "no lane scoping"
+	}{
+		{
+			name:   "no bounds anywhere → nil",
+			bounds: []upstreamBlockBounds{{id: "a", min: lo, max: hi}, {id: "b", min: lo, max: hi}},
+			bn:     5,
+			want:   nil,
+		},
+		{
+			name:   "historical block excludes recent-only node → proper subset",
+			bounds: []upstreamBlockBounds{archive, recent},
+			bn:     1,
+			want:   []string{"archive"},
+		},
+		{
+			name:   "in-range block: all eligible → nil",
+			bounds: []upstreamBlockBounds{archive, recent},
+			bn:     100,
+			want:   nil,
+		},
+		{
+			name:   "above an upper bound excludes the capped node",
+			bounds: []upstreamBlockBounds{archive, capped},
+			bn:     250,
+			want:   []string{"archive"},
+		},
+		{
+			name:   "windowed node included only inside its window",
+			bounds: []upstreamBlockBounds{archive, window},
+			bn:     150,
+			want:   nil, // both eligible inside the window
+		},
+		{
+			name:   "windowed node excluded below its window",
+			bounds: []upstreamBlockBounds{archive, window},
+			bn:     50,
+			want:   []string{"archive"},
+		},
+		{
+			name:   "no upstream can serve → empty (non-nil) lane",
+			bounds: []upstreamBlockBounds{recent},
+			bn:     1,
+			want:   []string{}, // recent is bounded and excluded → empty, NOT the full-pool nil
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := eligibleLane(tc.bounds, tc.bn)
+			if tc.want == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/policy/boundary_test.go
+++ b/internal/policy/boundary_test.go
@@ -1,0 +1,160 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func ids(ups []common.Upstream) []string {
+	out := make([]string, len(ups))
+	for i, u := range ups {
+		out[i] = u.Id()
+	}
+	return out
+}
+
+// TestEngine_PerBoundary_LaneScopesPool — with the boundary axis on, a
+// request scoped to a lane (a proper subset of upstream IDs) is evaluated
+// against ONLY that subset, while nil lane IDs use the full-pool wildcard.
+// The lane key is membership-based, so passing the same set in a different
+// order resolves to the same lane.
+func TestEngine_PerBoundary_LaneScopesPool(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", time.Minute)
+
+	enabled := true
+	cfg := &common.SelectionPolicyConfig{
+		EvalInterval:    common.Duration(50 * time.Millisecond),
+		EvalTimeout:     common.Duration(10 * time.Millisecond),
+		EvalScope:       common.EvalScopeNetwork,
+		EvalPerBoundary: &enabled,
+		EvalFunc:        "(ups, _ctx) => ups", // identity → pool passes through in order
+	}
+	require.NoError(t, cfg.SetDefaults())
+	require.NoError(t, cfg.Validate())
+
+	engine := policy.NewEngine(ctx, &logger, "p1", tracker, nil, nil)
+	defer engine.Stop()
+
+	ups := []common.Upstream{
+		&fakeUpstream{id: "rpc1"},
+		&fakeUpstream{id: "rpc2"},
+		&fakeUpstream{id: "rpc3"}, // e.g. the body-pruned node, out of range for old blocks
+	}
+	require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+
+	require.True(t, engine.PerBoundaryEnabled("evm:1"))
+
+	// Lane {rpc1, rpc2}: once the lazily-created lane slot has ticked, the
+	// pool excludes rpc3 entirely (capability, not health).
+	require.Eventually(t, func() bool {
+		got := engine.GetOrderedInLane("evm:1", "*", "*", []string{"rpc1", "rpc2"})
+		return len(got) == 2 && got[0].Id() == "rpc1" && got[1].Id() == "rpc2"
+	}, 2*time.Second, 10*time.Millisecond, "lane {rpc1,rpc2} should scope the pool to exactly those two")
+
+	// Same membership, different order → same lane, same scoped pool.
+	require.Eventually(t, func() bool {
+		got := engine.GetOrderedInLane("evm:1", "*", "*", []string{"rpc2", "rpc1"})
+		return len(got) == 2 && got[0].Id() == "rpc1" && got[1].Id() == "rpc2"
+	}, 2*time.Second, 10*time.Millisecond, "lane key must be order-independent")
+
+	// nil lane IDs → full-pool wildcard slot (populated synchronously at
+	// RegisterNetwork), so all three are returned.
+	full := engine.GetOrderedInLane("evm:1", "*", "*", nil)
+	require.Equal(t, []string{"rpc1", "rpc2", "rpc3"}, ids(full))
+}
+
+// TestEngine_PerBoundary_Off_IgnoresLane — with the axis off, lane IDs are
+// ignored and every request resolves to the full-pool wildcard slot
+// (identical behavior to GetOrdered).
+func TestEngine_PerBoundary_Off_IgnoresLane(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", time.Minute)
+
+	cfg := &common.SelectionPolicyConfig{
+		EvalInterval: common.Duration(50 * time.Millisecond),
+		EvalTimeout:  common.Duration(10 * time.Millisecond),
+		EvalScope:    common.EvalScopeNetwork,
+		EvalFunc:     "(ups, _ctx) => ups",
+		// EvalPerBoundary omitted → off
+	}
+	require.NoError(t, cfg.SetDefaults())
+	require.NoError(t, cfg.Validate())
+
+	engine := policy.NewEngine(ctx, &logger, "p1", tracker, nil, nil)
+	defer engine.Stop()
+
+	ups := []common.Upstream{
+		&fakeUpstream{id: "rpc1"},
+		&fakeUpstream{id: "rpc2"},
+		&fakeUpstream{id: "rpc3"},
+	}
+	require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+
+	require.False(t, engine.PerBoundaryEnabled("evm:1"))
+
+	// Even with a proper-subset lane passed, the axis is off → wildcard pool.
+	// The wildcard cache was populated by RegisterNetwork's synchronous tick,
+	// so this is deterministic without waiting.
+	got := engine.GetOrderedInLane("evm:1", "*", "*", []string{"rpc1"})
+	require.Equal(t, []string{"rpc1", "rpc2", "rpc3"}, ids(got))
+}
+
+// TestEngine_PerBoundary_LaneSlotEvicted — lane slots are narrow (non
+// all-wildcard) and must be reclaimed by the idle sweep, while the network
+// wildcard slot survives. Guards against lane-key cardinality growing the
+// slot map without bound.
+func TestEngine_PerBoundary_LaneSlotEvicted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", time.Minute)
+
+	enabled := true
+	cfg := &common.SelectionPolicyConfig{
+		EvalInterval:         common.Duration(0),
+		EvalTimeout:          common.Duration(500 * time.Millisecond),
+		EvalScope:            common.EvalScopeNetwork,
+		EvalPerBoundary:      &enabled,
+		EvalFunc:             "(ups, _ctx) => ups",
+		DisableTickerForTest: true,
+	}
+	require.NoError(t, cfg.SetDefaults())
+
+	engine := policy.NewEngine(ctx, &logger, "p1", tracker, nil, nil)
+	defer engine.Stop()
+	engine.SetIdleEvictionAfter(50 * time.Millisecond)
+
+	ups := []common.Upstream{
+		&fakeUpstream{id: "rpc1"},
+		&fakeUpstream{id: "rpc2"},
+		&fakeUpstream{id: "rpc3"},
+	}
+	require.NoError(t, engine.RegisterNetwork("evm:1", "", func() []common.Upstream { return ups }, cfg))
+
+	// Lazy-create two distinct lane slots in addition to the wildcard.
+	_ = engine.GetOrderedInLane("evm:1", "*", "*", []string{"rpc1", "rpc2"})
+	_ = engine.GetOrderedInLane("evm:1", "*", "*", []string{"rpc1"})
+	require.Equal(t, 3, policy.SlotCountForTest(engine),
+		"wildcard + two lane slots")
+
+	time.Sleep(100 * time.Millisecond)
+	policy.SweepIdleSlotsForTest(engine)
+
+	require.Equal(t, 1, policy.SlotCountForTest(engine),
+		"both idle lane slots evicted; only the wildcard remains")
+}

--- a/internal/policy/boundary_unit_test.go
+++ b/internal/policy/boundary_unit_test.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestBoundaryKey_CanonicalAndStable — the lane key must depend only on
+// WHICH upstreams are eligible, independent of their order, and must not
+// mutate the caller's slice. Empty/nil collapses to the full-pool wildcard.
+func TestBoundaryKey_CanonicalAndStable(t *testing.T) {
+	require.Equal(t, "*", boundaryKey(nil))
+	require.Equal(t, "*", boundaryKey([]string{}))
+	require.Equal(t, "a", boundaryKey([]string{"a"}))
+	require.Equal(t, "a|b|c", boundaryKey([]string{"c", "b", "a"}))
+
+	// Order-independent: same membership → same key (so a drifting numeric
+	// bound that re-derives the same set reuses the same slot).
+	require.Equal(t, boundaryKey([]string{"a", "b", "c"}), boundaryKey([]string{"c", "a", "b"}))
+	// Different membership → different key.
+	require.NotEqual(t, boundaryKey([]string{"a", "b"}), boundaryKey([]string{"a", "c"}))
+
+	// Must not mutate the caller's slice (the request path may reuse it).
+	in := []string{"c", "a", "b"}
+	_ = boundaryKey(in)
+	require.Equal(t, []string{"c", "a", "b"}, in)
+}
+
+// TestPerBoundaryEnabled — nil cfg / absent / explicit-false are all off;
+// only an explicit true turns the axis on.
+func TestPerBoundaryEnabled(t *testing.T) {
+	require.False(t, perBoundaryEnabled(nil))
+	require.False(t, perBoundaryEnabled(&common.SelectionPolicyConfig{}))
+	require.False(t, perBoundaryEnabled(&common.SelectionPolicyConfig{EvalPerBoundary: boolPtr(false)}))
+	require.True(t, perBoundaryEnabled(&common.SelectionPolicyConfig{EvalPerBoundary: boolPtr(true)}))
+}
+
+// TestEffectiveKey_BoundaryGating — the boundary dimension is honored only
+// when the axis is on, is orthogonal to the EvalScope method/finality axes,
+// and "*"/empty always collapses to the wildcard.
+func TestEffectiveKey_BoundaryGating(t *testing.T) {
+	// Axis OFF: a passed lane key is ignored → wildcard boundary.
+	cfgOff := &common.SelectionPolicyConfig{EvalScope: common.EvalScopeNetwork}
+	require.Equal(t,
+		slotKey{"evm:1", "*", "*", "*"},
+		effectiveKey(cfgOff, "evm:1", "eth_call", "finalized", "a|b"))
+
+	// Axis ON, scope=network: only the boundary narrows; method/finality stay "*".
+	cfgOn := &common.SelectionPolicyConfig{EvalScope: common.EvalScopeNetwork, EvalPerBoundary: boolPtr(true)}
+	require.Equal(t,
+		slotKey{"evm:1", "*", "*", "a|b"},
+		effectiveKey(cfgOn, "evm:1", "eth_call", "finalized", "a|b"))
+	// "*" boundary stays wildcard even with the axis on.
+	require.Equal(t,
+		slotKey{"evm:1", "*", "*", "*"},
+		effectiveKey(cfgOn, "evm:1", "eth_call", "finalized", "*"))
+
+	// Axis ON + scope=network-method: boundary AND method narrow; finality "*".
+	cfgMB := &common.SelectionPolicyConfig{EvalScope: common.EvalScopeNetworkMethod, EvalPerBoundary: boolPtr(true)}
+	require.Equal(t,
+		slotKey{"evm:1", "eth_call", "*", "a|b"},
+		effectiveKey(cfgMB, "evm:1", "eth_call", "finalized", "a|b"))
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -110,10 +112,19 @@ const DefaultEngineIdleEvictionAfter = 1 * time.Hour
 // tick. The legacy `EvalPerMethod` / `EvalPerFinality` config fields
 // are translated into `EvalScope` by `SetDefaults` and never reach the
 // engine — the engine reads `EvalScope` exclusively.
+//
+// The `boundary` dimension is orthogonal to EvalScope and gated by
+// `EvalPerBoundary`. It identifies a block-availability "lane" by the
+// canonical set of upstreams eligible to serve the request's block (see
+// `boundaryKey`) — NOT by a block range, so the key is stable as numeric
+// bounds drift; it only changes when the eligible membership changes.
+// "*" means the full-pool lane (boundary axis off, or a request with no
+// resolvable block number, e.g. by-hash).
 type slotKey struct {
 	network  string
 	method   string
 	finality string
+	boundary string
 }
 
 type networkRegistration struct {
@@ -217,7 +228,7 @@ func (e *Engine) sweepIdleSlots() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for k, slot := range e.slots {
-		if k.method == "*" && k.finality == "*" {
+		if k.method == "*" && k.finality == "*" && k.boundary == "*" {
 			continue // never evict the network's wildcard slot
 		}
 		if slot.lastAccessedAtMs.Load() >= cutoffMs {
@@ -298,8 +309,8 @@ func (e *Engine) RegisterNetwork(networkID, networkLabel string, upstreamsFn fun
 		}
 	}
 
-	wildcard := newSlot(e, networkID, networkLabel, "*", "*", upstreamsFn, cfg)
-	e.slots[slotKey{networkID, "*", "*"}] = wildcard
+	wildcard := newSlot(e, networkID, networkLabel, "*", "*", "*", upstreamsFn, cfg)
+	e.slots[slotKey{networkID, "*", "*", "*"}] = wildcard
 
 	// Initial eval is synchronous so the first request sees a populated cache.
 	wildcard.tickOnce()
@@ -341,7 +352,25 @@ func (e *Engine) UnregisterNetwork(networkID string) {
 // is the SAME backing array the slot stores atomically — callers MUST
 // treat it as read-only.
 func (e *Engine) GetOrdered(networkID, method, finality string) []common.Upstream {
-	slot, wildcard := e.lookupSlotWithFallback(networkID, method, finality)
+	return e.getOrdered(networkID, method, finality, nil)
+}
+
+// GetOrderedInLane is GetOrdered scoped to a block-availability lane.
+// `laneUpstreamIDs` is the set of upstream IDs eligible to serve the
+// request's block, computed by the caller from per-upstream availability
+// bounds. When the boundary axis is off — or the set is empty (no
+// resolvable block number, or every upstream is eligible) — it behaves
+// exactly like GetOrdered against the full-pool wildcard slot. When the
+// set is a proper subset, the policy evaluates against a lane-scoped pool
+// keyed by that set: an upstream that cannot serve the range is absent
+// from the pool (capability), and per-lane health/exclusion state is kept
+// separate from other lanes.
+func (e *Engine) GetOrderedInLane(networkID, method, finality string, laneUpstreamIDs []string) []common.Upstream {
+	return e.getOrdered(networkID, method, finality, laneUpstreamIDs)
+}
+
+func (e *Engine) getOrdered(networkID, method, finality string, laneIDs []string) []common.Upstream {
+	slot, wildcard := e.lookupSlotWithFallback(networkID, method, finality, laneIDs)
 	// Refresh both slots' idle timestamps — a request hitting THIS
 	// (method, finality) keeps both the narrow slot AND the wildcard
 	// fallback alive against the engine's sweep.
@@ -422,7 +451,7 @@ func (e *Engine) RecentDecisions(networkID, method, finality string, limit int) 
 // this to know which upstreams are currently "shadow re-probe
 // candidates."
 func (e *Engine) GetExcluded(networkID, method, finality string) []common.Upstream {
-	slot, wildcard := e.lookupSlotWithFallback(networkID, method, finality)
+	slot, wildcard := e.lookupSlotWithFallback(networkID, method, finality, nil)
 	if slot != nil {
 		// Honor the narrow slot whenever it has TICKED (non-nil pointer),
 		// even when its probe-candidate set is empty: with probe-blocking
@@ -549,8 +578,8 @@ func (e *Engine) GetScores(networkID, method, finality string) map[string]float6
 // `EvalScope` and niled the legacy fields. If the engine were to read
 // them again it would risk seeing the post-translation zero values
 // and silently degrade to the wrong grain.
-func effectiveKey(cfg *common.SelectionPolicyConfig, networkID, method, finality string) slotKey {
-	m, f := "*", "*"
+func effectiveKey(cfg *common.SelectionPolicyConfig, networkID, method, finality, boundary string) slotKey {
+	m, f, b := "*", "*", "*"
 	if cfg != nil {
 		perMethod, perFinality := scopeAxes(cfg.EvalScope)
 		if perMethod && method != "" && method != "*" {
@@ -559,8 +588,37 @@ func effectiveKey(cfg *common.SelectionPolicyConfig, networkID, method, finality
 		if perFinality && finality != "" && finality != "*" {
 			f = finality
 		}
+		if perBoundaryEnabled(cfg) && boundary != "" && boundary != "*" {
+			b = boundary
+		}
 	}
-	return slotKey{networkID, m, f}
+	return slotKey{networkID, m, f, b}
+}
+
+// perBoundaryEnabled reports whether the orthogonal block-availability
+// "lane" axis is on for this policy. Unlike the method/finality axes
+// (folded into EvalScope), boundary is read directly off the config so it
+// never touches the health-tracker grain.
+func perBoundaryEnabled(cfg *common.SelectionPolicyConfig) bool {
+	return cfg != nil && cfg.EvalPerBoundary != nil && *cfg.EvalPerBoundary
+}
+
+// boundaryKey canonicalizes a lane's eligible upstream IDs into a stable
+// slot dimension. The key is the sorted IDs joined by "|", so it depends
+// only on WHICH upstreams can serve the block — not on the (drifting)
+// numeric bounds that produced the set. An empty/nil set means "no lane
+// scoping" → the full-pool wildcard ("*"). The caller is expected to pass
+// an empty set when the eligible upstreams equal the whole pool (so an
+// all-eligible request reuses the wildcard slot rather than spawning a
+// redundant lane identical to it).
+func boundaryKey(laneIDs []string) string {
+	if len(laneIDs) == 0 {
+		return "*"
+	}
+	sorted := make([]string, len(laneIDs))
+	copy(sorted, laneIDs)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "|")
 }
 
 // scopeAxes decomposes the `EvalScope` enum back into the two axis
@@ -579,6 +637,20 @@ func scopeAxes(s common.EvalScope) (perMethod, perFinality bool) {
 	}
 }
 
+// PerBoundaryEnabled reports whether the network's selection policy opts
+// into the block-availability lane axis. The request path consults this
+// before doing the (cheap but non-free) per-upstream bounds scan that
+// derives a request's eligible lane — when off, that work is skipped
+// entirely and routing is identical to before this feature.
+func (e *Engine) PerBoundaryEnabled(networkID string) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if reg := e.networks[networkID]; reg != nil {
+		return perBoundaryEnabled(reg.cfg)
+	}
+	return false
+}
+
 // lookupSlot is the shared resolver used by per-slot accessors that
 // want a single slot to read from (admin endpoints, diagnostics):
 // exact `(network, method, finality)` match falls back to the network's
@@ -591,10 +663,10 @@ func (e *Engine) lookupSlot(networkID, method, finality string) *Slot {
 	if reg != nil {
 		cfg = reg.cfg
 	}
-	if slot, ok := e.slots[effectiveKey(cfg, networkID, method, finality)]; ok {
+	if slot, ok := e.slots[effectiveKey(cfg, networkID, method, finality, "*")]; ok {
 		return slot
 	}
-	return e.slots[slotKey{networkID, "*", "*"}]
+	return e.slots[slotKey{networkID, "*", "*", "*"}]
 }
 
 // lookupSlotWithFallback is the request-path resolver used by
@@ -611,17 +683,17 @@ func (e *Engine) lookupSlot(networkID, method, finality string) *Slot {
 //
 // First call for a fresh bucket pays a brief write-lock; later calls
 // are wait-free RLock reads like the rest of the request path.
-func (e *Engine) lookupSlotWithFallback(networkID, method, finality string) (slot *Slot, wildcard *Slot) {
+func (e *Engine) lookupSlotWithFallback(networkID, method, finality string, laneIDs []string) (slot *Slot, wildcard *Slot) {
 	e.mu.RLock()
 	reg, hasReg := e.networks[networkID]
 	var cfg *common.SelectionPolicyConfig
 	if hasReg {
 		cfg = reg.cfg
 	}
-	wildcard = e.slots[slotKey{networkID, "*", "*"}]
-	key := effectiveKey(cfg, networkID, method, finality)
+	wildcard = e.slots[slotKey{networkID, "*", "*", "*"}]
+	key := effectiveKey(cfg, networkID, method, finality, boundaryKey(laneIDs))
 	// No-narrowing case: key == wildcard, just return.
-	if key.method == "*" && key.finality == "*" {
+	if key.method == "*" && key.finality == "*" && key.boundary == "*" {
 		e.mu.RUnlock()
 		return wildcard, wildcard
 	}
@@ -650,7 +722,31 @@ func (e *Engine) lookupSlotWithFallback(networkID, method, finality string) (slo
 	if label == "" {
 		label = networkID
 	}
-	s := newSlot(e, networkID, label, key.method, key.finality, reg.upstreamsFn, reg.cfg)
+	// For a lane (boundary != "*") the slot's pool is the network's
+	// upstreams filtered to the eligible set. The membership is resolved
+	// at every tick from the LIVE upstreams list, so a restarted upstream
+	// (new pointer, same id) is picked up and a removed one drops out; a
+	// genuinely different membership produces a different boundary key and
+	// therefore a different slot (this one ages out via the idle sweep).
+	upstreamsFn := reg.upstreamsFn
+	if key.boundary != "*" {
+		laneSet := make(map[string]struct{}, len(laneIDs))
+		for _, id := range laneIDs {
+			laneSet[id] = struct{}{}
+		}
+		base := reg.upstreamsFn
+		upstreamsFn = func() []common.Upstream {
+			all := base()
+			out := make([]common.Upstream, 0, len(laneSet))
+			for _, u := range all {
+				if _, ok := laneSet[u.Id()]; ok {
+					out = append(out, u)
+				}
+			}
+			return out
+		}
+	}
+	s := newSlot(e, networkID, label, key.method, key.finality, key.boundary, upstreamsFn, reg.cfg)
 	e.slots[key] = s
 	e.mu.Unlock()
 	// Start the slot's ticker asynchronously so this request-path call

--- a/internal/policy/slot.go
+++ b/internal/policy/slot.go
@@ -28,6 +28,11 @@ type Slot struct {
 	networkLabel string
 	method       string
 	finality     string
+	// boundary is the block-availability lane key ("*" = full pool). It is
+	// part of the slot's identity and keeps per-lane eval state separate;
+	// it is intentionally NOT emitted as a metric label (boundary is a
+	// decision axis, not a metrics axis — see SelectionPolicyConfig.EvalPerBoundary).
+	boundary string
 
 	upstreamsFn func() []common.Upstream
 	cfg         *common.SelectionPolicyConfig
@@ -93,7 +98,7 @@ type Slot struct {
 	wg       sync.WaitGroup
 }
 
-func newSlot(e *Engine, networkID, networkLabel, method, finality string, upstreamsFn func() []common.Upstream, cfg *common.SelectionPolicyConfig) *Slot {
+func newSlot(e *Engine, networkID, networkLabel, method, finality, boundary string, upstreamsFn func() []common.Upstream, cfg *common.SelectionPolicyConfig) *Slot {
 	if networkLabel == "" {
 		networkLabel = networkID
 	}
@@ -103,6 +108,7 @@ func newSlot(e *Engine, networkID, networkLabel, method, finality string, upstre
 		networkLabel:  networkLabel,
 		method:        method,
 		finality:      finality,
+		boundary:      boundary,
 		upstreamsFn:   upstreamsFn,
 		cfg:           cfg,
 		excludedSince: make(map[string]int64),

--- a/internal/policy/testing.go
+++ b/internal/policy/testing.go
@@ -20,7 +20,7 @@ import (
 // SelectionPolicy.
 func OverrideOrderForTest(e *Engine, networkID string, ids ...string) {
 	e.mu.RLock()
-	slot, ok := e.slots[slotKey{networkID, "*", "*"}]
+	slot, ok := e.slots[slotKey{networkID, "*", "*", "*"}]
 	reg := e.networks[networkID]
 	e.mu.RUnlock()
 	if !ok || reg == nil {
@@ -80,9 +80,9 @@ func OverrideAllForTest(e *Engine, ids ...string) {
 // resulting order without sleeping.
 func TickForTest(e *Engine, networkID, method string) {
 	e.mu.RLock()
-	slot, ok := e.slots[slotKey{networkID, method, "*"}]
+	slot, ok := e.slots[slotKey{networkID, method, "*", "*"}]
 	if !ok {
-		slot = e.slots[slotKey{networkID, "*", "*"}]
+		slot = e.slots[slotKey{networkID, "*", "*", "*"}]
 	}
 	e.mu.RUnlock()
 	if slot != nil {
@@ -132,12 +132,12 @@ func WalkSlotsForTest(e *Engine, fn func(network, method, finality string, cache
 // no exact match exists.
 func TickForTestAtScope(e *Engine, networkID, method, finality string) {
 	e.mu.RLock()
-	slot, ok := e.slots[slotKey{networkID, method, finality}]
+	slot, ok := e.slots[slotKey{networkID, method, finality, "*"}]
 	if !ok {
-		slot, ok = e.slots[slotKey{networkID, method, "*"}]
+		slot, ok = e.slots[slotKey{networkID, method, "*", "*"}]
 	}
 	if !ok {
-		slot = e.slots[slotKey{networkID, "*", "*"}]
+		slot = e.slots[slotKey{networkID, "*", "*", "*"}]
 	}
 	e.mu.RUnlock()
 	if slot != nil {
@@ -216,9 +216,9 @@ func lookupSlotForTest(e *Engine, networkID, method string) *Slot {
 		return nil
 	}
 	e.mu.RLock()
-	slot, ok := e.slots[slotKey{networkID, method, "*"}]
+	slot, ok := e.slots[slotKey{networkID, method, "*", "*"}]
 	if !ok {
-		slot = e.slots[slotKey{networkID, "*", "*"}]
+		slot = e.slots[slotKey{networkID, "*", "*", "*"}]
 	}
 	e.mu.RUnlock()
 	return slot
@@ -231,9 +231,9 @@ func lookupSlotForTest(e *Engine, networkID, method string) *Slot {
 // any persistent ring buffer.
 func LatestDecisionOutputForTest(e *Engine, networkID, method string) (order []string, excluded []string) {
 	e.mu.RLock()
-	slot, ok := e.slots[slotKey{networkID, method, "*"}]
+	slot, ok := e.slots[slotKey{networkID, method, "*", "*"}]
 	if !ok {
-		slot = e.slots[slotKey{networkID, "*", "*"}]
+		slot = e.slots[slotKey{networkID, "*", "*", "*"}]
 	}
 	e.mu.RUnlock()
 	if slot == nil {


### PR DESCRIPTION
## What

Adds an orthogonal **`evalPerBoundary`** axis to the selection policy. When enabled, a single-block request is evaluated against the **lane** of upstreams whose configured block-availability bounds can actually serve the request's block. An upstream that can't serve the range is **absent from the pool** (a capability fact), and per-lane health/exclusion state is kept separate from other lanes.

This is useful when a network mixes upstreams with different served ranges — e.g. archive nodes alongside pruned / recent-only / snap-synced nodes that only retain block bodies above some floor. Today such a node can be ranked into a pool for a historical block it can't actually serve; the policy then scores and excludes over a population that includes upstreams that can't answer, and a separate per-upstream availability filter hides them afterward. The boundary axis makes the policy operate on the population that can actually serve the block.

## Design

- **A lane is identified by its eligible upstream *set*** (sorted-id key), not by a block range — so the slot key is stable as numeric bounds drift; it changes only when membership changes. Non-adjacent ranges with identical membership coalesce onto one slot.
- **Not folded into `EvalScope`.** Boundary must not change the health-tracker grain (it's a decision/pool axis, not a metrics axis), so the engine reads `EvalPerBoundary` directly. No new metric label dimensions.
- **One source of truth for reachability.** Lane membership reuses the same `EvmBlockAvailabilityBounds` predicate as the per-upstream availability gate, so the two never disagree.
- **Additive and safe.** Off by default; when off, routing is identical to before. Requests with no resolvable block number (e.g. `eth_getBlockByHash`) and all-eligible requests fall back to the full-pool wildcard slot. Lane slots are narrow and reclaimed by the idle sweep, so lane-key cardinality can't grow the slot map without bound.

## Changes

- `common/config.go`: `SelectionPolicyConfig.EvalPerBoundary *bool`.
- `internal/policy`: `slotKey` gains a `boundary` dimension; `GetOrderedInLane` + `PerBoundaryEnabled`; lane slots get a membership-filtered `upstreamsFn`; idle-sweep exemption tightened to the all-wildcard slot.
- `erpc/networks.go`: derive a request's eligible lane (`eligibleUpstreamIDsForBoundary` + pure `eligibleLane`) and pass it on the forward path, gated by `PerBoundaryEnabled`.

## Tests

Lane-key canonicalization/stability, boundary gating across scopes, lane pool scoping, axis-off no-op, idle eviction of lane slots, and the lane-derivation collapses (no-bounds / all-eligible → full-pool; out-of-range exclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)