### PR TITLE
feat(telemetry): add per-connector eth_getLogs cache block-range histogram

### DIFF
--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -49,6 +49,48 @@ func resolveBlockTagForGetLogs(ctx context.Context, network common.Network, bloc
 	return "", 0
 }
 
+// getLogsConcreteRangeSize returns the block-range size (toBlock-fromBlock+1) for an
+// eth_getLogs request whose bounds are already concrete hex numbers, with ok=true. It
+// returns ok=false when the request carries no numeric range — block tags (e.g. "latest"),
+// an EIP-234 blockHash filter, or malformed params — since those cannot be attributed to a
+// fixed range without network state. Unlike resolveBlockTagForGetLogs it performs no tag
+// resolution and no network I/O, so it is safe to call on hot paths such as cache hits,
+// where a cached getLogs always carries concrete bounds.
+func getLogsConcreteRangeSize(ctx context.Context, rpcReq *common.JsonRpcRequest) (float64, bool) {
+	if rpcReq == nil {
+		return 0, false
+	}
+	rpcReq.RLockWithTrace(ctx)
+	defer rpcReq.RUnlock()
+	if len(rpcReq.Params) < 1 {
+		return 0, false
+	}
+	filter, ok := rpcReq.Params[0].(map[string]interface{})
+	if !ok {
+		return 0, false
+	}
+	if _, ok := filter["blockHash"].(string); ok {
+		return 0, false
+	}
+	fbStr, _ := filter["fromBlock"].(string)
+	tbStr, _ := filter["toBlock"].(string)
+	if !strings.HasPrefix(fbStr, "0x") || !strings.HasPrefix(tbStr, "0x") {
+		return 0, false
+	}
+	fromBlock, err := common.HexToInt64(fbStr)
+	if err != nil {
+		return 0, false
+	}
+	toBlock, err := common.HexToInt64(tbStr)
+	if err != nil {
+		return 0, false
+	}
+	if fromBlock > 0 && toBlock >= fromBlock {
+		return float64(toBlock - fromBlock + 1), true
+	}
+	return 0, false
+}
+
 func BuildGetLogsRequest(fromBlock, toBlock int64, address interface{}, topics interface{}) (*common.JsonRpcRequest, error) {
 	fb, err := common.NormalizeHex(fromBlock)
 	if err != nil {

--- a/architecture/evm/eth_getLogs.go
+++ b/architecture/evm/eth_getLogs.go
@@ -85,7 +85,10 @@ func getLogsConcreteRangeSize(ctx context.Context, rpcReq *common.JsonRpcRequest
 	if err != nil {
 		return 0, false
 	}
-	if fromBlock > 0 && toBlock >= fromBlock {
+	// fromBlock >= 0 admits genesis-anchored ranges (0x0-...). Safe here because this
+	// helper only accepts concrete 0x hex — unlike the block-tag resolver, a 0 lower
+	// bound can only mean genesis, never an unresolved tag.
+	if fromBlock >= 0 && toBlock >= fromBlock {
 		return float64(toBlock - fromBlock + 1), true
 	}
 	return 0, false

--- a/architecture/evm/eth_getLogs_test.go
+++ b/architecture/evm/eth_getLogs_test.go
@@ -1461,6 +1461,18 @@ func TestGetLogsConcreteRangeSize(t *testing.T) {
 			expectedOk:   true,
 		},
 		{
+			name:         "genesis single block",
+			filter:       map[string]interface{}{"fromBlock": "0x0", "toBlock": "0x0"},
+			expectedSize: 1,
+			expectedOk:   true,
+		},
+		{
+			name:         "from genesis",
+			filter:       map[string]interface{}{"fromBlock": "0x0", "toBlock": "0x5"},
+			expectedSize: 6,
+			expectedOk:   true,
+		},
+		{
 			name:       "blockHash filter (EIP-234) has no range",
 			filter:     map[string]interface{}{"blockHash": "0xabc"},
 			expectedOk: false,

--- a/architecture/evm/eth_getLogs_test.go
+++ b/architecture/evm/eth_getLogs_test.go
@@ -1432,6 +1432,72 @@ func createTestRequest(filter interface{}) *common.NormalizedRequest {
 	return common.NewNormalizedRequestFromJsonRpcRequest(jrq)
 }
 
+func TestGetLogsConcreteRangeSize(t *testing.T) {
+	ctx := context.Background()
+	sizeOf := func(filter interface{}) (float64, bool) {
+		jrq, err := createTestRequest(filter).JsonRpcRequest(ctx)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+		return getLogsConcreteRangeSize(ctx, jrq)
+	}
+
+	tests := []struct {
+		name         string
+		filter       interface{}
+		expectedSize float64
+		expectedOk   bool
+	}{
+		{
+			name:         "multi-block concrete range",
+			filter:       map[string]interface{}{"fromBlock": "0x1", "toBlock": "0x4"},
+			expectedSize: 4,
+			expectedOk:   true,
+		},
+		{
+			name:         "single block",
+			filter:       map[string]interface{}{"fromBlock": "0x10", "toBlock": "0x10"},
+			expectedSize: 1,
+			expectedOk:   true,
+		},
+		{
+			name:       "blockHash filter (EIP-234) has no range",
+			filter:     map[string]interface{}{"blockHash": "0xabc"},
+			expectedOk: false,
+		},
+		{
+			name:       "block tag is not concrete",
+			filter:     map[string]interface{}{"fromBlock": "0x1", "toBlock": "latest"},
+			expectedOk: false,
+		},
+		{
+			name:       "missing toBlock",
+			filter:     map[string]interface{}{"fromBlock": "0x1"},
+			expectedOk: false,
+		},
+		{
+			name:       "inverted range",
+			filter:     map[string]interface{}{"fromBlock": "0x4", "toBlock": "0x1"},
+			expectedOk: false,
+		},
+		{
+			name:       "malformed fromBlock",
+			filter:     map[string]interface{}{"fromBlock": "invalid", "toBlock": "0x4"},
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size, ok := sizeOf(tt.filter)
+			assert.Equal(t, tt.expectedOk, ok)
+			if tt.expectedOk {
+				assert.Equal(t, tt.expectedSize, size)
+			}
+		})
+	}
+}
+
 func TestUpstreamPreForward_eth_getLogs_BlockHeadTolerance(t *testing.T) {
 	ctx := context.Background()
 	i64ptr := func(v int64) *int64 { return &v }

--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -153,6 +153,28 @@ func (c *EvmJsonRpcCache) SetPolicies(policies []*data.CachePolicy) {
 	c.policies = policies
 }
 
+// observeGetLogsRange records the concrete block-range size of an eth_getLogs
+// request into MetricCacheEvmGetLogsRange, tagged by the connector/policy/ttl
+// involved and the hit/miss outcome. It is a no-op for non-getLogs methods and
+// for requests whose range is not concrete (block tags, blockHash, malformed).
+func (c *EvmJsonRpcCache) observeGetLogsRange(ctx context.Context, req *common.NormalizedRequest, rpcReq *common.JsonRpcRequest, connectorId, policy, ttl, outcome string) {
+	if rpcReq == nil || rpcReq.Method != "eth_getLogs" {
+		return
+	}
+	rangeSize, ok := getLogsConcreteRangeSize(ctx, rpcReq)
+	if !ok {
+		return
+	}
+	telemetry.MetricCacheEvmGetLogsRange.WithLabelValues(
+		c.projectId,
+		req.NetworkLabel(),
+		connectorId,
+		policy,
+		ttl,
+		outcome,
+	).Observe(rangeSize)
+}
+
 func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error) {
 	ctx, span := common.StartSpan(ctx, "Cache.Get",
 		trace.WithAttributes(
@@ -532,6 +554,7 @@ drain:
 			labelPolicyStr,
 			labelTTL,
 		).Observe(time.Since(start).Seconds())
+		c.observeGetLogsRange(ctx, req, rpcReq, labelConnectorId, labelPolicyStr, labelTTL, "miss")
 		span.SetAttributes(attribute.Bool("cache.hit", false))
 		return nil, nil
 	}
@@ -556,6 +579,7 @@ drain:
 				policy.String(),
 				policy.GetTTL().String(),
 			).Observe(time.Since(start).Seconds())
+			c.observeGetLogsRange(ctx, req, rpcReq, connector.Id(), policy.String(), policy.GetTTL().String(), "miss")
 			span.SetAttributes(attribute.Bool("cache.hit", false))
 			return nil, nil
 		case common.CacheEmptyBehaviorAllow, common.CacheEmptyBehaviorOnly:
@@ -585,6 +609,7 @@ drain:
 		policy.String(),
 		policy.GetTTL().String(),
 	).Observe(time.Since(start).Seconds())
+	c.observeGetLogsRange(ctx, req, rpcReq, connector.Id(), policy.String(), policy.GetTTL().String(), "hit")
 	span.SetAttributes(attribute.Bool("cache.hit", true))
 	if c.logger.GetLevel() <= zerolog.DebugLevel {
 		result := jrr.GetResultBytes()

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -12794,6 +12794,330 @@
           ],
           "title": "Cache Latest-Block Age (staleness)",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Median eth_getLogs block-range size served from cache, by connector (hits only). Connectors that answer a wide range in one read show a high value; block-indexed connectors that only serve narrow/single-block ranges show a low value.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7700
+          },
+          "id": 910,
+          "interval": "1m",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.5, sum(rate(erpc_cache_evm_get_logs_range_bucket{namespace=~\"${namespace:regex}\", cluster=~\"${cluster:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", project=~\"${project:regex}\", outcome=\"hit\"}[1m])) by (le, project, network, connector))",
+              "legendFormat": "{{connector}} ({{network}})",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache eth_getLogs served range P50 (by connector)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "99th-percentile eth_getLogs block-range size served from cache, by connector (hits only).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7700
+          },
+          "id": 911,
+          "interval": "1m",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(erpc_cache_evm_get_logs_range_bucket{namespace=~\"${namespace:regex}\", cluster=~\"${cluster:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", project=~\"${project:regex}\", outcome=\"hit\"}[1m])) by (le, project, network, connector))",
+              "legendFormat": "{{connector}} ({{network}})",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache eth_getLogs served range P99 (by connector)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "eth_getLogs cache lookups per second by connector and hit/miss outcome. Falling request-count with a steady served range indicates request de-amplification (fewer, wider reads), not lost throughput.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 7708
+          },
+          "id": 912,
+          "interval": "1m",
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(erpc_cache_evm_get_logs_range_count{namespace=~\"${namespace:regex}\", cluster=~\"${cluster:regex}\", region=~\"${region:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", project=~\"${project:regex}\"}[$__rate_interval])) by (connector, outcome)",
+              "legendFormat": "{{connector}} {{outcome}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache eth_getLogs range reqs/s (by connector & outcome)",
+          "type": "timeseries"
         }
       ],
       "title": "Cache",

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -750,6 +750,7 @@ var (
 	MetricNetworkRequestDuration              *LabeledHistogram
 	MetricNetworkEvmGetLogsRangeRequested     *LabeledHistogram
 	MetricNetworkEvmTraceFilterRangeRequested *LabeledHistogram
+	MetricCacheEvmGetLogsRange                *LabeledHistogram
 	MetricNetworkHedgeDelaySeconds            *LabeledHistogram
 	MetricNetworkTimeoutDurationSeconds       *LabeledHistogram
 	MetricNetworkDataUnavailableWaitSeconds   *LabeledHistogram
@@ -802,6 +803,18 @@ func buildFilterAwareHistograms(bucketsStr string) error {
 		Help:      "trace_filter/arbtrace_filter requested block-range sizes.",
 		Buckets:   EvmGetLogsRangeHistogramBuckets,
 	}, []string{"project", "network", "method", "user", "finality"})
+
+	// Same block-range distribution as MetricNetworkEvmGetLogsRangeRequested but
+	// observed at the cache layer, partitioned by the connector involved and the
+	// hit/miss outcome. This exposes the per-connector served/missed range shape
+	// (e.g. connectors that answer wide ranges in one read vs. those that only
+	// serve narrow/single-block ranges, or the wide ranges a connector misses).
+	MetricCacheEvmGetLogsRange = NewLabeledHistogram(prometheus.HistogramOpts{
+		Namespace: "erpc",
+		Name:      "cache_evm_get_logs_range",
+		Help:      "eth_getLogs block-range sizes seen at the cache layer, partitioned by connector and hit/miss outcome.",
+		Buckets:   EvmGetLogsRangeHistogramBuckets,
+	}, []string{"project", "network", "connector", "policy", "ttl", "outcome"})
 
 	MetricNetworkHedgeDelaySeconds = NewLabeledHistogram(prometheus.HistogramOpts{
 		Namespace: "erpc",
@@ -948,6 +961,7 @@ func SetHistogramBuckets(bucketsStr string) error {
 	MetricNetworkRequestDuration = registerOrReuse(MetricNetworkRequestDuration)
 	MetricNetworkEvmGetLogsRangeRequested = registerOrReuse(MetricNetworkEvmGetLogsRangeRequested)
 	MetricNetworkEvmTraceFilterRangeRequested = registerOrReuse(MetricNetworkEvmTraceFilterRangeRequested)
+	MetricCacheEvmGetLogsRange = registerOrReuse(MetricCacheEvmGetLogsRange)
 	MetricNetworkHedgeDelaySeconds = registerOrReuse(MetricNetworkHedgeDelaySeconds)
 	MetricNetworkTimeoutDurationSeconds = registerOrReuse(MetricNetworkTimeoutDurationSeconds)
 	MetricNetworkDataUnavailableWaitSeconds = registerOrReuse(MetricNetworkDataUnavailableWaitSeconds)


### PR DESCRIPTION
## What

Adds `erpc_cache_evm_get_logs_range`, an `eth_getLogs` block-range-size histogram observed at the cache layer and partitioned by **connector**, `policy`, `ttl`, and a `hit`/`miss` **outcome** label.

## Why

Cache connectors can serve `eth_getLogs` across very different block-range widths — a block-indexed store may only answer narrow/single-block ranges, while a range-capable store answers a wide range in a single read. Today `network_evm_get_logs_range_requested` captures the *client-requested* range, but there is no per-connector or hit/miss view of the range actually seen at the cache layer. That makes it hard to:

- compare how wide a range each connector actually serves,
- spot request-count amplification (many narrow reads vs. one wide read that returns the same data), and
- see the wide ranges a connector *misses*.

## How

- New `LabeledHistogram` reusing the existing `EvmGetLogsRangeHistogramBuckets`.
- Observed at the existing cache hit and miss emission sites in `EvmJsonRpcCache.Get`, via a small `observeGetLogsRange` helper so all three sites stay in sync.
- The range is read with a new `getLogsConcreteRangeSize` helper that only parses already-concrete hex bounds — no block-tag resolution and no network I/O, so it is safe on the hot path (a cached `eth_getLogs` always carries concrete bounds). Non-`getLogs` methods, `blockHash` (EIP-234) filters, tag-based bounds, and malformed ranges are skipped.

## Metric

```
erpc_cache_evm_get_logs_range_bucket{project,network,connector,policy,ttl,outcome,le}
erpc_cache_evm_get_logs_range_count{project,network,connector,policy,ttl,outcome}
erpc_cache_evm_get_logs_range_sum{project,network,connector,policy,ttl,outcome}
```

`outcome` is `hit` or `miss`. This is the cache-layer, per-connector analogue of the existing network-level `network_evm_get_logs_range_requested`.

## Tests

- `TestGetLogsConcreteRangeSize` — table test covering concrete multi/single-block ranges, `blockHash`, block tags, a missing bound, an inverted range, and malformed input.
- `go build`, `go vet`, `go test ./telemetry/...`, and the evm `getLogs`/cache tests pass locally.

## Dashboard

Adds three panels to the **Cache** row of `monitoring/grafana/dashboards/erpc.json`:

- **Cache eth_getLogs served range P50 (by connector)** — `histogram_quantile(0.5, …_bucket{outcome="hit"})` by connector.
- **Cache eth_getLogs served range P99 (by connector)** — same at p99.
- **Cache eth_getLogs range reqs/s (by connector & outcome)** — `sum(rate(…_count))` by connector and hit/miss.

Together these show which connectors serve wide vs. narrow ranges and make request de-amplification (fewer, wider reads) legible at a glance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes on the cache GET path with a cheap param parse; no request routing, auth, or caching behavior changes.
> 
> **Overview**
> Adds **`erpc_cache_evm_get_logs_range`**, a histogram of `eth_getLogs` block-range sizes recorded when the EVM JSON-RPC cache resolves a lookup, labeled by **connector**, policy, TTL, and **`hit`/`miss`**. That complements the existing network-level “requested range” metric with what each cache connector actually sees on hits and misses (wide vs narrow ranges, de-amplification).
> 
> Range size is computed with a new **`getLogsConcreteRangeSize`** helper that only reads concrete `0x` `fromBlock`/`toBlock` bounds—no tag resolution or I/O—so it is safe on cache hot paths. Tag filters, EIP-234 `blockHash`, and malformed ranges are skipped.
> 
> **`observeGetLogsRange`** is wired into the three existing cache GET outcome sites (aggregate miss, empty-result miss, hit). Grafana’s **Cache** row gets P50/P99 served-range panels (hits) and a reqs/s panel by connector and outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b8d826a8537c31d74d17a4ec51ee13e94763cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->