### PR TITLE
fix(auth): validate verificationJwksUrl is absolute HTTP(S)

### DIFF
--- a/common/validation.go
+++ b/common/validation.go
@@ -871,8 +871,15 @@ func (s *SecretStrategyConfig) Validate() error {
 }
 
 func (j *JwtStrategyConfig) Validate() error {
-	if len(j.VerificationKeys) == 0 && strings.TrimSpace(j.VerificationJwksUrl) == "" {
+	jwksURL := strings.TrimSpace(j.VerificationJwksUrl)
+	if len(j.VerificationKeys) == 0 && jwksURL == "" {
 		return fmt.Errorf("auth.*.jwt.verificationKeys or auth.*.jwt.verificationJwksUrl is required")
+	}
+	if jwksURL != "" {
+		parsed, err := url.Parse(jwksURL)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			return fmt.Errorf("auth.*.jwt.verificationJwksUrl must be a valid HTTP or HTTPS URL, got: %s", j.VerificationJwksUrl)
+		}
 	}
 	for claim, values := range j.ClaimMatchers {
 		if len(values) == 0 {

--- a/common/validation.go
+++ b/common/validation.go
@@ -877,7 +877,9 @@ func (j *JwtStrategyConfig) Validate() error {
 	}
 	if jwksURL != "" {
 		parsed, err := url.Parse(jwksURL)
-		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		// Prefer Hostname() over Host: values like "https://:443/jwks" parse with
+		// Host=":443" but an empty hostname, which cannot be fetched.
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" {
 			return fmt.Errorf("auth.*.jwt.verificationJwksUrl must be a valid HTTP or HTTPS URL, got: %s", j.VerificationJwksUrl)
 		}
 	}

--- a/common/validation_jwt_test.go
+++ b/common/validation_jwt_test.go
@@ -39,3 +39,63 @@ func TestJwtStrategyConfigValidateClaimMatchers(t *testing.T) {
 		assert.Contains(t, err.Error(), "empty value not allowed")
 	})
 }
+
+func TestJwtStrategyConfigValidateVerificationJwksUrl(t *testing.T) {
+	t.Run("https URL is accepted", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "https://auth.example.com/.well-known/jwks.json"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("http URL is accepted", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "http://auth.localhost/jwks"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("URL with path query and port is accepted", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "https://auth.example.com:8443/keys?format=jwks"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("jwks URL alone satisfies key requirement", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "https://auth.example.com/jwks"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("scheme-less host is rejected", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "auth.example.com/jwks"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
+	})
+
+	t.Run("unsupported scheme is rejected", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "file:///etc/jwks.json"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
+	})
+
+	t.Run("missing host is rejected", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "https:///jwks"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
+	})
+
+	t.Run("whitespace-only URL falls back to keys requirement", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "   "}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "verificationKeys or auth.*.jwt.verificationJwksUrl is required")
+	})
+
+	t.Run("invalid URL with static keys is still rejected", func(t *testing.T) {
+		cfg := &JwtStrategyConfig{
+			VerificationKeys:    map[string]string{"default": "secret"},
+			VerificationJwksUrl: "not-a-url",
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
+	})
+}

--- a/common/validation_jwt_test.go
+++ b/common/validation_jwt_test.go
@@ -82,6 +82,14 @@ func TestJwtStrategyConfigValidateVerificationJwksUrl(t *testing.T) {
 		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
 	})
 
+	t.Run("port-only host is rejected", func(t *testing.T) {
+		// url.Parse sets Host=":443" but Hostname() is empty.
+		cfg := &JwtStrategyConfig{VerificationJwksUrl: "https://:443/jwks"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a valid HTTP or HTTPS URL")
+	})
+
 	t.Run("whitespace-only URL falls back to keys requirement", func(t *testing.T) {
 		cfg := &JwtStrategyConfig{VerificationJwksUrl: "   "}
 		err := cfg.Validate()

--- a/docs/pages/config/auth.mdx
+++ b/docs/pages/config/auth.mdx
@@ -219,7 +219,7 @@ YAML prefix: `auth.strategies[*].jwt`
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `jwt.verificationKeys` | `map[string]string` | `nil` | Map of `kid → keyData`. Value is PEM string, `"file:///path"`, or bare HMAC secret bytes. Empty map = ALL JWTs rejected (deny-all, not allow-all). <SourceLink file="auth/jwks.go" /> |
-| `jwt.verificationJwksUrl` | `string` | `""` | HTTP(S) URL returning a standard JWKS document (`{"keys":[...]}`). Fetched at startup and refreshed in the background. Static `verificationKeys` override JWKS entries with the same `kid`. <SourceLink file="auth/jwks.go" /> |
+| `jwt.verificationJwksUrl` | `string` | `""` | Absolute HTTP(S) URL returning a standard JWKS document (`{"keys":[...]}`). Fetched at startup and refreshed in the background. Static `verificationKeys` override JWKS entries with the same `kid`. Non-HTTP(S) or host-less values fail startup validation. <SourceLink file="common/validation.go" /> |
 | `jwt.verificationJwksRefreshInterval` | `Duration` | `1h` when JWKS URL set | Background JWKS refresh interval. <SourceLink file="common/defaults.go" /> |
 | `jwt.verificationJwksTlsInsecureSkipVerify` | `bool` | `false` | Skip TLS certificate verification when fetching the JWKS URL. **Do not enable in production** — intended for local development with self-signed certificates only. <SourceLink file="auth/jwks.go" /> |
 | `jwt.allowedAlgorithms` | `[]string` | `nil` (any algorithm) | e.g. `["RS256","ES256"]`. Prevents algorithm-confusion attacks. <SourceLink file="auth/strategy_jwt.go" /> |
@@ -627,6 +627,7 @@ they naturally expire. Always set `allowedAlgorithms` to prevent algorithm-confu
 23. **`AuthConfig` is shared across all three scopes.** The same `AuthConfig` type is used for `projects[*].auth`, `admin.auth`, and `healthCheck.auth`. All five strategy types can be configured in any scope. The only scope-specific hazard is `healthCheck.auth` — the healthcheck auth registry is created with a nil `rateLimitersRegistry`, so setting `rateLimitBudget` on any healthcheck strategy causes a nil pointer panic.
 24. **Redis `addr`/`username`/`password`/`db` are cleared after `SetDefaults`.** After initialization, only `uri` is set; all discrete fields are zeroed. Config exports show only the URI (with credentials URL-encoded in it). Because `password` has `json:"-"`, a JSON export shows the URI but not the password field. [<SourceLink file="common/defaults.go" lines="1012-1015" />]
 25. **Admin auth registry DOES support rate-limit budgets.** Unlike the healthcheck scope, the admin `AuthRegistry` is created with the same `rateLimitersRegistry` as projects. Rate-limit budgets on admin auth strategies are applied when configured.
+26. **`verificationJwksUrl` must be absolute HTTP(S).** Non-empty values are parsed at startup; scheme must be `http` or `https` and a host is required. Scheme-less hosts, `file://`, and other schemes fail validation even when static `verificationKeys` are also set. [<SourceLink file="common/validation.go" />]
 
 ### Observability
 


### PR DESCRIPTION
## Summary
- Reject non-HTTP(S) `verificationJwksUrl` values at config validation time (scheme-less hosts, `file://`, missing host).
- Fail fast at startup with a clear error instead of a later JWKS fetch failure.
- Document the constraint in the auth config reference.

## Test plan
- [x] `go test ./common/ -run TestJwtStrategyConfigValidate`
- [ ] Confirm valid `https://…` / `http://…` JWKS URLs still start normally
- [ ] Confirm scheme-less and `file://` URLs fail startup validation even when static `verificationKeys` are set

Made with [Cursor](https://cursor.com)