### PR TITLE
fix(monitoring): swapped to noble ubuntu supported LTS release

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,7 +1,7 @@
 FROM prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac as prometheus
 FROM grafana/grafana:12.4.5@sha256:26b8f35a9e4e4431995cf64c3f396505a4faf17bcfc19f9ed84943ec6bfd5ecd as grafana
 
-FROM ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 RUN apt-get update && apt-get install -y curl
 


### PR DESCRIPTION
While following the quick start part in `Bring up monitoring (optional)` on https://docs.erpc.cloud/, it seems that there is an error with the supported ubuntu image in the monitoring folder, when doing `docker compose up -d` I'm getting the next errors:

```sh
➜  erpc git:(main) docker compose up -d --build
[+] Building 2.1s (11/23)
 => [internal] load local bake definitions                                                                                                                                0.0s
 => => reading from stdin 556B                                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                                      0.0s
 => => transferring dockerfile: 1.23kB                                                                                                                                    0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                            0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)                                                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489                                   0.8s
 => [internal] load metadata for docker.io/prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac                                0.0s
 => [internal] load metadata for docker.io/grafana/grafana:12.4.5@sha256:26b8f35a9e4e4431995cf64c3f396505a4faf17bcfc19f9ed84943ec6bfd5ecd                                 0.0s
 => [internal] load .dockerignore                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                           0.0s
 => CACHED [stage-2  1/14] FROM docker.io/library/ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489                                    0.0s
 => => resolve docker.io/library/ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489                                                     0.0s
 => [internal] load build context                                                                                                                                         0.0s
 => => transferring context: 483B                                                                                                                                         0.0s
 => CACHED [prometheus 1/1] FROM docker.io/prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac                                0.0s
 => => resolve docker.io/prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac                                                  0.0s
 => CACHED [grafana 1/1] FROM docker.io/grafana/grafana:12.4.5@sha256:26b8f35a9e4e4431995cf64c3f396505a4faf17bcfc19f9ed84943ec6bfd5ecd                                    0.0s
 => => resolve docker.io/grafana/grafana:12.4.5@sha256:26b8f35a9e4e4431995cf64c3f396505a4faf17bcfc19f9ed84943ec6bfd5ecd                                                   0.0s
 => ERROR [stage-2  2/14] RUN apt-get update && apt-get install -y curl                                                                                                   1.1s
------
 > [stage-2  2/14] RUN apt-get update && apt-get install -y curl:
0.362 Ign:1 http://ports.ubuntu.com/ubuntu-ports kinetic InRelease
0.460 Ign:2 http://ports.ubuntu.com/ubuntu-ports kinetic-updates InRelease
0.554 Ign:3 http://ports.ubuntu.com/ubuntu-ports kinetic-backports InRelease
0.649 Ign:4 http://ports.ubuntu.com/ubuntu-ports kinetic-security InRelease
0.744 Err:5 http://ports.ubuntu.com/ubuntu-ports kinetic Release
0.744   404  Not Found [IP: 91.189.91.103 80]
0.838 Err:6 http://ports.ubuntu.com/ubuntu-ports kinetic-updates Release
0.838   404  Not Found [IP: 91.189.91.103 80]
0.932 Err:7 http://ports.ubuntu.com/ubuntu-ports kinetic-backports Release
0.932   404  Not Found [IP: 91.189.91.103 80]
1.027 Err:8 http://ports.ubuntu.com/ubuntu-ports kinetic-security Release
1.027   404  Not Found [IP: 91.189.91.103 80]
1.039 Reading package lists...
1.055 E: The repository 'http://ports.ubuntu.com/ubuntu-ports kinetic Release' does not have a Release file.
1.055 E: The repository 'http://ports.ubuntu.com/ubuntu-ports kinetic-updates Release' does not have a Release file.
1.055 E: The repository 'http://ports.ubuntu.com/ubuntu-ports kinetic-backports Release' does not have a Release file.
1.055 E: The repository 'http://ports.ubuntu.com/ubuntu-ports kinetic-security Release' does not have a Release file.
------
[+] up 0/1
 ⠙ Image erpc-monitoring Building                                                                                                                                          2.2s
Dockerfile:6

--------------------

   4 |     FROM ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489

   5 |

   6 | >>> RUN apt-get update && apt-get install -y curl

   7 |

   8 |     # Copy Prometheus files

--------------------

failed to solve: process "/bin/sh -c apt-get update && apt-get install -y curl" did not complete successfully: exit code: 100
```

It was using ubuntu:22.10 (kinetic),  a non-LTS release that went EOL in July 2023, so its apt repos were pulled from the mirrors, I changed to the ubuntu LTS Noble Numbat (24.04) and now it works fine.