### PR TITLE
feat(telemetry): opt-in trusted X-ERPC-User-Id header for the user label

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -592,11 +592,21 @@ type ProjectConfig struct {
 	Networks         []*NetworkConfig  `yaml:"networks,omitempty" json:"networks"`
 	RateLimitBudget  string            `yaml:"rateLimitBudget,omitempty" json:"rateLimitBudget"`
 	// Configure user agent tracking at the project level
-	UserAgentMode         UserAgentTrackingMode `yaml:"userAgentMode,omitempty" json:"userAgentMode"`
-	ForwardHeaders        []string              `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
-	AllowClientDirectives *string               `yaml:"allowClientDirectives,omitempty" json:"allowClientDirectives"`
-	IgnoreMethods         []string              `yaml:"ignoreMethods,omitempty" json:"ignoreMethods"`
-	AllowMethods          []string              `yaml:"allowMethods,omitempty" json:"allowMethods"`
+	UserAgentMode UserAgentTrackingMode `yaml:"userAgentMode,omitempty" json:"userAgentMode"`
+	// TrustUserIdHeader makes erpc read the caller's user identity from the
+	// X-ERPC-User-Id request header (see common.HeaderUserId) and use it for the
+	// `user` metric/log label — but only when no auth strategy resolved a user
+	// (auth wins) and only for attribution (no rate-limit budget is derived).
+	// This is for deployments that authenticate callers in front of erpc (e.g. a
+	// gateway) and want per-user erpc telemetry without erpc performing auth.
+	// erpc does NOT validate the header, so enable this ONLY when erpc is reachable
+	// solely by a trusted proxy that sets the header and strips any client copy —
+	// otherwise callers can spoof their own attribution. Default false.
+	TrustUserIdHeader     bool     `yaml:"trustUserIdHeader,omitempty" json:"trustUserIdHeader"`
+	ForwardHeaders        []string `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
+	AllowClientDirectives *string  `yaml:"allowClientDirectives,omitempty" json:"allowClientDirectives"`
+	IgnoreMethods         []string `yaml:"ignoreMethods,omitempty" json:"ignoreMethods"`
+	AllowMethods          []string `yaml:"allowMethods,omitempty" json:"allowMethods"`
 
 	// ScoreMetricsWindowSize is the tumbling window the per-upstream
 	// health tracker uses for its rolling counters (errorRate, p50/p70/

--- a/common/request.go
+++ b/common/request.go
@@ -103,6 +103,14 @@ const (
 	headerDirectiveValidateLogFields          = "X-ERPC-Validate-Log-Fields"
 )
 
+// HeaderUserId is the request header erpc reads as the caller's user identity
+// when a project enables ProjectConfig.TrustUserIdHeader. It lets a deployment
+// that authenticates callers *in front of* erpc (e.g. an API gateway) attribute
+// erpc's per-user metrics and logs without erpc performing auth itself. erpc
+// does NOT validate the value — the gateway is trusted to set it and to strip
+// any client-supplied copy. See [NormalizedRequest.SetUserFromTrustedHeader].
+const HeaderUserId = "X-ERPC-User-Id"
+
 const (
 	queryDirectiveRetryEmpty                 = "retry-empty"
 	queryDirectiveRetryPending               = "retry-pending"
@@ -459,6 +467,26 @@ func (r *NormalizedRequest) SetUser(user *User) {
 		return
 	}
 	r.user.Store(user)
+}
+
+// SetUserFromTrustedHeader assigns the request's user identity from a value
+// supplied by a trusted upstream (the [HeaderUserId] header), for deployments
+// that authenticate callers in front of erpc and want per-user metrics/logs
+// without erpc doing auth. It is a no-op when value is empty (after trimming)
+// or when an auth strategy already resolved a user — auth always wins. Only the
+// Id is set; no rate-limit budget is attached, so this never enables user-level
+// rate limiting. erpc does not validate value; gate it behind
+// ProjectConfig.TrustUserIdHeader and only trust the header from a proxy that
+// strips any client-supplied copy.
+func (r *NormalizedRequest) SetUserFromTrustedHeader(value string) {
+	if r == nil || r.User() != nil {
+		return
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	r.user.Store(&User{Id: value})
 }
 
 func (r *NormalizedRequest) User() *User {

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -723,3 +723,52 @@ func TestEnrichFromHttp_AllowClientDirectives(t *testing.T) {
 		}
 	})
 }
+
+func newReqForUser() *NormalizedRequest {
+	return NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}`))
+}
+
+func TestSetUserFromTrustedHeader(t *testing.T) {
+	t.Run("sets the user id when none was resolved", func(t *testing.T) {
+		req := newReqForUser()
+		req.SetUserFromTrustedHeader("proj_edge_ep1")
+		if u := req.User(); u == nil || u.Id != "proj_edge_ep1" {
+			t.Fatalf("expected user id %q, got %+v", "proj_edge_ep1", u)
+		}
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		req := newReqForUser()
+		req.SetUserFromTrustedHeader("  proj_edge_ep1\n")
+		if u := req.User(); u == nil || u.Id != "proj_edge_ep1" {
+			t.Fatalf("expected trimmed user id, got %+v", u)
+		}
+	})
+
+	t.Run("is a no-op for an empty or whitespace-only value", func(t *testing.T) {
+		for _, v := range []string{"", "   ", "\t\n"} {
+			req := newReqForUser()
+			req.SetUserFromTrustedHeader(v)
+			if u := req.User(); u != nil {
+				t.Fatalf("expected no user for value %q, got %+v", v, u)
+			}
+		}
+	})
+
+	t.Run("never derives a rate-limit budget", func(t *testing.T) {
+		req := newReqForUser()
+		req.SetUserFromTrustedHeader("proj_edge_ep1")
+		if u := req.User(); u == nil || u.RateLimitBudget != "" {
+			t.Fatalf("trusted-header user must carry no budget, got %+v", u)
+		}
+	})
+
+	t.Run("auth wins — does not overwrite an already-resolved user", func(t *testing.T) {
+		req := newReqForUser()
+		req.SetUser(&User{Id: "auth-resolved", RateLimitBudget: "tier-1"})
+		req.SetUserFromTrustedHeader("header-user")
+		if u := req.User(); u == nil || u.Id != "auth-resolved" || u.RateLimitBudget != "tier-1" {
+			t.Fatalf("auth-resolved user must be preserved, got %+v", u)
+		}
+	})
+}

--- a/erpc/grpc_server.go
+++ b/erpc/grpc_server.go
@@ -182,6 +182,9 @@ func (gs *GrpcServer) extractRequestInput(ctx context.Context, method string) (*
 		AuthPayload:  ap,
 		ClientIP:     gs.grpcClientIP(ctx, md),
 		UserAgent:    firstMD(md, "user-agent"),
+		// Raw trusted user-id metadata (gRPC lowercases header keys); applied only
+		// when the project sets TrustUserIdHeader — see RequestProcessor.
+		TrustedUserId: firstMD(md, "x-erpc-user-id"),
 	}, nil
 }
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -584,6 +584,17 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 					nq.SetUser(user)
 				}
 
+				// Trusted upstream identity: when auth resolved no user and the
+				// project opts in, take the user id from the X-ERPC-User-Id header
+				// (set by a trusted gateway that already authenticated the caller)
+				// so per-user metrics/logs stay attributed without erpc doing auth.
+				if project != nil && project.Config != nil && project.Config.TrustUserIdHeader && nq.User() == nil {
+					nq.SetUserFromTrustedHeader(headers.Get(common.HeaderUserId))
+					if user := nq.User(); user != nil {
+						rlg = rlg.With().Str("userId", user.Id).Logger()
+					}
+				}
+
 				if isAdmin {
 					if s.adminCfg != nil {
 						resp, err := s.erpc.AdminHandleRequest(requestCtx, nq)

--- a/erpc/request_processor.go
+++ b/erpc/request_processor.go
@@ -27,6 +27,11 @@ type RequestInput struct {
 	AuthPayload  *auth.AuthPayload
 	ClientIP     string
 	UserAgent    string
+	// TrustedUserId is the raw X-ERPC-User-Id header/metadata value extracted at
+	// the transport. It is applied as the user identity only when the project
+	// sets TrustUserIdHeader and auth resolved no user (see
+	// NormalizedRequest.SetUserFromTrustedHeader).
+	TrustedUserId string
 }
 
 func NewRequestProcessor(erpc *ERPC, logger *zerolog.Logger) *RequestProcessor {
@@ -55,6 +60,9 @@ func (rp *RequestProcessor) ProcessUnary(
 		return nil, err
 	}
 	nq.SetUser(user)
+	if project.Config != nil && project.Config.TrustUserIdHeader {
+		nq.SetUserFromTrustedHeader(input.TrustedUserId)
+	}
 
 	networkID := fmt.Sprintf("%s:%s", input.Architecture, input.ChainId)
 	network, err := project.GetNetwork(ctx, networkID)
@@ -117,6 +125,9 @@ func (rp *RequestProcessor) ProcessQueryStream(
 		return err
 	}
 	nq.SetUser(user)
+	if project.Config != nil && project.Config.TrustUserIdHeader {
+		nq.SetUserFromTrustedHeader(input.TrustedUserId)
+	}
 
 	network, err := project.GetNetwork(ctx, networkID)
 	if err != nil {


### PR DESCRIPTION
## Motivation

Many deployments run erpc **behind their own gateway/proxy** that already authenticates the caller. Today the per-request `user` metric/log label is only populated by an erpc auth strategy (`SetUser` after `AuthenticateConsumer`), so those operators face a choice: either re-implement auth inside erpc purely to get attribution, or lose per-user telemetry entirely.

This adds a small, opt-in way to keep per-user metrics/logs when auth is terminated upstream — without erpc performing auth itself.

## What

A new project-level flag, next to `userAgentMode` (the existing precedent for a project knob that controls a telemetry label):

```yaml
projects:
  - id: main
    trustUserIdHeader: true   # default: false
```

When enabled, erpc reads the caller identity from the well-known **`X-ERPC-User-Id`** request header (HTTP) / `x-erpc-user-id` metadata (gRPC) and uses it for the `user` label.

Three guarantees keep it safe and unsurprising:

- **Auth always wins.** It is a no-op when an auth strategy already resolved a user, so it never overrides real authentication — it only fills the gap when there is none.
- **Attribution only.** It sets `User.Id` and never a `RateLimitBudget`, so it cannot switch on user-level rate limiting.
- **Opt-in + trusted.** erpc does **not** validate the value. It is off by default and documented as safe only when erpc is reachable solely by a trusted proxy that sets the header and strips any client-supplied copy (otherwise a caller could spoof their own attribution). This is the same trust model as `trustedIPForwarders`/`X-Forwarded-For`.

## Design

Mirrors the existing `UserAgent → SetAgentName` plumbing exactly, so it covers both transports with no new subsystem:

- `common`: `HeaderUserId` constant + `NormalizedRequest.SetUserFromTrustedHeader(value)` — trims, applies the auth-wins guard, sets the id. One place, easy to test.
- `erpc/http_server.go`: after auth, when the project opts in and no user was resolved, apply `headers.Get(HeaderUserId)` and (re)bind the request logger so logs carry `userId`.
- `erpc/request_processor.go` + `erpc/grpc_server.go`: a `RequestInput.TrustedUserId` field (populated at the gRPC transport from metadata, like `UserAgent`) applied in `ProcessUnary` and `ProcessQueryStream`.

## Tests

`TestSetUserFromTrustedHeader` covers the helper semantics: sets when unresolved, trims whitespace, no-ops on empty/whitespace, carries no rate-limit budget, and never overwrites an auth-resolved user.

`go build`, `go vet`, and `go test ./common/ ./erpc/` all pass; the change is `+117/-5` across 6 files with no behavior change when the flag is unset (default).

---

> Draft for review. Happy to adjust naming (`trustUserIdHeader` / `X-ERPC-User-Id`), make the header name configurable, or gate it by source IP if preferred.