### PR TITLE
feat(bds): chain-identity enforcement + connection freshness for gRPC BDS clients

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -459,6 +460,12 @@ func (e *EvmStatePoller) PollLatestBlockNumber(ctx context.Context) (int64, erro
 		e.latestBlockFailureCount = 0
 		e.stateMu.Unlock()
 
+		// A major move must pass a fresh chain-identity check before entering
+		// the shared counter / tracker (see verifyChainIdOnMajorHeadMove).
+		if !e.verifyChainIdOnMajorHeadMove(ctx, "latest", e.latestBlockShared.GetValue(), blockNum) {
+			return 0, nil
+		}
+
 		// Directly update tracker with the correct timestamp for this locally-fetched block
 		// This happens BEFORE the OnValue callback is triggered, ensuring only the fetching node emits the metric
 		e.tracker.SetLatestBlockNumber(e.upstream, blockNum, blockTimestamp)
@@ -486,7 +493,6 @@ func (e *EvmStatePoller) SuggestLatestBlock(blockNumber int64) {
 			Msg("skipping latest block suggestion as it's not newer")
 		return
 	}
-
 	newValue := e.latestBlockShared.TryUpdate(e.appCtx, blockNumber)
 	e.logger.Trace().
 		Int64("blockNumber", blockNumber).
@@ -497,6 +503,84 @@ func (e *EvmStatePoller) SuggestLatestBlock(blockNumber int64) {
 
 func (e *EvmStatePoller) LatestBlock() int64 {
 	return e.latestBlockShared.GetValue()
+}
+
+// verifyChainIdOnMajorHeadMove gates a polled head sample that moved beyond
+// the shared rollback tolerance (in either direction) behind a fresh chain
+// identity check. Such moves are exactly what a cross-wired endpoint — a DNS
+// record or load balancer briefly answering for another chain — produces, and
+// once a bogus sample enters the shared counters and the tracker, every
+// lag-based routing decision is skewed until corrected. Built from existing
+// primitives only: the shared tolerance constant, EvmGetChainId (always a
+// real upstream call), and Cordon on proven mismatch (the selection policy
+// already excludes cordoned upstreams). Legitimate deep reorgs and
+// post-downtime catch-ups pass the probe and are accepted unchanged; a failed
+// probe drops the sample for this cycle only — the next poll re-observes the
+// same height seconds later.
+//
+// The out-of-band Suggest* paths are deliberately NOT gated: suggestion-driven
+// upward bursts are designed behavior (response enrichment, halted-chain
+// resumes — see networks_served_tip_test.go) and cannot be verified in those
+// hot paths. A bogus suggestion self-heals within one poll cycle: the next
+// verified poll observes the real head and the >tolerance rollback is
+// accepted as a correction by both the shared counter and the tracker.
+func (e *EvmStatePoller) verifyChainIdOnMajorHeadMove(ctx context.Context, tag string, current, polled int64) bool {
+	if current <= 0 || absInt64(polled-current) <= common.DefaultToleratedBlockHeadRollback {
+		return true
+	}
+	cfgChainId := int64(0)
+	if cfg := e.upstream.Config(); cfg != nil && cfg.Evm != nil {
+		cfgChainId = cfg.Evm.ChainId
+	}
+	if cfgChainId <= 0 {
+		// Chain identity not pinned yet (auto-detection still in flight) —
+		// nothing trustworthy to verify against.
+		return true
+	}
+	eu, ok := e.upstream.(common.EvmUpstream)
+	if !ok {
+		return true
+	}
+	detected, err := eu.EvmGetChainId(ctx)
+	if err != nil {
+		// The gRPC BDS client surfaces a cross-wired server as a typed
+		// mismatch (it compares the ChainId response itself) — treat that as
+		// proof, same as a differing answer below.
+		if common.HasErrorCode(err, common.ErrCodeEndpointChainIdMismatch) {
+			e.cordonForChainIdMismatch(tag, current, polled, err)
+			return false
+		}
+		e.logger.Warn().Err(err).
+			Str("tag", tag).
+			Int64("currentValue", current).
+			Int64("polledValue", polled).
+			Msg("major head move: chainId re-validation failed, dropping sample until next poll")
+		return false
+	}
+	if detected != strconv.FormatInt(cfgChainId, 10) {
+		e.cordonForChainIdMismatch(tag, current, polled, fmt.Errorf("eth_chainId returned %s but upstream is configured for chainId %d", detected, cfgChainId))
+		return false
+	}
+	return true
+}
+
+// cordonForChainIdMismatch fails loud on a proven cross-wired endpoint: the
+// sample is rejected and the upstream is cordoned (admins uncordon via the
+// existing erpc_uncordonUpstream admin method once the endpoint is fixed).
+func (e *EvmStatePoller) cordonForChainIdMismatch(tag string, current, polled int64, cause error) {
+	e.logger.Error().Err(cause).
+		Str("tag", tag).
+		Int64("currentValue", current).
+		Int64("polledValue", polled).
+		Msg("major head move REJECTED: upstream answers for a different chain — cordoning upstream")
+	e.upstream.Cordon("*", fmt.Sprintf("chain identity mismatch on major %s head move: %s", tag, cause.Error()))
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 
 func (e *EvmStatePoller) PollFinalizedBlockNumber(ctx context.Context) (int64, error) {
@@ -561,6 +645,11 @@ func (e *EvmStatePoller) PollFinalizedBlockNumber(ctx context.Context) (int64, e
 		e.finalizedBlockSuccessfulOnce = true
 		e.finalizedBlockFailureCount = 0
 		e.stateMu.Unlock()
+
+		// Same chain-identity gate as the latest ratchet (see there).
+		if !e.verifyChainIdOnMajorHeadMove(ctx, "finalized", e.finalizedBlockShared.GetValue(), blockNum) {
+			return 0, nil
+		}
 
 		e.logger.Debug().
 			Int64("blockNumber", blockNum).

--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sync/atomic"
 
 	_ "github.com/blockchain-data-standards/manifesto/common"
 	"github.com/blockchain-data-standards/manifesto/evm"
@@ -51,6 +52,31 @@ type GenericGrpcBdsClient struct {
 	appCtx          context.Context
 	logger          *zerolog.Logger
 	isLogLevelTrace bool
+
+	// expectedChainId is the chainId this client is configured to serve
+	// (0 = unknown). When set, it is (a) stamped into every BDS request that
+	// carries an optional chainId field — a chain-aware server then REJECTS
+	// requests reaching the wrong chain's backend, so a cross-wired endpoint
+	// (a stale DNS record or reused address answering for another chain)
+	// fails loudly per request instead of silently answering with another
+	// chain's data — and (b) verified by the pool's connection maintainer via
+	// the ChainId RPC (see grpc_bds_resilience.go). Atomic: the cache
+	// connector arms it via SetExpectedChainId after probing.
+	expectedChainId atomic.Uint64
+}
+
+// SetExpectedChainId arms chain-identity enforcement after construction —
+// for callers that only learn the server's chain by probing it (the gRPC
+// cache connector). From then on every request carries the chainId assertion
+// and the pool maintainer keeps re-verifying the connections. Deliberately
+// NOT part of the GrpcBdsClient interface (callers type-assert) so existing
+// interface implementations stay compatible. Safe to call concurrently with
+// in-flight requests.
+func (c *GenericGrpcBdsClient) SetExpectedChainId(chainId uint64) {
+	c.expectedChainId.Store(chainId)
+	if c.pool != nil {
+		c.pool.expectedChainId.Store(chainId)
+	}
 }
 
 // NewGrpcBdsClient builds a BDS gRPC client backed by a round-robin connection
@@ -77,6 +103,11 @@ func NewGrpcBdsClient(
 		upstreamId:      upsId,
 		isLogLevelTrace: logger.GetLevel() == zerolog.TraceLevel,
 		headers:         make(map[string]string),
+	}
+	if upstream != nil {
+		if cfg := upstream.Config(); cfg != nil && cfg.Evm != nil && cfg.Evm.ChainId > 0 {
+			client.expectedChainId.Store(uint64(cfg.Evm.ChainId))
+		}
 	}
 
 	// Apply any grpc.headers configured on the upstream as gRPC metadata on
@@ -127,7 +158,7 @@ func NewGrpcBdsClient(
 		}]
 	}`
 
-	pool, err := newBdsPool(logger, projectId, upsId, target, transportCredentials, serviceConfig, poolSize)
+	pool, err := newBdsPool(appCtx, logger, projectId, upsId, target, transportCredentials, serviceConfig, poolSize, client.expectedChainId.Load())
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +177,19 @@ func NewGrpcBdsClient(
 		Msg("created gRPC BDS client")
 
 	return client, nil
+}
+
+// chainIdParam returns the configured chainId as the optional per-request
+// chain assertion, or nil when unknown. Chain-aware BDS servers validate
+// this field on every RPC and reject mismatches, so a request that lands on
+// the wrong chain's backend errors loudly instead of being answered with
+// another chain's data.
+func (c *GenericGrpcBdsClient) chainIdParam() *uint64 {
+	v := c.expectedChainId.Load()
+	if v == 0 {
+		return nil
+	}
+	return &v
 }
 
 // grpcResponseMetadataInterceptor captures all response metadata (headers)
@@ -372,6 +416,7 @@ func (c *GenericGrpcBdsClient) handleGetBlockByNumber(ctx context.Context, conn 
 		grpcReq := &evm.GetBlockByHashRequest{
 			BlockHash:           blockHash,
 			IncludeTransactions: includeTransactions,
+			ChainId:             c.chainIdParam(),
 		}
 
 		hashHex := hex.EncodeToString(blockHash)
@@ -429,6 +474,7 @@ func (c *GenericGrpcBdsClient) handleGetBlockByNumber(ctx context.Context, conn 
 	grpcReq := &evm.GetBlockByNumberRequest{
 		BlockNumber:         blockNumber,
 		IncludeTransactions: includeTransactions,
+		ChainId:             c.chainIdParam(),
 	}
 
 	c.logger.Debug().
@@ -524,6 +570,7 @@ func (c *GenericGrpcBdsClient) handleGetBlockByHash(ctx context.Context, conn *b
 	grpcReq := &evm.GetBlockByHashRequest{
 		BlockHash:           blockHash,
 		IncludeTransactions: includeTransactions,
+		ChainId:             c.chainIdParam(),
 	}
 
 	c.logger.Debug().
@@ -639,6 +686,7 @@ func (c *GenericGrpcBdsClient) handleGetLogs(ctx context.Context, conn *bdsConn,
 		ToBlock:   toBlock,
 		Addresses: addresses,
 		Topics:    topics,
+		ChainId:   c.chainIdParam(),
 	}
 
 	c.logger.Debug().
@@ -718,6 +766,7 @@ func (c *GenericGrpcBdsClient) handleGetTransactionByHash(ctx context.Context, c
 
 	grpcReq := &evm.GetTransactionByHashRequest{
 		TransactionHash: txHash,
+		ChainId:         c.chainIdParam(),
 	}
 
 	c.logger.Debug().
@@ -785,6 +834,7 @@ func (c *GenericGrpcBdsClient) handleGetTransactionReceipt(ctx context.Context, 
 
 	grpcReq := &evm.GetTransactionReceiptRequest{
 		TransactionHash: txHash,
+		ChainId:         c.chainIdParam(),
 	}
 
 	c.logger.Debug().
@@ -837,6 +887,16 @@ func (c *GenericGrpcBdsClient) handleChainId(ctx context.Context, conn *bdsConn,
 		return nil, fmt.Errorf("gRPC call failed: %w", err)
 	}
 
+	// A server answering for a different chain than this client is configured
+	// for is a cross-wired endpoint (stale DNS record / reused address) — fail
+	// loudly instead of propagating another chain's identity (and, through the
+	// state poller, its heads).
+	if expected := c.expectedChainId.Load(); expected > 0 && grpcResp.ChainId != expected {
+		mismatchErr := fmt.Errorf("BDS server reports chainId %d but this upstream is configured for chainId %d (cross-wired endpoint)", grpcResp.ChainId, expected)
+		c.logger.Error().Err(mismatchErr).Str("target", c.Url.String()).Msg("chainId mismatch from BDS server")
+		return nil, common.NewErrEndpointTransportFailure(c.Url, mismatchErr)
+	}
+
 	// Convert chain ID to hex string per JSON-RPC standard
 	result := fmt.Sprintf("0x%x", grpcResp.ChainId)
 
@@ -879,7 +939,7 @@ func (c *GenericGrpcBdsClient) handleGetBlockReceipts(ctx context.Context, conn 
 		return nil, fmt.Errorf("failed to parse block parameter: %w", err)
 	}
 
-	grpcReq := &evm.GetBlockReceiptsRequest{}
+	grpcReq := &evm.GetBlockReceiptsRequest{ChainId: c.chainIdParam()}
 
 	// If we got a block hash, use it directly
 	if blockHash != nil {
@@ -1112,6 +1172,9 @@ func (c *GenericGrpcBdsClient) handleQueryBlocks(ctx context.Context, conn *bdsC
 	if err != nil {
 		return nil, fmt.Errorf("invalid eth_queryBlocks params: %w", err)
 	}
+	if grpcReq.ChainId == nil {
+		grpcReq.ChainId = c.chainIdParam()
+	}
 
 	ctx, span := common.StartDetailSpan(ctx, "GrpcBdsClient.QueryBlocks")
 	defer span.End()
@@ -1153,6 +1216,9 @@ func (c *GenericGrpcBdsClient) handleQueryTransactions(ctx context.Context, conn
 	if err != nil {
 		return nil, fmt.Errorf("invalid eth_queryTransactions params: %w", err)
 	}
+	if grpcReq.ChainId == nil {
+		grpcReq.ChainId = c.chainIdParam()
+	}
 
 	ctx, span := common.StartDetailSpan(ctx, "GrpcBdsClient.QueryTransactions")
 	defer span.End()
@@ -1187,6 +1253,9 @@ func (c *GenericGrpcBdsClient) handleQueryLogs(ctx context.Context, conn *bdsCon
 	grpcReq, err := evm.QueryLogsRequestFromJsonRpc(rawParams)
 	if err != nil {
 		return nil, fmt.Errorf("invalid eth_queryLogs params: %w", err)
+	}
+	if grpcReq.ChainId == nil {
+		grpcReq.ChainId = c.chainIdParam()
 	}
 
 	ctx, span := common.StartDetailSpan(ctx, "GrpcBdsClient.QueryLogs")
@@ -1224,6 +1293,9 @@ func (c *GenericGrpcBdsClient) handleQueryTraces(ctx context.Context, conn *bdsC
 	if err != nil {
 		return nil, fmt.Errorf("invalid eth_queryTraces params: %w", err)
 	}
+	if grpcReq.ChainId == nil {
+		grpcReq.ChainId = c.chainIdParam()
+	}
 
 	ctx, span := common.StartDetailSpan(ctx, "GrpcBdsClient.QueryTraces")
 	defer span.End()
@@ -1259,6 +1331,9 @@ func (c *GenericGrpcBdsClient) handleQueryTransfers(ctx context.Context, conn *b
 	grpcReq, err := evm.QueryTransfersRequestFromJsonRpc(rawParams)
 	if err != nil {
 		return nil, fmt.Errorf("invalid eth_queryTransfers params: %w", err)
+	}
+	if grpcReq.ChainId == nil {
+		grpcReq.ChainId = c.chainIdParam()
 	}
 
 	ctx, span := common.StartDetailSpan(ctx, "GrpcBdsClient.QueryTransfers")

--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -892,7 +892,7 @@ func (c *GenericGrpcBdsClient) handleChainId(ctx context.Context, conn *bdsConn,
 	// loudly instead of propagating another chain's identity (and, through the
 	// state poller, its heads).
 	if expected := c.expectedChainId.Load(); expected > 0 && grpcResp.ChainId != expected {
-		mismatchErr := fmt.Errorf("BDS server reports chainId %d but this upstream is configured for chainId %d (cross-wired endpoint)", grpcResp.ChainId, expected)
+		mismatchErr := common.NewErrEndpointChainIdMismatch(grpcResp.ChainId, expected)
 		c.logger.Error().Err(mismatchErr).Str("target", c.Url.String()).Msg("chainId mismatch from BDS server")
 		return nil, common.NewErrEndpointTransportFailure(c.Url, mismatchErr)
 	}

--- a/clients/grpc_bds_pool_size_test.go
+++ b/clients/grpc_bds_pool_size_test.go
@@ -18,6 +18,7 @@ func newTestPool(t *testing.T, poolSize int) *bdsPool {
 	t.Helper()
 	logger := zerolog.New(io.Discard)
 	p, err := newBdsPool(
+		context.Background(),
 		&logger,
 		"test-project",
 		"n/a",
@@ -25,6 +26,7 @@ func newTestPool(t *testing.T, poolSize int) *bdsPool {
 		insecure.NewCredentials(),
 		"{}",
 		poolSize,
+		0, // no expected chainId — identity checks stay disarmed in this test
 	)
 	require.NoError(t, err)
 	t.Cleanup(p.Shutdown)

--- a/clients/grpc_bds_resilience.go
+++ b/clients/grpc_bds_resilience.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
@@ -51,6 +53,30 @@ var (
 	// bdsReplacementDedupWindow stops two simultaneous threshold-breaches
 	// from double-closing the same slot in quick succession.
 	bdsReplacementDedupWindow = 5 * time.Second
+
+	// bdsConnMaxAge bounds how long a pooled connection may live before the
+	// maintainer proactively re-dials it (each conn gets ±20% jitter so the
+	// pool never recycles in lockstep). Re-dialing re-resolves DNS, so a
+	// connection pinned to an address that no longer backs the record —
+	// backend gone, or the address reused by ANOTHER chain's server — cannot
+	// outlive this bound. Correctness does not depend on it (per-request
+	// chainId assertions and the identity verification below catch
+	// cross-wires directly); this is the freshness / load-balancing hygiene
+	// layer.
+	bdsConnMaxAge = 5 * time.Minute
+
+	// bdsMaintainInterval is how often the pool maintainer wakes to verify
+	// the chain identity behind each connection and enforce bdsConnMaxAge.
+	bdsMaintainInterval = 60 * time.Second
+
+	// bdsVerifyTimeout bounds a single ChainId verification probe.
+	bdsVerifyTimeout = 5 * time.Second
+
+	// bdsAgeRecycleLinger delays closing an age-recycled conn so its in-flight
+	// RPCs can finish; new picks already go to the replacement. Mismatch
+	// recycles close immediately — a wrong-chain conn must not serve one more
+	// call than necessary.
+	bdsAgeRecycleLinger = 30 * time.Second
 )
 
 // errBdsHardCapExceeded is the context cause set by SendRequest's
@@ -72,6 +98,11 @@ type bdsConn struct {
 	conn        *grpc.ClientConn
 	rpcClient   evm.RPCQueryServiceClient
 	queryClient evm.QueryServiceClient
+
+	// dialedAt/maxAge drive the maintainer's age-based recycling; maxAge is
+	// per-conn jittered at dial time (0 = age recycling disabled).
+	dialedAt time.Time
+	maxAge   time.Duration
 
 	stuckMu    sync.Mutex
 	stuckTimes []time.Time
@@ -98,20 +129,36 @@ type bdsPool struct {
 	projectId  string
 	upstreamId string
 	logger     *zerolog.Logger
+
+	// appCtx bounds the maintainer goroutine and verification probes;
+	// expectedChainId (0 = unknown) is what those probes assert against —
+	// atomic because the cache connector arms it after probing the server.
+	appCtx          context.Context
+	expectedChainId atomic.Uint64
+	stopCh          chan struct{}
+	stopOnce        sync.Once
 }
 
 // newBdsPool builds a round-robin pool of poolSize independent connections.
 // A poolSize <= 0 means "unconfigured" and falls back to bdsPoolSize, so an
 // absent/zero/negative config value preserves the historical default.
+// expectedChainId (0 = unknown) arms chain-identity verification: a proven
+// mismatch at construction fails the pool, and a background maintainer keeps
+// re-verifying every connection and recycles those past their max age.
 func newBdsPool(
+	appCtx context.Context,
 	logger *zerolog.Logger,
 	projectId, upstreamId, target string,
 	creds credentials.TransportCredentials,
 	serviceConfig string,
 	poolSize int,
+	expectedChainId uint64,
 ) (*bdsPool, error) {
 	if poolSize <= 0 {
 		poolSize = bdsPoolSize
+	}
+	if appCtx == nil {
+		appCtx = context.Background()
 	}
 	p := &bdsPool{
 		target:        target,
@@ -121,7 +168,10 @@ func newBdsPool(
 		projectId:     projectId,
 		upstreamId:    upstreamId,
 		logger:        logger,
+		appCtx:        appCtx,
+		stopCh:        make(chan struct{}),
 	}
+	p.expectedChainId.Store(expectedChainId)
 	for i := 0; i < poolSize; i++ {
 		c, err := p.dial()
 		if err != nil {
@@ -134,7 +184,163 @@ func newBdsPool(
 		}
 		p.conns[i] = c
 	}
+	// Chain-identity gate at construction: probe one fresh conn (round_robin
+	// spreads subsequent traffic over the same resolved backends). A PROVEN
+	// mismatch fails the pool — never bootstrap onto a cross-wired endpoint.
+	// Transient probe errors keep the historical lazy-dial behavior; the
+	// maintainer re-checks every tick and every request carries its own
+	// chainId assertion regardless.
+	if expectedChainId > 0 {
+		if ok, detected, err := p.verifyConn(appCtx, p.conns[0]); err == nil && !ok {
+			p.Shutdown()
+			return nil, fmt.Errorf("BDS endpoint %s answers for chainId %d but this client expects chainId %d (cross-wired endpoint)", target, detected, expectedChainId)
+		}
+	}
+	go p.maintainLoop()
 	return p, nil
+}
+
+// verifyConn probes the server behind c with the ChainId RPC and compares the
+// answer to the pool's expected chainId. Returns (matched, detected, err);
+// err != nil means the identity could not be determined (transport failure) —
+// matched is meaningless in that case.
+func (p *bdsPool) verifyConn(ctx context.Context, c *bdsConn) (bool, uint64, error) {
+	expected := p.expectedChainId.Load()
+	if expected == 0 || c == nil || c.rpcClient == nil {
+		return true, 0, nil
+	}
+	vctx, cancel := context.WithTimeout(ctx, bdsVerifyTimeout)
+	defer cancel()
+	resp, err := c.rpcClient.ChainId(vctx, &evm.ChainIdRequest{})
+	if err != nil {
+		return false, 0, err
+	}
+	if resp.ChainId != expected {
+		return false, resp.ChainId, nil
+	}
+	return true, resp.ChainId, nil
+}
+
+// maintainLoop periodically re-verifies the chain identity behind every
+// pooled connection and recycles connections past their (jittered) max age.
+// Identity mismatches recycle immediately; age recycles are capped at one per
+// tick so the pool never churns in bulk. Exits on Shutdown / app shutdown.
+func (p *bdsPool) maintainLoop() {
+	ticker := time.NewTicker(bdsMaintainInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-p.appCtx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		p.poolMu.RLock()
+		conns := append([]*bdsConn(nil), p.conns...)
+		p.poolMu.RUnlock()
+
+		agedRecycled := false
+		for _, c := range conns {
+			if c == nil {
+				continue
+			}
+			// A conn quarantined by a previous mismatch (closed in place
+			// because the replacement dial failed) errors on verification;
+			// retry replacing it every tick until a good conn lands.
+			if c.conn != nil && c.conn.GetState() == connectivity.Shutdown {
+				p.recycleConn(c, "closed")
+				continue
+			}
+			if ok, detected, err := p.verifyConn(p.appCtx, c); err == nil && !ok {
+				p.logger.Error().
+					Str("target", p.target).
+					Str("upstream.id", p.upstreamId).
+					Uint64("expectedChainId", p.expectedChainId.Load()).
+					Uint64("detectedChainId", detected).
+					Msg("BDS maintainer: connection answers for a DIFFERENT chain (cross-wired endpoint) — quarantining immediately")
+				// Quarantine FIRST: closing the conn fails every in-flight and
+				// future RPC on it instantly (surfacing through the normal
+				// request-error paths), so nothing more can be served by the
+				// wrong chain even by a server that doesn't validate chainId.
+				// The replacement below then restores capacity.
+				_ = c.conn.Close()
+				p.recycleConn(c, "chainid_mismatch")
+				continue
+			}
+			if !agedRecycled && c.maxAge > 0 && time.Since(c.dialedAt) > c.maxAge {
+				p.recycleConn(c, "age")
+				agedRecycled = true
+			}
+		}
+	}
+}
+
+// recycleConn dials a verified replacement for c and swaps it into c's slot.
+// reason is `age`, `chainid_mismatch` or `closed`. On age recycles the old
+// conn closes after a linger (lets in-flight RPCs finish; new picks already go
+// to the replacement); on mismatch/closed the old conn is already closed (or
+// closes immediately) — a proven wrong-chain conn must not serve another call.
+func (p *bdsPool) recycleConn(c *bdsConn, reason string) {
+	replacement, err := p.dial()
+	if err != nil {
+		p.logger.Warn().Err(err).Str("target", p.target).Str("reason", reason).Msg("BDS maintainer: failed to dial replacement; will retry next tick")
+		return
+	}
+	if ok, detected, verr := p.verifyConn(p.appCtx, replacement); verr == nil && !ok {
+		_ = replacement.conn.Close()
+		p.logger.Error().
+			Str("target", p.target).
+			Str("upstream.id", p.upstreamId).
+			Uint64("expectedChainId", p.expectedChainId.Load()).
+			Uint64("detectedChainId", detected).
+			Msg("BDS maintainer: replacement answers for a different chain (cross-wired endpoint); will retry next tick")
+		return
+	}
+	slot, swapped := p.swapInReplacement(c, replacement)
+	if !swapped {
+		_ = replacement.conn.Close()
+		return
+	}
+	p.logger.Info().
+		Str("target", p.target).
+		Str("upstream.id", p.upstreamId).
+		Int("slot", slot).
+		Str("reason", reason).
+		Msg("BDS maintainer: recycled pool connection")
+	if c.conn != nil {
+		if reason == "age" {
+			old := c.conn
+			time.AfterFunc(bdsAgeRecycleLinger, func() { _ = old.Close() })
+		} else {
+			_ = c.conn.Close()
+		}
+	}
+}
+
+// swapInReplacement installs replacement in c's slot if c is still pooled and
+// outside the dedup window. Returns (slot, false) without installing when the
+// swap cannot be committed — the caller must close the replacement then.
+func (p *bdsPool) swapInReplacement(c, replacement *bdsConn) (int, bool) {
+	p.poolMu.Lock()
+	defer p.poolMu.Unlock()
+	slot := -1
+	for i, existing := range p.conns {
+		if existing == c {
+			slot = i
+			break
+		}
+	}
+	if slot < 0 {
+		return -1, false
+	}
+	if last := c.closedAt.Load(); last > 0 && time.Since(time.Unix(0, last)) < bdsReplacementDedupWindow {
+		return -1, false
+	}
+	c.closedAt.Store(time.Now().UnixNano())
+	p.conns[slot] = replacement
+	return slot, true
 }
 
 // Size returns the number of connection slots in the pool.
@@ -172,10 +378,17 @@ func (p *bdsPool) dial() (*bdsConn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial gRPC server at %s: %w", p.target, err)
 	}
+	maxAge := time.Duration(0)
+	if bdsConnMaxAge > 0 {
+		// ±20% jitter so pool conns never expire in lockstep.
+		maxAge = time.Duration(float64(bdsConnMaxAge) * (0.8 + 0.4*rand.Float64())) // #nosec G404 -- recycle-spread jitter, not security-sensitive
+	}
 	return &bdsConn{
 		conn:        conn,
 		rpcClient:   evm.NewRPCQueryServiceClient(conn),
 		queryClient: evm.NewQueryServiceClient(conn),
+		dialedAt:    time.Now(),
+		maxAge:      maxAge,
 	}, nil
 }
 
@@ -226,24 +439,9 @@ func (p *bdsPool) recordStuck(c *bdsConn) bool {
 // failure (e.g. DNS hiccup) leaves the existing conn in place rather
 // than parking the slot with a permanently-closed *grpc.ClientConn.
 // Skipped if the slot was replaced within bdsReplacementDedupWindow.
+// Dial and identity verification happen OUTSIDE the pool lock — only the
+// slot swap itself takes it — so Pick() is never blocked behind a probe.
 func (p *bdsPool) replaceConn(c *bdsConn) {
-	p.poolMu.Lock()
-	defer p.poolMu.Unlock()
-
-	slot := -1
-	for i, existing := range p.conns {
-		if existing == c {
-			slot = i
-			break
-		}
-	}
-	if slot < 0 {
-		return
-	}
-	if last := c.closedAt.Load(); last > 0 && time.Since(time.Unix(0, last)) < bdsReplacementDedupWindow {
-		return
-	}
-
 	// Dial first. If dial fails, leave the old conn in place — it's
 	// likely still broken but at least grpc-go can keep retrying
 	// through it (with its own reconnect backoff), which is strictly
@@ -255,8 +453,26 @@ func (p *bdsPool) replaceConn(c *bdsConn) {
 		return
 	}
 
-	// Dial succeeded — commit the swap and close the old conn.
-	c.closedAt.Store(time.Now().UnixNano())
+	// Never install a replacement that PROVABLY serves another chain
+	// (transient verification errors fall through — same lazy semantics as
+	// the original dial; the maintainer re-checks periodically).
+	if ok, detected, verr := p.verifyConn(p.appCtx, replacement); verr == nil && !ok {
+		_ = replacement.conn.Close()
+		p.logger.Error().
+			Str("target", p.target).
+			Str("upstream.id", p.upstreamId).
+			Uint64("expectedChainId", p.expectedChainId.Load()).
+			Uint64("detectedChainId", detected).
+			Msg("BDS watchdog: replacement answers for a different chain (cross-wired endpoint); keeping old conn")
+		return
+	}
+
+	slot, swapped := p.swapInReplacement(c, replacement)
+	if !swapped {
+		_ = replacement.conn.Close()
+		return
+	}
+
 	p.logger.Warn().
 		Str("target", p.target).
 		Str("upstream.id", p.upstreamId).
@@ -264,16 +480,16 @@ func (p *bdsPool) replaceConn(c *bdsConn) {
 		Msg("BDS watchdog: replacing wedged connection")
 	telemetry.MetricGrpcBdsConnReplacementsTotal.WithLabelValues(p.projectId, p.upstreamId).Inc()
 
-	p.conns[slot] = replacement
 	if c.conn != nil {
 		_ = c.conn.Close()
 	}
 }
 
-// Shutdown closes every connection in the pool. Idempotent.
-// Takes the write lock to serialize with any in-flight replaceConn
-// (so we don't close a conn that's just been swapped out).
+// Shutdown stops the maintainer and closes every connection in the pool.
+// Idempotent. Takes the write lock to serialize with any in-flight
+// replaceConn (so we don't close a conn that's just been swapped out).
 func (p *bdsPool) Shutdown() {
+	p.stopOnce.Do(func() { close(p.stopCh) })
 	p.poolMu.Lock()
 	defer p.poolMu.Unlock()
 	for _, c := range p.conns {

--- a/common/errors.go
+++ b/common/errors.go
@@ -1868,6 +1868,29 @@ func (e *ErrEndpointUnauthorized) ErrorStatusCode() int {
 	return 401
 }
 
+type ErrEndpointChainIdMismatch struct{ BaseError }
+
+const ErrCodeEndpointChainIdMismatch = "ErrEndpointChainIdMismatch"
+
+// NewErrEndpointChainIdMismatch marks a PROVEN cross-wired endpoint: the
+// server answering for this upstream reported a different chainId than the
+// upstream is configured for (e.g. a stale DNS record or reused address
+// pointing at another chain's server). Consumers treat this as strong
+// evidence the endpoint must not be used (see the state poller's major-move
+// guard, which cordons the upstream on this code).
+var NewErrEndpointChainIdMismatch = func(detected, expected uint64) error {
+	return &ErrEndpointChainIdMismatch{
+		BaseError{
+			Code:    ErrCodeEndpointChainIdMismatch,
+			Message: "endpoint answers for a different chainId than configured (cross-wired endpoint)",
+			Details: map[string]interface{}{
+				"detectedChainId": detected,
+				"expectedChainId": expected,
+			},
+		},
+	}
+}
+
 type ErrEndpointUnsupported struct{ BaseError }
 
 const ErrCodeEndpointUnsupported = "ErrEndpointUnsupported"

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -172,6 +172,17 @@ func NewGrpcConnector(
 					gc.logger.Error().Str("server", serverURL).Str("networkId", networkId).Msg("duplicate gRPC server for network detected; ignoring")
 					return nil
 				}
+				// Arm chain-identity enforcement with the probed chainId: from
+				// here on every request to this server carries the chainId
+				// assertion and the client's pool maintainer keeps
+				// re-verifying the connections — the bootstrap probe alone
+				// cannot catch an endpoint that gets cross-wired LATER (stale
+				// DNS / reused address answering for another chain). Narrow
+				// assertion: the method is intentionally not on the
+				// GrpcBdsClient interface.
+				if armer, ok := cli.(interface{ SetExpectedChainId(uint64) }); ok {
+					armer.SetExpectedChainId(uval)
+				}
 				gc.clientByNetwork[networkId] = cli
 				gc.logger.Info().Str("server", serverURL).Str("networkId", networkId).Msg("gRPC client initialized for network")
 				return nil

--- a/erpc/grpc_server.go
+++ b/erpc/grpc_server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/blockchain-data-standards/manifesto/evm"
 	"github.com/bytedance/sonic"
@@ -17,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
@@ -102,6 +104,23 @@ func NewGrpcServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(gs.panicRecoveryUnary()),
 		grpc.ChainStreamInterceptor(gs.panicRecoveryStream()),
+		// MaxConnectionAge forces long-lived client channels to reconnect
+		// periodically (GOAWAY + grace for in-flight streams). Clients that
+		// dial through DNS re-resolve on reconnect, so a connection pinned to
+		// a stale backend address is bounded to Age+Grace instead of living
+		// until it breaks — the server-side half of the endpoint-freshness
+		// contract (the BDS client's conn max-age is the client-side half).
+		// Jitter (±10%) is added by grpc-go itself.
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionAge:      10 * time.Minute,
+			MaxConnectionAgeGrace: 30 * time.Second,
+		}),
+		// Allow well-behaved clients (our BDS client pings every 30s, also
+		// without active streams) without tripping the server's ping police.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	}
 	if cfg.TLS != nil && cfg.TLS.Enabled {
 		creds, err := credentials.NewServerTLSFromFile(cfg.TLS.CertFile, cfg.TLS.KeyFile)

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -15608,7 +15608,26 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
+        "name": "cluster_group",
+        "label": "cluster group",
+        "description": "Quick scope for the cluster list: All, or all / prod / dev edge-rpc clusters. Pick a group, then 'cluster' lists only those (leave cluster on All to select every cluster in the group).",
+        "type": "custom",
+        "multi": false,
+        "includeAll": false,
+        "query": "All : .*, Edge (all) : edge-rpc-.*, Edge (prod) : edge-rpc-.*-prod, Edge (dev) : edge-rpc-.*-dev",
+        "current": {
+          "text": "All",
+          "value": ".*"
+        },
+        "options": [
+          { "text": "All", "value": ".*", "selected": true },
+          { "text": "Edge (all)", "value": "edge-rpc-.*", "selected": false },
+          { "text": "Edge (prod)", "value": "edge-rpc-.*-prod", "selected": false },
+          { "text": "Edge (dev)", "value": "edge-rpc-.*-dev", "selected": false }
+        ]
+      },
+      {
+        "allValue": "",
         "current": {
           "text": "All",
           "value": "$__all"
@@ -15617,17 +15636,17 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(cluster)",
+        "definition": "label_values({cluster=~\"$cluster_group\"}, cluster)",
         "includeAll": true,
         "multi": true,
         "name": "cluster",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(cluster)",
+          "query": "label_values({cluster=~\"$cluster_group\"}, cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "type": "query"
       },

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1457,6 +1457,18 @@ func (u *Upstream) detectFeatures(ctx context.Context) error {
 		u.networkId.Store(util.EvmNetworkId(cfg.Evm.ChainId))
 		u.chainIdValidated.Store(true)
 
+		// Arm chain-identity enforcement on clients that support it (the gRPC
+		// BDS client asserts this chainId on every request and keeps verifying
+		// its connections). Clients constructed from a configured chainId are
+		// armed at construction already; this covers the auto-detected case
+		// (config chainId 0), where the chain is only known now. No request
+		// can route to this upstream before detection completes — its
+		// networkId is derived from the chainId — so enforcement is in place
+		// for every served request.
+		if armer, ok := u.Client.(interface{ SetExpectedChainId(uint64) }); ok {
+			armer.SetExpectedChainId(uint64(realChainID))
+		}
+
 		// @deprecated: NodeType-specific logic removed; availability is handled by blockAvailability bounds.
 
 		// TODO evm: check trace methods availability (by engine? erigon/geth/etc)


### PR DESCRIPTION
## Why

A gRPC BDS endpoint can silently become **cross-wired**: a DNS record or load balancer briefly pointing at another chain's server (stale records, reused addresses behind `dns:///` targets). Today nothing on the request path detects this — chainId is validated once at upstream bootstrap through one pooled connection, so a later cross-wire serves another chain's heads and data until the connection happens to break. #976 makes the tracker recover from a bogus head sample; this PR prevents bogus heads/data from being accepted at all, and bounds how long any stale connection can live.

## What

**Per-request chain assertion** — the client stamps its configured `chainId` into every BDS request that carries the optional field (`GetBlockByNumber/ByHash`, `GetLogs`, `GetTransactionByHash/Receipt`, `GetBlockReceipts`, all `Query*`). Chain-aware servers reject mismatches per request — atomic, survives mid-connection re-targeting. `eth_chainId` responses are also checked and return an error on mismatch.

**Armed from the very first request, on every path:**
- *configured chainId*: stored in the constructor before the pool exists — the first request ever is stamped;
- *auto-detected chainId (config 0)*: armed in upstream bootstrap right after detection — no request can route earlier (the upstream's networkId derives from the chainId);
- *cache connector*: armed with the probed chainId **before** the client is published into `clientByNetwork` — connector traffic only reaches the client through that map.

**Fail-closed on detection** — the pool maintainer re-verifies the ChainId behind each connection every 60s; a mismatch **closes the connection first** (every in-flight and future RPC on it errors immediately — nothing more can be served even by a server that doesn't validate chainId), then swaps in a verified replacement; a still-closed slot is retried every tick. A *proven* mismatch at pool construction fails the client outright. No new metrics: mismatches log at ERROR and surface as request errors through the existing error tracking.

**Connection max-age** — pooled conns are recycled after 5m (±20% jitter, one age-recycle per tick, 30s linger for in-flight RPCs), so re-resolution keeps conns aligned with current DNS truth.

**Server keepalive** — erpc's own gRPC server sets `MaxConnectionAge 10m + Grace 30s` (+ enforcement policy permitting 30s client pings) so its consumers re-resolve periodically too.

## Notes

- `SetExpectedChainId` is a concrete method on `*GenericGrpcBdsClient` (narrow type assertion at call sites), NOT an addition to the `GrpcBdsClient` interface — existing implementations stay compatible.
- No behavior change for servers that ignore the optional chainId field or clients without a configured/probed chainId (enforcement stays disarmed at 0).
- Dial/verify happen outside the pool lock, so `Pick()` is never blocked behind a probe.

## Validation

`go build ./...` clean; `clients`, `data`, `upstream`, and the erpc bootstrap/query shards pass locally; rebased on #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)