### PR TITLE
fix(config): un-break tygo TS generation (main docker builds failing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Generate types
         run: |
-          go install github.com/gzuidhof/tygo@latest
+          go install github.com/gzuidhof/tygo@v0.2.21
           tygo generate
       
       - name: Setup Syft

--- a/common/config.go
+++ b/common/config.go
@@ -2622,15 +2622,18 @@ type DatabaseFailOpenConfig struct {
 }
 
 type JwtStrategyConfig struct {
-	AllowedIssuers                        []string            `yaml:"allowedIssuers" json:"allowedIssuers"`
-	AllowedAudiences                      []string            `yaml:"allowedAudiences" json:"allowedAudiences"`
-	AllowedAlgorithms                     []string            `yaml:"allowedAlgorithms" json:"allowedAlgorithms"`
-	RequiredClaims                        []string            `yaml:"requiredClaims" json:"requiredClaims"`
-	ClaimMatchers                         map[string][]string `yaml:"claimMatchers,omitempty" json:"claimMatchers,omitempty"`
-	VerificationKeys                      map[string]string   `yaml:"verificationKeys,omitempty" json:"verificationKeys,omitempty"`
-	VerificationJwksUrl                   string              `yaml:"verificationJwksUrl,omitempty" json:"verificationJwksUrl,omitempty"`
-	VerificationJwksRefreshInterval       Duration            `yaml:"verificationJwksRefreshInterval,omitempty" json:"verificationJwksRefreshInterval" tstype:"Duration"`
-	VerificationJwksTlsInsecureSkipVerify bool                `yaml:"verificationJwksTlsInsecureSkipVerify,omitempty" json:"verificationJwksTlsInsecureSkipVerify,omitempty"` //nolint:gosec
+	AllowedIssuers                  []string            `yaml:"allowedIssuers" json:"allowedIssuers"`
+	AllowedAudiences                []string            `yaml:"allowedAudiences" json:"allowedAudiences"`
+	AllowedAlgorithms               []string            `yaml:"allowedAlgorithms" json:"allowedAlgorithms"`
+	RequiredClaims                  []string            `yaml:"requiredClaims" json:"requiredClaims"`
+	ClaimMatchers                   map[string][]string `yaml:"claimMatchers,omitempty" json:"claimMatchers,omitempty"`
+	VerificationKeys                map[string]string   `yaml:"verificationKeys,omitempty" json:"verificationKeys,omitempty"`
+	VerificationJwksUrl             string              `yaml:"verificationJwksUrl,omitempty" json:"verificationJwksUrl,omitempty"`
+	VerificationJwksRefreshInterval Duration            `yaml:"verificationJwksRefreshInterval,omitempty" json:"verificationJwksRefreshInterval" tstype:"Duration"`
+	// Skipping TLS verification is an explicit operator opt-in for the JWKS
+	// fetch, not a hardcoded bypass.
+	//nolint:gosec
+	VerificationJwksTlsInsecureSkipVerify bool `yaml:"verificationJwksTlsInsecureSkipVerify,omitempty" json:"verificationJwksTlsInsecureSkipVerify,omitempty"`
 	// RateLimitBudgetClaimName is the JWT claim name that, if present,
 	// will be used to set the per-user RateLimitBudget override.
 	// Defaults to "rlm".

--- a/common/exec_state.go
+++ b/common/exec_state.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -44,46 +43,6 @@ const (
 	SelectionReasonConsensusSlot UpstreamSelectionReason = "consensus_slot" // one consensus participant
 	SelectionReasonSweep         UpstreamSelectionReason = "sweep"          // try-all-upstreams iteration
 )
-
-// Context markers for selection reasons only the spawning executor knows.
-// The attempt recorder (upstream tryForward's deferred record) runs at the
-// bottom of the failsafe chain and cannot see WHICH executor caused this
-// attempt to exist, so fan-out executors tag the context they hand each
-// attempt: the consensus executor marks every participant slot
-// (consensus_slot) and the network sweep marks its non-first picks (sweep).
-// Keys follow the repo's ContextKey convention (see RequestContextKey).
-
-// ConsensusSlotContextKey marks a context executing inside one consensus
-// participant slot.
-const ConsensusSlotContextKey ContextKey = "consensusSlot"
-
-// SweepIterationContextKey marks a context executing a non-first pick of
-// the try-all-upstreams sweep within one execution.
-const SweepIterationContextKey ContextKey = "sweepIteration"
-
-// WithConsensusSlot returns ctx marked as a consensus participant slot.
-func WithConsensusSlot(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ConsensusSlotContextKey, true)
-}
-
-// IsConsensusSlot reports whether ctx executes inside a consensus
-// participant slot.
-func IsConsensusSlot(ctx context.Context) bool {
-	v, _ := ctx.Value(ConsensusSlotContextKey).(bool)
-	return v
-}
-
-// WithSweepIteration returns ctx marked as a non-first sweep pick.
-func WithSweepIteration(ctx context.Context) context.Context {
-	return context.WithValue(ctx, SweepIterationContextKey, true)
-}
-
-// IsSweepIteration reports whether ctx executes a non-first pick of the
-// try-all-upstreams sweep.
-func IsSweepIteration(ctx context.Context) bool {
-	v, _ := ctx.Value(SweepIterationContextKey).(bool)
-	return v
-}
 
 // UpstreamAttempt is one (upstream, attempt) record. The executors
 // append these as participants come and go so operators can answer
@@ -280,8 +239,8 @@ func (s *ExecState) Snapshot() ExecStateSnapshot {
 		// upstream invocation chain, already counted in UpstreamAttempts).
 		Attempts: upAttempts + chAttempts,
 		// Retries and Hedges ARE distinct events per scope; safe to sum.
-		Retries: upRetries + nwRetries + chRetries,
-		Hedges:  upHedges + nwHedges + chHedges,
+		Retries:                  upRetries + nwRetries + chRetries,
+		Hedges:                   upHedges + nwHedges + chHedges,
 		UpstreamAttempts:         upAttempts,
 		UpstreamRetries:          upRetries,
 		UpstreamHedges:           upHedges,

--- a/common/request.go
+++ b/common/request.go
@@ -30,6 +30,48 @@ const (
 const RequestContextKey ContextKey = "rq"
 const UpstreamsContextKey ContextKey = "ups"
 
+// Context markers for selection reasons only the spawning executor knows.
+// The attempt recorder (upstream tryForward's deferred record) runs at the
+// bottom of the failsafe chain and cannot see WHICH executor caused this
+// attempt to exist, so fan-out executors tag the context they hand each
+// attempt: the consensus executor marks every participant slot
+// (consensus_slot) and the network sweep marks its non-first picks (sweep).
+// They live here with the other ContextKey constants — request.go is
+// excluded from tygo generation, and these keys are server-internal (the
+// ContextKey type has no TypeScript counterpart).
+
+// ConsensusSlotContextKey marks a context executing inside one consensus
+// participant slot.
+const ConsensusSlotContextKey ContextKey = "consensusSlot"
+
+// SweepIterationContextKey marks a context executing a non-first pick of
+// the try-all-upstreams sweep within one execution.
+const SweepIterationContextKey ContextKey = "sweepIteration"
+
+// WithConsensusSlot returns ctx marked as a consensus participant slot.
+func WithConsensusSlot(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ConsensusSlotContextKey, true)
+}
+
+// IsConsensusSlot reports whether ctx executes inside a consensus
+// participant slot.
+func IsConsensusSlot(ctx context.Context) bool {
+	v, _ := ctx.Value(ConsensusSlotContextKey).(bool)
+	return v
+}
+
+// WithSweepIteration returns ctx marked as a non-first sweep pick.
+func WithSweepIteration(ctx context.Context) context.Context {
+	return context.WithValue(ctx, SweepIterationContextKey, true)
+}
+
+// IsSweepIteration reports whether ctx executes a non-first pick of the
+// try-all-upstreams sweep.
+func IsSweepIteration(ctx context.Context) bool {
+	v, _ := ctx.Value(SweepIterationContextKey).(bool)
+	return v
+}
+
 type directiveKeyNames struct {
 	header string
 	query  string

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1524,7 +1524,12 @@ export interface JwtStrategyConfig {
   verificationKeys?: { [key: string]: string};
   verificationJwksUrl?: string;
   verificationJwksRefreshInterval?: Duration;
-  verificationJwksTlsInsecureSkipVerify?: boolean; //   /**
+  /**
+   * Skipping TLS verification is an explicit operator opt-in for the JWKS
+   * fetch, not a hardcoded bypass.
+   */
+  verificationJwksTlsInsecureSkipVerify?: boolean;
+  /**
    * RateLimitBudgetClaimName is the JWT claim name that, if present,
    * will be used to set the per-user RateLimitBudget override.
    * Defaults to "rlm".
@@ -1684,16 +1689,6 @@ export const SelectionReasonHedge: UpstreamSelectionReason = "hedge"; // specula
 export const SelectionReasonConsensusSlot: UpstreamSelectionReason = "consensus_slot"; // one consensus participant
 export const SelectionReasonSweep: UpstreamSelectionReason = "sweep"; // try-all-upstreams iteration
 /**
- * ConsensusSlotContextKey marks a context executing inside one consensus
- * participant slot.
- */
-export const ConsensusSlotContextKey: ContextKey = "consensusSlot";
-/**
- * SweepIterationContextKey marks a context executing a non-first pick of
- * the try-all-upstreams sweep within one execution.
- */
-export const SweepIterationContextKey: ContextKey = "sweepIteration";
-/**
  * UpstreamAttempt is one (upstream, attempt) record. The executors
  * append these as participants come and go so operators can answer
  * "which upstreams were involved in this request, why were they
@@ -1720,8 +1715,9 @@ export interface UpstreamAttempt {
   /**
    * CreditUnits is the vendor credit-unit cost this attempt accrued
    * (the upstream's resolved table — vendor defaults merged with config
-   * overrides; 0 when the vendor exposes no pricing or the attempt
-   * provably never dialed it, e.g. skipped / breaker-open).
+   * overrides; vendors with no table default to a flat 1 credit per
+   * request). 0 when the attempt provably never dialed the vendor
+   * (skipped / breaker-open) or the vendor was opted out ("*": 0).
    */
   creditunits: number /* int64 */;
 }


### PR DESCRIPTION
## Problem

Release docker builds on `main` fail at `pnpm build` in `@erpc-cloud/config` (first seen on [run 29102669582](https://github.com/erpc/erpc/actions/runs/29102669582/attempts/1)) with two `generated.ts` defects introduced by the #987 tygo regeneration:

1. **esbuild `Unexpected "*"`** — tygo (v0.2.21, current `@latest`) glues a field's *trailing* comment onto the next field's doc-comment opener, emitting `boolean; //   /**` and leaving bare ` * ` lines. Trigger: the trailing `//nolint:gosec` on `VerificationJwksTlsInsecureSkipVerify`.
2. **tsc `Cannot find name 'ContextKey'`** — the consensus_slot/sweep context markers landed in `exec_state.go` (tygo-generated), while the `ContextKey` type lives in the excluded `utils.go`.

PR CI stayed green because the TS build only runs in the release workflow — the breakage lands on `main` instead of the PR that caused it.

## Fix

- Move the `//nolint:gosec` to a leading comment (same lint semantics); it now renders as a valid JSDoc block.
- Move the context-marker consts + `With`/`Is` helpers to `request.go`, beside `RequestContextKey`/`UpstreamsContextKey` where every other `ContextKey` constant already lives (already tygo-excluded; the type has no TS counterpart). No behavior change — same package.
- Regenerate `generated.ts` with tygo v0.2.21, and **pin that version in the release workflow** (was `@latest`) so generator drift can't silently rewrite a committed artifact.

Noticed but deliberately not touched (pre-existing, separate): the committed `typescript/config/lib/` artifacts are stale relative to `src` (e.g. missing `grpcReflection`).

## Test plan

- `pnpm build` at the repo root (the exact command the docker build runs): `build:lib` (esbuild) + `build:types` (tsc) both green.
- `go test ./common/ ./upstream/ ./consensus/` green (marker tests unchanged — same package).
- `grep -c ContextKey typescript/config/src/generated.ts` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)