### PR TITLE
feat(envio): sync HyperRPC supported networks (add Unichain + 33 chains, fix Chiliz/Hyperliquid)

### DIFF
--- a/thirdparty/envio.go
+++ b/thirdparty/envio.go
@@ -68,6 +68,40 @@ var envioKnownSupportedChains = map[int64]struct{}{
 	999:        {}, // Hyperliquid
 	1750:       {}, // Metall2
 	50104:      {}, // Sophon
+	130:        {}, // Unichain
+	36888:      {}, // Ab
+	5042002:    {}, // Arc Testnet
+	4114:       {}, // Citrea
+	33111:      {}, // Curtis
+	42793:      {}, // Etherlink
+	252:        {}, // Fraxtal
+	560048:     {}, // Hoodi
+	1776:       {}, // Injective
+	57073:      {}, // Ink
+	747474:     {}, // Katana
+	1135:       {}, // Lisk
+	4201:       {}, // Lukso Testnet
+	4326:       {}, // Megaeth
+	6343:       {}, // Megaeth Testnet2
+	4200:       {}, // Merlin
+	34443:      {}, // Mode
+	143:        {}, // Monad
+	10143:      {}, // Monad Testnet
+	2818:       {}, // Morph
+	204:        {}, // opBNB
+	9745:       {}, // Plasma
+	98866:      {}, // Plume
+	1329:       {}, // Sei
+	1328:       {}, // Sei Testnet
+	1868:       {}, // Soneium
+	146:        {}, // Sonic
+	14601:      {}, // Sonic Testnet
+	531050104:  {}, // Sophon Testnet
+	5330:       {}, // Superseed
+	1923:       {}, // Swell
+	4217:       {}, // Tempo
+	480:        {}, // Worldchain
+	48900:      {}, // Zircuit
 }
 
 type EnvioVendor struct {

--- a/thirdparty/envio.go
+++ b/thirdparty/envio.go
@@ -28,45 +28,33 @@ var envioKnownSupportedChains = map[int64]struct{}{
 	8453:       {}, // Base
 	84532:      {}, // Base Sepolia
 	81457:      {}, // Blast
-	168587773:  {}, // Blast Sepolia
 	288:        {}, // Boba
 	56:         {}, // Bsc
 	97:         {}, // Bsc Testnet
-	2001:       {}, // C1 Milkomeda
 	42220:      {}, // Celo
-	44:         {}, // Crab
-	46:         {}, // Darwinia
 	1:          {}, // Ethereum Mainnet
 	250:        {}, // Fantom
 	14:         {}, // Flare
 	43113:      {}, // Fuji
 	100:        {}, // Gnosis
 	10200:      {}, // Gnosis Chiado
-	5:          {}, // Goerli
 	1666600000: {}, // Harmony Shard 0
 	17000:      {}, // Holesky
-	9090:       {}, // Inco Gentry Testnet
-	1802203764: {}, // Kakarot Sepolia
 	255:        {}, // Kroma
 	59144:      {}, // Linea
 	42:         {}, // Lukso
 	169:        {}, // Manta
 	5000:       {}, // Mantle
-	1088:       {}, // Metis
-	17864:      {}, // Mev Commit
 	1284:       {}, // Moonbeam
 	10:         {}, // Optimism
 	11155420:   {}, // Optimism Sepolia
 	137:        {}, // Polygon
 	80002:      {}, // Polygon Amoy
 	1101:       {}, // Polygon zkEVM
-	424:        {}, // Publicgoods
 	30:         {}, // Rsk
 	534352:     {}, // Scroll
 	11155111:   {}, // Sepolia
 	148:        {}, // Shimmer Evm
-	196:        {}, // X Layer
-	195:        {}, // X Layer Testnet
 	7000:       {}, // Zeta
 	324:        {}, // ZKsync
 	7777777:    {}, // Zora
@@ -75,12 +63,10 @@ var envioKnownSupportedChains = map[int64]struct{}{
 	2741:       {}, // Abstract
 	5115:       {}, // Citrea Testnet
 	7560:       {}, // Cyber
-	80084:      {}, // Berachain Bartio
 	80094:      {}, // Berachain
-	8888:       {}, // Chiliz
-	645749:     {}, // Hyperliquid
+	88888:      {}, // Chiliz
+	999:        {}, // Hyperliquid
 	1750:       {}, // Metall2
-	1287:       {}, // Moonbase Alpha
 	50104:      {}, // Sophon
 }
 


### PR DESCRIPTION
Syncs the Envio HyperRPC known-supported chains list in `thirdparty/envio.go` with the [current HyperRPC supported-networks page](https://docs.envio.dev/docs/HyperRPC/hyperrpc-supported-networks). Adds 34 chains now served by Envio — including **Unichain (130)**, Sei, Monad, Sonic, Etherlink, Ink, Katana, Soneium, Worldchain, Zircuit and opBNB — so they resolve as supported without a live probe. Also corrects two wrong chain IDs (Chiliz `8888`→`88888`, Hyperliquid `645749`→`999`) and prunes 14 chains Envio no longer serves (Blast Sepolia, Goerli, Metis, X Layer, Berachain Bartio, Moonbase Alpha, and others). Holesky is intentionally kept since it's an active testnet the docs table merely omits. Net change: +36/−16 lines in one file.