### PR TITLE
feat: add Satelink vendor (Polygon pay-per-call RPC)

### DIFF
--- a/thirdparty/satelink.go
+++ b/thirdparty/satelink.go
@@ -1,0 +1,104 @@
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+)
+
+var satelinkNetworkNames = map[int64]string{
+	137:   "polygon",
+	80002: "amoy",
+}
+
+type SatelinkVendor struct {
+	common.Vendor
+}
+
+func CreateSatelinkVendor() common.Vendor {
+	return &SatelinkVendor{}
+}
+
+func (v *SatelinkVendor) Name() string {
+	return "satelink"
+}
+
+func (v *SatelinkVendor) SupportsNetwork(ctx context.Context, logger *zerolog.Logger, settings common.VendorSettings, networkId string) (bool, error) {
+	if !strings.HasPrefix(networkId, "evm:") {
+		return false, nil
+	}
+
+	chainID, err := strconv.ParseInt(strings.TrimPrefix(networkId, "evm:"), 10, 64)
+	if err != nil {
+		return false, err
+	}
+	_, ok := satelinkNetworkNames[chainID]
+	return ok, nil
+}
+
+func (v *SatelinkVendor) GenerateConfigs(ctx context.Context, logger *zerolog.Logger, upstream *common.UpstreamConfig, settings common.VendorSettings) ([]*common.UpstreamConfig, error) {
+	if upstream.JsonRpc == nil {
+		upstream.JsonRpc = &common.JsonRpcUpstreamConfig{}
+	}
+
+	if upstream.Endpoint == "" {
+		apiKey, ok := settings["apiKey"].(string)
+		if !ok || apiKey == "" {
+			// Self-service keys: POST https://rpc.satelink.network/v1/machine/register
+			// with {"mode":"instant"} returns a key in one call (no signup).
+			return nil, fmt.Errorf("apiKey is required in satelink settings")
+		}
+		if upstream.Evm == nil {
+			return nil, fmt.Errorf("satelink vendor requires upstream.evm to be defined")
+		}
+		chainID := upstream.Evm.ChainId
+		if chainID == 0 {
+			return nil, fmt.Errorf("satelink vendor requires upstream.evm.chainId to be defined")
+		}
+		netName, ok := satelinkNetworkNames[chainID]
+		if !ok {
+			return nil, fmt.Errorf("unsupported network chain ID for Satelink: %d", chainID)
+		}
+
+		upstream.Endpoint = fmt.Sprintf("https://rpc.satelink.network/rpc/%s", netName)
+		upstream.Type = common.UpstreamTypeEvm
+
+		// Satelink authenticates via the X-API-Key header (same pattern as
+		// the blockdaemon vendor's Authorization header).
+		if upstream.JsonRpc.Headers == nil {
+			upstream.JsonRpc.Headers = make(map[string]string)
+		}
+		if upstream.JsonRpc.Headers["X-API-Key"] == "" && upstream.JsonRpc.Headers["x-api-key"] == "" {
+			upstream.JsonRpc.Headers["X-API-Key"] = apiKey
+		}
+	}
+
+	return []*common.UpstreamConfig{upstream}, nil
+}
+
+func (v *SatelinkVendor) GetVendorSpecificErrorIfAny(req *common.NormalizedRequest, resp *http.Response, jrr interface{}, details map[string]interface{}) error {
+	bodyMap, ok := jrr.(*common.JsonRpcResponse)
+	if !ok {
+		return nil
+	}
+
+	err := bodyMap.Error
+	if err.Data != "" {
+		details["data"] = err.Data
+	}
+
+	return nil
+}
+
+func (v *SatelinkVendor) OwnsUpstream(ups *common.UpstreamConfig) bool {
+	if strings.HasPrefix(ups.Endpoint, "satelink://") || strings.HasPrefix(ups.Endpoint, "evm+satelink://") {
+		return true
+	}
+
+	return strings.Contains(ups.Endpoint, "rpc.satelink.network")
+}

--- a/thirdparty/vendors_registry.go
+++ b/thirdparty/vendors_registry.go
@@ -31,6 +31,7 @@ func NewVendorsRegistry() *VendorsRegistry {
 	r.Register(CreateBlockPiVendor())
 	r.Register(CreateAnkrVendor())
 	r.Register(CreateRoutemeshVendor())
+	r.Register(CreateSatelinkVendor())
 	r.Register(CreateBlockdaemonVendor())
 	return r
 }


### PR DESCRIPTION
Adds Satelink (`rpc.satelink.network`) as a vendor, per the proposal in #991.

**Why:** three erpc deployments already route through our public Polygon endpoint via custom upstream URLs (~1,100 calls/day sustained — visible in our traffic as `erpc` user-agents). As anonymous traffic they hit our 500/day/IP free tier and silently lose the upstream mid-day; with a vendor + apiKey they get their own quota.

**Implementation** (modeled on `ankr.go` for structure and `blockdaemon.go` for header auth):
- Networks: Polygon PoS (137), Polygon Amoy (80002)
- Endpoint: `https://rpc.satelink.network/rpc/{network}`
- Auth: `X-API-Key` header via `upstream.JsonRpc.Headers` (keys are self-service — `POST /v1/machine/register {"mode":"instant"}` returns a key in one call, no signup; prepaid pay-per-call at $0.00003/call beyond the free tier, no subscription)
- `OwnsUpstream`: `satelink://` prefix or `rpc.satelink.network` substring

Config example:
```yaml
upstreams:
  - vendorName: satelink
    settings:
      apiKey: sk_...
    evm:
      chainId: 137
```

Service details (machine-readable): https://rpc.satelink.network/.well-known/satelink.json — happy to adjust anything to fit conventions, add tests mirroring `ankr`'s if wanted, and we're offering founding-customer terms (higher quotas, direct operator support) to erpc users per #991.