### PR TITLE
fix(evm): pin eth_blockNumber to the majority tip in served-tip mode

### DIFF
--- a/architecture/evm/eth_blockNumber.go
+++ b/architecture/evm/eth_blockNumber.go
@@ -10,12 +10,21 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// networkPostForward_eth_blockNumber enforces the highest-known block on every
-// eth_blockNumber response regardless of its source — a live upstream OR the
-// cache. It compares the returned block number against the network's served
-// tip and, when the response is behind, replaces it with the tip. The
-// correction is a pure in-memory synthesis (poller state), never an extra
-// upstream call.
+// networkPostForward_eth_blockNumber enforces the network's served tip on
+// every eth_blockNumber response regardless of its source — a live upstream OR
+// the cache. The correction is a pure in-memory synthesis (poller state),
+// never an extra upstream call.
+//
+// In the default max mode the served tip is the MAX head across upstreams, so
+// the enforcement is floor-only: a response behind the tip is raised to it and
+// a response at/above it is fresher truth that passes through. In majority
+// served-tip mode (EvmServedTipConfig.EnabledFor "latest") the response is
+// pinned to the tip EXACTLY — above-tip responses are capped too — because
+// "latest" interpolation (resolveBlockTagToHex) anchors block-tagged methods
+// (eth_call, eth_getLogs, ...) to that same majority tip: letting a fresher
+// head, or a cache entry written from one, through the floor-only check makes
+// clients observe eth_blockNumber AHEAD of the block "latest" actually
+// executes at, even when the same upstream serves both calls.
 //
 // Positioning this at the network post-forward layer (it used to be a project
 // pre-forward wrapper that explicitly skipped FromCache responses) is what
@@ -68,12 +77,39 @@ func networkPostForward_eth_blockNumber(ctx context.Context, network common.Netw
 		)
 	}
 
-	if highestBlock <= blockNumber {
+	if highestBlock <= 0 {
+		// Unknown tip (pollers cold, all upstreams syncing): fail open like
+		// resolveBlockTagToHex — never synthesize a block number from nothing.
+		return nr, re
+	}
+
+	pinToTip := false
+	if cfg := network.Config(); cfg != nil && cfg.Evm != nil {
+		pinToTip = cfg.Evm.ServedTipEnabledFor("latest")
+	}
+	if pinToTip {
+		if blockNumber == highestBlock {
+			return nr, re
+		}
+	} else if highestBlock <= blockNumber {
 		return nr, re
 	}
 
 	ups := nr.Upstream()
-	if ups != nil {
+	if blockNumber > highestBlock {
+		// Pin-down (served-tip mode only): the response is AHEAD of the
+		// majority tip — freshness, not staleness, so the stale-block metric
+		// stays out of it.
+		evt := network.Logger().Debug().
+			Str("method", "eth_blockNumber").
+			Int64("servedTip", highestBlock).
+			Int64("responseBlockNumber", blockNumber).
+			Bool("fromCache", nr.FromCache())
+		if ups != nil {
+			evt = evt.Str("upstreamId", ups.Id())
+		}
+		evt.Msg("response is ahead of the served tip, pinning to the majority tip")
+	} else if ups != nil {
 		telemetry.MetricUpstreamStaleLatestBlock.WithLabelValues(
 			network.ProjectId(),
 			ups.VendorName(),

--- a/architecture/evm/eth_blockNumber_test.go
+++ b/architecture/evm/eth_blockNumber_test.go
@@ -1,0 +1,109 @@
+package evm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Decision matrix for networkPostForward_eth_blockNumber across the two
+// served-tip modes (common.EvmServedTipConfig):
+//
+//	max mode (default): floor only — below-tip responses are raised, at/above
+//	pass through (a response above the last-computed MAX is fresher truth).
+//	majority mode ("latest" in servedTip.enabledFor): pinned EXACTLY — above-tip
+//	responses are capped too, so eth_blockNumber can never run ahead of the
+//	majority tip that "latest" interpolation anchors eth_call & friends to.
+//
+// Both modes fail open on an unknown tip (0) and honor the per-request
+// enforce-highest-block directive.
+func TestNetworkPostForward_EthBlockNumber(t *testing.T) {
+	netWith := func(servedTipLatest bool, tip int64) *testNetwork {
+		evmCfg := &common.EvmNetworkConfig{ChainId: 123}
+		if servedTipLatest {
+			evmCfg.ServedTip = &common.EvmServedTipConfig{EnabledFor: []string{"latest"}}
+		}
+		return &testNetwork{
+			cfg: &common.NetworkConfig{
+				Architecture: common.ArchitectureEvm,
+				Evm:          evmCfg,
+			},
+			highestLatest: tip,
+		}
+	}
+
+	run := func(t *testing.T, network common.Network, enforce bool, respHex string, fromCache bool) (*common.NormalizedResponse, int64) {
+		t.Helper()
+		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`))
+		req.SetDirectives(&common.RequestDirectives{EnforceHighestBlock: enforce})
+		jrr, err := common.NewJsonRpcResponse(1, respHex, nil)
+		require.NoError(t, err)
+		resp := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+		if fromCache {
+			resp.WithFromCache(true)
+		}
+		out, err := networkPostForward_eth_blockNumber(context.Background(), network, req, resp, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		_, bn, err := ExtractBlockReferenceFromResponse(context.Background(), out)
+		require.NoError(t, err)
+		return out, bn
+	}
+
+	t.Run("MaxMode_BelowTipIsRaisedToTip", func(t *testing.T) {
+		_, bn := run(t, netWith(false, 0x1000), true, "0x800", false)
+		assert.Equal(t, int64(0x1000), bn)
+	})
+
+	t.Run("MaxMode_AboveTipPassesThrough", func(t *testing.T) {
+		_, bn := run(t, netWith(false, 0x1000), true, "0x1200", false)
+		assert.Equal(t, int64(0x1200), bn,
+			"in max mode a response above the last-computed max is fresher truth and must never be capped")
+	})
+
+	t.Run("MaxMode_UnknownTipFailsOpen", func(t *testing.T) {
+		_, bn := run(t, netWith(false, 0), true, "0x800", false)
+		assert.Equal(t, int64(0x800), bn)
+	})
+
+	t.Run("ServedTip_BelowTipIsRaisedToTip", func(t *testing.T) {
+		_, bn := run(t, netWith(true, 0x1000), true, "0x800", false)
+		assert.Equal(t, int64(0x1000), bn)
+	})
+
+	t.Run("ServedTip_AtTipPassesThrough", func(t *testing.T) {
+		_, bn := run(t, netWith(true, 0x1000), true, "0x1000", false)
+		assert.Equal(t, int64(0x1000), bn)
+	})
+
+	t.Run("ServedTip_AboveTipIsPinnedToTip", func(t *testing.T) {
+		// The inversion bug: a fresher head passing the floor-only check lets
+		// eth_blockNumber run ahead of the majority tip that "latest"
+		// interpolation anchors eth_call to (on-chain block.number reads then
+		// come back BELOW eth_blockNumber, even via the same upstream).
+		_, bn := run(t, netWith(true, 0x1000), true, "0x1002", false)
+		assert.Equal(t, int64(0x1000), bn,
+			"served-tip mode must cap eth_blockNumber to the majority tip")
+	})
+
+	t.Run("ServedTip_AboveTipCacheHitIsPinnedAndKeepsCacheAttribution", func(t *testing.T) {
+		out, bn := run(t, netWith(true, 0x1000), true, "0x1002", true)
+		assert.Equal(t, int64(0x1000), bn)
+		assert.True(t, out.FromCache(),
+			"the pinned response was synthesized from a cache hit and must keep cache attribution")
+	})
+
+	t.Run("ServedTip_UnknownTipFailsOpen", func(t *testing.T) {
+		_, bn := run(t, netWith(true, 0), true, "0x1002", false)
+		assert.Equal(t, int64(0x1002), bn,
+			"an unknown tip must never pin the response down to a synthesized 0")
+	})
+
+	t.Run("ServedTip_EnforcementDisabledServesRaw", func(t *testing.T) {
+		_, bn := run(t, netWith(true, 0x1000), false, "0x1002", false)
+		assert.Equal(t, int64(0x1002), bn)
+	})
+}

--- a/architecture/evm/eth_getBlockByNumber_test.go
+++ b/architecture/evm/eth_getBlockByNumber_test.go
@@ -13,6 +13,7 @@ import (
 type testNetwork struct {
 	cfg           *common.NetworkConfig
 	finalityState common.DataFinalityState
+	highestLatest int64
 }
 
 func (t *testNetwork) Architecture() common.NetworkArchitecture {
@@ -52,7 +53,7 @@ func (t *testNetwork) Logger() *zerolog.Logger {
 }
 
 func (t *testNetwork) EvmHighestLatestBlockNumber(ctx context.Context) int64 {
-	return 0
+	return t.highestLatest
 }
 
 func (t *testNetwork) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {

--- a/erpc/http_server_blocknumber_servedtip_test.go
+++ b/erpc/http_server_blocknumber_servedtip_test.go
@@ -1,0 +1,134 @@
+package erpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/erpc/erpc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This suite pins eth_blockNumber semantics when the majority served tip is
+// enabled for "latest" (EvmServedTipConfig). In that mode "latest"
+// interpolation (resolveBlockTagToHex) anchors block-tagged methods — eth_call,
+// eth_getLogs, ... — to the majority tip before forwarding, so eth_blockNumber
+// must be pinned to that SAME tip: floor-only enforcement lets a fresher head
+// (or a cache entry written from one) through, and clients observe
+// eth_blockNumber AHEAD of the block "latest" actually executes at (an
+// on-chain block.number read via eth_call comes back BELOW eth_blockNumber,
+// even when the same upstream serves both calls).
+//
+// Topology (shared bni* helpers): rpc1 head 0x800, rpc2 head 0x1000. With two
+// upstreams the majority tip is the LOWER head (evm.PickServedTip: N=2 → the
+// 2nd-highest), so the served tip is 0x800 while rpc2 answers 0x1000.
+
+// bniServedTipConfig is bniConfig (modern, no deprecated integrity block) with
+// the majority served tip enabled for "latest".
+func bniServedTipConfig(withCache bool) *common.Config {
+	cfg := bniConfig(withCache, nil)
+	cfg.Projects[0].Networks[0].Evm.ServedTip = &common.EvmServedTipConfig{EnabledFor: []string{"latest"}}
+	return cfg
+}
+
+// bniServedTipBoot mirrors bniBoot with a caller-chosen upstream order and a
+// wait condition for served-tip mode: max==0x1000 requires rpc2's poller and
+// majority==0x800 requires BOTH pollers, so together they make the tip
+// deterministic before any assertion runs.
+func bniServedTipBoot(t *testing.T, cfg *common.Config, order ...string) (
+	func(body string, headers map[string]string, queryParams map[string]string) (int, map[string]string, string),
+	*Network,
+	func(),
+) {
+	t.Helper()
+	sendRequest, _, _, shutdown, erpcInstance := createServerTestFixtures(cfg, t)
+
+	prj, err := erpcInstance.GetProject("test_project")
+	require.NoError(t, err)
+	policy.OverrideAllForTest(prj.policyEngine, order...)
+
+	ntw, err := prj.GetNetwork(context.Background(), util.EvmNetworkId(123))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		ctx := context.Background()
+		return ntw.evmHighestBlockMax(ctx, false) == bniHealthyHead &&
+			ntw.EvmHighestLatestBlockNumber(ctx) == bniLaggingHead
+	}, 5*time.Second, 50*time.Millisecond,
+		"pollers must learn both heads (majority tip=0x800, max=0x1000) before the scenario starts")
+
+	return sendRequest, ntw, shutdown
+}
+
+func TestHttpServer_EthBlockNumberServedTipPin(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+
+	t.Run("Bug_FreshResponseAboveTipMustBePinnedToServedTip", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		// Fresh upstream first: rpc2 serves 0x1000, above the majority tip.
+		send, _, shutdown := bniServedTipBoot(t, bniServedTipConfig(false), "rpc2", "rpc1")
+		defer shutdown()
+
+		got, _ := bniSend(t, send, nil, nil)
+		assert.Equal(t, bniLaggingHead, got,
+			"eth_blockNumber must be pinned to the majority tip (0x%x) that \"latest\" interpolation uses, not the fresher upstream head (0x%x)",
+			bniLaggingHead, bniHealthyHead)
+	})
+
+	t.Run("Bug_CacheHitAboveTipMustBePinnedToServedTip", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, ntw, shutdown := bniServedTipBoot(t, bniServedTipConfig(true), "rpc2", "rpc1")
+		defer shutdown()
+
+		// A fresh rpc2 response planted in the (possibly shared) cache — the
+		// dominant path in practice: eth_blockNumber is realtime-cached, so
+		// most reads are HITs carrying a value above the majority tip.
+		bniSeedCache(t, ntw, "0x1000")
+
+		got, hdrs := bniSend(t, send, nil, nil)
+		t.Logf("response: block=0x%x cacheHeader=%q", got, hdrs["X-Erpc-Cache"])
+		assert.Equal(t, bniLaggingHead, got,
+			"a cache-hit response above the majority tip must be pinned down just like a fresh response")
+	})
+
+	t.Run("Baseline_ResponseAtServedTipPassesThrough", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		// Lagging upstream first: rpc1 serves 0x800 == the majority tip.
+		send, _, shutdown := bniServedTipBoot(t, bniServedTipConfig(false), "rpc1", "rpc2")
+		defer shutdown()
+
+		got, _ := bniSend(t, send, nil, nil)
+		assert.Equal(t, bniLaggingHead, got)
+	})
+
+	t.Run("Baseline_PerRequestOverrideServesRawValue", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		setupBniPollerMocks()
+		setupBniBlockNumberMocks()
+
+		send, _, shutdown := bniServedTipBoot(t, bniServedTipConfig(false), "rpc2", "rpc1")
+		defer shutdown()
+
+		// enforce-highest-block=false must bypass the pin exactly like it
+		// bypasses max-mode enforcement.
+		got, _ := bniSend(t, send, nil, map[string]string{"enforce-highest-block": "false"})
+		assert.Equal(t, bniHealthyHead, got)
+	})
+}


### PR DESCRIPTION
## Problem

With `servedTip.enabledFor: ["latest"]`, two consumers of the network tip disagree:

- **`"latest"` interpolation** (`resolveBlockTagToHex` → `EvmHighestLatestBlockNumber`) anchors block-tagged methods — `eth_call`, `eth_getLogs`, … — to the **majority tip** before forwarding.
- **`eth_blockNumber` enforcement** (`networkPostForward_eth_blockNumber`) was **floor-only**: `if highestBlock <= blockNumber { return }`. A response from a fresher upstream — or a realtime-cache entry written from one — passed through *above* the majority tip.

So a client pairing `eth_blockNumber` with a `latest` read observes an inversion: an on-chain `block.number` read via `eth_call` comes back **below** `eth_blockNumber`, by roughly the live head-spread across upstreams (1–3 blocks with 4 upstreams). It reproduces even when the *same* upstream serves both calls, because the tip is a network-level majority independent of which upstream answers — and it's amplified by `eth_blockNumber` being realtime-cached (most reads are HITs carrying a fresh head). Single-provider setups never show this, which makes it look like data corruption rather than a consistency-mode artifact.

## Fix

In majority served-tip mode, the post-forward hook now pins `eth_blockNumber` to **exactly** the majority tip:

- **above-tip** responses (fresher upstream head, or a cache entry written from one) are capped down — new behavior;
- **below-tip** responses are raised, as before;
- **default max mode is unchanged** (floor-only — a response above the last-computed MAX is fresher truth and must never be capped);
- **unknown tip (`0`) fails open** in both modes, matching `resolveBlockTagToHex` — never synthesize a block number from nothing;
- the pin-down path logs without incrementing `erpc_upstream_stale_latest_block` (the response is fresh, not stale);
- per-request `enforce-highest-block=false` still bypasses enforcement entirely.

The deliberate trade this mode already makes (consistency over freshness) now applies uniformly: `eth_blockNumber` sits at the same majority tip that `latest` execution actually uses, instead of running ahead of it.

## Tests

- `architecture/evm/eth_blockNumber_test.go` — decision matrix for the hook across both modes: floor-only vs exact-pin, unknown-tip fail-open, cache-attribution preservation, directive override.
- `erpc/http_server_blocknumber_servedtip_test.go` — full HTTP server + real cache + real pollers (reusing the `bni*` fixtures): fresh above-tip response pinned, cache-hit above-tip pinned, at-tip pass-through, per-request override.

Both `Bug_*` HTTP subtests and the two `ServedTip_AboveTip*` unit cases fail against the previous hook (verified red before the fix) and pass with it; the pre-existing `TestHttpServer_EthBlockNumberIntegrity` and `TestServedTip_*` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-visible `eth_blockNumber` semantics in served-tip mode (including cached responses); scope is limited to that config path with explicit tests and unchanged default max behavior.
> 
> **Overview**
> When **`servedTip.enabledFor` includes `"latest"`**, `eth_blockNumber` post-forward enforcement now **pins the result to the majority served tip exactly**, not only as a floor. Fresher upstream heads and realtime-cache hits above that tip are **capped** so `eth_blockNumber` cannot run ahead of the same tip used for **`"latest"`** on `eth_call`, `eth_getLogs`, etc.
> 
> **Default max mode is unchanged** (floor-only; above-max responses still pass through). **Unknown tip (`0`)** fails open in both modes. Pin-down skips the stale-block metric; **`enforce-highest-block=false`** still bypasses enforcement.
> 
> Adds a **unit decision-matrix** for `networkPostForward_eth_blockNumber` and **HTTP integration tests** (fresh vs cache above-tip, baselines, override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85cd1e63bfcb5d38039d0485d4695dc94087904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->