### PR TITLE
feat(grpc): implement BDS StreamService.StreamBlocks (event-driven, poller-backed)

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -505,6 +505,20 @@ func (e *EvmStatePoller) LatestBlock() int64 {
 	return e.latestBlockShared.GetValue()
 }
 
+// OnLatestBlock registers cb to fire on every forward advance of the latest block
+// number, regardless of source — a proactive poll, a SuggestLatestBlock
+// write-through from request traffic, or cross-node propagation of the shared
+// counter all flow through the same callback.
+//
+// IMPORTANT: cb runs synchronously inside the shared-variable update path, so it
+// MUST NOT block (do a non-blocking hand-off and return). Callbacks cannot be
+// unregistered, so register once per long-lived consumer, never per request.
+func (e *EvmStatePoller) OnLatestBlock(cb func(int64)) {
+	if e.latestBlockShared != nil {
+		e.latestBlockShared.OnValue(cb)
+	}
+}
+
 // verifyChainIdOnMajorHeadMove gates a polled head sample that moved beyond
 // the shared rollback tolerance (in either direction) behind a fresh chain
 // identity check. Such moves are exactly what a cross-wired endpoint — a DNS

--- a/erpc/block_stream.go
+++ b/erpc/block_stream.go
@@ -1,0 +1,223 @@
+package erpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/blockchain-data-standards/manifesto/evm"
+	"github.com/bytedance/sonic"
+	"github.com/erpc/erpc/common"
+)
+
+// blockStreamMaxBackfill bounds how many blocks a single advance may backfill.
+// A live subscriber is at most a few blocks behind, so a larger gap means a cold
+// start (head still 0 / just observed) or a >tolerance deep reorg — in either
+// case we resync to the current head rather than replay a long (or historical)
+// range down a live tip stream. Reorg-correct replay is ChainView's job.
+const blockStreamMaxBackfill = 256
+
+// blockStreamManager owns one long-lived head-watch hub per (project, network).
+// It is the reorg-unaware, poller-backed implementation of the head feed the
+// StreamBlocks handler consumes; ChainView will later provide the same head
+// signal (gap-free, reorg-aware) behind this same seam without touching the
+// handler.
+type blockStreamManager struct {
+	mu   sync.Mutex
+	hubs map[string]*blockStreamHub
+}
+
+func newBlockStreamManager() *blockStreamManager {
+	return &blockStreamManager{hubs: make(map[string]*blockStreamHub)}
+}
+
+// hubFor returns the hub for a network, creating it (and wiring its head callback
+// onto the network's upstream pollers) exactly once. The callback registration is
+// permanent — OnLatestBlock cannot be undone — so it must happen once per network,
+// not per subscriber, which is why the hub is cached here.
+func (m *blockStreamManager) hubFor(ctx context.Context, network *Network) *blockStreamHub {
+	key := network.projectId + "/" + network.networkId
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if h, ok := m.hubs[key]; ok {
+		return h
+	}
+
+	h := &blockStreamHub{subs: make(map[*blockStreamSub]struct{})}
+	// Wire the hub onto every upstream's latest-block callback and seed the head
+	// with the highest value any of them already observed. The head is the max
+	// across upstreams; advance() merges the independent callbacks monotonically.
+	for _, up := range network.upstreamsRegistry.GetNetworkUpstreams(ctx, network.networkId) {
+		sp := up.EvmStatePoller()
+		if sp == nil || sp.IsObjectNull() {
+			continue
+		}
+		if v := sp.LatestBlock(); v > h.head.Load() {
+			h.head.Store(v)
+		}
+		if reg, ok := sp.(interface{ OnLatestBlock(func(int64)) }); ok {
+			reg.OnLatestBlock(h.advance)
+		}
+	}
+	m.hubs[key] = h
+	return h
+}
+
+// blockStreamHub fans a network's head advances out to its live subscribers.
+type blockStreamHub struct {
+	head atomic.Int64
+
+	mu   sync.Mutex
+	subs map[*blockStreamSub]struct{}
+}
+
+// blockStreamSub is one subscriber's edge-triggered wake-up. The channel is
+// buffered(1) and sends are non-blocking, so a burst of advances coalesces into a
+// single pending signal; the subscriber then reads the current head and catches up.
+type blockStreamSub struct {
+	ch chan struct{}
+}
+
+// advance records a new head and wakes subscribers. It runs synchronously inside
+// the poller's shared-variable update path, so it only does a monotonic CAS and
+// non-blocking sends — never any blocking work.
+func (h *blockStreamHub) advance(v int64) {
+	for {
+		cur := h.head.Load()
+		if v <= cur {
+			return
+		}
+		if h.head.CompareAndSwap(cur, v) {
+			break
+		}
+	}
+
+	h.mu.Lock()
+	for s := range h.subs {
+		select {
+		case s.ch <- struct{}{}:
+		default:
+		}
+	}
+	h.mu.Unlock()
+}
+
+func (h *blockStreamHub) subscribe() *blockStreamSub {
+	s := &blockStreamSub{ch: make(chan struct{}, 1)}
+	h.mu.Lock()
+	h.subs[s] = struct{}{}
+	h.mu.Unlock()
+	return s
+}
+
+func (h *blockStreamHub) unsubscribe(s *blockStreamSub) {
+	h.mu.Lock()
+	delete(h.subs, s)
+	h.mu.Unlock()
+}
+
+// ProcessBlockStream subscribes to the network's head and pushes one header per
+// new block, in ascending order, until ctx is done. It backfills every number
+// between advances so no block number is skipped (forward-only — a reorg that
+// replaces an already-sent number is not corrected here; see blockStreamMaxBackfill
+// and the ChainView follow-up).
+func (rp *RequestProcessor) ProcessBlockStream(
+	ctx context.Context,
+	input *RequestInput,
+	onBlock func(*evm.BlockHeader) error,
+) error {
+	project, err := rp.erpc.GetProject(input.ProjectId)
+	if err != nil {
+		return err
+	}
+	networkID := fmt.Sprintf("%s:%s", input.Architecture, input.ChainId)
+	network, err := project.GetNetwork(ctx, networkID)
+	if err != nil {
+		return err
+	}
+
+	// Authenticate once up front so an unauthorized subscriber is rejected
+	// immediately rather than holding a subscription until the next block; each
+	// header fetch below re-checks through the normal request path.
+	nq := common.NewNormalizedRequestFromJsonRpcRequest(
+		common.NewJsonRpcRequest("eth_getBlockByNumber", []interface{}{}),
+	)
+	nq.SetClientIP(input.ClientIP)
+	if _, err := project.AuthenticateConsumer(ctx, nq, "eth_getBlockByNumber", input.AuthPayload); err != nil {
+		return err
+	}
+
+	hub := rp.blockStream.hubFor(ctx, network)
+	sub := hub.subscribe()
+	defer hub.unsubscribe(sub)
+
+	// Tip subscription: start from the current head and emit only strictly-new
+	// blocks (never backfill history for a fresh subscriber).
+	lastSent := hub.head.Load()
+	for {
+		select {
+		case <-ctx.Done():
+			// Client cancelled / disconnected — a clean end of stream, not an error.
+			return nil
+		case <-sub.ch:
+			head := hub.head.Load()
+			if lastSent == 0 || head-lastSent > blockStreamMaxBackfill {
+				// Cold start or a gap too large to be a live tail — resync forward.
+				lastSent = head
+				continue
+			}
+			for n := lastSent + 1; n <= head; n++ {
+				header, err := rp.fetchBlockHeader(ctx, input, n)
+				if err != nil {
+					return err
+				}
+				if header == nil {
+					// Head advanced but this block isn't retrievable yet; leave
+					// lastSent behind it and retry on the next advance.
+					break
+				}
+				if err := onBlock(header); err != nil {
+					return err
+				}
+				lastSent = n
+			}
+		}
+	}
+}
+
+// fetchBlockHeader resolves one block's header through the normal cached request
+// path (eth_getBlockByNumber, hashes-only). Concurrent identical fetches across
+// subscribers are coalesced by erpc, so a shared head yields ~one upstream call
+// per block. Returns (nil, nil) when the block is not yet available.
+func (rp *RequestProcessor) fetchBlockHeader(
+	ctx context.Context,
+	input *RequestInput,
+	blockNumber int64,
+) (*evm.BlockHeader, error) {
+	resp, err := rp.ProcessUnary(
+		ctx,
+		input,
+		buildJSONRPCRequest("eth_getBlockByNumber", []interface{}{fmt.Sprintf("0x%x", blockNumber), false}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	result, err := parseJSONRPCResult(ctx, resp)
+	if err != nil {
+		return nil, err
+	}
+	if string(result) == "null" {
+		return nil, nil
+	}
+	var block evm.JsonRpcBlock
+	if err := sonic.Unmarshal(result, &block); err != nil {
+		return nil, err
+	}
+	protoBlock, err := block.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	return protoBlock.Header, nil
+}

--- a/erpc/block_stream_test.go
+++ b/erpc/block_stream_test.go
@@ -1,0 +1,102 @@
+package erpc
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestHub() *blockStreamHub {
+	return &blockStreamHub{subs: make(map[*blockStreamSub]struct{})}
+}
+
+func TestBlockStreamHub_AdvanceMonotonicAndSignals(t *testing.T) {
+	h := newTestHub()
+	sub := h.subscribe()
+
+	h.advance(100)
+	if got := h.head.Load(); got != 100 {
+		t.Fatalf("head = %d, want 100", got)
+	}
+	select {
+	case <-sub.ch:
+	default:
+		t.Fatal("expected a wake signal after advance to 100")
+	}
+
+	// A lower value is ignored (head is monotonic) and produces no signal.
+	h.advance(50)
+	if got := h.head.Load(); got != 100 {
+		t.Fatalf("head after rollback = %d, want 100 (monotonic)", got)
+	}
+	select {
+	case <-sub.ch:
+		t.Fatal("did not expect a signal for a non-advancing head")
+	default:
+	}
+
+	h.advance(101)
+	if got := h.head.Load(); got != 101 {
+		t.Fatalf("head = %d, want 101", got)
+	}
+	select {
+	case <-sub.ch:
+	default:
+		t.Fatal("expected a wake signal after forward advance to 101")
+	}
+}
+
+func TestBlockStreamHub_AdvanceIsNonBlocking(t *testing.T) {
+	h := newTestHub()
+	_ = h.subscribe() // deliberately never drained
+
+	// advance runs inside the poller's synchronous update path: buffered(1) +
+	// non-blocking send means a burst against an undrained subscriber must never
+	// block.
+	done := make(chan struct{})
+	go func() {
+		for i := int64(1); i <= 1000; i++ {
+			h.advance(i)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("advance blocked with an undrained subscriber")
+	}
+	if got := h.head.Load(); got != 1000 {
+		t.Fatalf("head = %d, want 1000", got)
+	}
+}
+
+func TestBlockStreamHub_Unsubscribe(t *testing.T) {
+	h := newTestHub()
+	sub := h.subscribe()
+	h.unsubscribe(sub)
+
+	if n := len(h.subs); n != 0 {
+		t.Fatalf("subs = %d after unsubscribe, want 0", n)
+	}
+	// Advancing after unsubscribe must not panic and must not signal a gone sub.
+	h.advance(10)
+	select {
+	case <-sub.ch:
+		t.Fatal("an unsubscribed subscriber should not be signaled")
+	default:
+	}
+}
+
+func TestBlockStreamHub_FansOutToAllSubscribers(t *testing.T) {
+	h := newTestHub()
+	a := h.subscribe()
+	b := h.subscribe()
+
+	h.advance(7)
+	for i, s := range []*blockStreamSub{a, b} {
+		select {
+		case <-s.ch:
+		default:
+			t.Fatalf("subscriber %d was not signaled on advance", i)
+		}
+	}
+}

--- a/erpc/grpc_server.go
+++ b/erpc/grpc_server.go
@@ -40,6 +40,7 @@ type GrpcServer struct {
 
 	evm.UnimplementedRPCQueryServiceServer
 	evm.UnimplementedQueryServiceServer
+	evm.UnimplementedStreamServiceServer
 }
 
 func grpcSharesHttpV4(cfg *common.ServerConfig) bool {
@@ -133,6 +134,7 @@ func NewGrpcServer(
 	gs.server = grpc.NewServer(opts...)
 	evm.RegisterRPCQueryServiceServer(gs.server, gs)
 	evm.RegisterQueryServiceServer(gs.server, gs)
+	evm.RegisterStreamServiceServer(gs.server, gs)
 	// Server reflection lets tools (grpcurl, Postman, buf) discover the BDS
 	// services/messages without a local copy of the .proto files. Enabled by
 	// default; set server.grpcReflection=false to turn it off.
@@ -472,6 +474,16 @@ func (gs *GrpcServer) QueryTransfers(req *evm.QueryTransfersRequest, stream evm.
 	return gs.processor.ProcessQueryStream(stream.Context(), input, req, func(page proto.Message) error {
 		return stream.Send(page.(*evm.QueryTransfersResponse))
 	})
+}
+
+func (gs *GrpcServer) StreamBlocks(req *evm.StreamBlocksRequest, stream evm.StreamService_StreamBlocksServer) error {
+	input, err := gs.extractRequestInput(stream.Context(), "eth_getBlockByNumber")
+	if err != nil {
+		return err
+	}
+	return gs.mapToGRPCStatus(gs.processor.ProcessBlockStream(stream.Context(), input, func(header *evm.BlockHeader) error {
+		return stream.Send(&evm.StreamBlocksResponse{Header: header})
+	}))
 }
 
 func (gs *GrpcServer) panicRecoveryUnary() grpc.UnaryServerInterceptor {

--- a/erpc/request_processor.go
+++ b/erpc/request_processor.go
@@ -15,8 +15,9 @@ import (
 )
 
 type RequestProcessor struct {
-	erpc   *ERPC
-	logger *zerolog.Logger
+	erpc        *ERPC
+	logger      *zerolog.Logger
+	blockStream *blockStreamManager
 }
 
 type RequestInput struct {
@@ -29,7 +30,7 @@ type RequestInput struct {
 }
 
 func NewRequestProcessor(erpc *ERPC, logger *zerolog.Logger) *RequestProcessor {
-	return &RequestProcessor{erpc: erpc, logger: logger}
+	return &RequestProcessor{erpc: erpc, logger: logger, blockStream: newBlockStreamManager()}
 }
 
 func (rp *RequestProcessor) ProcessUnary(

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DataDog/sketches-go v1.4.8
 	github.com/IGLOU-EU/go-wildcard/v2 v2.1.1
 	github.com/aws/aws-sdk-go v1.55.8
-	github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650
+	github.com/blockchain-data-standards/manifesto v0.0.0-20260708135603-35add417e724
 	github.com/bytedance/sonic v1.15.2
 	github.com/coder/websocket v1.8.15
 	github.com/dgraph-io/ristretto/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650 h1:1x8E2huS+AGPFxVj2Zt57JygwpBSOKnScsDHp/pqgIo=
 github.com/blockchain-data-standards/manifesto v0.0.0-20260506191942-991c5f924650/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260708135603-35add417e724 h1:sy+SPSOba5HPkQZ0EwgrDtpvM+sRD4cmTFJIDFGpRZo=
+github.com/blockchain-data-standards/manifesto v0.0.0-20260708135603-35add417e724/go.mod h1:BEP+UJDL+dSqF4UddiHmITKlV2l0aaDEagPS9nbbYIc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## What

Implements the new BDS `StreamService.StreamBlocks` server-streaming method: the server pushes one `BlockHeader` per new block, in ascending block-number order, as the chain head advances, until the client cancels.

## How

- **Event-driven off the state poller.** New concrete-type hook `OnLatestBlock(cb)` on `*architecture/evm.EvmStatePoller` (wraps the shared latest-block variable's `OnValue`) — **no `common.EvmStatePoller` interface change**, so the fake/mocks are untouched. It fires on every forward advance regardless of source: a proactive poll, a `SuggestLatestBlock` write-through from request traffic, or cross-node propagation of the shared counter.
- **One long-lived head-watch hub per (project, network)** (`erpc/block_stream.go`). `OnValue` can't be unregistered, so the callback is registered exactly once per network and cached; the hub fans head advances out to live subscribers via **non-blocking, buffered(1)** wakeups — safe to run inside the poller's *synchronous* update path.
- **Backfill, no skipped numbers.** Each subscriber emits `lastSent+1..head`, fetching each header through the existing cached `eth_getBlockByNumber` path (concurrent identical fetches coalesce → ~1 upstream call per block across all subscribers). `blockStreamMaxBackfill` resyncs on cold-start / pathological gaps.
- Registered on the gRPC server alongside `RPCQueryService` / `QueryService`.

## Reorg behavior (intentional for now)

Forward-only and **reorg-unaware**: the poller tracks block *numbers*, so a reorg that replaces an already-sent number is **not** corrected on the stream (a same-height reorg is invisible to a number-tracker; a sub-tolerance head dip is held at the high-water mark). Consumers can still self-detect via `hash`/`parentHash` discontinuity. Reorg-correct replay (UNDO/finality) is deferred to **ChainView**, which will implement the same head-feed seam without touching this handler.

## Tests

`block_stream_test.go` covers the concurrency-sensitive hub core (monotonic head, edge-triggered signalling, non-blocking fan-out under an undrained subscriber, unsubscribe) and passes under `-race`. Full-module `go build ./...` and `gofmt` clean.

## Dependency

Bumps `blockchain-data-standards/manifesto` to the merged `StreamService` proto (blockchain-data-standards/manifesto#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)