### PR TITLE
feat(server): add gRPC server reflection (enabled by default)

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -146,6 +146,7 @@ type ServerConfig struct {
 	GrpcPortV6          *int              `yaml:"grpcPortV6,omitempty" json:"grpcPortV6"`
 	GrpcMaxRecvMsgSize  *int              `yaml:"grpcMaxRecvMsgSize,omitempty" json:"grpcMaxRecvMsgSize"`
 	GrpcMaxSendMsgSize  *int              `yaml:"grpcMaxSendMsgSize,omitempty" json:"grpcMaxSendMsgSize"`
+	GrpcReflection      *bool             `yaml:"grpcReflection,omitempty" json:"grpcReflection"`
 	MaxTimeout          *Duration         `yaml:"maxTimeout,omitempty" json:"maxTimeout" tstype:"Duration"`
 	ReadTimeout         *Duration         `yaml:"readTimeout,omitempty" json:"readTimeout" tstype:"Duration"`
 	WriteTimeout        *Duration         `yaml:"writeTimeout,omitempty" json:"writeTimeout" tstype:"Duration"`

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -691,6 +691,9 @@ func (s *ServerConfig) SetDefaults() error {
 	if s.GrpcMaxSendMsgSize == nil {
 		s.GrpcMaxSendMsgSize = util.IntPtr(100 * 1024 * 1024)
 	}
+	if s.GrpcReflection == nil {
+		s.GrpcReflection = util.BoolPtr(true)
+	}
 	if s.MaxTimeout == nil {
 		d := Duration(150 * time.Second)
 		s.MaxTimeout = &d

--- a/common/defaults_test.go
+++ b/common/defaults_test.go
@@ -200,6 +200,9 @@ func TestServerConfigSetDefaults_GrpcPortDefaultsToHttpPort(t *testing.T) {
 	assert.Equal(t, "[::1]", *server.GrpcHostV6)
 	assert.Equal(t, 4311, *server.GrpcPortV4)
 	assert.Equal(t, 5311, *server.GrpcPortV6)
+	// gRPC server reflection defaults to enabled.
+	assert.NotNil(t, server.GrpcReflection)
+	assert.True(t, *server.GrpcReflection)
 }
 
 func TestSetDefaults_UpstreamConfig(t *testing.T) {

--- a/erpc/grpc_server.go
+++ b/erpc/grpc_server.go
@@ -19,6 +19,7 @@ import (
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -113,6 +114,12 @@ func NewGrpcServer(
 	gs.server = grpc.NewServer(opts...)
 	evm.RegisterRPCQueryServiceServer(gs.server, gs)
 	evm.RegisterQueryServiceServer(gs.server, gs)
+	// Server reflection lets tools (grpcurl, Postman, buf) discover the BDS
+	// services/messages without a local copy of the .proto files. Enabled by
+	// default; set server.grpcReflection=false to turn it off.
+	if cfg.GrpcReflection == nil || *cfg.GrpcReflection {
+		reflection.Register(gs.server)
+	}
 	return gs, nil
 }
 

--- a/erpc/grpc_server_test.go
+++ b/erpc/grpc_server_test.go
@@ -147,6 +147,9 @@ func TestHttpServer_CanSharePortWithGrpc(t *testing.T) {
 	httpServer, err := NewHttpServer(ctx, &logger, cfg.Server, cfg.HealthCheck, cfg.Admin, erpcInstance)
 	require.NoError(t, err)
 	require.NotNil(t, httpServer.sharedGrpcServer)
+	// Reflection is enabled by default, so the reflection service is registered
+	// alongside the BDS services on the shared gRPC server.
+	require.Contains(t, httpServer.sharedGrpcServer.server.GetServiceInfo(), "grpc.reflection.v1.ServerReflection")
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -182,6 +182,7 @@ export interface ServerConfig {
   grpcPortV6?: number /* int */;
   grpcMaxRecvMsgSize?: number /* int */;
   grpcMaxSendMsgSize?: number /* int */;
+  grpcReflection?: boolean;
   maxTimeout?: Duration;
   readTimeout?: Duration;
   writeTimeout?: Duration;
@@ -544,6 +545,7 @@ export interface ProjectConfig {
    */
   userAgentMode?: UserAgentTrackingMode;
   forwardHeaders?: string[];
+  allowClientDirectives?: string;
   ignoreMethods?: string[];
   allowMethods?: string[];
   /**


### PR DESCRIPTION
## What

Adds **gRPC server reflection** to the eRPC gRPC server, behind a new `server.grpcReflection` config flag that **defaults to `true`**.

Today the gRPC server registers the BDS services (`bds.evm.RPCQueryService`, `bds.evm.QueryService`) but not the reflection service, so clients must carry a local copy of the [`blockchain-data-standards/manifesto`](https://github.com/blockchain-data-standards/manifesto) `.proto` files to call anything. With reflection on, `grpcurl`/Postman/buf can discover the services and message types directly:

```bash
grpcurl edge.example.com:443 list
grpcurl edge.example.com:443 describe bds.evm.RPCQueryService
```

## Changes

- **`common`** — new `ServerConfig.GrpcReflection *bool` (`grpcReflection` yaml/json), defaulted to `true` in `SetDefaults`.
- **`erpc`** — `reflection.Register(gs.server)` in `NewGrpcServer`, gated on the flag. Because it lives in the single constructor, it covers both the standalone gRPC listener and the h2c shared-port mux.
- **typescript config types** — regenerated via `tygo`. This also syncs the previously-missed `allowClientDirectives` field from #953 (the committed `generated.ts` was stale).
- **tests** — assert the default is `true`, and assert the reflection service is registered on the shared gRPC server in `TestHttpServer_CanSharePortWithGrpc`.

No `go.mod` change — `google.golang.org/grpc/reflection` ships with the already-vendored `google.golang.org/grpc`.

## To disable

```yaml
server:
  grpcReflection: false
```

Reflection publishes the full service/method/message schema to anyone who can reach the endpoint. BDS is an open standard so this is usually fine, but operators who front a public endpoint and would rather not advertise the schema can flip it off.

## Verification

- `go build ./...`, `go test ./common/ -run GrpcPort`, `go test ./erpc/ -run CanSharePortWithGrpc` all pass.
- Confirmed the deployed edge already serves the BDS methods over gRPC (unary `ChainId`/`GetBlockByNumber` and streaming `QueryBlocks`) but returns `server does not support the reflection API` — this PR is what closes that gap.

## Follow-up (deploy side)

Once this merges and a new `erpc` image is published, bump the pinned image digest in the `erpc-deployments` edge Dockerfile and redeploy; reflection then comes on by default (no per-target config needed).
