### PR TITLE
fix(evm): gate major out-of-band head suggestions behind the chain-identity check

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -91,6 +91,13 @@ type EvmStatePoller struct {
 	// Track if updates are in progress to avoid goroutine pile-up
 	finalizedUpdateInProgress sync.Mutex
 
+	// Serializes the off-hot-path chain-identity verification for a MAJOR
+	// forward jump suggested out-of-band via SuggestLatestBlock. At most one
+	// verification is in flight per poller; a concurrent major suggestion is
+	// dropped and re-observed on the next suggestion (or verified poll). Small
+	// keep-fresh advances never touch this.
+	latestMajorVerifyInProgress sync.Mutex
+
 	// Earliest per probe tracking
 	earliestByProbe              map[common.EvmAvailabilityProbeType]data.CounterInt64SharedVariable
 	earliestSchedulerStarted     map[common.EvmAvailabilityProbeType]bool
@@ -493,12 +500,67 @@ func (e *EvmStatePoller) SuggestLatestBlock(blockNumber int64) {
 			Msg("skipping latest block suggestion as it's not newer")
 		return
 	}
+
+	// A major forward jump from an out-of-band suggestion has the exact shape of
+	// a cross-wired / poisoned upstream: a 200-OK response carrying another
+	// chain's (higher) height. The verified poll path already gates such moves
+	// behind a fresh chain-identity check (verifyChainIdOnMajorHeadMove); route
+	// suggestions through the same gate before the sample can enter the shared
+	// counter and skew every lag-based routing decision. That check makes a live
+	// eth_chainId call, so it runs OFF the hot path and this function stays
+	// non-blocking. Small advances (the common keep-fresh case) still apply
+	// inline with zero added latency, exactly as before.
+	if currentValue > 0 && blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback {
+		e.verifyThenSuggestLatestBlock(blockNumber)
+		return
+	}
+
 	newValue := e.latestBlockShared.TryUpdate(e.appCtx, blockNumber)
 	e.logger.Trace().
 		Int64("blockNumber", blockNumber).
 		Int64("previousValue", currentValue).
 		Int64("newValue", newValue).
 		Msg("latest block suggestion applied")
+}
+
+// verifyThenSuggestLatestBlock validates a MAJOR suggested forward jump with a
+// fresh chain-identity check and applies it to the shared counter only if it
+// passes. A proven cross-wired endpoint is cordoned by the check itself; an
+// unverifiable one (a transient eth_chainId failure) drops the suggestion for
+// now and it is re-observed on the next suggestion or verified poll. Runs in
+// its own goroutine so the caller (response enrichment) never blocks, and at
+// most one verification is in flight per poller.
+func (e *EvmStatePoller) verifyThenSuggestLatestBlock(blockNumber int64) {
+	if !e.latestMajorVerifyInProgress.TryLock() {
+		return
+	}
+	go func() {
+		defer e.latestMajorVerifyInProgress.Unlock()
+
+		ctx, cancel := context.WithTimeout(e.appCtx, 5*time.Second)
+		defer cancel()
+
+		// Re-read: another path may have advanced the head while this was queued,
+		// turning the jump into a small (or already-applied) one.
+		currentValue := e.latestBlockShared.GetValue()
+		if blockNumber <= currentValue {
+			return
+		}
+		if blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback &&
+			!e.verifyChainIdOnMajorHeadMove(ctx, "latest", currentValue, blockNumber) {
+			e.logger.Warn().
+				Int64("blockNumber", blockNumber).
+				Int64("currentValue", currentValue).
+				Msg("dropping major latest block suggestion: chain-identity check did not pass")
+			return
+		}
+		newValue := e.latestBlockShared.TryUpdate(e.appCtx, blockNumber)
+		e.logger.Debug().
+			Int64("blockNumber", blockNumber).
+			Int64("previousValue", currentValue).
+			Int64("newValue", newValue).
+			Msg("verified major latest block suggestion applied")
+	}()
 }
 
 func (e *EvmStatePoller) LatestBlock() int64 {
@@ -532,12 +594,15 @@ func (e *EvmStatePoller) OnLatestBlock(cb func(int64)) {
 // probe drops the sample for this cycle only — the next poll re-observes the
 // same height seconds later.
 //
-// The out-of-band Suggest* paths are deliberately NOT gated: suggestion-driven
-// upward bursts are designed behavior (response enrichment, halted-chain
-// resumes — see networks_served_tip_test.go) and cannot be verified in those
-// hot paths. A bogus suggestion self-heals within one poll cycle: the next
-// verified poll observes the real head and the >tolerance rollback is
-// accepted as a correction by both the shared counter and the tracker.
+// The out-of-band Suggest* paths gate only MAJOR (> tolerance) forward jumps,
+// and do so OFF the hot path: SuggestLatestBlock hands a major jump to a single
+// background verification and SuggestFinalizedBlock already runs in its own
+// goroutine, so response enrichment never blocks on the live eth_chainId call.
+// Small keep-fresh advances stay ungated and inline. The gate is required
+// because a poisoned major suggestion does NOT reliably self-heal: a
+// cross-wired upstream that never returns a correct low sample (it errors out
+// or keeps serving the wrong chain) would otherwise leave the bogus head pinned
+// in the shared counter and skew lag-based routing until manually corrected.
 func (e *EvmStatePoller) verifyChainIdOnMajorHeadMove(ctx context.Context, tag string, current, polled int64) bool {
 	if current <= 0 || absInt64(polled-current) <= common.DefaultToleratedBlockHeadRollback {
 		return true
@@ -707,6 +772,20 @@ func (e *EvmStatePoller) SuggestFinalizedBlock(blockNumber int64) {
 		// Create a timeout context to avoid blocking forever on Redis operations
 		ctx, cancel := context.WithTimeout(e.appCtx, 5*time.Second)
 		defer cancel()
+
+		// Gate a major forward jump behind a fresh chain-identity check, the same
+		// protection the verified poll path and SuggestLatestBlock apply: a
+		// cross-wired endpoint reporting another chain's height must not enter the
+		// shared finalized counter. Already off the hot path here (own goroutine),
+		// so the live eth_chainId call is safe to make.
+		if blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback &&
+			!e.verifyChainIdOnMajorHeadMove(ctx, "finalized", currentValue, blockNumber) {
+			e.logger.Warn().
+				Int64("blockNumber", blockNumber).
+				Int64("currentValue", currentValue).
+				Msg("dropping major finalized block suggestion: chain-identity check did not pass")
+			return
+		}
 
 		e.finalizedBlockShared.TryUpdate(ctx, blockNumber)
 		e.logger.Trace().

--- a/architecture/evm/evm_state_poller_suggest_gate_test.go
+++ b/architecture/evm/evm_state_poller_suggest_gate_test.go
@@ -1,0 +1,240 @@
+package evm
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the chain-identity gate on the out-of-band Suggest* paths.
+// A cross-wired / poisoned upstream can answer an ordinary request with a 200-OK
+// carrying ANOTHER chain's (much higher) block height; that height reaches the
+// shared counter via SuggestLatestBlock / SuggestFinalizedBlock. Without a gate
+// it pins a bogus head that skews every lag-based routing decision and does not
+// self-heal while the endpoint keeps erroring or serving the wrong chain. A
+// MAJOR (> DefaultToleratedBlockHeadRollback) forward jump suggested off-band
+// must therefore pass the same fresh eth_chainId check the verified poll path
+// uses before it is accepted. Small keep-fresh advances stay ungated and inline.
+
+// suggestGateUpstream is a common.EvmUpstream double with a fully settable
+// eth_chainId response (value + error) and an observable Cordon.
+type suggestGateUpstream struct {
+	id       string
+	cfg      *common.UpstreamConfig
+	logger   zerolog.Logger
+	mu       sync.Mutex
+	chainId  string
+	chainErr error
+	cordoned bool
+	reason   string
+}
+
+func newSuggestGateUpstream(configuredChainId int64, detected string, detectErr error) *suggestGateUpstream {
+	return &suggestGateUpstream{
+		id:       "test-ups",
+		cfg:      &common.UpstreamConfig{Id: "test-ups", Evm: &common.EvmUpstreamConfig{ChainId: configuredChainId}},
+		logger:   zerolog.Nop(),
+		chainId:  detected,
+		chainErr: detectErr,
+	}
+}
+
+func (u *suggestGateUpstream) setChainId(detected string, detectErr error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.chainId = detected
+	u.chainErr = detectErr
+}
+
+func (u *suggestGateUpstream) isCordoned() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.cordoned
+}
+
+// common.Upstream
+func (u *suggestGateUpstream) Id() string                      { return u.id }
+func (u *suggestGateUpstream) VendorName() string              { return "" }
+func (u *suggestGateUpstream) NetworkId() string               { return "evm:123" }
+func (u *suggestGateUpstream) NetworkLabel() string            { return "evm:123" }
+func (u *suggestGateUpstream) Config() *common.UpstreamConfig  { return u.cfg }
+func (u *suggestGateUpstream) Logger() *zerolog.Logger         { return &u.logger }
+func (u *suggestGateUpstream) Vendor() common.Vendor           { return nil }
+func (u *suggestGateUpstream) Tracker() common.HealthTracker   { return nil }
+func (u *suggestGateUpstream) IgnoreMethod(string)             {}
+func (u *suggestGateUpstream) Uncordon(_, _ string)            {}
+func (u *suggestGateUpstream) ShouldHandleMethod(string) (bool, error) {
+	return true, nil
+}
+func (u *suggestGateUpstream) Forward(context.Context, *common.NormalizedRequest, bool, bool) (*common.NormalizedResponse, error) {
+	return nil, nil
+}
+func (u *suggestGateUpstream) Cordon(_, reason string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.cordoned = true
+	u.reason = reason
+}
+
+// common.EvmUpstream
+func (u *suggestGateUpstream) EvmGetChainId(context.Context) (string, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.chainId, u.chainErr
+}
+func (u *suggestGateUpstream) EvmIsBlockFinalized(context.Context, int64, bool) (bool, error) {
+	return false, nil
+}
+func (u *suggestGateUpstream) EvmAssertBlockAvailability(context.Context, string, common.AvailbilityConfidence, bool, int64) (bool, error) {
+	return true, nil
+}
+func (u *suggestGateUpstream) EvmSyncingState() common.EvmSyncingState { return common.EvmSyncingStateUnknown }
+func (u *suggestGateUpstream) EvmStatePoller() common.EvmStatePoller   { return nil }
+func (u *suggestGateUpstream) EvmEffectiveLatestBlock() int64          { return 0 }
+func (u *suggestGateUpstream) EvmEffectiveFinalizedBlock() int64       { return 0 }
+func (u *suggestGateUpstream) EvmBlockAvailabilityBounds() (int64, int64) {
+	return math.MinInt64, math.MaxInt64
+}
+
+func newGateTestPoller(t *testing.T, up common.Upstream) *EvmStatePoller {
+	t.Helper()
+	appCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", 2*time.Second)
+	ssr, err := data.NewSharedStateRegistry(appCtx, &logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: common.DriverMemory,
+			Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+		},
+	})
+	require.NoError(t, err)
+	return NewEvmStatePoller("test", appCtx, &logger, up, tracker, ssr)
+}
+
+const gateTolerance = int64(common.DefaultToleratedBlockHeadRollback)
+
+// --- SuggestLatestBlock ---
+
+func TestSuggestLatestBlock_SmallAdvanceAppliesInline(t *testing.T) {
+	// Configured chainId matches; but a small advance must never even reach the
+	// gate — it applies synchronously.
+	up := newSuggestGateUpstream(123, "123", nil)
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000) // from 0 → inline (cold start)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(1000 + gateTolerance) // small (== tolerance, not major)
+	require.Equal(t, int64(1000+gateTolerance), p.LatestBlock(), "small advance applies inline & synchronously")
+	require.False(t, up.isCordoned())
+}
+
+func TestSuggestLatestBlock_MajorJumpMatchingChainIdApplies(t *testing.T) {
+	up := newSuggestGateUpstream(123, "123", nil) // detected == configured
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(1000 + gateTolerance + 1000) // MAJOR forward jump
+	require.Eventually(t, func() bool {
+		return p.LatestBlock() == 1000+gateTolerance+1000
+	}, 2*time.Second, 10*time.Millisecond, "verified major jump must be applied")
+	require.False(t, up.isCordoned(), "a matching chainId must not cordon")
+}
+
+func TestSuggestLatestBlock_MajorJumpChainIdMismatchDroppedAndCordoned(t *testing.T) {
+	up := newSuggestGateUpstream(123, "999", nil) // detected != configured
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(5_000_000) // MAJOR (another chain's height)
+	require.Eventually(t, up.isCordoned, 2*time.Second, 10*time.Millisecond, "a proven cross-wired endpoint must be cordoned")
+	assert.Equal(t, int64(1000), p.LatestBlock(), "the bogus major jump must NOT enter the shared counter")
+}
+
+func TestSuggestLatestBlock_MajorJumpChainIdErrorDroppedNotCordoned(t *testing.T) {
+	// A transient eth_chainId failure (not a proven mismatch) drops the sample
+	// for now and does NOT cordon — the next verified poll re-observes it.
+	up := newSuggestGateUpstream(123, "", assert.AnError)
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(5_000_000) // MAJOR
+	require.Never(t, func() bool {
+		return p.LatestBlock() != 1000
+	}, 300*time.Millisecond, 20*time.Millisecond, "unverifiable major jump must be dropped")
+	assert.False(t, up.isCordoned(), "a transient probe error must not cordon")
+}
+
+func TestSuggestLatestBlock_MajorJumpTypedMismatchErrorCordons(t *testing.T) {
+	// The gRPC BDS client surfaces a cross-wired server as a typed mismatch error
+	// on the chainId probe itself — treated as proof, same as a differing answer.
+	up := newSuggestGateUpstream(123, "", common.NewErrEndpointChainIdMismatch(999, 123))
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(5_000_000)
+	require.Eventually(t, up.isCordoned, 2*time.Second, 10*time.Millisecond, "typed chainId-mismatch error must cordon")
+	assert.Equal(t, int64(1000), p.LatestBlock())
+}
+
+func TestSuggestLatestBlock_UnpinnedChainIdSkipsGate(t *testing.T) {
+	// Chain identity not pinned yet (ChainId <= 0): there is nothing trustworthy
+	// to verify against, so the gate passes and the (cold-start) jump applies.
+	up := newSuggestGateUpstream(0, "", assert.AnError)
+	p := newGateTestPoller(t, up)
+
+	p.SuggestLatestBlock(1000)
+	require.Equal(t, int64(1000), p.LatestBlock())
+
+	p.SuggestLatestBlock(5_000_000) // major, but chainId not pinned → not gated
+	require.Eventually(t, func() bool {
+		return p.LatestBlock() == 5_000_000
+	}, 2*time.Second, 10*time.Millisecond)
+	require.False(t, up.isCordoned())
+}
+
+// --- SuggestFinalizedBlock ---
+
+func TestSuggestFinalizedBlock_MajorJumpMatchingApplies(t *testing.T) {
+	up := newSuggestGateUpstream(123, "123", nil)
+	p := newGateTestPoller(t, up)
+
+	p.SuggestFinalizedBlock(1000)
+	require.Eventually(t, func() bool { return p.FinalizedBlock() == 1000 }, 2*time.Second, 10*time.Millisecond)
+
+	p.SuggestFinalizedBlock(1000 + gateTolerance + 1000) // MAJOR
+	require.Eventually(t, func() bool {
+		return p.FinalizedBlock() == 1000+gateTolerance+1000
+	}, 2*time.Second, 10*time.Millisecond, "verified major finalized jump must be applied")
+	require.False(t, up.isCordoned())
+}
+
+func TestSuggestFinalizedBlock_MajorJumpChainIdMismatchDroppedAndCordoned(t *testing.T) {
+	up := newSuggestGateUpstream(123, "999", nil)
+	p := newGateTestPoller(t, up)
+
+	p.SuggestFinalizedBlock(1000)
+	require.Eventually(t, func() bool { return p.FinalizedBlock() == 1000 }, 2*time.Second, 10*time.Millisecond)
+
+	p.SuggestFinalizedBlock(5_000_000) // MAJOR wrong-chain height
+	require.Eventually(t, up.isCordoned, 2*time.Second, 10*time.Millisecond)
+	assert.Equal(t, int64(1000), p.FinalizedBlock(), "bogus major finalized jump must not enter the shared counter")
+}

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -617,8 +617,13 @@ func TestServedTip_NoNetworkLevelStickiness(t *testing.T) {
 
 	// And no downward stickiness either: the moment the remaining head
 	// advances, the pick follows it up.
+	// (9_000 → 11_000 is a MAJOR jump, so it passes the poller's off-hot-path
+	// chain-identity check — mocked eth_chainId matches — before it applies.)
 	ups[2].EvmStatePoller().SuggestLatestBlock(11_000)
-	assert.Equal(t, int64(11_000), network.EvmHighestLatestBlockNumber(ctx))
+	require.Eventually(t, func() bool {
+		return network.EvmHighestLatestBlockNumber(ctx) == 11_000
+	}, 2*time.Second, 10*time.Millisecond,
+		"the pick must follow the verified major forward jump with no stickiness")
 }
 
 // A halted chain that resumes with a burst (sequencer outage ending, L2 batch


### PR DESCRIPTION
## Problem

`EvmStatePoller.PollLatestBlockNumber` already routes a *major* head move — a jump beyond `DefaultToleratedBlockHeadRollback` — through `verifyChainIdOnMajorHeadMove`, which makes a fresh `eth_chainId` call and cordons an upstream that turns out to be answering for a different chain.

The out-of-band `SuggestLatestBlock` / `SuggestFinalizedBlock` paths — fed by response enrichment and halted-chain resumes — were deliberately left ungated, on the assumption that a bogus suggestion self-heals within one poll cycle.

That assumption breaks when the suggesting upstream never returns a correct low sample afterwards: a cross-wired endpoint that starts answering with another chain's (much higher) block height and then only errors or keeps serving the wrong chain. Its bogus head enters the shared counter via the suggestion path, is persisted, and skews every lag-based routing decision derived from the network head until an operator intervenes.

## Change

Route a **major forward jump** from either suggestion path through the same `verifyChainIdOnMajorHeadMove` gate, off the hot path:

- **`SuggestLatestBlock`**: a jump beyond the tolerance is handed to a single background verification (`verifyThenSuggestLatestBlock`); at most one runs at a time per poller, and it applies the suggestion only if the chain-identity check passes. Small keep-fresh advances still apply inline with zero added latency.
- **`SuggestFinalizedBlock`**: already runs in its own goroutine, so the gate is added inline there.

A proven cross-wired endpoint is cordoned by the check itself; an unverifiable one (a transient `eth_chainId` failure) simply drops the suggestion and is re-observed on the next suggestion or verified poll. Non-major suggestions are unchanged, so the hot path stays non-blocking.

**Observable semantics change:** a major forward suggestion no longer takes effect synchronously — it lands after the background `eth_chainId` round-trip (typically one probe latency). Small advances, halted-chain resume bursts within the tolerance, and the verified poll path are unaffected. This deliberately trades a moment of tip latency on >tolerance out-of-band jumps for keeping a never-self-correcting cross-wired endpoint out of the shared counter.

## Tests

`architecture/evm/evm_state_poller_suggest_gate_test.go` covers:

- small advance applies inline and synchronously;
- major jump with a matching chain id is applied;
- major jump with a mismatching chain id is dropped **and** the upstream cordoned;
- major jump with a transient probe error is dropped **without** cordoning;
- major jump surfaced as a typed chain-id-mismatch error cordons;
- unpinned chain id (`ChainId <= 0`) skips the gate (cold start);
- the finalized-axis equivalents.

`erpc/networks_served_tip_test.go` — `TestServedTip_NoNetworkLevelStickiness` drives a >tolerance jump (9_000 → 11_000), so its assertion now waits (`require.Eventually`) for the verified suggestion to apply; the invariant it pins (zero network-level stickiness — the pick follows the heads) is unchanged. The sibling halted-chain-resume test stays synchronous: its 500-block burst is within tolerance and still applies inline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path-adjacent head tracking and routing inputs (shared counters, cordoning) for legitimate large catch-up jumps, with async verification that can briefly delay major suggests; behavior is heavily tested but affects core upstream selection semantics.
> 
> **Overview**
> **Out-of-band block head suggestions** from response enrichment and similar paths now go through the same **`verifyChainIdOnMajorHeadMove`** protection as verified polls when the jump is **major** (forward by more than `DefaultToleratedBlockHeadRollback`). That blocks cross-wired upstreams from pinning a wrong-chain height in shared counters and skewing lag-based routing when the bad endpoint never self-corrects.
> 
> For **`SuggestLatestBlock`**, major jumps are handled by **`verifyThenSuggestLatestBlock`**: a single background goroutine per poller runs `eth_chainId`; small keep-fresh advances still **`TryUpdate` inline** with no extra latency. **`SuggestFinalizedBlock`** adds the same gate inside its existing async update path before **`TryUpdate`**.
> 
> Proven chain mismatch still **cordons** the upstream; transient `eth_chainId` failures **drop** the suggestion without cordoning. Docs on **`verifyChainIdOnMajorHeadMove`** are updated to match (no longer claiming suggest paths are ungated).
> 
> New **`evm_state_poller_suggest_gate_test.go`** covers latest/finalized suggest behavior; **`networks_served_tip_test`** waits asynchronously for a major verified suggest to apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b431dd59f544057ea413b6ebafa170d6bc342f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
