### PR TITLE
fix(upstream): make state-poller bootstrap idempotent to stop poller/goroutine leak

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/erpc/erpc/common"
@@ -34,6 +35,13 @@ var _ common.EvmStatePoller = &EvmStatePoller{}
 
 type EvmStatePoller struct {
 	Enabled bool
+
+	// started guards the background ticker goroutine: Bootstrap may be called
+	// more than once on the same poller (upstream bootstrap tasks are retried
+	// and may be re-executed against an already-registered upstream). The
+	// ticker goroutine is bound to appCtx and has no other stop mechanism, so
+	// spawning a duplicate would poll the upstream forever.
+	started atomic.Bool
 
 	projectId    string
 	appCtx       context.Context
@@ -168,11 +176,22 @@ func (e *EvmStatePoller) Bootstrap(ctx context.Context) error {
 
 	if cfg.Evm != nil {
 		if cfg.Evm.StatePollerDebounce != 0 {
+			// Guarded by stateMu: live poll goroutines read this via
+			// resolveDebounce while Bootstrap may run again concurrently.
+			e.stateMu.Lock()
 			e.debounceInterval = cfg.Evm.StatePollerDebounce.Duration()
+			e.stateMu.Unlock()
 		}
 	}
 
 	e.logger.Debug().Msgf("bootstrapping evm state poller to track upstream latest/finalized blocks and syncing states")
+
+	if !e.started.CompareAndSwap(false, true) {
+		// A ticker goroutine is already running for this poller. Do not spawn
+		// another one — just refresh the state once so the caller still gets
+		// an up-to-date view.
+		return e.Poll(ctx)
+	}
 	e.Enabled = true
 
 	go (func() {
@@ -374,7 +393,10 @@ func (e *EvmStatePoller) Poll(ctx context.Context) error {
 //
 //	user config → block time → network FallbackStatePollerDebounce → 1s default
 func (e *EvmStatePoller) resolveDebounce(cfg *common.EvmNetworkConfig) time.Duration {
-	if dbi := e.debounceInterval; dbi != 0 {
+	e.stateMu.RLock()
+	dbi := e.debounceInterval
+	e.stateMu.RUnlock()
+	if dbi != 0 {
 		return dbi
 	}
 	if blockTime := e.tracker.GetNetworkBlockTime(e.upstream.NetworkId()); blockTime != 0 {

--- a/architecture/evm/evm_state_poller_test.go
+++ b/architecture/evm/evm_state_poller_test.go
@@ -1,0 +1,152 @@
+package evm
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePollerUpstream is a minimal common.Upstream implementation whose Forward
+// simply counts invocations and fails, which is enough to observe how many
+// poll loops are live without standing up a real JSON-RPC endpoint.
+type fakePollerUpstream struct {
+	cfg      *common.UpstreamConfig
+	logger   zerolog.Logger
+	forwards atomic.Int64
+}
+
+func (f *fakePollerUpstream) Id() string                     { return f.cfg.Id }
+func (f *fakePollerUpstream) VendorName() string             { return "test" }
+func (f *fakePollerUpstream) NetworkId() string              { return "evm:123" }
+func (f *fakePollerUpstream) NetworkLabel() string           { return "evm:123" }
+func (f *fakePollerUpstream) Config() *common.UpstreamConfig { return f.cfg }
+func (f *fakePollerUpstream) Logger() *zerolog.Logger        { return &f.logger }
+func (f *fakePollerUpstream) Vendor() common.Vendor          { return nil }
+func (f *fakePollerUpstream) Tracker() common.HealthTracker  { return nil }
+func (f *fakePollerUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
+	f.forwards.Add(1)
+	return nil, errors.New("fake upstream: forward always fails")
+}
+func (f *fakePollerUpstream) Cordon(method string, reason string)   {}
+func (f *fakePollerUpstream) Uncordon(method string, reason string) {}
+func (f *fakePollerUpstream) IgnoreMethod(method string)            {}
+func (f *fakePollerUpstream) ShouldHandleMethod(method string) (bool, error) {
+	return true, nil
+}
+
+var _ common.Upstream = (*fakePollerUpstream)(nil)
+
+func newTestStatePoller(t *testing.T, interval, debounce time.Duration) (*EvmStatePoller, *fakePollerUpstream, context.Context) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	logger := zerolog.Nop()
+	up := &fakePollerUpstream{
+		logger: logger,
+		cfg: &common.UpstreamConfig{
+			Id:   "test-upstream",
+			Type: common.UpstreamTypeEvm,
+			Evm: &common.EvmUpstreamConfig{
+				ChainId:             123,
+				StatePollerInterval: common.Duration(interval),
+				StatePollerDebounce: common.Duration(debounce),
+			},
+		},
+	}
+
+	ssr, err := data.NewSharedStateRegistry(ctx, &logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: "memory",
+			Memory: &common.MemoryConnectorConfig{
+				MaxItems:     100_000,
+				MaxTotalSize: "1GB",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	tracker := health.NewTracker(&logger, "test", 2*time.Second)
+	poller := NewEvmStatePoller("test", ctx, &logger, up, tracker, ssr)
+	return poller, up, ctx
+}
+
+// countGoroutinesStable samples runtime.NumGoroutine after letting transient
+// goroutines (Poll's short-lived workers) finish.
+func countGoroutinesStable() int {
+	time.Sleep(150 * time.Millisecond)
+	runtime.GC()
+	return runtime.NumGoroutine()
+}
+
+func TestEvmStatePoller_RepeatedBootstrapDoesNotLeakTickerGoroutines(t *testing.T) {
+	// Long interval: the ticker never fires during the test, so any goroutine
+	// growth is the ticker goroutines themselves.
+	poller, _, ctx := newTestStatePoller(t, time.Hour, time.Millisecond)
+
+	before := countGoroutinesStable()
+
+	// Simulate what a retried/re-executed bootstrap task does: call Bootstrap
+	// over and over on the same poller. Poll errors are irrelevant here.
+	for range 25 {
+		_ = poller.Bootstrap(ctx)
+	}
+
+	after := countGoroutinesStable()
+
+	// Exactly one ticker goroutine must exist (allow small scheduler noise).
+	// Without the started-guard this grows by one goroutine per Bootstrap.
+	assert.LessOrEqual(t, after-before, 3,
+		"expected a single ticker goroutine after 25 Bootstrap calls, got %d new goroutines", after-before)
+}
+
+func TestEvmStatePoller_RepeatedBootstrapDoesNotMultiplyPollRate(t *testing.T) {
+	// Short interval and tiny debounce so every tick reaches Forward.
+	poller, up, ctx := newTestStatePoller(t, 40*time.Millisecond, time.Millisecond)
+
+	_ = poller.Bootstrap(ctx)
+
+	base1 := up.forwards.Load()
+	time.Sleep(600 * time.Millisecond)
+	singleTickerCalls := up.forwards.Load() - base1
+	require.Greater(t, singleTickerCalls, int64(0), "single ticker should be polling")
+
+	// Re-bootstrap several times; with the guard this must not add tickers.
+	for range 4 {
+		_ = poller.Bootstrap(ctx)
+	}
+
+	base2 := up.forwards.Load()
+	time.Sleep(600 * time.Millisecond)
+	afterRebootstrapCalls := up.forwards.Load() - base2
+
+	// With five tickers the second window would see ~5x the calls of the
+	// first. Allow generous scheduling slack, but reject any multiplication.
+	assert.Less(t, afterRebootstrapCalls, singleTickerCalls*2+8,
+		"poll rate multiplied after repeated Bootstrap calls: first window %d calls, second window %d calls",
+		singleTickerCalls, afterRebootstrapCalls)
+}
+
+func TestEvmStatePoller_BootstrapWithZeroIntervalStartsNothing(t *testing.T) {
+	poller, up, ctx := newTestStatePoller(t, 0, 0)
+
+	before := countGoroutinesStable()
+	require.NoError(t, poller.Bootstrap(ctx))
+	require.NoError(t, poller.Bootstrap(ctx))
+	after := countGoroutinesStable()
+
+	assert.LessOrEqual(t, after-before, 0, "interval=0 must not start any poll loop")
+	assert.Equal(t, int64(0), up.forwards.Load(), "interval=0 must not poll the upstream")
+	assert.False(t, poller.Enabled)
+}

--- a/upstream/registry.go
+++ b/upstream/registry.go
@@ -46,6 +46,14 @@ type UpstreamsRegistry struct {
 
 	providerOnce sync.Map // networkId -> *sync.Once
 
+	// pendingUpstreams holds Upstream instances created by bootstrap task
+	// attempts that have not completed successfully yet, keyed by upstream id.
+	// Retried or concurrent attempts MUST reuse the same instance: creating a
+	// fresh one per attempt duplicates HTTP clients and — once an attempt
+	// reaches Upstream.Bootstrap — state pollers, whose ticker goroutines can
+	// only be stopped by the app context.
+	pendingUpstreams sync.Map // upstreamId -> *Upstream
+
 	onUpstreamRegistered func(ups *Upstream) error
 }
 
@@ -443,12 +451,29 @@ func (u *UpstreamsRegistry) buildUpstreamBootstrapTask(upsCfg *common.UpstreamCo
 			}
 			u.upstreamsMu.RUnlock()
 
+			if ups == nil {
+				// Reuse the instance created by a previous failed attempt, if any,
+				// instead of building a new one per retry.
+				if v, ok := u.pendingUpstreams.Load(cfg.Id); ok {
+					ups = v.(*Upstream)
+				}
+			}
+
 			var err error
 			if ups == nil {
-				ups, err = u.NewUpstream(cfg)
+				var created *Upstream
+				// Copy the config per attempt: NewUpstream mutates it (vendor
+				// detection), and concurrent attempts of this task would
+				// otherwise race on the shared task-level copy.
+				created, err = u.NewUpstream(cfg.Copy())
 				if err != nil {
 					return err
 				}
+				// LoadOrStore so concurrent attempts of this task converge on a
+				// single instance; the loser is discarded before it starts any
+				// background work.
+				actual, _ := u.pendingUpstreams.LoadOrStore(cfg.Id, created)
+				ups = actual.(*Upstream)
 			}
 
 			err = ups.Bootstrap(ctx)
@@ -456,6 +481,7 @@ func (u *UpstreamsRegistry) buildUpstreamBootstrapTask(upsCfg *common.UpstreamCo
 				return err
 			}
 			u.doRegisterBootstrappedUpstream(ups)
+			u.pendingUpstreams.Delete(cfg.Id)
 
 			if u.onUpstreamRegistered != nil {
 				// TODO Refactor the upstream<->network relationship to avoid circular dependency. Then we can remove this goroutine.
@@ -568,7 +594,18 @@ func (u *UpstreamsRegistry) doRegisterBootstrappedUpstream(ups *Upstream) {
 	u.upstreamsMu.Lock()
 	defer u.upstreamsMu.Unlock()
 
-	u.allUpstreams = append(u.allUpstreams, ups)
+	// A bootstrap task may be re-executed against an already-registered
+	// upstream; never register the same instance twice.
+	alreadyInAll := false
+	for _, existing := range u.allUpstreams {
+		if existing == ups {
+			alreadyInAll = true
+			break
+		}
+	}
+	if !alreadyInAll {
+		u.allUpstreams = append(u.allUpstreams, ups)
+	}
 
 	// Add to network upstreams map
 	isShadow := ups.Config() != nil && ups.Config().Shadow != nil && ups.Config().Shadow.Enabled

--- a/upstream/registry_bootstrap_test.go
+++ b/upstream/registry_bootstrap_test.go
@@ -1,0 +1,220 @@
+package upstream
+
+import (
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/data"
+	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/thirdparty"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const bootstrapTestEndpoint = "http://rpc1.localhost"
+
+func newBootstrapTestRegistry(t *testing.T) (*UpstreamsRegistry, *common.UpstreamConfig) {
+	t.Helper()
+
+	ctx := t.Context()
+	logger := zerolog.Nop()
+
+	vr := thirdparty.NewVendorsRegistry()
+	pr, err := thirdparty.NewProvidersRegistry(&logger, vr, []*common.ProviderConfig{}, nil)
+	require.NoError(t, err)
+
+	ssr, err := data.NewSharedStateRegistry(ctx, &logger, &common.SharedStateConfig{
+		Connector: &common.ConnectorConfig{
+			Driver: "memory",
+			Memory: &common.MemoryConnectorConfig{
+				MaxItems:     100_000,
+				MaxTotalSize: "1GB",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rlr, err := NewRateLimitersRegistry(ctx, &common.RateLimiterConfig{
+		Budgets: []*common.RateLimitBudgetConfig{},
+	}, &logger)
+	require.NoError(t, err)
+
+	mt := health.NewTracker(&logger, "test", 2*time.Second)
+
+	cfg := &common.UpstreamConfig{
+		Id:       "rpc1",
+		Type:     common.UpstreamTypeEvm,
+		Endpoint: bootstrapTestEndpoint,
+		Evm: &common.EvmUpstreamConfig{
+			ChainId: 123,
+			// Long interval so ticker goroutines exist but never fire in-test.
+			StatePollerInterval: common.Duration(time.Hour),
+		},
+	}
+
+	reg := NewUpstreamsRegistry(
+		ctx, &logger, "test",
+		[]*common.UpstreamConfig{cfg},
+		ssr, rlr, vr, pr, nil, mt, nil,
+	)
+	return reg, cfg
+}
+
+func gockBodyContains(s string) func(*http.Request) bool {
+	return func(r *http.Request) bool {
+		return strings.Contains(util.SafeReadBody(r), s)
+	}
+}
+
+// mockChainIdFailures makes the next `times` eth_chainId calls fail with a
+// retryable server error, simulating a provider outage during startup.
+func mockChainIdFailures(times int) {
+	gock.New(bootstrapTestEndpoint).
+		Post("").
+		Times(times).
+		Filter(gockBodyContains("eth_chainId")).
+		Reply(500).
+		JSON([]byte(`{"error":{"code":-32603,"message":"simulated startup failure"}}`))
+}
+
+// mockUpstreamHealthy serves everything an upstream bootstrap and its state
+// poller need: chainId detection plus latest/finalized block and syncing.
+func mockUpstreamHealthy() {
+	gock.New(bootstrapTestEndpoint).
+		Post("").
+		Persist().
+		Filter(gockBodyContains("eth_chainId")).
+		Reply(200).
+		JSON([]byte(`{"result":"0x7b"}`))
+	gock.New(bootstrapTestEndpoint).
+		Post("").
+		Persist().
+		Filter(gockBodyContains("eth_getBlockByNumber")).
+		Reply(200).
+		JSON([]byte(`{"result":{"number":"0x11118888","timestamp":"0x6702a8f0"}}`))
+	gock.New(bootstrapTestEndpoint).
+		Post("").
+		Persist().
+		Filter(gockBodyContains("eth_syncing")).
+		Reply(200).
+		JSON([]byte(`{"result":false}`))
+}
+
+func TestUpstreamBootstrapTask_RetriedAttemptsReuseSameInstance(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	// First two chainId detections fail (transient), then the endpoint heals.
+	mockChainIdFailures(2)
+	mockUpstreamHealthy()
+
+	reg, cfg := newBootstrapTestRegistry(t)
+	task := reg.buildUpstreamBootstrapTask(cfg)
+	ctx := t.Context()
+
+	// Attempt 1: fails, but the created instance must be parked for reuse.
+	require.Error(t, task.Fn(ctx))
+	v1, ok := reg.pendingUpstreams.Load(cfg.Id)
+	require.True(t, ok, "failed attempt must park its Upstream instance for reuse")
+
+	// Attempt 2: fails again and must NOT have built a second instance.
+	require.Error(t, task.Fn(ctx))
+	v2, ok := reg.pendingUpstreams.Load(cfg.Id)
+	require.True(t, ok)
+	assert.Same(t, v1, v2, "retried attempt must reuse the instance from the previous attempt")
+
+	// Attempt 3: succeeds; the SAME instance must be the one registered.
+	require.NoError(t, task.Fn(ctx))
+	all := reg.GetAllUpstreams()
+	require.Len(t, all, 1)
+	assert.Same(t, v1, all[0], "the registered upstream must be the reused instance")
+	require.NotNil(t, all[0].EvmStatePoller(), "registered upstream must have a state poller")
+
+	_, stillPending := reg.pendingUpstreams.Load(cfg.Id)
+	assert.False(t, stillPending, "successful registration must clear the pending entry")
+}
+
+func TestUpstreamBootstrapTask_ReexecutionDoesNotDuplicatePollersOrRegistrations(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	mockUpstreamHealthy()
+
+	reg, cfg := newBootstrapTestRegistry(t)
+	task := reg.buildUpstreamBootstrapTask(cfg)
+	ctx := t.Context()
+
+	require.NoError(t, task.Fn(ctx))
+	all := reg.GetAllUpstreams()
+	require.Len(t, all, 1)
+	ups := all[0]
+	poller := ups.EvmStatePoller()
+	require.NotNil(t, poller)
+
+	time.Sleep(150 * time.Millisecond)
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	// Re-execute the bootstrap task against the already-registered upstream,
+	// as a retry loop (or a task re-armed for any reason) would.
+	for range 10 {
+		require.NoError(t, task.Fn(ctx))
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	assert.True(t, poller == ups.EvmStatePoller(),
+		"re-executed bootstrap must not replace the upstream's state poller")
+	assert.LessOrEqual(t, after-before, 3,
+		"re-executed bootstrap must not accumulate poller goroutines, got %d new goroutines", after-before)
+	assert.Len(t, reg.GetAllUpstreams(), 1,
+		"re-executed bootstrap must not register the upstream again")
+}
+
+func TestUpstreamBootstrapTask_ConcurrentAttemptsConvergeOnSingleInstance(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	// All concurrent attempts fail chainId detection, then the endpoint heals.
+	mockChainIdFailures(8)
+	mockUpstreamHealthy()
+
+	reg, cfg := newBootstrapTestRegistry(t)
+	task := reg.buildUpstreamBootstrapTask(cfg)
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = task.Fn(ctx)
+		}()
+	}
+	wg.Wait()
+
+	// However many attempts raced, at most one instance may be parked and
+	// nothing may be registered yet.
+	pendingCount := 0
+	var pending any
+	reg.pendingUpstreams.Range(func(_, v any) bool {
+		pendingCount++
+		pending = v
+		return true
+	})
+	require.Equal(t, 1, pendingCount, "concurrent attempts must converge on a single parked instance")
+	assert.Empty(t, reg.GetAllUpstreams())
+
+	// Once the endpoint heals, the parked instance is the one registered.
+	require.NoError(t, task.Fn(ctx))
+	all := reg.GetAllUpstreams()
+	require.Len(t, all, 1)
+	assert.Same(t, pending, all[0])
+}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -129,6 +129,7 @@ type Upstream struct {
 	rateLimitersRegistry *RateLimitersRegistry
 	rateLimiterAutoTuner *RateLimitAutoTuner
 	evmStatePoller       common.EvmStatePoller
+	statePollerOnce      sync.Once
 	// True after successful chainId detection/validation; enables short-circuit in EvmGetChainId.
 	chainIdValidated atomic.Bool
 }
@@ -228,7 +229,14 @@ func (u *Upstream) Bootstrap(ctx context.Context) error {
 	}
 
 	if u.config.Type == common.UpstreamTypeEvm {
-		u.evmStatePoller = evm.NewEvmStatePoller(u.ProjectId, u.appCtx, u.logger, u, u.metricsTracker, u.sharedStateRegistry)
+		// Create the poller exactly once per Upstream: Bootstrap can run more
+		// than once (bootstrap tasks are retried, and a retry may re-invoke
+		// Bootstrap on an already-registered upstream). Replacing the poller
+		// would orphan the previous instance while its ticker goroutine keeps
+		// polling the upstream forever (it only stops via appCtx).
+		u.statePollerOnce.Do(func() {
+			u.evmStatePoller = evm.NewEvmStatePoller(u.ProjectId, u.appCtx, u.logger, u, u.metricsTracker, u.sharedStateRegistry)
+		})
 	}
 
 	if u.evmStatePoller != nil {


### PR DESCRIPTION
## Problem

Upstream bootstrap tasks can execute **more than once for the same upstream**, and each execution created a **new EVM state poller** whose ticker goroutine is bound only to `appCtx` — there is no per-poller stop path. Duplicates therefore poll the upstream for the entire life of the process.

Two mechanisms in the initializer make repeat execution normal, not exceptional:
- failed tasks are auto-retried forever (permanently-failing upstreams and `ErrNetworkNotSupported` provider/network combinations retry by design);
- a timed-out attempt is re-attempted while the original attempt goroutine may still be running.

Three spots compound into an unbounded leak:
1. `EvmStatePoller.Bootstrap` unconditionally spawns the ticker goroutine.
2. `Upstream.Bootstrap` unconditionally constructs a new `EvmStatePoller`, orphaning the previous one (whose ticker keeps polling).
3. `buildUpstreamBootstrapTask` builds a fresh `Upstream` on every failed attempt, and `doRegisterBootstrappedUpstream` appends to `allUpstreams` unconditionally.

In a long-lived process with even a handful of permanently-failing upstreams, duplicate pollers and goroutines accumulate **linearly for the life of the process**: the per-upstream request rate to those endpoints climbs without bound (state-poll traffic — `eth_getBlockByNumber` for latest/finalized plus `eth_syncing`), and goroutine count / memory grow until OOM. It is most visible on chains configured with a short `statePollerInterval`, but the accumulation happens on every network.

## Fix

Enforce a single invariant — **at most one live state poller per upstream id per process**:

- **`EvmStatePoller.Bootstrap`** — guard the ticker goroutine with an atomic CAS (`started`). A second call only refreshes state via `Poll(ctx)`; it never spawns another ticker.
- **`Upstream.Bootstrap`** — create the poller exactly once via `sync.Once`, so a re-bootstrapped upstream keeps its existing poller instead of orphaning it.
- **`buildUpstreamBootstrapTask`** — park the created `Upstream` in `pendingUpstreams` (`LoadOrStore`) so retried and concurrent attempts converge on a single instance; clear it once registration succeeds.
- **`doRegisterBootstrappedUpstream`** — never append the same instance to `allUpstreams` twice.

This is intentionally minimal and changes no happy-path behavior: a fresh boot creates exactly one poller per upstream, exactly as before. The invariant holds regardless of retry policy, task timeouts, or process lifetime.

### Incidental races fixed (surfaced by the new tests under `-race`)

- `debounceInterval` was written in `Bootstrap` while live poll goroutines read it via `resolveDebounce`; now guarded by `stateMu`.
- Concurrent attempts of the same task mutated the shared task-level `UpstreamConfig` (vendor detection writes to it); each attempt now copies the config before `NewUpstream`.

## Tests

New tests, each verified to **fail on `main`** and pass here, all green under `-race`:

- `TestEvmStatePoller_RepeatedBootstrapDoesNotLeakTickerGoroutines` — 25 `Bootstrap` calls ⇒ one ticker goroutine (fails on main: 25).
- `TestEvmStatePoller_RepeatedBootstrapDoesNotMultiplyPollRate` — poll rate stays flat after repeated `Bootstrap`.
- `TestEvmStatePoller_BootstrapWithZeroIntervalStartsNothing`.
- `TestUpstreamBootstrapTask_RetriedAttemptsReuseSameInstance`.
- `TestUpstreamBootstrapTask_ReexecutionDoesNotDuplicatePollersOrRegistrations`.
- `TestUpstreamBootstrapTask_ConcurrentAttemptsConvergeOnSingleInstance`.

`upstream/` and `architecture/evm/` pass under `-race`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upstream bootstrap and long-lived background polling; happy-path behavior is unchanged but incorrect idempotency would still leak resources or duplicate registry entries.
> 
> **Overview**
> Repeated upstream bootstrap (retries, timeouts, re-execution) could spawn **extra EVM state poller tickers** and **new `Upstream` instances** per attempt, leaking goroutines and multiplying background RPC (`eth_getBlockByNumber`, `eth_syncing`) for the process lifetime.
> 
> This PR enforces **one live poller per upstream**: `EvmStatePoller.Bootstrap` uses an atomic `started` guard so only the first call starts the ticker; later calls run a one-off `Poll` instead. `Upstream.Bootstrap` creates the poller with `sync.Once`. The registry **parks** in-flight upstreams in `pendingUpstreams` for reuse on retry/concurrency, copies config per `NewUpstream` attempt, skips duplicate `allUpstreams` registration, and clears pending on success. **`debounceInterval`** reads/writes are synchronized under `stateMu`.
> 
> New tests cover repeated bootstrap (goroutine count, poll rate), zero interval, retry reuse, re-execution, and concurrent convergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95e6e44525c8fe1cbd0f793adbce4f449e3dc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->