### PR TITLE
fix(server): drain keep-alive connections during waitBeforeShutdown grace window

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -209,6 +209,19 @@ func NewHttpServer(
 
 	go func() {
 		<-ctx.Done()
+		// Actively drain keep-alive connections during the grace window: stamp
+		// `Connection: close` on every HTTP/1.1 response (and let Shutdown GOAWAY
+		// tracked HTTP/2 conns) so pooled clients migrate to healthy instances
+		// BEFORE Shutdown starts closing connections. Load balancers that preserve
+		// established flows (e.g. AWS NLB) never break these pools on their own —
+		// without this, a client pushing traffic over kept-alive connections rides
+		// them straight into Shutdown and sees resets (502s) on every deploy.
+		if srv.serverV4 != nil {
+			srv.serverV4.SetKeepAlivesEnabled(false)
+		}
+		if srv.serverV6 != nil {
+			srv.serverV6.SetKeepAlivesEnabled(false)
+		}
 		// wait for readiness probe to mark the pod NotReady
 		// ideally (period_seconds * failure_threshold) + safety margin (1s)
 		if srv.serverCfg.WaitBeforeShutdown != nil {

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -8178,6 +8178,14 @@ func TestHttpServer_Evm_GetLogs_MemoryProfile(t *testing.T) {
 // AWS NLB) never break those pools on their own — without active drain every
 // deploy turns pooled in-flight requests into connection resets (client 502s).
 func TestHttpServer_DrainStampsConnectionClose(t *testing.T) {
+	// Bootstrap starts the EVM state poller, which calls the configured upstream
+	// in the background. gock's mock registry is global, so an unmocked poller
+	// consumes mocks belonging to other tests in this package — give it its own
+	// (this also resets gock and re-allows real localhost calls, which the
+	// assertions below depend on).
+	util.SetupMocksForEvmStatePoller()
+	defer util.ResetGock()
+
 	logger := log.Logger
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -8240,9 +8248,13 @@ func TestHttpServer_DrainStampsConnectionClose(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 
+	// The assertion is about the HTTP layer (does the response tell the client to
+	// close?), not about routing — so target an unknown project. erpc answers
+	// from the handler without an upstream call, keeping the test independent of
+	// upstream mocks and their consumption ordering.
 	sendRequest := func() *http.Response {
 		body := strings.NewReader(`{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}`)
-		req, err := http.NewRequest("POST", baseURL+"/test_project/evm/123", body)
+		req, err := http.NewRequest("POST", baseURL+"/no_such_project/evm/123", body)
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -8170,3 +8170,98 @@ func TestHttpServer_Evm_GetLogs_MemoryProfile(t *testing.T) {
 	require.NoError(t, pprof.Lookup("heap").WriteTo(f, 0))
 	t.Logf("heap profile saved to: %s", heapPath)
 }
+
+// During the waitBeforeShutdown grace window the server must stamp
+// `Connection: close` on responses (SetKeepAlivesEnabled(false)) so pooled
+// keep-alive clients migrate to healthy instances before Shutdown starts
+// closing connections. Load balancers that preserve established flows (e.g.
+// AWS NLB) never break those pools on their own — without active drain every
+// deploy turns pooled in-flight requests into connection resets (client 502s).
+func TestHttpServer_DrainStampsConnectionClose(t *testing.T) {
+	logger := log.Logger
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &common.Config{
+		Server: &common.ServerConfig{
+			MaxTimeout:         common.Duration(2 * time.Second).Ptr(),
+			ListenV4:           util.BoolPtr(true),
+			WaitBeforeShutdown: common.Duration(3 * time.Second).Ptr(),
+			WaitAfterShutdown:  common.Duration(10 * time.Millisecond).Ptr(),
+		},
+		Projects: []*common.ProjectConfig{
+			{
+				Id: "test_project",
+				Networks: []*common.NetworkConfig{
+					{
+						Architecture: common.ArchitectureEvm,
+						Evm:          &common.EvmNetworkConfig{ChainId: 123},
+					},
+				},
+				Upstreams: []*common.UpstreamConfig{
+					{
+						Type:     common.UpstreamTypeEvm,
+						Endpoint: "http://rpc1.localhost",
+						Evm:      &common.EvmUpstreamConfig{ChainId: 123},
+					},
+				},
+			},
+		},
+		RateLimiters: &common.RateLimiterConfig{},
+	}
+
+	ssr, err := data.NewSharedStateRegistry(ctx, &logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: "memory",
+			Memory: &common.MemoryConnectorConfig{
+				MaxItems: 100_000, MaxTotalSize: "1GB",
+			},
+		},
+	})
+	require.NoError(t, err)
+	erpcInstance, err := NewERPC(ctx, &logger, ssr, nil, cfg)
+	require.NoError(t, err)
+	erpcInstance.Bootstrap(ctx)
+
+	httpServer, err := NewHttpServer(ctx, &logger, cfg.Server, cfg.HealthCheck, cfg.Admin, erpcInstance)
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		if err := httpServer.serverV4.Serve(listener); err != nil && err != http.ErrServerClosed {
+			t.Errorf("Server error: %v", err)
+		}
+	}()
+	defer httpServer.serverV4.Shutdown(context.Background()) //nolint:errcheck
+
+	time.Sleep(100 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+
+	sendRequest := func() *http.Response {
+		body := strings.NewReader(`{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}`)
+		req, err := http.NewRequest("POST", baseURL+"/test_project/evm/123", body)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.ReadAll(resp.Body)
+		return resp
+	}
+
+	// Steady state: keep-alives on, no Connection: close on responses.
+	resp := sendRequest()
+	require.False(t, resp.Close, "steady-state responses must keep connections alive")
+
+	// Enter the drain window.
+	cancel()
+	time.Sleep(300 * time.Millisecond)
+
+	// Still serving (grace window), but every response now tells the client
+	// to reconnect elsewhere.
+	resp = sendRequest()
+	require.True(t, resp.Close, "drain-window responses must carry Connection: close so pooled clients migrate before Shutdown")
+}


### PR DESCRIPTION
## Problem

On SIGTERM the server sleeps `waitBeforeShutdown`, then calls `http.Server.Shutdown()`. During that grace window **keep-alives stay enabled**, so nothing tells connected clients to move.

Behind load balancers that preserve established TCP flows (e.g. AWS NLB), pooled HTTP clients (gateways, sidecars, aggregators) keep pushing requests over kept-alive connections through the entire grace window — the sleep migrates nothing. `Shutdown()` then stops the listener and closes connections under live traffic: requests racing the close see resets, which surface as 502s at the client on **every deploy**.

We measured this in production: ~150 client-facing 502/504s per regional rolling deploy at ~1k rps through an NLB (fast 0.2–0.6s 502s = resets on pooled connections; 504s = in-flight work caught by the shutdown context deadline), even with `waitBeforeShutdown: 30s`, ECS `stopTimeout: 120` and NLB `deregistration_delay: 120` all correctly aligned.

## Fix

Disable keep-alives at drain start (`SetKeepAlivesEnabled(false)` on both v4/v6 servers) before the `waitBeforeShutdown` sleep:

- every HTTP/1.1 response during the grace window carries `Connection: close`, so a high-rate pooled client migrates its entire pool to healthy instances within seconds;
- HTTP/2 connections tracked by the server get GOAWAY from `Shutdown()` as before;
- by the time `Shutdown()` runs, the instance holds no pooled connections and exits clean.

`waitBeforeShutdown` thus becomes an *active drain* window instead of a passive sleep. No config or behavior change for k8s users — readiness-probe-based draining works as before, this only adds connection migration on top.

## Test

`TestHttpServer_DrainStampsConnectionClose`: steady-state responses keep connections alive; after ctx cancellation (drain window) the server still serves but every response carries `Connection: close`. Verified the test **fails without the fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)