### PR TITLE
fix: retry trace/debug "insufficient funds" toward the network

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -349,7 +349,7 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 
 		if strings.Contains(msg, "insufficient funds") ||
 			strings.Contains(msg, "insufficient balance") {
-			return common.NewErrEndpointExecutionException(
+			execErr := common.NewErrEndpointExecutionException(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),
 					common.JsonRpcErrorTransactionRejected,
@@ -358,6 +358,23 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 					details,
 				),
 			)
+			// Tracing methods (trace_*, debug_*, eth_trace*) re-execute historical
+			// transactions against the parent block's pre-state. An "insufficient
+			// funds" reply there is a state-reconstruction artifact: the transaction
+			// was mined, so it provably had funds; the tracer simply could not resolve
+			// the exact pre-state. Another upstream that holds the state (e.g. an
+			// archive node) usually traces the same block, so retry toward the network.
+			// Writes (eth_sendRawTransaction) and live simulations (eth_call /
+			// eth_estimateGas) remain deterministic and non-retried.
+			if nr != nil && nr.Request() != nil {
+				if m, _ := nr.Request().Method(); strings.HasPrefix(m, "trace_") ||
+					strings.HasPrefix(m, "debug_") || strings.HasPrefix(m, "eth_trace") {
+					if re, ok := execErr.(common.RetryableError); ok {
+						return re.WithRetryableTowardNetwork(true)
+					}
+				}
+			}
+			return execErr
 		}
 
 		//----------------------------------------------------------------

--- a/architecture/evm/error_normalizer_test.go
+++ b/architecture/evm/error_normalizer_test.go
@@ -55,3 +55,82 @@ func TestExtractJsonRpcError_RequestTooLargeNormalization(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractJsonRpcError_InsufficientFunds_TracingMethodsRetryable verifies that
+// "insufficient funds"/"insufficient balance" replies are retried toward the network
+// for tracing methods (trace_*, debug_*, eth_trace*). For those methods the error is a
+// state-reconstruction artifact (the traced transaction was mined, so it provably had
+// funds; the tracer could not resolve the exact pre-state), and another upstream that
+// holds the state typically traces the same block. Writes (eth_sendRawTransaction) and
+// live simulations (eth_call) stay deterministic and non-retried.
+func TestExtractJsonRpcError_InsufficientFunds_TracingMethodsRetryable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		method        string
+		message       string
+		wantRetryable bool
+	}{
+		{
+			name:          "trace_block insufficient funds is retried toward network",
+			method:        "trace_block",
+			message:       "txIndex 2: insufficient funds for gas * price + value: address 0xD9F2 have 22995378262500 want 123605240381889",
+			wantRetryable: true,
+		},
+		{
+			name:          "debug_traceTransaction insufficient balance is retried",
+			method:        "debug_traceTransaction",
+			message:       "insufficient balance",
+			wantRetryable: true,
+		},
+		{
+			name:          "eth_traceBlock insufficient funds is retried (eth_trace prefix)",
+			method:        "eth_traceBlock",
+			message:       "insufficient funds for gas * price + value",
+			wantRetryable: true,
+		},
+		{
+			name:          "eth_sendRawTransaction insufficient funds stays non-retried",
+			method:        "eth_sendRawTransaction",
+			message:       "insufficient funds for gas * price + value",
+			wantRetryable: false,
+		},
+		{
+			name:          "eth_call insufficient funds stays non-retried (live simulation)",
+			method:        "eth_call",
+			message:       "insufficient funds for gas * price + value",
+			wantRetryable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := common.NewNormalizedRequest([]byte(
+				`{"jsonrpc":"2.0","method":"` + tc.method + `","params":[],"id":1}`))
+			nr := common.NewNormalizedResponse().WithRequest(req)
+
+			r := &http.Response{StatusCode: 200, Header: http.Header{}}
+			jrErr := common.NewErrJsonRpcExceptionExternal(
+				int(common.JsonRpcErrorCallException),
+				tc.message,
+				"",
+			)
+			jr := common.MustNewJsonRpcResponse(1, nil, jrErr)
+
+			err := ExtractJsonRpcError(r, nr, jr, nil)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !common.HasErrorCode(err, common.ErrCodeEndpointExecutionException) {
+				t.Fatalf("expected ErrEndpointExecutionException, got %T: %v", err, err)
+			}
+			if got := common.IsRetryableTowardNetwork(err); got != tc.wantRetryable {
+				t.Fatalf("IsRetryableTowardNetwork: got %v, want %v (method=%s)", got, tc.wantRetryable, tc.method)
+			}
+		})
+	}
+}

--- a/docs/pages/reference/errors.mdx
+++ b/docs/pages/reference/errors.mdx
@@ -280,7 +280,7 @@ Entry point: <SourceLink file="architecture/evm/error_normalizer.go" lines="20" 
 | 10 | "EVM error: InvalidJump" (Berachain) | `ErrEndpointExecutionException` | 3 | no | no (yes for `eth_sendRawTransaction`) |
 | 11 | Duplicate-tx: "already known", "tx already in mempool", "transaction already exists", etc. — **must precede rule 14** | `ErrEndpointNonceException` (`already_known`) | −32003 | yes | no |
 | 12 | Nonce conflict: "nonce too low", "nonce has already been used" | `ErrEndpointNonceException` (`nonce_too_low`) | −32003 | yes | no |
-| 13 | "insufficient funds", "insufficient balance" — **no** `eth_sendRawTransaction` override | `ErrEndpointExecutionException` | −32003 | no | no |
+| 13 | "insufficient funds", "insufficient balance" | `ErrEndpointExecutionException` | −32003 | no | yes (`trace_*`/`debug_*`/`eth_trace*` only — state-reconstruction artifact; non-retried for writes & live simulations) |
 | 14 | code == −32003, "out of gas", "gas too low", "IntrinsicGas" | `ErrEndpointExecutionException` | −32003 | no | no (yes for `eth_sendRawTransaction`) |
 | 15a | "not found"/"not available" AND ("Method"\|"module") | `ErrEndpointUnsupported` | −32601 | no | yes |
 | 15b | same outer AND ("header"\|"block"\|"transaction"\|"state") | `ErrEndpointMissingData` | −32014 | yes | yes |


### PR DESCRIPTION
## Problem

`trace_block` and other tracing methods can return `"insufficient funds for gas * price + value"` for a transaction that was **mined** in the traced block — i.e. it provably had funds at execution time. This is a **state-reconstruction artifact**: tracing re-executes historical transactions against the parent block's pre-state, and when a node can't fully materialize that state trie it computes a wrong/zero balance and emits `insufficient funds`.

The error is transient **across nodes** — an upstream that holds the state (e.g. an archive node, or a fresh full node) traces the same block correctly. But eRPC currently returns it to the client with `attempts: 1, retries: 0, hedges: 0` — no failover.

## Root cause

`ExtractJsonRpcError` classifies `"insufficient funds"` / `"insufficient balance"` as `ErrEndpointExecutionException` with `retryableTowardNetwork: false` for **all** methods. That `false` propagates into both failover gates:

- `network_executor.shouldRetryWithReason` returns `""` for a non-retriable execution exception → **no retry**.
- `network_executor.runHedge`'s `keep(err)` returns `!IsRetryableTowardNetwork(err)` = `true` → the hedge race **stops on the error**, cancelling in-flight siblings.

So no `retry` / `hedge` / `consensus` policy can recover it — the classification is terminal. PR #834 introduced this branch with the correct intent ("non-retriable **for `eth_sendRawTransaction`**"), but the implementation dropped the method guard, making it non-retriable for every method.

## Fix

Scope retryability to tracing methods (`trace_*`, `debug_*`, `eth_trace*`), mirroring the method-aware pattern already used by the adjacent "out of gas" / "Transaction rejected" branch. Writes (`eth_sendRawTransaction`) and live simulations (`eth_call` / `eth_estimateGas`) keep the deterministic, non-retried behavior — for those, `insufficient funds` is a real result, not a reconstruction artifact.

## Test coverage

- New `TestExtractJsonRpcError_InsufficientFunds_TracingMethodsRetryable` (table-driven): `trace_block` / `debug_traceTransaction` / `eth_traceBlock` → retryable toward network; `eth_sendRawTransaction` / `eth_call` → non-retried.
- Existing `TestNetwork_SendRawTransaction_Idempotency/InsufficientFundsIsNotRetriedAcrossUpstreams` still passes (#834 behavior preserved).
- `docs/pages/reference/errors.mdx` error-classification table updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to EVM error normalization and retry flags; writes and live simulations are explicitly excluded, with tests locking in both paths.
> 
> **Overview**
> **Tracing `trace_*` / `debug_*` / `eth_trace*` requests that return "insufficient funds" or "insufficient balance" are now classified as network-retryable** in `ExtractJsonRpcError`, so eRPC can fail over to another upstream (e.g. an archive node) instead of stopping after one attempt.
> 
> The change treats those replies as state-reconstruction artifacts when re-executing mined transactions, not as real balance failures. **`eth_sendRawTransaction`, `eth_call`, and `eth_estimateGas` keep the prior behavior** — insufficient funds stays non-retried as a deterministic execution result.
> 
> Adds table-driven coverage in `error_normalizer_test.go` and updates rule 13 in `docs/pages/reference/errors.mdx` for the method-scoped retry flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad9b9fc1f23d4eeb63ca84911fec827ac20395f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->