### PR TITLE
fix(ratelimit): single-owner auto-tuner per shared budget across projects

### DIFF
--- a/upstream/ratelimiter_autotuner_owner_test.go
+++ b/upstream/ratelimiter_autotuner_owner_test.go
@@ -1,0 +1,67 @@
+package upstream
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaimAutoTuner_SingleOwnerPerBudget verifies that auto-tuning ownership of a
+// shared budget is single-project: the first project to claim a budget owns it,
+// the same project keeps ownership across its multiple upstreams (preserving
+// today's single-project behavior), and other co-resident projects are denied so
+// they cannot run competing tuners against the same MaxCount.
+func TestClaimAutoTuner_SingleOwnerPerBudget(t *testing.T) {
+	r := &RateLimitersRegistry{}
+
+	// First project to claim a budget owns tuning for it.
+	require.True(t, r.ClaimAutoTuner("budget-a", "projA"), "first claim must succeed")
+
+	// The SAME project claiming again (e.g. a second upstream that legally shares
+	// the same budget) must still own it — this preserves single-project behavior
+	// where multiple auto-tuned upstreams share one budget.
+	require.True(t, r.ClaimAutoTuner("budget-a", "projA"), "same project re-claim must succeed")
+
+	// A DIFFERENT project must NOT get a competing tuner on the same budget.
+	require.False(t, r.ClaimAutoTuner("budget-a", "projB"), "other project must be denied")
+	require.False(t, r.ClaimAutoTuner("budget-a", "projB"), "other project stays denied")
+
+	// A different budget is independent — its first claimer owns it.
+	require.True(t, r.ClaimAutoTuner("budget-b", "projB"))
+	require.False(t, r.ClaimAutoTuner("budget-b", "projA"))
+
+	// Empty budget id never claims.
+	require.False(t, r.ClaimAutoTuner("", "projA"))
+}
+
+// TestClaimAutoTuner_ConcurrentSingleWinner hammers one budget from many projects
+// concurrently and asserts exactly one project wins ownership (run with -race).
+func TestClaimAutoTuner_ConcurrentSingleWinner(t *testing.T) {
+	r := &RateLimitersRegistry{}
+	const projects = 8
+	const perProject = 64
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	winners := map[string]bool{}
+
+	for p := 0; p < projects; p++ {
+		pid := fmt.Sprintf("proj%d", p)
+		for i := 0; i < perProject; i++ {
+			wg.Add(1)
+			go func(pid string) {
+				defer wg.Done()
+				if r.ClaimAutoTuner("hot-budget", pid) {
+					mu.Lock()
+					winners[pid] = true
+					mu.Unlock()
+				}
+			}(pid)
+		}
+	}
+	wg.Wait()
+
+	require.Len(t, winners, 1, "exactly one project may own auto-tuning for a shared budget")
+}

--- a/upstream/ratelimiter_registry.go
+++ b/upstream/ratelimiter_registry.go
@@ -33,6 +33,13 @@ type RateLimitersRegistry struct {
 	statsManager    stats.Manager
 	cacheMu         sync.RWMutex
 	initializer     *util.Initializer
+	// autoTuneOwners records which project owns rate-limit auto-tuning for each
+	// budget id (budgetId -> projectId). Budgets are shared across co-resident
+	// projects; without a single owner, each project would run its own auto-tuner
+	// against the same budget's MaxCount and tug it in opposite directions
+	// (last-writer-wins oscillation). The first project to claim a budget owns
+	// tuning for it; other projects skip.
+	autoTuneOwners sync.Map
 }
 
 func NewRateLimitersRegistry(appCtx context.Context, cfg *common.RateLimiterConfig, logger *zerolog.Logger) (*RateLimitersRegistry, error) {
@@ -231,6 +238,21 @@ func (r *RateLimitersRegistry) GetBudget(budgetId string) (*RateLimiterBudget, e
 	}
 
 	return nil, common.NewErrRateLimitBudgetNotFound(budgetId)
+}
+
+// ClaimAutoTuner reports whether projectId owns rate-limit auto-tuning for
+// budgetId. The first project to call for a given budget becomes the sole owner;
+// subsequent calls from the SAME project also return true (so every upstream of
+// that project on the budget keeps its tuner, preserving single-project behavior
+// exactly), while calls from OTHER projects return false. This prevents
+// co-resident projects that share a budget from running competing auto-tuners
+// against the same rule.Config.MaxCount. An empty budgetId never claims.
+func (r *RateLimitersRegistry) ClaimAutoTuner(budgetId, projectId string) bool {
+	if budgetId == "" {
+		return false
+	}
+	owner, _ := r.autoTuneOwners.LoadOrStore(budgetId, projectId)
+	return owner.(string) == projectId
 }
 
 func (r *RateLimitersRegistry) GetBudgets() []*common.RateLimitBudgetConfig {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1323,7 +1323,11 @@ func (u *Upstream) initRateLimitAutoTuner() {
 		cfg := u.config.RateLimitAutoTune
 		if cfg.Enabled != nil && *cfg.Enabled {
 			budget, err := u.rateLimitersRegistry.GetBudget(u.config.RateLimitBudget)
-			if err == nil {
+			// Only the project that owns auto-tuning for this (potentially shared)
+			// budget builds a tuner. Co-resident projects sharing a budget must not
+			// run competing tuners against the same rule.Config.MaxCount; non-owners
+			// leave rateLimiterAutoTuner nil (record* calls are nil-guarded).
+			if err == nil && u.rateLimitersRegistry.ClaimAutoTuner(u.config.RateLimitBudget, u.ProjectId) {
 				u.rateLimiterAutoTuner = NewRateLimitAutoTuner(
 					u.logger,
 					budget,


### PR DESCRIPTION
## Summary

Rate-limit budgets are shared — the `RateLimitersRegistry` is passed to every project and budgets are looked up by name — but each `Upstream` builds its **own** `RateLimitAutoTuner`. When two co-resident projects declare the same upstreams, they reference the same budget id and run **two** auto-tuners that both mutate the shared `rule.Config.MaxCount`. With no coordination they tug it in opposite directions (last-writer-wins oscillation), invisible to either operator, and can throttle one project or over-open the bucket.

## What changes

- New `RateLimitersRegistry.ClaimAutoTuner(budgetId, projectId)`: the first project to claim a budget owns auto-tuning for it.
- `initRateLimitAutoTuner` gates tuner construction on ownership; non-owners leave `rateLimiterAutoTuner` nil (the `record*` calls are already nil-guarded).

## Why it's a no-op for single-project

Ownership is keyed by **`(budgetId → projectId)`**, not `budgetId` alone. Within one project, multiple upstreams may legally share a budget (`RateLimitBudget`/`RateLimitAutoTune` are per-upstream with no 1:1 validation), and each keeps its tuner — single-project behavior is byte-for-byte unchanged. Only **other** projects sharing the budget are denied, which closes the cross-project race. No signature churn.

## Testing

`upstream/ratelimiter_autotuner_owner_test.go`:
- first claim owns; **same project re-claims** (multi-upstream single-project invariance); other project denied; independent budgets are independent; empty budget never claims;
- a concurrent single-winner race test (run with `-race`).

Existing `./upstream` rate-limiter/auto-tuner/budget tests still pass. `go build ./...` ✅ · `go vet ./upstream/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who dynamically adjusts shared rate-limit budgets in multi-tenant deployments; non-owning projects stop auto-tuning but enforcement paths are unchanged and single-project setups are explicitly preserved.
> 
> **Overview**
> Co-resident projects that share a rate-limit budget id could each spin up a `RateLimitAutoTuner`, all adjusting the same shared `rule.Config.MaxCount` and fighting each other. This PR elects **one project per budget** as the sole auto-tuner owner.
> 
> `RateLimitersRegistry` gains `ClaimAutoTuner(budgetId, projectId)` backed by a `sync.Map` (`LoadOrStore`): the first caller wins the budget; **re-claims from the same project still succeed** so multiple upstreams in one project keep tuners unchanged. `Upstream.initRateLimitAutoTuner` only constructs a tuner when the claim succeeds; losers leave `rateLimiterAutoTuner` nil (existing nil guards on record paths).
> 
> New tests cover ownership rules, per-budget isolation, empty budget id, and a concurrent single-winner race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260e1afcd375e0fa587c3dc9f4401ff2536e35bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->