### PR TITLE
feat(cache): add skipCacheWrite request directive (symmetric to skipCacheRead)

### DIFF
--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -635,6 +635,14 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 	))
 	defer span.End()
 
+	// Skip persisting the response when the request opts out of cache writes.
+	// Co-resident projects share a cache connector and the cache key omits
+	// projectId, so a tier that must not backfill another tier's cache sets this.
+	if req.ShouldSkipCacheWrite() {
+		span.SetAttributes(attribute.Bool("cache.write_skipped", true))
+		return nil
+	}
+
 	if common.IsTracingDetailed {
 		span.SetAttributes(
 			attribute.String("request.id", fmt.Sprintf("%v", req.ID())),

--- a/common/config.go
+++ b/common/config.go
@@ -2181,6 +2181,7 @@ type DirectiveDefaultsConfig struct {
 	RetryEmpty        *bool       `yaml:"retryEmpty,omitempty" json:"retryEmpty"`
 	RetryPending      *bool       `yaml:"retryPending,omitempty" json:"retryPending"`
 	SkipCacheRead     interface{} `yaml:"skipCacheRead,omitempty" json:"skipCacheRead"`
+	SkipCacheWrite    *bool       `yaml:"skipCacheWrite,omitempty" json:"skipCacheWrite"`
 	UseUpstream       *string     `yaml:"useUpstream,omitempty" json:"useUpstream"`
 	SkipInterpolation *bool       `yaml:"skipInterpolation,omitempty" json:"skipInterpolation"`
 	SkipConsensus     *bool       `yaml:"skipConsensus,omitempty" json:"skipConsensus"`

--- a/common/request.go
+++ b/common/request.go
@@ -39,6 +39,7 @@ const (
 	headerDirectiveRetryEmpty                 = "X-ERPC-Retry-Empty"
 	headerDirectiveRetryPending               = "X-ERPC-Retry-Pending"
 	headerDirectiveSkipCacheRead              = "X-ERPC-Skip-Cache-Read"
+	headerDirectiveSkipCacheWrite             = "X-ERPC-Skip-Cache-Write"
 	headerDirectiveUseUpstream                = "X-ERPC-Use-Upstream"
 	headerDirectiveSkipInterpolation          = "X-ERPC-Skip-Interpolation"
 	headerDirectiveSkipConsensus              = "X-ERPC-Skip-Consensus"
@@ -65,6 +66,7 @@ const (
 	queryDirectiveRetryEmpty                 = "retry-empty"
 	queryDirectiveRetryPending               = "retry-pending"
 	queryDirectiveSkipCacheRead              = "skip-cache-read"
+	queryDirectiveSkipCacheWrite             = "skip-cache-write"
 	queryDirectiveUseUpstream                = "use-upstream"
 	queryDirectiveSkipInterpolation          = "skip-interpolation"
 	queryDirectiveSkipConsensus              = "skip-consensus"
@@ -91,6 +93,7 @@ var directiveKeyRegistry = []directiveKeyNames{
 	{header: headerDirectiveRetryEmpty, query: queryDirectiveRetryEmpty},
 	{header: headerDirectiveRetryPending, query: queryDirectiveRetryPending},
 	{header: headerDirectiveSkipCacheRead, query: queryDirectiveSkipCacheRead},
+	{header: headerDirectiveSkipCacheWrite, query: queryDirectiveSkipCacheWrite},
 	{header: headerDirectiveUseUpstream, query: queryDirectiveUseUpstream},
 	{header: headerDirectiveSkipInterpolation, query: queryDirectiveSkipInterpolation},
 	{header: headerDirectiveSkipConsensus, query: queryDirectiveSkipConsensus},
@@ -144,6 +147,14 @@ type RequestDirectives struct {
 	// Accepts "true" to skip all, "false" or "" to skip none,
 	// or a connector ID pattern (e.g. "redis*", "memory*|dynamo*") to skip specific cache drivers.
 	SkipCacheRead string `json:"skipCacheRead"`
+
+	// Instruct the proxy to skip cache writes (Set) for this request, so the
+	// response is not persisted to the shared cache. Useful for co-resident
+	// projects that share a cache connector (the cache key omits projectId): a
+	// tier that must not backfill another tier's cache (e.g. a consensus/integrity
+	// lane that also sets skipCacheRead) sets this so its writes cannot be read by
+	// the other tier. Default false = writes happen as today.
+	SkipCacheWrite bool `json:"skipCacheWrite"`
 
 	// Instruct the proxy to forward the request to a specific upstream(s) only.
 	// Value can use "*" star char as a wildcard to target multiple upstreams.
@@ -254,6 +265,7 @@ func (d *RequestDirectives) Clone() *RequestDirectives {
 		RetryEmpty:                      d.RetryEmpty,
 		RetryPending:                    d.RetryPending,
 		SkipCacheRead:                   d.SkipCacheRead,
+		SkipCacheWrite:                  d.SkipCacheWrite,
 		UseUpstream:                     d.UseUpstream,
 		ByPassMethodExclusion:           d.ByPassMethodExclusion,
 		SkipInterpolation:               d.SkipInterpolation,
@@ -615,6 +627,9 @@ func (r *NormalizedRequest) ApplyDirectiveDefaults(directiveDefaults *DirectiveD
 	if directiveDefaults.SkipConsensus != nil {
 		r.directives.SkipConsensus = *directiveDefaults.SkipConsensus
 	}
+	if directiveDefaults.SkipCacheWrite != nil {
+		r.directives.SkipCacheWrite = *directiveDefaults.SkipCacheWrite
+	}
 
 	// Validation: Block Integrity
 	if directiveDefaults.EnforceHighestBlock != nil {
@@ -784,6 +799,9 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 	if hv := getHeader(headerDirectiveSkipConsensus); hv != "" {
 		r.directives.SkipConsensus = strings.ToLower(strings.TrimSpace(hv)) == "true"
 	}
+	if hv := getHeader(headerDirectiveSkipCacheWrite); hv != "" {
+		r.directives.SkipCacheWrite = strings.ToLower(strings.TrimSpace(hv)) == "true"
+	}
 
 	// Validation Headers
 	if hv := getHeader(headerDirectiveEnforceHighestBlock); hv != "" {
@@ -878,6 +896,10 @@ func (r *NormalizedRequest) EnrichFromHttp(headers http.Header, queryArgs url.Va
 		r.directives.SkipConsensus = strings.ToLower(strings.TrimSpace(skipConsensus)) == "true"
 	}
 
+	if skipCacheWrite := getQueryArg(queryDirectiveSkipCacheWrite); skipCacheWrite != "" {
+		r.directives.SkipCacheWrite = strings.ToLower(strings.TrimSpace(skipCacheWrite)) == "true"
+	}
+
 	// Validation query parameters
 	if v := getQueryArg(queryDirectiveEnforceHighestBlock); v != "" {
 		r.directives.EnforceHighestBlock = strings.ToLower(strings.TrimSpace(v)) == "true"
@@ -957,6 +979,15 @@ func (r *NormalizedRequest) ShouldSkipCacheRead(connectorId string) bool {
 	}
 	matched, _ := WildcardMatch(v, connectorId)
 	return matched
+}
+
+// ShouldSkipCacheWrite reports whether the cache write (Set) should be skipped
+// for this request, so its response is not persisted to the shared cache.
+func (r *NormalizedRequest) ShouldSkipCacheWrite() bool {
+	if r == nil || r.directives == nil {
+		return false
+	}
+	return r.directives.SkipCacheWrite
 }
 
 func (r *NormalizedRequest) Directives() *RequestDirectives {

--- a/common/request_skipcachewrite_test.go
+++ b/common/request_skipcachewrite_test.go
@@ -1,0 +1,145 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// SkipCacheWrite directive
+// ----------------------------------------------------------------------------
+
+func TestSkipCacheWriteDirective_DefaultIsFalse(t *testing.T) {
+	req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+	req.EnrichFromHttp(http.Header{}, url.Values{}, UserAgentTrackingModeSimplified)
+
+	if req.ShouldSkipCacheWrite() {
+		t.Fatalf("expected ShouldSkipCacheWrite=false by default, got true")
+	}
+}
+
+func TestSkipCacheWriteDirective_FromHeader(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"  true  ", true},
+		{"false", false},
+		{"1", false}, // only "true" is truthy, mirroring the other bool directives
+		{"yes", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("X-ERPC-Skip-Cache-Write=%s", tc.value), func(t *testing.T) {
+			req := NewNormalizedRequest(nil)
+			h := http.Header{}
+			h.Set("X-ERPC-Skip-Cache-Write", tc.value)
+			req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+			if got := req.ShouldSkipCacheWrite(); got != tc.want {
+				t.Fatalf("expected ShouldSkipCacheWrite=%v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSkipCacheWriteDirective_FromQuery(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"false", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("skip-cache-write=%q", tc.value), func(t *testing.T) {
+			req := NewNormalizedRequest(nil)
+			q := url.Values{}
+			if tc.value != "" {
+				q.Set("skip-cache-write", tc.value)
+			}
+			req.EnrichFromHttp(nil, q, UserAgentTrackingModeSimplified)
+			if got := req.ShouldSkipCacheWrite(); got != tc.want {
+				t.Fatalf("expected ShouldSkipCacheWrite=%v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSkipCacheWriteDirective_DefaultsFromConfig(t *testing.T) {
+	tr := true
+	fa := false
+
+	t.Run("default_true_applies_when_no_request_override", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipCacheWrite: &tr})
+		if !req.ShouldSkipCacheWrite() {
+			t.Fatalf("expected SkipCacheWrite=true from defaults")
+		}
+	})
+
+	t.Run("default_false_applies_when_no_request_override", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipCacheWrite: &fa})
+		if req.ShouldSkipCacheWrite() {
+			t.Fatalf("expected SkipCacheWrite=false from defaults")
+		}
+	})
+
+	t.Run("nil_default_leaves_false", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{})
+		if req.ShouldSkipCacheWrite() {
+			t.Fatalf("expected SkipCacheWrite=false when default unset")
+		}
+	})
+
+	t.Run("header_overrides_default_true_to_false", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipCacheWrite: &tr})
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Cache-Write", "false")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+		if req.ShouldSkipCacheWrite() {
+			t.Fatalf("expected SkipCacheWrite=false after header override")
+		}
+	})
+
+	t.Run("query_overrides_default_false_to_true", func(t *testing.T) {
+		req := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call"}`))
+		req.ApplyDirectiveDefaults(&DirectiveDefaultsConfig{SkipCacheWrite: &fa})
+		q := url.Values{}
+		q.Set("skip-cache-write", "true")
+		req.EnrichFromHttp(nil, q, UserAgentTrackingModeSimplified)
+		if !req.ShouldSkipCacheWrite() {
+			t.Fatalf("expected SkipCacheWrite=true after query override")
+		}
+	})
+}
+
+func TestSkipCacheWriteDirective_Clone(t *testing.T) {
+	d := &RequestDirectives{SkipCacheWrite: true}
+	cloned := d.Clone()
+	if !cloned.SkipCacheWrite {
+		t.Fatalf("Clone() did not preserve SkipCacheWrite")
+	}
+	// Independent copy: mutating the clone must not affect the original.
+	cloned.SkipCacheWrite = false
+	if !d.SkipCacheWrite {
+		t.Fatalf("Clone() returned an aliased reference; original mutated")
+	}
+}
+
+func TestShouldSkipCacheWrite_NilSafety(t *testing.T) {
+	var nilReq *NormalizedRequest
+	if nilReq.ShouldSkipCacheWrite() {
+		t.Fatalf("nil request must report false")
+	}
+	req := NewNormalizedRequest(nil) // directives not yet populated
+	if req.ShouldSkipCacheWrite() {
+		t.Fatalf("request with no directives must report false")
+	}
+}

--- a/erpc/evm_json_rpc_cache_skipcachewrite_test.go
+++ b/erpc/evm_json_rpc_cache_skipcachewrite_test.go
@@ -1,0 +1,74 @@
+package erpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvmJsonRpcCache_Set_RespectsSkipCacheWriteDirective verifies that a request
+// carrying the skipCacheWrite directive does not persist its response to the
+// shared cache, while the same request without the directive does. This is the
+// write-side complement to skipCacheRead, used by co-resident projects that share
+// a cache connector (the cache key omits projectId) so one tier cannot backfill
+// another tier's cache.
+func TestEvmJsonRpcCache_Set_RespectsSkipCacheWriteDirective(t *testing.T) {
+	t.Run("skipCacheWrite_true_does_not_persist", func(t *testing.T) {
+		ctx := context.Background()
+		conns, network, upstreams, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+			{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+		})
+		policy, err := data.NewCachePolicy(&common.CachePolicyConfig{
+			Network: "evm:123",
+			Method:  "eth_getBlockByNumber",
+		}, conns[0])
+		require.NoError(t, err)
+		cache.SetPolicies([]*data.CachePolicy{policy})
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",false],"id":1}`))
+		req.SetNetwork(network)
+		req.SetCacheDal(cache)
+		req.SetDirectives(&common.RequestDirectives{SkipCacheWrite: true})
+		resp := common.NewNormalizedResponse().WithRequest(req).WithBody(stringToReaderCloser(`{"result":{"hash":"0xabc","number":"0x2"}}`))
+		resp.SetUpstream(upstreams[0])
+		req.SetLastValidResponse(ctx, resp)
+
+		conns[0].On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		err = cache.Set(context.Background(), req, resp)
+		assert.NoError(t, err)
+		conns[0].AssertNotCalled(t, "Set")
+	})
+
+	t.Run("skipCacheWrite_false_persists", func(t *testing.T) {
+		ctx := context.Background()
+		conns, network, upstreams, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+			{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+		})
+		policy, err := data.NewCachePolicy(&common.CachePolicyConfig{
+			Network: "evm:123",
+			Method:  "eth_getBlockByNumber",
+		}, conns[0])
+		require.NoError(t, err)
+		cache.SetPolicies([]*data.CachePolicy{policy})
+
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",false],"id":1}`))
+		req.SetNetwork(network)
+		req.SetCacheDal(cache)
+		req.SetDirectives(&common.RequestDirectives{SkipCacheWrite: false})
+		resp := common.NewNormalizedResponse().WithRequest(req).WithBody(stringToReaderCloser(`{"result":{"hash":"0xabc","number":"0x2"}}`))
+		resp.SetUpstream(upstreams[0])
+		req.SetLastValidResponse(ctx, resp)
+
+		conns[0].On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		err = cache.Set(context.Background(), req, resp)
+		assert.NoError(t, err)
+		conns[0].AssertCalled(t, "Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -1141,6 +1141,7 @@ export interface DirectiveDefaultsConfig {
     retryEmpty?: boolean;
     retryPending?: boolean;
     skipCacheRead?: any;
+    skipCacheWrite?: boolean;
     useUpstream?: string;
     skipInterpolation?: boolean;
     skipConsensus?: boolean;


### PR DESCRIPTION
## Summary

The eRPC JSON-RPC cache key omits `projectId` and the `EvmJsonRpcCache` instance is shared across projects, so when multiple projects run co-resident and share a cache connector, one project's writes can be served to another. `skipCacheRead` already lets a project avoid **reading** another project's cached values — but there was no symmetric way to avoid **writing**.

This adds a `skipCacheWrite` directive that gates `EvmJsonRpcCache.Set`.

## What changes

- New per-request directive `skipCacheWrite` (default `false`), mirroring `skipConsensus` exactly: config `*bool` default, `Clone`, `ApplyDirectiveDefaults`, `X-ERPC-Skip-Cache-Write` header, `skip-cache-write` query param, and a `ShouldSkipCacheWrite()` accessor.
- When set, `EvmJsonRpcCache.Set` returns `nil` early (before persisting), emitting a `cache.write_skipped` span attribute.

## Why it's non-breaking

- Additive per-request bool; **default zero-value `false` = current behavior**, so single-project deployments are unaffected.
- **Zero signature churn** — no registry/constructor call sites change.

For full cross-project cache isolation a project sets **both** `skipCacheRead` (don't read others') and `skipCacheWrite` (don't write for others').

## Testing

- `common/request_skipcachewrite_test.go`: header/query parsing, default, config-default + header/query override, `Clone`, nil-safety.
- `erpc/evm_json_rpc_cache_skipcachewrite_test.go`: `skipCacheWrite:true` → connector `Set` **not** called; `false` → `Set` called.
- `go build ./...` ✅ · `go vet ./common/ ./architecture/evm/ ./erpc/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive opt-in behavior with default false; only skips cache writes and does not change read paths or existing single-project deployments.
> 
> **Overview**
> Adds a **`skipCacheWrite`** per-request directive (default **off**) so responses are not persisted to the shared EVM JSON-RPC cache—complementing **`skipCacheRead`** when co-resident projects share a connector and cache keys omit **`projectId`**.
> 
> Operators can enable it via **`directiveDefaults.skipCacheWrite`**, **`X-ERPC-Skip-Cache-Write`**, or **`skip-cache-write`**. **`EvmJsonRpcCache.Set`** returns early when **`ShouldSkipCacheWrite()`** is true and records **`cache.write_skipped`** on the span. Generated TS types include the new default field.
> 
> Unit tests cover directive parsing, config defaults/overrides, clone/nil safety, and cache **`Set`** skipping vs normal writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822784f7dbc7b36f4e9c8827f32321f5e8808c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->