### PR TITLE
feat(clients): share http.Transport connection pool across projects per upstream

### DIFF
--- a/clients/http_json_rpc_client.go
+++ b/clients/http_json_rpc_client.go
@@ -102,30 +102,21 @@ func NewGenericHttpJsonRpcClient(
 		errorExtractor:  extractor,
 	}
 
-	// Default fallback transport (no proxy). Optimized for high-latency,
-	// high-RPS scenarios to prevent connection churn. DialContext via
-	// util.DefaultOutboundDialer enables kernel-level TCP keepalive so
-	// wedged outbound flows are detected within ~45s (3 missed probes)
-	// instead of the OS default tcp_keepalive_time of 2h on Linux.
-	transport := &http.Transport{
-		DialContext:           util.DefaultOutboundDialer().DialContext,
-		MaxIdleConns:          1024,
-		MaxIdleConnsPerHost:   256,
-		MaxConnsPerHost:       0, // Unlimited active connections (prevents bottleneck)
-		IdleConnTimeout:       90 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-
 	if util.IsTest() {
+		// Tests rely on http.DefaultTransport so HTTP mocking (gock/httpmock,
+		// which patch DefaultTransport) can intercept outbound requests.
 		client.httpClient = &http.Client{
 			Transport: http.DefaultTransport,
 		}
 	} else {
+		// Share ONE *http.Transport (connection pool) per unique upstream across
+		// every project. Two projects configuring the identical endpoint reuse the
+		// same pool instead of each holding a full idle-connection set + TLS cache.
+		// Keying by UniqueUpstreamKey preserves per-upstream isolation within a
+		// project and only deduplicates across projects. See transport_pool.go.
 		client.httpClient = &http.Client{
 			Timeout:   60 * time.Second,
-			Transport: transport,
+			Transport: sharedTransportPool.GetOrCreate(common.UniqueUpstreamKey(upstream)),
 		}
 	}
 

--- a/clients/transport_pool.go
+++ b/clients/transport_pool.go
@@ -1,0 +1,83 @@
+package clients
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/erpc/erpc/util"
+)
+
+// sharedTransportPool is the process-wide pool of *http.Transport instances,
+// keyed by common.UniqueUpstreamKey. Multiple eRPC projects that configure the
+// SAME upstream endpoint (identical id + endpoint + headers) reuse ONE
+// connection pool instead of each allocating a full http.Transport — with its
+// idle-connection pool (MaxIdleConns=1024, MaxIdleConnsPerHost=256), TLS
+// session cache, and per-host buffers — per project.
+//
+// This is the co-resident multi-project deduplication: without it, N projects
+// pointing at the same endpoint hold N independent connection pools to it.
+// http.Transport is safe for concurrent use by many goroutines, so the sharing
+// is transparent to every caller.
+var sharedTransportPool = NewTransportPool()
+
+// TransportPool hands out shared *http.Transport instances keyed by an opaque
+// string (the upstream's UniqueUpstreamKey). Distinct keys get distinct
+// transports, so per-upstream connection-pool isolation WITHIN a project is
+// unchanged; the pool only deduplicates transports ACROSS projects (or any
+// other callers) that resolve to the identical upstream key.
+type TransportPool struct {
+	mu         sync.Mutex
+	transports map[string]*http.Transport
+}
+
+// NewTransportPool returns an empty pool. The package uses a single global
+// instance (sharedTransportPool); this constructor is exported so tests can
+// exercise the pool in isolation.
+func NewTransportPool() *TransportPool {
+	return &TransportPool{transports: make(map[string]*http.Transport)}
+}
+
+// GetOrCreate returns the shared transport for key, lazily creating the standard
+// high-RPS transport on first use. The transport tuning is identical for every
+// upstream, so callers only ever vary the key (the sharing granularity), never
+// the shape of the transport.
+func (p *TransportPool) GetOrCreate(key string) *http.Transport {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if t, ok := p.transports[key]; ok {
+		return t
+	}
+	t := newDefaultTransport()
+	p.transports[key] = t
+	return t
+}
+
+// size reports how many distinct transports the pool currently holds. Used by
+// tests to assert deduplication.
+func (p *TransportPool) size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.transports)
+}
+
+// newDefaultTransport builds the standard non-proxy outbound transport. It is
+// the single source of truth for the tuning; the pool caches one per upstream
+// key.
+//
+// Optimized for high-latency, high-RPS scenarios to prevent connection churn.
+// DialContext via util.DefaultOutboundDialer enables kernel-level TCP keepalive
+// so wedged outbound flows are detected within ~45s (3 missed probes) instead of
+// the OS default tcp_keepalive_time of 2h on Linux.
+func newDefaultTransport() *http.Transport {
+	return &http.Transport{
+		DialContext:           util.DefaultOutboundDialer().DialContext,
+		MaxIdleConns:          1024,
+		MaxIdleConnsPerHost:   256,
+		MaxConnsPerHost:       0, // Unlimited active connections (prevents bottleneck)
+		IdleConnTimeout:       90 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/clients/transport_pool_test.go
+++ b/clients/transport_pool_test.go
@@ -1,0 +1,180 @@
+package clients
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransportPool_SameKeyReturnsSameTransport is the core invariant: repeated
+// GetOrCreate for the same key returns the SAME *http.Transport (one connection
+// pool), and the pool holds exactly one entry.
+func TestTransportPool_SameKeyReturnsSameTransport(t *testing.T) {
+	p := NewTransportPool()
+
+	t1 := p.GetOrCreate("key-a")
+	t2 := p.GetOrCreate("key-a")
+
+	require.NotNil(t, t1)
+	require.Same(t, t1, t2, "same key must return the identical transport pointer")
+	require.Equal(t, 1, p.size(), "same key must not create a second transport")
+}
+
+// TestTransportPool_DifferentKeysReturnDistinctTransports verifies distinct keys
+// get distinct transports, so per-upstream isolation WITHIN a project is
+// preserved (two different upstreams never share a pool).
+func TestTransportPool_DifferentKeysReturnDistinctTransports(t *testing.T) {
+	p := NewTransportPool()
+
+	ta := p.GetOrCreate("key-a")
+	tb := p.GetOrCreate("key-b")
+
+	require.NotNil(t, ta)
+	require.NotNil(t, tb)
+	require.NotSame(t, ta, tb, "different keys must return different transports")
+	require.Equal(t, 2, p.size())
+
+	// Re-fetching each key is still stable.
+	require.Same(t, ta, p.GetOrCreate("key-a"))
+	require.Same(t, tb, p.GetOrCreate("key-b"))
+	require.Equal(t, 2, p.size())
+}
+
+// TestTransportPool_EmptyKey ensures the pool is robust to an empty key (treated
+// as any other distinct key) rather than panicking.
+func TestTransportPool_EmptyKey(t *testing.T) {
+	p := NewTransportPool()
+	t1 := p.GetOrCreate("")
+	t2 := p.GetOrCreate("")
+	require.NotNil(t, t1)
+	require.Same(t, t1, t2)
+	require.Equal(t, 1, p.size())
+}
+
+// TestTransportPool_ConcurrentSameKey hammers a single key from many goroutines.
+// Run with -race, this proves the pool is safe for concurrent use and never
+// creates a duplicate transport under a lost-update race.
+func TestTransportPool_ConcurrentSameKey(t *testing.T) {
+	p := NewTransportPool()
+
+	const goroutines = 200
+	var wg sync.WaitGroup
+	results := make([]*http.Transport, goroutines)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = p.GetOrCreate("hot-key")
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, p.size(), "concurrent GetOrCreate of one key must yield exactly one transport")
+	first := results[0]
+	require.NotNil(t, first)
+	for i, got := range results {
+		require.Samef(t, first, got, "goroutine %d observed a different transport pointer", i)
+	}
+}
+
+// TestTransportPool_ConcurrentMixedKeys exercises many keys concurrently and
+// asserts each key resolves to exactly one stable transport.
+func TestTransportPool_ConcurrentMixedKeys(t *testing.T) {
+	p := NewTransportPool()
+
+	keys := []string{"k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7"}
+	const perKey = 50
+
+	var mu sync.Mutex
+	seen := make(map[string]*http.Transport)
+
+	var wg sync.WaitGroup
+	for _, k := range keys {
+		for i := 0; i < perKey; i++ {
+			wg.Add(1)
+			go func(key string) {
+				defer wg.Done()
+				tr := p.GetOrCreate(key)
+				mu.Lock()
+				if prev, ok := seen[key]; ok {
+					require.Same(t, prev, tr)
+				} else {
+					seen[key] = tr
+				}
+				mu.Unlock()
+			}(k)
+		}
+	}
+	wg.Wait()
+
+	require.Equal(t, len(keys), p.size(), "each distinct key must create exactly one transport")
+	// Every key's transport must be distinct from the others.
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			require.NotSame(t, seen[keys[i]], seen[keys[j]], "keys %q and %q must not share a transport", keys[i], keys[j])
+		}
+	}
+}
+
+// TestNewDefaultTransport_Config pins the transport tuning so an accidental edit
+// (e.g. dropping the idle-conn caps that keep connection churn down under
+// high-RPS edge load) is caught by CI rather than in production.
+func TestNewDefaultTransport_Config(t *testing.T) {
+	tr := newDefaultTransport()
+
+	require.NotNil(t, tr.DialContext, "DialContext must be set (kernel TCP keepalive)")
+	require.Equal(t, 1024, tr.MaxIdleConns)
+	require.Equal(t, 256, tr.MaxIdleConnsPerHost)
+	require.Equal(t, 0, tr.MaxConnsPerHost, "active connections must stay unlimited")
+	require.Equal(t, 90*time.Second, tr.IdleConnTimeout)
+	require.Equal(t, 30*time.Second, tr.ResponseHeaderTimeout)
+	require.Equal(t, 10*time.Second, tr.TLSHandshakeTimeout)
+	require.Equal(t, 1*time.Second, tr.ExpectContinueTimeout)
+
+	// Each call builds a fresh transport (the pool is what makes them shared).
+	require.NotSame(t, tr, newDefaultTransport())
+}
+
+// TestSharedTransportPool_Global verifies the package-global instance the HTTP
+// client uses is initialized and behaves like any other pool.
+func TestSharedTransportPool_Global(t *testing.T) {
+	require.NotNil(t, sharedTransportPool)
+	a := sharedTransportPool.GetOrCreate("global-test-key-A")
+	b := sharedTransportPool.GetOrCreate("global-test-key-A")
+	require.Same(t, a, b)
+}
+
+// TestTransportPool_DedupByUniqueUpstreamKey is the end-to-end intent: when two
+// projects declare the SAME upstream (identical id + endpoint + headers), their
+// upstreams resolve to the same UniqueUpstreamKey and therefore share ONE
+// transport — while an upstream with a different endpoint gets its own. This is
+// the co-resident multi-project connection-pool deduplication.
+func TestTransportPool_DedupByUniqueUpstreamKey(t *testing.T) {
+	p := NewTransportPool()
+
+	// Same id + endpoint + network → identical UniqueUpstreamKey (the same
+	// upstream declared by two different projects).
+	projectAUps := common.NewFakeUpstream("alchemy-eth")
+	projectAUps.Config().Endpoint = "https://eth.example.com/v2/key"
+	projectBUps := common.NewFakeUpstream("alchemy-eth")
+	projectBUps.Config().Endpoint = "https://eth.example.com/v2/key"
+
+	require.Equal(t, common.UniqueUpstreamKey(projectAUps), common.UniqueUpstreamKey(projectBUps),
+		"identical upstream config must yield identical UniqueUpstreamKey")
+
+	tA := p.GetOrCreate(common.UniqueUpstreamKey(projectAUps))
+	tB := p.GetOrCreate(common.UniqueUpstreamKey(projectBUps))
+	require.Same(t, tA, tB, "two projects on the same endpoint must share one connection pool")
+
+	// A genuinely different endpoint keeps its own pool.
+	otherUps := common.NewFakeUpstream("alchemy-base")
+	otherUps.Config().Endpoint = "https://base.example.com/v2/key"
+	tOther := p.GetOrCreate(common.UniqueUpstreamKey(otherUps))
+	require.NotSame(t, tA, tOther)
+	require.Equal(t, 2, p.size(), "one shared transport for the shared endpoint + one for the distinct endpoint")
+}


### PR DESCRIPTION
## Summary

Each eRPC project builds its own `ClientRegistry`, so a deployment that runs **multiple projects declaring the same upstream endpoint** ends up with one full `http.Transport` per (project, upstream) — i.e. N independent idle-connection pools (`MaxIdleConns=1024` / `MaxIdleConnsPerHost=256`), TLS session caches, and per-host buffers for a single physical endpoint.

This PR shares one connection pool per endpoint across projects.

## What changes

- New `clients/transport_pool.go`: a process-global `TransportPool` keyed by `UniqueUpstreamKey`.
- `NewGenericHttpJsonRpcClient` obtains its `*http.Transport` from the pool instead of allocating one.

Two projects that declare the identical upstream (same id + endpoint + headers → same `UniqueUpstreamKey`) now share **one** `http.Transport`. Distinct upstreams within a project still get distinct pools, so per-upstream isolation is unchanged; only cross-project duplication is removed.

## Why it's non-breaking

- **No signature changes.** The pool is package-internal to `clients`, so no registry/constructor call sites move.
- **Test path untouched.** `util.IsTest()` still returns `http.DefaultTransport`, so HTTP mocking (gock/httpmock, which patch `DefaultTransport`) keeps intercepting; the pool is production-only.
- **Client identity unchanged.** projectId `User-Agent`, upstream labels, spans, and metrics are all still per-project — only the underlying transport is shared, and `http.Transport` is safe for concurrent use.

## Not included (on purpose)

Sharing the EVM state poller. Its expensive work (latest/finalized/earliest block polling) is **already** deduplicated across projects via the `SharedState` counters (keyed by `UniqueUpstreamKey`, which omits projectId, + `TryUpdateIfStale` skipping the fetch when fresh), and each project's tracker already receives the shared block numbers via the counter's `OnValue` fan-out. The only remaining per-project poller state is `eth_syncing` (`EvmSyncingState`), which gates upstream selection (`networks.go`, `upstream.go`, `upstream_executor.go`) — sharing the poller goroutine would require moving that into `SharedState` and touching the selection path, so it's left per-project.

## Testing

`clients/transport_pool_test.go` (run with `-race`): same-key dedup, distinct-key isolation, empty key, high-concurrency single/mixed keys, transport-config pinning, the package-global instance, and end-to-end dedup through `UniqueUpstreamKey`.

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race ./clients/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces global shared outbound connection state keyed by upstream identity; behavior is standard for `http.Transport` but affects all co-resident projects hitting the same endpoint.
> 
> **Overview**
> **Production HTTP JSON-RPC clients no longer allocate a dedicated `http.Transport` per project/upstream pair.** Outbound tuning is centralized in `newDefaultTransport()` and reused via a process-wide `TransportPool` keyed by `common.UniqueUpstreamKey` (id, endpoint, network, headers).
> 
> `NewGenericHttpJsonRpcClient` now sets `http.Client.Transport` from `sharedTransportPool.GetOrCreate(...)` instead of building a transport inline. **Distinct upstreams still get distinct pools**; only identical upstream definitions across co-resident projects share one idle-connection set and TLS cache. The **test path is unchanged** (`http.DefaultTransport` when `util.IsTest()`), so gock/httpmock keep working.
> 
> Adds `transport_pool_test.go` covering deduplication, per-key isolation, concurrency under `-race`, transport config pinning, and `UniqueUpstreamKey` end-to-end behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5459a21828287764bbe2a675eeebbd39a8ce9f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->