### PR TITLE
fix(upstream): force-poll tip before rejecting on a stale configured upper bound

### DIFF
--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -999,21 +999,36 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 		return false, nil
 	}
 	if maxBound != math.MaxInt64 && blockNumber > maxBound {
-		telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
-			u.ProjectId,
-			u.VendorName(),
-			u.NetworkLabel(),
-			u.Id(),
-			forMethod,
-			confidence.String(),
-		).Inc()
-		u.logger.Debug().
-			Int64("blockNumber", blockNumber).
-			Int64("maxBound", maxBound).
-			Str("method", forMethod).
-			Str("upstreamId", u.config.Id).
-			Msg("block rejected: above upper availability bound")
-		return false, nil
+		// Freshness escape: a configured upper bound derived from the state
+		// poller's last-known latest can lag the network tip on fast chains (the
+		// bound refreshes only every statePollerInterval). When the caller asks
+		// for fresh data, force-poll the tip once and recompute before rejecting
+		// — mirroring the legacy blockHead path below. Only the upper bound is
+		// re-evaluated; lower bounds can only tighten as latest advances.
+		if forceFreshIfStale && u.evmStatePoller != nil && !u.evmStatePoller.IsObjectNull() {
+			if freshLatest, err := u.evmStatePoller.PollLatestBlockNumber(ctx); err == nil && freshLatest > 0 {
+				if freshMin, freshMax := u.resolveAvailabilityBoundsWithLatest(freshLatest); freshMax != maxBound {
+					minBound, maxBound = freshMin, freshMax
+				}
+			}
+		}
+		if blockNumber > maxBound {
+			telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
+				u.ProjectId,
+				u.VendorName(),
+				u.NetworkLabel(),
+				u.Id(),
+				forMethod,
+				confidence.String(),
+			).Inc()
+			u.logger.Debug().
+				Int64("blockNumber", blockNumber).
+				Int64("maxBound", maxBound).
+				Str("method", forMethod).
+				Str("upstreamId", u.config.Id).
+				Msg("block rejected: above upper availability bound")
+			return false, nil
+		}
 	}
 
 	switch confidence {
@@ -1104,6 +1119,13 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 // resolveAvailabilityBounds computes effective [min,max] based on BlockAvailabilityConfig.
 // Returns MinInt64/MaxInt64 when a side is unbounded.
 func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
+	return u.resolveAvailabilityBoundsWithLatest(0)
+}
+
+// resolveAvailabilityBoundsWithLatest is the core resolver. When latest > 0 it
+// is used as the state poller's latest block instead of the cached value, so a
+// force-polled tip can recompute bounds without mutating poller state.
+func (u *Upstream) resolveAvailabilityBoundsWithLatest(latest int64) (int64, int64) {
 	cfg := u.Config()
 	if cfg == nil || cfg.Evm == nil {
 		return math.MinInt64, math.MaxInt64
@@ -1112,8 +1134,7 @@ func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
 	// MaxAvailableRecentBlocks is set, treat lower bound as latest - N.
 	if cfg.Evm.BlockAvailability == nil {
 		if cfg.Evm.MaxAvailableRecentBlocks > 0 {
-			latest := int64(0)
-			if u.evmStatePoller != nil {
+			if latest == 0 && u.evmStatePoller != nil {
 				latest = u.evmStatePoller.LatestBlock()
 			}
 			if latest > 0 {
@@ -1122,7 +1143,11 @@ func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
 		}
 		return math.MinInt64, math.MaxInt64
 	}
-	latest := int64(0)
+	// latest carries an optional override (force-polled tip) into the compute
+	// closure; when 0 the closure falls back to the cached poller value.
+	if latest == 0 && u.evmStatePoller != nil {
+		latest = u.evmStatePoller.LatestBlock()
+	}
 
 	compute := func(bound *common.EvmAvailabilityBoundConfig, isLower bool) int64 {
 		if bound == nil {

--- a/upstream/upstream_block_availability_test.go
+++ b/upstream/upstream_block_availability_test.go
@@ -883,6 +883,107 @@ func TestEvmAssertBlockAvailability_ConcurrentAccess(t *testing.T) {
 	})
 }
 
+// TestEvmAssertBlockAvailability_ConfiguredUpperBoundFreshnessEscape covers the
+// freshness escape for a configured blockAvailability.upper bound. On fast
+// chains the bound (derived from the state poller's last-known latest) lags the
+// network tip; when forceFreshIfStale is set, a just-rejected block should be
+// re-evaluated after force-polling the tip once.
+func TestEvmAssertBlockAvailability_ConfiguredUpperBoundFreshnessEscape(t *testing.T) {
+	zero := int64(0)
+
+	newUpstream := func(poller common.EvmStatePoller) *Upstream {
+		return &Upstream{
+			config: &common.UpstreamConfig{
+				Type: common.UpstreamTypeEvm,
+				Evm: &common.EvmUpstreamConfig{
+					BlockAvailability: &common.EvmBlockAvailabilityConfig{
+						Upper: &common.EvmAvailabilityBoundConfig{
+							LatestBlockMinus: &zero,
+						},
+					},
+				},
+			},
+			logger:         &zerolog.Logger{},
+			evmStatePoller: poller,
+		}
+	}
+
+	t.Run("forceFresh recovers tip block when poller is stale", func(t *testing.T) {
+		// Cached latest is 1000; a force-poll advances the tip to 1003.
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:      1000,
+			finalizedBlock:   900,
+			blockProgression: []int64{1003},
+		}
+		u := newUpstream(poller)
+
+		// Block 1003 is beyond the cached bound (1000) but the force-poll
+		// discovers it, so the request is admitted.
+		canHandle, err := u.EvmAssertBlockAvailability(context.Background(), "eth_getBlockReceipts", common.AvailbilityConfidenceBlockHead, true, 1003)
+		assert.NoError(t, err)
+		assert.True(t, canHandle, "forceFresh should re-evaluate the upper bound after polling the tip")
+	})
+
+	t.Run("without forceFresh a stale bound rejects the tip", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:    1000,
+			finalizedBlock: 900,
+		}
+		u := newUpstream(poller)
+
+		canHandle, err := u.EvmAssertBlockAvailability(context.Background(), "eth_getBlockReceipts", common.AvailbilityConfidenceBlockHead, false, 1003)
+		assert.NoError(t, err)
+		assert.False(t, canHandle, "a stale cached bound should reject a tip block when forceFresh is not requested")
+	})
+
+	t.Run("forceFresh does not over-admit past the fresh tip", func(t *testing.T) {
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:      1000,
+			finalizedBlock:   900,
+			blockProgression: []int64{1003},
+		}
+		u := newUpstream(poller)
+
+		// 1004 is beyond even the fresh tip; it must still be rejected.
+		canHandle, err := u.EvmAssertBlockAvailability(context.Background(), "eth_getBlockReceipts", common.AvailbilityConfidenceBlockHead, true, 1004)
+		assert.NoError(t, err)
+		assert.False(t, canHandle)
+	})
+
+	t.Run("forceFresh honors an explicit LatestBlockMinus margin", func(t *testing.T) {
+		minus := int64(2)
+		poller := &mockEvmStatePollerEnhanced{
+			latestBlock:      1000,
+			finalizedBlock:   900,
+			blockProgression: []int64{1003},
+		}
+		u := &Upstream{
+			config: &common.UpstreamConfig{
+				Type: common.UpstreamTypeEvm,
+				Evm: &common.EvmUpstreamConfig{
+					BlockAvailability: &common.EvmBlockAvailabilityConfig{
+						Upper: &common.EvmAvailabilityBoundConfig{
+							LatestBlockMinus: &minus,
+						},
+					},
+				},
+			},
+			logger:         &zerolog.Logger{},
+			evmStatePoller: poller,
+		}
+
+		// Fresh tip 1003 with a 2-block margin admits up to 1001.
+		canHandle, err := u.EvmAssertBlockAvailability(context.Background(), "eth_getBlockReceipts", common.AvailbilityConfidenceBlockHead, true, 1001)
+		assert.NoError(t, err)
+		assert.True(t, canHandle)
+
+		// 1002 is within the fresh tip but past the 2-block margin.
+		canHandle, err = u.EvmAssertBlockAvailability(context.Background(), "eth_getBlockReceipts", common.AvailbilityConfidenceBlockHead, true, 1002)
+		assert.NoError(t, err)
+		assert.False(t, canHandle)
+	})
+}
+
 // TestEvmEffectiveLatestBlock tests the EvmEffectiveLatestBlock method
 // which returns latest block adjusted for the upper availability bound.
 func TestEvmEffectiveLatestBlock(t *testing.T) {


### PR DESCRIPTION
## Problem

A configured `blockAvailability.upper` bound is derived from the state poller's last-known latest block, which refreshes only once per `statePollerInterval`. On fast-producing chains the cached bound can lag the network tip, so a request for a freshly-produced block is rejected **before forwarding** — even though the upstream already has the data. The selection layer never sees the request and a different upstream serves it instead.

The legacy `blockHead` confidence path already guards against this with a **force-poll-once** escape when `forceFreshIfStale` is set (`upstream.go`, *"if the requested block is beyond the current latest block, it will force-poll the latest block number once"*). That escape was unreachable once a configured upper bound short-circuited the check first:

```go
minBound, maxBound := u.resolveAvailabilityBounds()
// ...
if maxBound != math.MaxInt64 && blockNumber > maxBound {
    // immediately returns false — never reaches the force-poll below
    return false, nil
}
```

## Change

Extend the same freshness escape to the configured-bound path: when the bound rejects and `forceFreshIfStale` is set, poll the tip once, recompute the bound, and re-evaluate before rejecting.

- Refactor `resolveAvailabilityBounds` → `resolveAvailabilityBoundsWithLatest(latest)` so the recomputation uses the freshly-polled tip without mutating poller state.
- Only the **upper** bound is re-evaluated. Lower bounds derived from `latest` can only *tighten* as `latest` advances, so re-polling them would never admit a previously-rejected block.
- When the fresh bound still rejects, behavior is unchanged (metric incremented, `false, nil`).
- The poll is best-effort: on error or a non-positive result the original stale bound decides, so a transient poll failure degrades to the prior behavior rather than failing the request.

## Tests

New `TestEvmAssertBlockAvailability_ConfiguredUpperBoundFreshnessEscape`:
- `forceFresh` recovers a tip block the cached bound rejects
- without `forceFresh`, the stale bound still rejects (no behavior change)
- `forceFresh` does not over-admit past the fresh tip
- an explicit `LatestBlockMinus` margin is honored after the re-poll

Full `./upstream/` suite and the `./erpc/` availability/race tests pass.

## Risk

Minimal. The new code path runs only when (a) a configured upper bound is present and (b) the caller passed `forceFreshIfStale=true`. The no-config / no-forceFresh paths are byte-for-byte unchanged. Worst case on a poll failure is the previous stale-bound behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow new path (configured upper bound + forceFreshIfStale); poll errors degrade to existing reject behavior with no new failure modes for default callers.
> 
> **Overview**
> Fixes **false upstream skips** when `blockAvailability.upper` is derived from a **stale** state-poller latest on fast chains: requests for the real tip were rejected before forward, so selection never tried that upstream.
> 
> When a block fails the configured **upper** bound and the caller sets **`forceFreshIfStale`**, `EvmAssertBlockAvailability` now **polls latest once**, recomputes bounds via new **`resolveAvailabilityBoundsWithLatest(latest)`** (optional tip override without mutating poller cache), and only then rejects—matching the existing blockHead freshness escape that configured bounds used to short-circuit.
> 
> Paths without a configured upper bound or without `forceFreshIfStale` are unchanged; poll failures keep the prior stale-bound behavior. Tests cover recovery at tip, no over-admission, and `LatestBlockMinus` margins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74a94978ed3dddd1405da6a8f9958be3e440d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->