### PR TITLE
fix(health): anchor the block-head lag reference to the corroborated freshest head

### DIFF
--- a/erpc/networks_selection_policy_realpoll_test.go
+++ b/erpc/networks_selection_policy_realpoll_test.go
@@ -279,6 +279,10 @@ func TestNetworkPolicy_RealPoll_LaggingUpstreamExcluded(t *testing.T) {
 // TestNetworkPolicy_RealPoll_WithinTolerance_NoneExcluded guards the other
 // direction: small, normal lag (a few blocks behind the tip) must NOT trip
 // blockNumberLagAbove(16). Same real-poll path, no exclusion expected.
+//
+// Lag is measured against the CORROBORATED freshest head (the second-highest,
+// 998 here — see health.Tracker networkLagReference), not the single most-ahead
+// node: u1's small lead does not count against its peers.
 func TestNetworkPolicy_RealPoll_WithinTolerance_NoneExcluded(t *testing.T) {
 	util.ResetGock()
 	defer util.ResetGock()
@@ -288,13 +292,13 @@ func TestNetworkPolicy_RealPoll_WithinTolerance_NoneExcluded(t *testing.T) {
 
 	network := setupRealPollLagNetwork(t, ctx, []realPollFixture{
 		{id: "u1", latest: 1000},
-		{id: "u2", latest: 998}, // 2 behind
-		{id: "u3", latest: 995}, // 5 behind — still within the 16-block tolerance
+		{id: "u2", latest: 998}, // at the corroborated tip
+		{id: "u3", latest: 995}, // 3 behind it — well within the 16-block tolerance
 	})
 
 	require.EqualValues(t, 0, blockHeadLagOf(t, network, "u1"))
-	require.EqualValues(t, 2, blockHeadLagOf(t, network, "u2"))
-	require.EqualValues(t, 5, blockHeadLagOf(t, network, "u3"))
+	require.EqualValues(t, 0, blockHeadLagOf(t, network, "u2"))
+	require.EqualValues(t, 3, blockHeadLagOf(t, network, "u3"))
 
 	order, excluded := policy.LatestDecisionOutputForTest(network.policyEngine, network.networkId, "*")
 	assert.NotContains(t, excluded, "u1")

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -56,6 +56,15 @@ type NetworkMetadata struct {
 	evmLatestBlockTimestamp atomic.Int64
 	evmFinalizedBlockNumber atomic.Int64
 
+	// Last lag reference applied per axis (see networkLagReference). The
+	// corroborated second-highest head can move while the network max stands
+	// still (the corroborating upstream catches up to the leader); comparing
+	// against the previous reference triggers the same global lag recompute a
+	// max advance does, so no upstream is left holding a lag computed against
+	// a stale reference.
+	evmLatestLagRef    atomic.Int64
+	evmFinalizedLagRef atomic.Int64
+
 	// Dynamic block time via EMA on on-chain block timestamps.
 	// Uses block.timestamp (integer seconds) normalized by block count gap.
 	// For fast chains where consecutive blocks share the same timestamp,
@@ -1181,6 +1190,9 @@ func (t *Tracker) updateNetworkLagMetrics(
 				return true
 			}
 			lag := networkValue - upsValue
+			if lag < 0 {
+				lag = 0
+			}
 			setLag(tm, lag)
 			gauge := getGauge(t.projectId, k.ups.VendorName(), k.ups.NetworkLabel(), k.ups.Id())
 			gauge.Set(float64(lag))
@@ -1204,6 +1216,9 @@ func (t *Tracker) updateNetworkLagMetrics(
 					continue
 				}
 				lag := networkValue - upsValue
+				if lag < 0 {
+					lag = 0
+				}
 				setLag(tm, lag)
 				// Block-head/finalization lag is a per-upstream property, but the
 				// (ups,method) dedup index stores a single, arbitrary-finality key
@@ -1311,6 +1326,109 @@ func (t *Tracker) recomputeNetworkBlockHead(net string, getVal func(*NetworkMeta
 	return maxVal
 }
 
+// minLagReferenceUpstreams is the smallest network fan-out at which the
+// block-head lag reference can be the corroborated second-highest head. It is
+// derived, not tuned: the design discounts exactly ONE far-future outlier
+// (the same k=1 hardcoded in evm.ServedTipPick.Freshest), and discounting k
+// outliers takes k+2 upstreams — the (k+1)-th highest as a reference that
+// still tracks the honest fleet's tip, plus at least one node measurable
+// against it. At N=2 the second-highest IS the lower head: both nodes would
+// always read zero lag and blockNumberLagAbove would go structurally dead for
+// every two-upstream network. Below the quorum the raw maximum is kept —
+// preserving the historical single/two-upstream behavior, where a genuinely
+// behind node is still measured against its one peer, and a lone rogue peer
+// remains an accepted, test-pinned exposure: with one vote against one vote,
+// height alone cannot say which side is right.
+const minLagReferenceUpstreams = 3
+
+// networkLagReference returns the block-head value used as the reference for
+// per-upstream lag — and therefore for the blockNumberLagAbove /
+// blockSecondsLagAbove selection-policy predicates. It is the CORROBORATED
+// FRESHEST head: the second-highest positive head across the network's
+// upstreams — the same statistic the served-tip subsystem designates as its
+// lag reference (evm.ServedTipPick.Freshest), so both layers agree on what
+// the trustworthy tip is.
+//
+// The raw maximum let a single most-ahead upstream define the tip. A
+// cross-wired or poisoned endpoint briefly reporting another chain's (much
+// higher) height inflated every honest upstream's lag by millions of blocks,
+// so the lag predicate evicted the whole healthy majority and routing
+// collapsed onto the poisoned node. The second-highest head is by definition
+// corroborated-or-exceeded by at least one other upstream, so no single rogue
+// can move it. The absolute per-upstream maxima remain observable via
+// erpc_upstream_latest_block_number.
+//
+// Semantics: lag measures each upstream's distance to the corroborated tip,
+// not to the single most-ahead node — a lone leader a few blocks ahead no
+// longer counts against its peers. Residual (inherent to height-only
+// corroboration): two or more upstreams agreeing on a bogus far-future head
+// corroborate each other and are not rejected. With fewer than
+// minLagReferenceUpstreams positive heads there is nothing to corroborate, so
+// networkMax is returned unchanged.
+//
+// Computed here — over ALL upstreams the tracker has observed, not the
+// selection-policy-eligible subset — deliberately: the reference FEEDS the
+// policy, so deriving it from the policy's own post-exclusion set would be
+// circular (an eviction removes a head from the input, freezing the state
+// that caused it). It is also independent of the served-tip opt-in, so
+// default max-mode networks get the same protection, and it stays a
+// zero-allocation streaming scan on the per-sample hot path.
+//
+// current is the upstream whose update triggered this recompute; it is always
+// counted (its per-method metrics entry is created only at the END of
+// SetLatestBlockNumber, so it is not yet visible to the index/range below and
+// would otherwise be undercounted on the very update that matters).
+func (t *Tracker) networkLagReference(net string, current common.Upstream, getVal func(*NetworkMetadata) int64, networkMax int64) int64 {
+	t.mu.RLock()
+	relevantKeys := t.upstreamsByNetwork[net]
+	t.mu.RUnlock()
+
+	seen := make(map[common.Upstream]struct{}, len(relevantKeys)+1)
+	var top, second int64 // two highest positive heads seen so far (top >= second)
+	found := 0
+	consider := func(ups common.Upstream) {
+		if ups == nil {
+			return
+		}
+		if _, done := seen[ups]; done {
+			return
+		}
+		seen[ups] = struct{}{}
+		v := getVal(t.getMetadata(metadataKey{ups, net}))
+		if v <= 0 {
+			return
+		}
+		found++
+		if v > top {
+			second = top
+			top = v
+		} else if v > second {
+			second = v
+		}
+	}
+	consider(current) // always count the triggering upstream (may be nil)
+	if len(relevantKeys) == 0 {
+		// Fallback if the index is not ready — mirrors recomputeNetworkBlockHead.
+		t.upsMetrics.Range(func(key, _ any) bool {
+			if k, ok := key.(upstreamKey); ok && k.ups != nil && k.ups.NetworkId() == net {
+				consider(k.ups)
+			}
+			return true
+		})
+	} else {
+		for _, k := range relevantKeys {
+			consider(k.ups)
+		}
+	}
+
+	if found < minLagReferenceUpstreams {
+		return networkMax
+	}
+	// The corroborated freshest: at least one other upstream is at or beyond
+	// this height (see evm.ServedTipPick.Freshest for the served-tip twin).
+	return second
+}
+
 func (t *Tracker) SetLatestBlockNumber(upstream common.Upstream, blockNumber int64, blockTimestamp int64) {
 	id := upstream.Id()
 	net := upstream.NetworkId()
@@ -1400,14 +1518,28 @@ func (t *Tracker) SetLatestBlockNumber(upstream common.Upstream, blockNumber int
 		}
 	}
 
-	// 3) Recompute block head lag for this upstream
+	// 3) Recompute block head lag for this upstream. The reference is the
+	// corroborated freshest head (second-highest; see networkLagReference), so
+	// a lone poisoned upstream cannot inflate every other upstream's lag and
+	// get the healthy majority evicted by blockNumberLagAbove.
 	ntwBn := ntwMeta.evmLatestBlockNumber.Load()
 	if ntwBn <= 0 {
 		lg.Warn().Int64("value", ntwBn).Msg("ignoring block head lag tracking for non-positive block number in tracker")
 		return
 	}
+	lagRef := t.networkLagReference(net, upstream, func(meta *NetworkMetadata) int64 {
+		return meta.evmLatestBlockNumber.Load()
+	}, ntwBn)
+	if ntwMeta.evmLatestLagRef.Swap(lagRef) != lagRef {
+		// The reference itself moved — every stored lag is now relative to a
+		// stale reference, not just this upstream's. Recompute all.
+		needsGlobalUpdate = true
+	}
 
-	upsLag := ntwBn - upsMeta.evmLatestBlockNumber.Load()
+	upsLag := lagRef - upsMeta.evmLatestBlockNumber.Load()
+	if upsLag < 0 {
+		upsLag = 0
+	}
 	gLag := t.getHeadLagGauge(t.projectId, vendor, netLabel, id)
 	gLag.Set(float64(upsLag))
 
@@ -1416,7 +1548,7 @@ func (t *Tracker) SetLatestBlockNumber(upstream common.Upstream, blockNumber int
 		// Recompute for every upstream in the network
 		t.updateNetworkLagMetrics(
 			net,
-			ntwBn,
+			lagRef,
 			func(meta *NetworkMetadata) int64 { return meta.evmLatestBlockNumber.Load() },
 			func(tm *TrackedMetrics, lag int64) { tm.BlockHeadLag.Store(lag) },
 			t.getHeadLagGauge,
@@ -1611,15 +1743,28 @@ func (t *Tracker) SetFinalizedBlockNumber(upstream common.Upstream, blockNumber 
 		}
 	}
 
-	// Recompute finalization lag for this upstream
+	// Recompute finalization lag for this upstream. Corroborated-freshest
+	// reference, same rationale as SetLatestBlockNumber — a lone far-future
+	// outlier must not inflate finalization lag and evict the healthy majority
+	// via blockSecondsLagAbove. See networkLagReference.
 	ntwVal := ntwMeta.evmFinalizedBlockNumber.Load()
 	if ntwVal <= 0 {
 		lg.Warn().Int64("value", ntwVal).Msg("ignoring finalization lag tracking for negative block number in tracker")
 		return
 	}
+	lagRef := t.networkLagReference(net, upstream, func(meta *NetworkMetadata) int64 {
+		return meta.evmFinalizedBlockNumber.Load()
+	}, ntwVal)
+	if ntwMeta.evmFinalizedLagRef.Swap(lagRef) != lagRef {
+		// Same reference-motion trigger as the latest axis.
+		needsGlobalUpdate = true
+	}
 
 	upsVal := upsMeta.evmFinalizedBlockNumber.Load()
-	upsLag := ntwVal - upsVal
+	upsLag := lagRef - upsVal
+	if upsLag < 0 {
+		upsLag = 0
+	}
 
 	// Update Prometheus for this upstream
 	gLag := t.getFinalizationLagGauge(t.projectId, vendor, netLabel, id)
@@ -1630,7 +1775,7 @@ func (t *Tracker) SetFinalizedBlockNumber(upstream common.Upstream, blockNumber 
 		// Recompute for every upstream in the network
 		t.updateNetworkLagMetrics(
 			net,
-			ntwVal,
+			lagRef,
 			func(meta *NetworkMetadata) int64 { return meta.evmFinalizedBlockNumber.Load() },
 			func(tm *TrackedMetrics, lag int64) { tm.FinalizationLag.Store(lag) },
 			t.getFinalizationLagGauge,

--- a/health/tracker_blockhead_rollback_test.go
+++ b/health/tracker_blockhead_rollback_test.go
@@ -127,27 +127,34 @@ func TestTrackerLatestBlockRollbackTolerance(t *testing.T) {
 		// upsA delivers a bogus sample far ahead of the real chain.
 		tracker.SetLatestBlockNumber(upsA, 100_000_000, 0)
 
+		// The raw network head still tracks the max (observable via
+		// erpc_upstream_latest_block_number), but the LAG reference is the
+		// corroborated second-highest (32_000_050) — so the lone bogus sample
+		// cannot make the healthy upstreams appear to lag by tens of millions
+		// of blocks.
 		assert.Equal(t, int64(100_000_000), networkLatest(tracker, net))
-		assert.Equal(t, int64(100_000_000-32_000_000), blockHeadLag(tracker, upsB),
-			"healthy upstreams appear to lag the bogus head")
+		assert.Equal(t, int64(50), blockHeadLag(tracker, upsB),
+			"corroborated lag reference ignores the lone bogus head")
 
-		// upsA's next real observation corrects it.
+		// upsA's next real observation corrects it; the network head is then
+		// re-derived from the remaining per-upstream values, and the lag
+		// reference is the corroborated freshest of the corrected heads.
 		tracker.SetLatestBlockNumber(upsA, 32_000_100, 0)
 
 		assert.Equal(t, int64(32_000_100), upstreamLatest(tracker, upsA))
 		assert.Equal(t, int64(32_000_100), networkLatest(tracker, net),
 			"network head re-derived as max over per-upstream values")
 		assert.Equal(t, int64(0), blockHeadLag(tracker, upsA))
-		assert.Equal(t, int64(100), blockHeadLag(tracker, upsB),
-			"healthy upstreams' lag recomputed against the corrected head")
-		assert.Equal(t, int64(50), blockHeadLag(tracker, upsC))
+		assert.Equal(t, int64(50), blockHeadLag(tracker, upsB),
+			"lag measured against the corroborated freshest (32_000_050), not the lone max")
+		assert.Equal(t, int64(0), blockHeadLag(tracker, upsC))
 
 		// Gauges follow the corrected values.
 		assert.Equal(t, float64(32_000_100),
 			promUtil.ToFloat64(tracker.getLatestBlockGauge(tracker.projectId, "*", upsA.NetworkLabel(), "*")))
 		assert.Equal(t, float64(32_000_100),
 			promUtil.ToFloat64(tracker.getLatestBlockGauge(tracker.projectId, upsA.VendorName(), upsA.NetworkLabel(), upsA.Id())))
-		assert.Equal(t, float64(100),
+		assert.Equal(t, float64(50),
 			promUtil.ToFloat64(tracker.getHeadLagGauge(tracker.projectId, upsB.VendorName(), upsB.NetworkLabel(), upsB.Id())))
 	})
 

--- a/health/tracker_lag_reference_test.go
+++ b/health/tracker_lag_reference_test.go
@@ -1,0 +1,219 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests pin the block-head / finalization LAG reference used by the
+// selection-policy predicates (blockNumberLagAbove / blockSecondsLagAbove). The
+// reference is the "corroborated freshest" head — the SECOND-highest positive
+// head across the network's upstreams — NOT the raw network maximum. The raw
+// maximum let a single most-ahead upstream (a cross-wired / poisoned node
+// briefly reporting another chain's much-higher height) inflate every honest
+// upstream's lag past the exclusion threshold, so the whole healthy majority got
+// evicted and routing collapsed onto the poisoned node. See
+// Tracker.networkLagReference and evm.ServedTipPick.Freshest.
+
+// evictionThreshold is a representative blockNumberLagAbove(N) bound; the tests
+// assert honest upstreams stay well under it and genuine laggards stay over it.
+const evictionThreshold = int64(16)
+
+func newLagTracker(t *testing.T, projectID string) *Tracker {
+	return newRollbackTestTracker(t, projectID)
+}
+
+// TestLagReference_LoneFutureOutlierDoesNotEvictMajority reproduces the incident:
+// seven honest sepolia-height upstreams plus one poisoned upstream reporting a
+// far-higher (mainnet) height. The honest majority must NOT be marked as
+// lagging.
+func TestLagReference_LoneFutureOutlierDoesNotEvictMajority(t *testing.T) {
+	tracker := newLagTracker(t, "test-lagref-incident")
+
+	const sepolia = int64(44_122_190)
+	const mainnetPoison = int64(48_590_164) // ~4.47M blocks ahead — another chain
+
+	honest := make([]common.Upstream, 7)
+	for i := range honest {
+		honest[i] = common.NewFakeUpstream(string(rune('a' + i)))
+		tracker.SetLatestBlockNumber(honest[i], sepolia, 0)
+	}
+	// The poison arrives LAST and advances the raw network max, forcing a global
+	// lag recompute across every upstream.
+	poison := common.NewFakeUpstream("poison")
+	tracker.SetLatestBlockNumber(poison, mainnetPoison, 0)
+
+	// Raw per-upstream max is still observable (unchanged behavior).
+	assert.Equal(t, mainnetPoison, networkLatest(tracker, poison.NetworkId()),
+		"raw network max still reflects the most-ahead upstream")
+
+	// The corroborated reference is the honest majority height, so every honest
+	// upstream reads ~zero lag and stays eligible.
+	for _, u := range honest {
+		lag := blockHeadLag(tracker, u)
+		assert.Equal(t, int64(0), lag, "honest upstream %s must not be marked as lagging", u.Id())
+		assert.Less(t, lag, evictionThreshold)
+	}
+	// The lone outlier is not itself excluded (its negative lag is clamped to 0)
+	// — harmless; the point is it can no longer evict the majority.
+	assert.Equal(t, int64(0), blockHeadLag(tracker, poison))
+}
+
+// TestLagReference_GenuineLaggardStillExcluded proves the fix does not
+// under-exclude: an upstream genuinely behind the majority still shows a large
+// lag and stays excludable.
+func TestLagReference_GenuineLaggardStillExcluded(t *testing.T) {
+	tracker := newLagTracker(t, "test-lagref-laggard")
+
+	a := common.NewFakeUpstream("a")
+	b := common.NewFakeUpstream("b")
+	c := common.NewFakeUpstream("c")
+	stale := common.NewFakeUpstream("stale")
+
+	tracker.SetLatestBlockNumber(a, 1000, 0)
+	tracker.SetLatestBlockNumber(b, 1000, 0)
+	tracker.SetLatestBlockNumber(c, 1000, 0)
+	tracker.SetLatestBlockNumber(stale, 200, 0)
+
+	assert.Equal(t, int64(0), blockHeadLag(tracker, a))
+	assert.Equal(t, int64(0), blockHeadLag(tracker, b))
+	assert.Equal(t, int64(800), blockHeadLag(tracker, stale))
+	assert.Greater(t, blockHeadLag(tracker, stale), evictionThreshold)
+}
+
+// TestLagReference_OutlierAndLaggardTogether is the decisive case: a poison
+// outlier AND a genuine laggard in the same network. The outlier must not evict
+// the healthy majority, and the laggard must still be caught.
+func TestLagReference_OutlierAndLaggardTogether(t *testing.T) {
+	tracker := newLagTracker(t, "test-lagref-both")
+
+	a := common.NewFakeUpstream("a")
+	b := common.NewFakeUpstream("b")
+	c := common.NewFakeUpstream("c")
+	stale := common.NewFakeUpstream("stale")
+	poison := common.NewFakeUpstream("poison")
+
+	tracker.SetLatestBlockNumber(a, 1000, 0)
+	tracker.SetLatestBlockNumber(b, 1000, 0)
+	tracker.SetLatestBlockNumber(c, 1000, 0)
+	tracker.SetLatestBlockNumber(stale, 200, 0)
+	tracker.SetLatestBlockNumber(poison, 999_999, 0) // last → global recompute
+
+	// Healthy majority: not lagging.
+	assert.Equal(t, int64(0), blockHeadLag(tracker, a))
+	assert.Equal(t, int64(0), blockHeadLag(tracker, b))
+	assert.Equal(t, int64(0), blockHeadLag(tracker, c))
+	// Genuine laggard: still excludable (reference is the majority 1000).
+	assert.Equal(t, int64(800), blockHeadLag(tracker, stale))
+	assert.Greater(t, blockHeadLag(tracker, stale), evictionThreshold)
+	// Outlier: clamped to 0, cannot evict others.
+	assert.Equal(t, int64(0), blockHeadLag(tracker, poison))
+}
+
+// TestLagReference_SingleUpstreamNeverLags: with one upstream there is no
+// reference to compare against — it can never be marked as lagging.
+func TestLagReference_SingleUpstreamNeverLags(t *testing.T) {
+	tracker := newLagTracker(t, "test-lagref-single")
+	a := common.NewFakeUpstream("a")
+	tracker.SetLatestBlockNumber(a, 1000, 0)
+	assert.Equal(t, int64(0), blockHeadLag(tracker, a))
+}
+
+// TestLagReference_TwoUpstreamsFallBackToMax documents the sub-quorum behavior:
+// with fewer than minLagReferenceUpstreams upstreams there is no second opinion
+// to appeal to, so the raw maximum is kept. A genuine laggard is still
+// detected; a lone outlier is NOT yet protected against — that protection
+// needs a real quorum (>= 3 upstreams), exercised by the other tests here.
+func TestLagReference_TwoUpstreamsFallBackToMax(t *testing.T) {
+	t.Run("genuineLaggardDetected", func(t *testing.T) {
+		tracker := newLagTracker(t, "test-lagref-two-laggard")
+		a := common.NewFakeUpstream("a")
+		b := common.NewFakeUpstream("b")
+		tracker.SetLatestBlockNumber(a, 1000, 0)
+		tracker.SetLatestBlockNumber(b, 990, 0)
+		assert.Equal(t, int64(0), blockHeadLag(tracker, a))
+		assert.Equal(t, int64(10), blockHeadLag(tracker, b), "with 2 upstreams the max is still the reference")
+	})
+	t.Run("outlierNotYetProtectedBelowQuorum", func(t *testing.T) {
+		tracker := newLagTracker(t, "test-lagref-two-poison")
+		a := common.NewFakeUpstream("a")
+		poison := common.NewFakeUpstream("poison")
+		tracker.SetLatestBlockNumber(a, 1000, 0)
+		tracker.SetLatestBlockNumber(poison, 999_999, 0)
+		assert.Equal(t, int64(998_999), blockHeadLag(tracker, a),
+			"below quorum the outlier still defines the reference (known limitation)")
+	})
+}
+
+// TestLagReference_FinalizationLagCorroborated mirrors the protection on the
+// finalized axis (blockSecondsLagAbove reads FinalizationLag).
+func TestLagReference_FinalizationLagCorroborated(t *testing.T) {
+	tracker := newLagTracker(t, "test-lagref-finalized")
+
+	honest := make([]common.Upstream, 3)
+	for i := range honest {
+		honest[i] = common.NewFakeUpstream(string(rune('a' + i)))
+		tracker.SetFinalizedBlockNumber(honest[i], 5000)
+	}
+	poison := common.NewFakeUpstream("poison")
+	tracker.SetFinalizedBlockNumber(poison, 9_000_000)
+
+	for _, u := range honest {
+		assert.Equal(t, int64(0), finalizationLag(tracker, u), "honest upstream %s finalization lag must stay 0", u.Id())
+	}
+	assert.Equal(t, int64(0), finalizationLag(tracker, poison))
+
+	// A genuinely behind upstream is still caught on the finalized axis.
+	behind := common.NewFakeUpstream("behind")
+	tracker.SetFinalizedBlockNumber(behind, 4000)
+	assert.Equal(t, int64(1000), finalizationLag(tracker, behind))
+}
+
+// TestNetworkLagReference_OrderStatistic pins the pure order-statistic of the
+// reference across fan-outs and ties — the second-highest positive head at or
+// above the corroboration quorum (N >= 3), the supplied max below it, and the
+// supplied max when there are no positive heads.
+func TestNetworkLagReference_OrderStatistic(t *testing.T) {
+	getLatest := func(m *NetworkMetadata) int64 { return m.evmLatestBlockNumber.Load() }
+
+	cases := []struct {
+		name   string
+		heads  []int64
+		expect int64
+	}{
+		{"single", []int64{100}, 100},
+		{"two_below_quorum_uses_max", []int64{200, 100}, 200},
+		{"three_small_spread_uses_second", []int64{102, 101, 100}, 101},
+		{"lone_rogue_ignored", []int64{999_999_999, 101, 100}, 101},
+		{"eight_incident_shape", []int64{48_590_164, 44_122_190, 44_122_190, 44_122_190, 44_122_190, 44_122_190, 44_122_190, 44_122_190}, 44_122_190},
+		{"all_equal", []int64{100, 100, 100}, 100},
+		// Two agreeing rogues corroborate each other — inherent to height-only
+		// corroboration; the second-highest is still one of the rogues.
+		{"two_agreeing_rogues_corroborate", []int64{999_999_999, 999_999_998, 300, 200, 100}, 999_999_998},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := newLagTracker(t, "test-orderstat-"+tc.name)
+			net := ""
+			var rawMax int64
+			for i, h := range tc.heads {
+				u := common.NewFakeUpstream("u" + string(rune('0'+i)))
+				net = u.NetworkId()
+				tracker.SetLatestBlockNumber(u, h, 0)
+				if h > rawMax {
+					rawMax = h
+				}
+			}
+			got := tracker.networkLagReference(net, nil, getLatest, rawMax)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+
+	t.Run("no_positive_heads_falls_back_to_max", func(t *testing.T) {
+		tracker := newLagTracker(t, "test-orderstat-empty")
+		// Nothing recorded for this network → fall back to the supplied max.
+		assert.Equal(t, int64(12345), tracker.networkLagReference("evm:123", nil, getLatest, 12345))
+	})
+}


### PR DESCRIPTION
## Problem

Per-upstream block-head lag — the value `blockNumberLagAbove` / `blockSecondsLagAbove` read to exclude stale upstreams — is computed in the tracker as `networkMax - upstreamHead`, where `networkMax` is the single most-ahead upstream's head.

That lets one wrongly-ahead upstream define the tip. A cross-wired or otherwise misbehaving endpoint that briefly reports another chain's (much higher) height sets the max millions of blocks ahead of the real chain. Every *healthy* upstream then appears to lag by that margin, trips the lag-exclusion predicate, and is dropped — so the selection policy evicts the entire healthy majority and routing collapses onto the one bad upstream.

## Change

The lag reference is now the **corroborated freshest** head: the second-highest positive head across the network's upstreams — the same statistic the served-tip subsystem already designates as its lag reference (`evm.ServedTipPick.Freshest`), so both layers agree on what the trustworthy tip is. No single rogue can move a value that at least one other upstream corroborates. With fewer than 3 positive heads there is nothing to corroborate, so the raw max is kept (preserving one/two-upstream laggard detection).

It is computed in the tracker, over **all** observed upstreams, deliberately:

- the reference *feeds* the selection policy, so deriving it from the policy's own post-exclusion eligible set would be circular (an eviction would remove a head from the input and freeze the state that caused it);
- it covers default max-mode networks identically (served-tip serving is opt-in);
- `health` cannot import `architecture/evm`, and the serve-side clamps (guaranteed-methods floor, selector partitions) are correct for "what do we advertise" but would under-measure "how stale is this node";
- it stays a zero-allocation streaming scan on the per-sample hot path.

Because the second-highest can move while the network max stands still (the corroborating upstream catches up to the leader), a change of the reference now triggers the same global lag recompute a max advance does — otherwise other upstreams would hold lags computed against a stale reference until their own next sample.

**Semantics shift, pinned by tests:** lag now measures distance to the corroborated tip rather than to the single most-ahead node — heads `[1000, 998, 995]` read lags `0/0/3` instead of `0/2/5`. A lone leader's small lead no longer counts against its peers.

**Known residual, also pinned:** two or more upstreams agreeing on a bogus far-future head corroborate each other — inherent to any height-only corroboration. The absolute per-upstream maxima remain observable via `erpc_upstream_latest_block_number`.

## Tests

- `health/tracker_lag_reference_test.go` — the incident shape (one poisoned far-future head vs. an honest majority), genuine laggard still excluded, outlier + laggard together, single/two-upstream fallback, finalized axis, and the pure order-statistic across fan-outs and ties.
- `health/tracker_blockhead_rollback_test.go` — rollback re-derivation now asserts corroborated-freshest lags after correction.
- `erpc/networks_selection_policy_realpoll_test.go` — end-to-end real-poll path: laggard excluded, within-tolerance topology keeps all upstreams with the new lag values.
- `internal/policy/stdlib` observability leaf-attribution passes with the reference-motion recompute (previously an upstream could hold a stale lag when the reference moved under a stable max).

Full `./health/` (with `-race`), `./internal/policy/...`, and `./erpc/` suites pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how lag feeds `blockNumberLagAbove` / routing exclusions on every poll; behavior is well-tested but alters production selection semantics and has known limits below 3 upstreams or with multiple agreeing bad heads.
> 
> **Overview**
> Fixes a routing failure where one far-ahead (poisoned) upstream made every honest peer look massively stale against `networkMax`, tripping `blockNumberLagAbove` and evicting the healthy majority.
> 
> **Lag reference** for `BlockHeadLag` / `FinalizationLag` (and thus selection-policy predicates) is now the **corroborated freshest** head—the **second-highest** positive head when there are at least **3** upstreams—aligned with served-tip semantics. Below that quorum, behavior stays on the raw max. Per-upstream lag is **clamped to ≥ 0**; when the reference moves without the network max changing, stored `evmLatestLagRef` / `evmFinalizedLagRef` trigger a **network-wide lag recompute**.
> 
> **Semantics shift:** lag is distance to the corroborated tip, not the lone leader (e.g. heads `1000/998/995` → lags `0/0/3`). Raw network max metrics are unchanged.
> 
> New and updated tests cover the incident shape, genuine laggards, finalized axis, order statistics, rollback, and real-poll policy integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d332dcfeba2ad08687b2b35087e131fa569d78b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->