### PR TITLE
fix: classify Alchemy code 3 missing-data errors as retryable missing data

### DIFF
--- a/thirdparty/alchemy.go
+++ b/thirdparty/alchemy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	archEvm "github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
 	"github.com/rs/zerolog"
 )
@@ -350,6 +351,23 @@ func (v *AlchemyVendor) GetVendorSpecificErrorIfAny(req *common.NormalizedReques
 				),
 			).WithRetryableTowardNetwork(false)
 		} else if code == 3 {
+			// Alchemy uses code 3 both for EVM execution errors (reverts) and for
+			// data-availability errors such as "Unknown block" on near-tip reads.
+			// The latter is missing data that another upstream may have, so it must
+			// remain retryable toward the network instead of being classified as a
+			// deterministic revert.
+			if archEvm.IsMissingDataError(err) {
+				return common.NewErrEndpointMissingData(
+					common.NewErrJsonRpcExceptionInternal(
+						code,
+						common.JsonRpcErrorMissingData,
+						msg,
+						nil,
+						details,
+					),
+					req.LastUpstream(),
+				)
+			}
 			return common.NewErrEndpointExecutionException(
 				common.NewErrJsonRpcExceptionInternal(
 					code,

--- a/thirdparty/alchemy_test.go
+++ b/thirdparty/alchemy_test.go
@@ -231,3 +231,28 @@ func swapAlchemyApiURL(t *testing.T, newURL string) string {
 	alchemyApiUrl = newURL
 	return prev
 }
+
+func TestAlchemyVendor_Code3_MissingDataIsRetryable(t *testing.T) {
+	v := CreateAlchemyVendor()
+
+	makeErr := func(msg string) error {
+		jrr, err := common.NewJsonRpcResponse(1, nil, common.NewErrJsonRpcExceptionExternal(3, msg, ""))
+		require.NoError(t, err)
+		return v.GetVendorSpecificErrorIfAny(nil, &http.Response{StatusCode: 400}, jrr, map[string]interface{}{})
+	}
+
+	// Code 3 with a data-availability message must be classified as missing
+	// data (retryable toward other upstreams), not as an execution revert.
+	for _, msg := range []string{"Unknown block", "block not found with number 0x1234abc"} {
+		err := makeErr(msg)
+		require.Error(t, err)
+		assert.True(t, common.HasErrorCode(err, common.ErrCodeEndpointMissingData), "expected missing-data for %q, got %v", msg, err)
+		assert.True(t, common.IsRetryableTowardNetwork(err), "missing-data must stay network-retryable for %q", msg)
+	}
+
+	// A genuine execution revert on code 3 keeps the existing classification.
+	err := makeErr("execution reverted")
+	require.Error(t, err)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeEndpointExecutionException), "expected execution exception, got %v", err)
+	assert.False(t, common.IsRetryableTowardNetwork(err))
+}


### PR DESCRIPTION
## Problem

Alchemy returns JSON-RPC error code `3` for two very different situations:

1. Genuine EVM execution errors (reverts) — correctly non-retryable, since they are deterministic.
2. Data-availability errors such as `"Unknown block"` on near-tip reads (observed with `eth_getBlockReceipts` when a block has not fully propagated yet).

`AlchemyVendor.GetVendorSpecificErrorIfAny` mapped **every** code-3 response to `ErrEndpointExecutionException`, whose constructor sets `retryableTowardNetwork: false`. Because vendor-specific handlers run before the generic normalizer, these responses never reached `evm.IsMissingDataError` — which already matches `"Unknown block"` / `"block not found"` — so eRPC surfaced the error instead of failing over to another upstream that may have the block.

Example (sanitized):

```json
{"code":"ErrUpstreamRequest","cause":{"code":"ErrEndpointExecutionException","details":{"retryableTowardNetwork":false},"cause":{"code":"ErrJsonRpcExceptionInternal","message":"Unknown block","details":{"originalCode":3,"statusCode":400}}}}
```

## Fix

In the code-3 branch, check `evm.IsMissingDataError` first and return `ErrEndpointMissingData` (retryable toward the network) for data-availability messages. Genuine reverts keep the existing `ErrEndpointExecutionException` classification.

## Testing

Added `TestAlchemyVendor_Code3_MissingDataIsRetryable` covering both directions:
- `"Unknown block"` / `"block not found …"` → `ErrEndpointMissingData`, `IsRetryableTowardNetwork == true`
- `"execution reverted"` → `ErrEndpointExecutionException`, `IsRetryableTowardNetwork == false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Alchemy vendor error mapping and failover behavior; reverts unchanged and covered by tests.
> 
> **Overview**
> **Alchemy JSON-RPC code `3`** is no longer always mapped to a non-retryable execution revert. In `GetVendorSpecificErrorIfAny`, messages that match **`archEvm.IsMissingDataError`** (e.g. `"Unknown block"`, `"block not found …"`) are returned as **`ErrEndpointMissingData`**, so eRPC can fail over to other upstreams on near-tip / propagation gaps. Genuine **`execution reverted`** responses on code `3` still become **`ErrEndpointExecutionException`** and stay non-retryable toward the network.
> 
> Adds **`TestAlchemyVendor_Code3_MissingDataIsRetryable`** to lock in both classifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29614de56faafbc90b4c4eb654d1bd8ca0524f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->