### PR TITLE
fix(health): tolerate large block-head rollbacks in tracker

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -25,7 +25,9 @@ const FullySyncedThreshold = 4
 // networks (not statically configured in erpc.yaml). at the moment an "evm state poller"
 // might be initiated "before" a network is physically created and configured
 // (e.g. when a new network is lazy-loaded from a Repository Provider)
-const DefaultToleratedBlockHeadRollback = 1024
+// Alias of the shared default so the poller counters and the health tracker
+// apply the same rollback tolerance to block heads.
+const DefaultToleratedBlockHeadRollback = common.DefaultToleratedBlockHeadRollback
 
 var _ common.EvmStatePoller = &EvmStatePoller{}
 

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -2036,6 +2036,14 @@ const DefaultEvmStatePollerDebounce = Duration(5 * time.Second)
 const DefaultDynamicBlockTimeDebounceMultiplier = 0.7
 const DefaultBlockUnavailableDelayMultiplier = 1.0
 
+// DefaultToleratedBlockHeadRollback is the tolerance (in blocks) applied when a
+// freshly observed block head is behind the stored one: decreases within the
+// tolerance are noise from lagging providers and are ignored, while larger
+// decreases are a genuine correction (a deep reorg, or a previously recorded
+// bogus sample) and are accepted. Shared by the state-poller shared counters
+// and the health tracker so both layers converge on the same head.
+const DefaultToleratedBlockHeadRollback = 1024
+
 // DefaultEmptyResultMaxAttempts bounds retries when the requested data isn't on the
 // upstream yet (empty/missing-data point-lookups, pending tx-lookups, and
 // ErrUpstreamBlockUnavailable): one original attempt + one retry after ~one block.

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -1270,6 +1270,47 @@ func (t *Tracker) updateSingleUpstreamLag(
 	}
 }
 
+// recomputeNetworkBlockHead re-derives a network-level block head as the max of
+// the stored per-upstream values (getVal picks the latest vs finalized axis).
+// Called after an accepted per-upstream rollback: the network head is monotonic
+// under forward progress, so the only safe way to move it backwards is to
+// re-derive it from its inputs — adopting a single (possibly lagging) upstream's
+// sample directly would let genuinely-behind upstreams drag the head down.
+func (t *Tracker) recomputeNetworkBlockHead(net string, getVal func(*NetworkMetadata) int64) int64 {
+	t.mu.RLock()
+	relevantKeys := t.upstreamsByNetwork[net]
+	t.mu.RUnlock()
+
+	var maxVal int64
+	seen := make(map[common.Upstream]struct{}, len(relevantKeys))
+	consider := func(ups common.Upstream) {
+		if ups == nil {
+			return
+		}
+		if _, done := seen[ups]; done {
+			return
+		}
+		seen[ups] = struct{}{}
+		if v := getVal(t.getMetadata(metadataKey{ups, net})); v > maxVal {
+			maxVal = v
+		}
+	}
+	if len(relevantKeys) == 0 {
+		// Fallback if the index is not ready — mirrors updateNetworkLagMetrics.
+		t.upsMetrics.Range(func(key, _ any) bool {
+			if k, ok := key.(upstreamKey); ok && k.ups != nil && k.ups.NetworkId() == net {
+				consider(k.ups)
+			}
+			return true
+		})
+	} else {
+		for _, k := range relevantKeys {
+			consider(k.ups)
+		}
+	}
+	return maxVal
+}
+
 func (t *Tracker) SetLatestBlockNumber(upstream common.Upstream, blockNumber int64, blockTimestamp int64) {
 	id := upstream.Id()
 	net := upstream.NetworkId()
@@ -1327,6 +1368,36 @@ func (t *Tracker) SetLatestBlockNumber(upstream common.Upstream, blockNumber int
 		upsMeta.evmLatestBlockNumber.Store(blockNumber)
 		g := t.getLatestBlockGauge(t.projectId, vendor, netLabel, id)
 		g.Set(float64(blockNumber))
+	} else if oldUpsVal-blockNumber > common.DefaultToleratedBlockHeadRollback {
+		// The upstream reports a head far behind the one stored for it: treat it
+		// as a correction (a deep reorg, or a previously recorded bogus sample),
+		// mirroring the shared-state counter semantics. Max-only storage would
+		// pin the bad sample — and every lag-based routing decision derived
+		// from it — until process restart.
+		upsMeta.evmLatestBlockNumber.Store(blockNumber)
+		g := t.getLatestBlockGauge(t.projectId, vendor, netLabel, id)
+		g.Set(float64(blockNumber))
+		lg.Warn().
+			Int64("previousValue", oldUpsVal).
+			Int64("newValue", blockNumber).
+			Msg("applied large latest block rollback for upstream in tracker")
+
+		// The rolled-back value may have been the network head: re-derive it
+		// from the remaining per-upstream values.
+		if ntwVal := ntwMeta.evmLatestBlockNumber.Load(); ntwVal > blockNumber {
+			recomputed := t.recomputeNetworkBlockHead(net, func(meta *NetworkMetadata) int64 {
+				return meta.evmLatestBlockNumber.Load()
+			})
+			if recomputed > 0 && recomputed < ntwVal {
+				ntwMeta.evmLatestBlockNumber.Store(recomputed)
+				t.getLatestBlockGauge(t.projectId, "*", netLabel, "*").Set(float64(recomputed))
+				needsGlobalUpdate = true
+				lg.Warn().
+					Int64("previousValue", ntwVal).
+					Int64("newValue", recomputed).
+					Msg("re-derived network latest block after upstream rollback in tracker")
+			}
+		}
 	}
 
 	// 3) Recompute block head lag for this upstream
@@ -1405,9 +1476,15 @@ func (t *Tracker) updateBlockTimeSample(ntwMeta *NetworkMetadata, netLabel strin
 		return
 	}
 
-	// Reject out-of-order or duplicate blocks.
+	// Reject out-of-order or duplicate blocks. A block far behind prev means the
+	// head was corrected by a large rollback: re-anchor so sampling resumes
+	// instead of stalling until the chain re-passes the old (possibly bogus) prev.
 	blockGap := blockNumber - prevBlock
 	if blockGap <= 0 {
+		if prevBlock-blockNumber > common.DefaultToleratedBlockHeadRollback {
+			ntwMeta.evmBlockTimePrevBlock = blockNumber
+			ntwMeta.evmBlockTimePrevTimestamp = blockTimestamp
+		}
 		return
 	}
 
@@ -1507,6 +1584,31 @@ func (t *Tracker) SetFinalizedBlockNumber(upstream common.Upstream, blockNumber 
 		upsMeta.evmFinalizedBlockNumber.Store(blockNumber)
 		g := t.getFinalizedBlockGauge(t.projectId, vendor, netLabel, id)
 		g.Set(float64(blockNumber))
+	} else if oldUpsVal-blockNumber > common.DefaultToleratedBlockHeadRollback {
+		// Same rollback semantics as SetLatestBlockNumber: accept large
+		// corrections instead of pinning a bogus sample until restart.
+		upsMeta.evmFinalizedBlockNumber.Store(blockNumber)
+		g := t.getFinalizedBlockGauge(t.projectId, vendor, netLabel, id)
+		g.Set(float64(blockNumber))
+		lg.Warn().
+			Int64("previousValue", oldUpsVal).
+			Int64("newValue", blockNumber).
+			Msg("applied large finalized block rollback for upstream in tracker")
+
+		if ntwBn := ntwMeta.evmFinalizedBlockNumber.Load(); ntwBn > blockNumber {
+			recomputed := t.recomputeNetworkBlockHead(net, func(meta *NetworkMetadata) int64 {
+				return meta.evmFinalizedBlockNumber.Load()
+			})
+			if recomputed > 0 && recomputed < ntwBn {
+				ntwMeta.evmFinalizedBlockNumber.Store(recomputed)
+				t.getFinalizedBlockGauge(t.projectId, "*", netLabel, "*").Set(float64(recomputed))
+				needsGlobalUpdate = true
+				lg.Warn().
+					Int64("previousValue", ntwBn).
+					Int64("newValue", recomputed).
+					Msg("re-derived network finalized block after upstream rollback in tracker")
+			}
+		}
 	}
 
 	// Recompute finalization lag for this upstream

--- a/health/tracker_blockhead_rollback_test.go
+++ b/health/tracker_blockhead_rollback_test.go
@@ -1,0 +1,266 @@
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests pin the rollback tolerance of the tracker's block-head state:
+// a single bogus head sample (e.g. a provider briefly reporting another
+// chain's height, or a corrupted response) must not pin the per-upstream
+// latest/finalized values — nor the network-level head and every lag-based
+// routing decision derived from it — until process restart. The semantics
+// mirror the shared-state counter (data.CounterInt64SharedVariable): forward
+// progress is always accepted, decreases within
+// common.DefaultToleratedBlockHeadRollback are ignored as noise, larger
+// decreases are accepted as corrections. The network head is never lowered by
+// adopting a single sample; it is re-derived as the max over the per-upstream
+// values, so genuinely-behind upstreams can never drag it down.
+
+func newRollbackTestTracker(t *testing.T, projectID string) *Tracker {
+	t.Helper()
+	tracker := NewTracker(&log.Logger, projectID, time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	tracker.Bootstrap(ctx)
+	return tracker
+}
+
+func networkLatest(t *Tracker, net string) int64 {
+	return t.getMetadata(metadataKey{nil, net}).evmLatestBlockNumber.Load()
+}
+
+func upstreamLatest(t *Tracker, ups common.Upstream) int64 {
+	return t.getMetadata(metadataKey{ups, ups.NetworkId()}).evmLatestBlockNumber.Load()
+}
+
+func networkFinalized(t *Tracker, net string) int64 {
+	return t.getMetadata(metadataKey{nil, net}).evmFinalizedBlockNumber.Load()
+}
+
+func upstreamFinalized(t *Tracker, ups common.Upstream) int64 {
+	return t.getMetadata(metadataKey{ups, ups.NetworkId()}).evmFinalizedBlockNumber.Load()
+}
+
+func blockHeadLag(t *Tracker, ups common.Upstream) int64 {
+	return t.GetUpstreamMethodMetrics(ups, "*", common.DataFinalityStateAll).BlockHeadLag.Load()
+}
+
+func finalizationLag(t *Tracker, ups common.Upstream) int64 {
+	return t.GetUpstreamMethodMetrics(ups, "*", common.DataFinalityStateAll).FinalizationLag.Load()
+}
+
+func TestTrackerLatestBlockRollbackTolerance(t *testing.T) {
+	tolerance := int64(common.DefaultToleratedBlockHeadRollback)
+
+	t.Run("ForwardProgressAccepted", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-forward")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetLatestBlockNumber(ups, 1000, 0)
+		tracker.SetLatestBlockNumber(ups, 2000, 0)
+
+		assert.Equal(t, int64(2000), upstreamLatest(tracker, ups))
+		assert.Equal(t, int64(2000), networkLatest(tracker, ups.NetworkId()))
+		assert.Equal(t, int64(0), blockHeadLag(tracker, ups))
+	})
+
+	t.Run("EqualValueIsNoop", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-equal")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetLatestBlockNumber(ups, 1000, 0)
+		tracker.SetLatestBlockNumber(ups, 1000, 0)
+
+		assert.Equal(t, int64(1000), upstreamLatest(tracker, ups))
+		assert.Equal(t, int64(1000), networkLatest(tracker, ups.NetworkId()))
+	})
+
+	t.Run("SmallRollbackIgnored", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-small")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetLatestBlockNumber(ups, 10_000, 0)
+		// Gap of exactly the tolerance is still "small" (mirrors the counter:
+		// only gaps STRICTLY greater than the tolerance are corrections).
+		tracker.SetLatestBlockNumber(ups, 10_000-tolerance, 0)
+
+		assert.Equal(t, int64(10_000), upstreamLatest(tracker, ups))
+		assert.Equal(t, int64(10_000), networkLatest(tracker, ups.NetworkId()))
+		assert.Equal(t, int64(0), blockHeadLag(tracker, ups))
+	})
+
+	t.Run("RollbackJustBeyondToleranceApplied", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-boundary")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetLatestBlockNumber(ups, 10_000, 0)
+		tracker.SetLatestBlockNumber(ups, 10_000-tolerance-1, 0)
+
+		assert.Equal(t, 10_000-tolerance-1, upstreamLatest(tracker, ups))
+		// Sole upstream: the re-derived network head follows its correction.
+		assert.Equal(t, 10_000-tolerance-1, networkLatest(tracker, ups.NetworkId()))
+		assert.Equal(t, int64(0), blockHeadLag(tracker, ups))
+	})
+
+	// The poisoned-head scenario this change exists for: one upstream briefly
+	// reports a bogus far-ahead head. Before the fix, the bogus sample pinned
+	// both its own stored value and the network head forever, which made every
+	// OTHER (healthy) upstream appear to lag by tens of millions of blocks —
+	// selection policies using blockNumberLagAbove then excluded all of them
+	// until the process restarted.
+	t.Run("BogusHeadCorrectedAndNetworkRederived", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-rederive")
+		upsA := common.NewFakeUpstream("a")
+		upsB := common.NewFakeUpstream("b")
+		upsC := common.NewFakeUpstream("c")
+		net := upsA.NetworkId()
+
+		tracker.SetLatestBlockNumber(upsB, 32_000_000, 0)
+		tracker.SetLatestBlockNumber(upsC, 32_000_050, 0)
+		// upsA delivers a bogus sample far ahead of the real chain.
+		tracker.SetLatestBlockNumber(upsA, 100_000_000, 0)
+
+		assert.Equal(t, int64(100_000_000), networkLatest(tracker, net))
+		assert.Equal(t, int64(100_000_000-32_000_000), blockHeadLag(tracker, upsB),
+			"healthy upstreams appear to lag the bogus head")
+
+		// upsA's next real observation corrects it.
+		tracker.SetLatestBlockNumber(upsA, 32_000_100, 0)
+
+		assert.Equal(t, int64(32_000_100), upstreamLatest(tracker, upsA))
+		assert.Equal(t, int64(32_000_100), networkLatest(tracker, net),
+			"network head re-derived as max over per-upstream values")
+		assert.Equal(t, int64(0), blockHeadLag(tracker, upsA))
+		assert.Equal(t, int64(100), blockHeadLag(tracker, upsB),
+			"healthy upstreams' lag recomputed against the corrected head")
+		assert.Equal(t, int64(50), blockHeadLag(tracker, upsC))
+
+		// Gauges follow the corrected values.
+		assert.Equal(t, float64(32_000_100),
+			promUtil.ToFloat64(tracker.getLatestBlockGauge(tracker.projectId, "*", upsA.NetworkLabel(), "*")))
+		assert.Equal(t, float64(32_000_100),
+			promUtil.ToFloat64(tracker.getLatestBlockGauge(tracker.projectId, upsA.VendorName(), upsA.NetworkLabel(), upsA.Id())))
+		assert.Equal(t, float64(100),
+			promUtil.ToFloat64(tracker.getHeadLagGauge(tracker.projectId, upsB.VendorName(), upsB.NetworkLabel(), upsB.Id())))
+	})
+
+	t.Run("LaggingUpstreamCannotDragNetworkHead", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-nodrag")
+		upsA := common.NewFakeUpstream("a")
+		upsB := common.NewFakeUpstream("b")
+		net := upsA.NetworkId()
+
+		tracker.SetLatestBlockNumber(upsA, 1_000_000, 0)
+
+		// A far-behind upstream reporting forward progress of its own never
+		// lowers the network head.
+		tracker.SetLatestBlockNumber(upsB, 100, 0)
+		tracker.SetLatestBlockNumber(upsB, 200, 0)
+		assert.Equal(t, int64(1_000_000), networkLatest(tracker, net))
+		assert.Equal(t, int64(1_000_000-200), blockHeadLag(tracker, upsB))
+
+		// Even when upsB goes bogus-high and then corrects itself, the head is
+		// re-derived from the remaining values (upsA's), NOT lowered to upsB's
+		// corrected sample.
+		tracker.SetLatestBlockNumber(upsB, 90_000_000, 0)
+		assert.Equal(t, int64(90_000_000), networkLatest(tracker, net))
+		tracker.SetLatestBlockNumber(upsB, 300, 0)
+		assert.Equal(t, int64(300), upstreamLatest(tracker, upsB))
+		assert.Equal(t, int64(1_000_000), networkLatest(tracker, net),
+			"head re-derived to the healthy upstream's value, not the corrector's")
+		assert.Equal(t, int64(0), blockHeadLag(tracker, upsA))
+		assert.Equal(t, int64(1_000_000-300), blockHeadLag(tracker, upsB))
+	})
+
+	t.Run("LeaderReassertsAfterMistakenRollback", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-reassert")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetLatestBlockNumber(ups, 5_000_000, 0)
+		tracker.SetLatestBlockNumber(ups, 1_000, 0) // deep rollback accepted
+		assert.Equal(t, int64(1_000), networkLatest(tracker, ups.NetworkId()))
+
+		// If the rollback was wrong, the very next genuine observation
+		// restores the head — the state is never pinned in either direction.
+		tracker.SetLatestBlockNumber(ups, 5_000_001, 0)
+		assert.Equal(t, int64(5_000_001), upstreamLatest(tracker, ups))
+		assert.Equal(t, int64(5_000_001), networkLatest(tracker, ups.NetworkId()))
+		assert.Equal(t, int64(0), blockHeadLag(tracker, ups))
+	})
+}
+
+func TestTrackerFinalizedBlockRollbackTolerance(t *testing.T) {
+	tolerance := int64(common.DefaultToleratedBlockHeadRollback)
+
+	t.Run("SmallRollbackIgnored", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-fin-rollback-small")
+		ups := common.NewFakeUpstream("a")
+
+		tracker.SetFinalizedBlockNumber(ups, 10_000)
+		tracker.SetFinalizedBlockNumber(ups, 10_000-tolerance)
+
+		assert.Equal(t, int64(10_000), upstreamFinalized(tracker, ups))
+		assert.Equal(t, int64(10_000), networkFinalized(tracker, ups.NetworkId()))
+	})
+
+	t.Run("BogusFinalizedCorrectedAndNetworkRederived", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-fin-rollback-rederive")
+		upsA := common.NewFakeUpstream("a")
+		upsB := common.NewFakeUpstream("b")
+		net := upsA.NetworkId()
+
+		tracker.SetFinalizedBlockNumber(upsB, 31_000_000)
+		tracker.SetFinalizedBlockNumber(upsA, 99_000_000) // bogus
+
+		assert.Equal(t, int64(99_000_000), networkFinalized(tracker, net))
+		assert.Equal(t, int64(99_000_000-31_000_000), finalizationLag(tracker, upsB))
+
+		tracker.SetFinalizedBlockNumber(upsA, 31_000_010)
+
+		assert.Equal(t, int64(31_000_010), upstreamFinalized(tracker, upsA))
+		assert.Equal(t, int64(31_000_010), networkFinalized(tracker, net))
+		assert.Equal(t, int64(0), finalizationLag(tracker, upsA))
+		assert.Equal(t, int64(10), finalizationLag(tracker, upsB))
+	})
+}
+
+// After a head rollback the block-time EMA must keep sampling: its previous
+// anchor may sit at the (bogus) old head, and without re-anchoring every
+// subsequent block would look out-of-order until the chain re-passed it —
+// freezing dynamic block time estimation indefinitely.
+func TestTrackerBlockTimeReanchorsAfterHeadRollback(t *testing.T) {
+	tracker := newRollbackTestTracker(t, "test-rollback-blocktime")
+	ups := common.NewFakeUpstream("a")
+	net := ups.NetworkId()
+	base := int64(1_700_000_000)
+
+	// Establish a ~1s/block EMA (4 observations → 3 samples).
+	tracker.SetLatestBlockNumber(ups, 100, base)
+	tracker.SetLatestBlockNumber(ups, 101, base+1)
+	tracker.SetLatestBlockNumber(ups, 102, base+2)
+	tracker.SetLatestBlockNumber(ups, 103, base+3)
+	assert.InDelta(t, float64(time.Second), float64(tracker.GetNetworkBlockTime(net)), float64(50*time.Millisecond))
+
+	// Bogus far-ahead sample moves the EMA anchor to the bogus height.
+	tracker.SetLatestBlockNumber(ups, 90_000_000, base+4)
+	// Correction rolls the head back (no EMA sample of its own).
+	tracker.SetLatestBlockNumber(ups, 104, base+5)
+	assert.Equal(t, int64(104), networkLatest(tracker, net))
+
+	// Sampling resumes: the first forward observation re-anchors, the next one
+	// produces a sample again (3s/block here), and the EMA starts moving.
+	tracker.SetLatestBlockNumber(ups, 105, base+8)
+	tracker.SetLatestBlockNumber(ups, 106, base+11)
+
+	bt := tracker.GetNetworkBlockTime(net)
+	assert.Greater(t, int64(bt), int64(1050*time.Millisecond),
+		"EMA must move toward the new 3s/block cadence instead of staying frozen")
+	assert.Less(t, int64(bt), int64(2*time.Second))
+}


### PR DESCRIPTION
## Problem

The health tracker stores the per-upstream latest/finalized block and the network-level highest head **max-only** (`if blockNumber > oldVal`). A single bogus head sample — a provider briefly returning another chain's height, a corrupted response, a misrouted backend — permanently poisons both values for the life of the process:

- the poisoned network head makes **every healthy upstream** appear to lag by the bogus delta, so selection policies using `blockNumberLagAbove(...)` exclude all of them; with the healthy upstreams sidelined, requests on methods the remaining upstream can't serve exhaust retries/hedges and overall latency multiplies;
- the shared-state counters (`data.CounterInt64SharedVariable`) already handle this class of fault — decreases larger than `DefaultToleratedBlockHeadRollback` are accepted as corrections — so the poller layer self-heals within one poll, but the correction dies at the tracker boundary (`OnValue → SetLatestBlockNumber → silently dropped as lower`);
- the majority served-tip logic protects what block the network *serves* as latest, but it never writes back into the tracker, so lag-based routing stays poisoned;
- nothing resets the tracker except a process restart.

## Fix

Mirror the shared-state counter semantics in the tracker, with one refinement for the aggregated value:

- **Per-upstream latest/finalized:** accept decreases when the gap exceeds `DefaultToleratedBlockHeadRollback` (moved to `common` so the poller counters and the tracker share one constant); smaller decreases remain ignored as provider noise.
- **Network-level head:** never adopt a single (possibly lagging) sample downward. After an accepted per-upstream rollback, **re-derive** the head as the max over the stored per-upstream values. A genuinely-behind upstream can never drag the head down; the head only moves backwards when the former max-holder itself corrects.
- **Lags:** an accepted rollback triggers the existing full-network lag recompute, so `BlockHeadLag`/`FinalizationLag` (including the `{*, All}` wildcard bucket read by selection policies) converge immediately.
- **Block-time EMA:** re-anchor the previous-block marker when a sample arrives far behind it, so dynamic block-time estimation resumes instead of stalling until the chain re-passes the old (bogus) height.

Accepted rollbacks and network-head re-derivations are logged at warn for operability.

## Tests

`health/tracker_blockhead_rollback_test.go`:

- forward progress / equal value unchanged; gap == tolerance still ignored; gap == tolerance+1 applied (boundary);
- the poisoned-head scenario end-to-end: bogus far-ahead sample → healthy upstreams show huge lag → next real observation rolls the upstream back, re-derives the network head, and recomputes all upstreams' lags (asserted via `TrackedMetrics` and Prometheus gauges);
- a far-behind upstream can never drag the network head down — including after its own bogus-high + correction cycle (head re-derives to the healthy upstream's value, not the corrector's);
- a mistaken rollback self-corrects on the next genuine observation (no pinning in either direction);
- finalized axis mirrored;
- block-time EMA resumes sampling after a head rollback instead of freezing.

Full `./health/` and `./architecture/evm/` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core routing inputs (network head, block/finalization lag) used by selection policies; behavior is intentional and tested but affects production upstream scoring when heads roll back or correct.
> 
> **Overview**
> Fixes **poisoned block-head state** in the health tracker: bogus far-ahead samples could pin per-upstream and network latest/finalized heads (max-only updates), inflating `BlockHeadLag` and breaking lag-based upstream selection until restart—even when EVM state poller shared counters already accepted corrections.
> 
> **`common.DefaultToleratedBlockHeadRollback` (1024)** is centralized; the poller aliases it so tolerance matches the tracker. Per-upstream latest/finalized now mirror shared-counter rules: forward progress always wins, small rollbacks are ignored, gaps **strictly above** tolerance apply as corrections (with warn logs). After an accepted upstream rollback, the **network head is re-derived as the max** of per-upstream values—not lowered from a single lagging upstream—and lags/gauges refresh accordingly.
> 
> **Block-time EMA** re-anchors its previous-block marker on large backward samples so estimation does not stall after a bogus head. New **`health/tracker_blockhead_rollback_test.go`** covers boundaries, bogus-head recovery, multi-upstream re-derive, finalized axis, and block-time re-anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ceac9343720d8c65d571a6616a43ee4b13befe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->