### PR TITLE
fix(server): gate X-ERPC version/commit headers behind executionHeaders:off

### DIFF
--- a/docs/pages/config/server.mdx
+++ b/docs/pages/config/server.mdx
@@ -365,7 +365,7 @@ Note: `writeFatalError` (panics, write failures) and the timeout/cancel paths fo
 - Batch responses are always HTTP 200; each element is written as a streaming JSON array. They carry ONE aggregated `X-ERPC-*` diagnostic header set (counters summed, `X-ERPC-Cache` gains `PARTIAL:<n>`, slowest-sub-call duration, trace capped at 50 segments; no single-winner `X-ERPC-Upstream`) under the same `executionHeaders` mode — see [directives](/operation/directives). Source: <SourceLink file="erpc/http_server.go" lines="706-712" />
 
 **Diagnostic response headers** (per-response set on singles via `setResponseHeaders`; aggregated set on batches via `writeBatchExecHeaders`):
-- `X-ERPC-Version`, `X-ERPC-Commit` — emitted on every response (build-time ldflags vars, defaults `"dev"` and `"none"`). <SourceLink file="erpc/http_server.go" lines="260-261" />
+- `X-ERPC-Version`, `X-ERPC-Commit` — build-identity headers (ldflags vars, defaults `"dev"` and `"none"`); emitted unless `executionHeaders: "off"`. <SourceLink file="erpc/http_server.go" lines="275-278" />
 - `X-ERPC-Attempts`, `X-ERPC-Upstream-Attempts/-Retries/-Hedges`, `X-ERPC-Network-Attempts/-Retries/-Hedges` — counters, **zero-filled on early errors** (not omitted; only `mode: off` removes them). <SourceLink file="erpc/http_server.go" lines="1149-1166" />
 - `X-ERPC-Cache-Attempts/-Retries/-Hedges` — emitted only when the cache scope was exercised. <SourceLink file="erpc/http_server.go" lines="1170-1174" />
 - `X-ERPC-Consensus-Slots`, `X-ERPC-Consensus-Disputes`, `X-ERPC-Consensus-Low-Participants` — emitted only when consensus was exercised and the count is > 0. <SourceLink file="erpc/http_server.go" lines="1175-1183" />

--- a/docs/pages/operation/directives.mdx
+++ b/docs/pages/operation/directives.mdx
@@ -328,14 +328,14 @@ Retry, hedge, circuit-breaker, and timeout still apply — only the dispute/agre
 | Header | Value | Source |
 |---|---|---|
 | `Content-Type` | `application/json` | [`erpc/http_server.go:259`](https://github.com/erpc/erpc/blob/main/erpc/http_server.go#L259) |
-| `X-ERPC-Version` | eRPC version string | [`erpc/http_server.go:260`](https://github.com/erpc/erpc/blob/main/erpc/http_server.go#L260) |
-| `X-ERPC-Commit` | git commit SHA | [`erpc/http_server.go:261`](https://github.com/erpc/erpc/blob/main/erpc/http_server.go#L261) |
 | custom `server.responseHeaders` | static values, env-expanded at startup | [`erpc/http_server.go:263-266`](https://github.com/erpc/erpc/blob/main/erpc/http_server.go#L263-L266) |
 
 **Execution diagnostic headers** (controlled by `server.executionHeaders`; single responses get the per-response set, batch responses get ONE aggregated set — counters summed across sub-calls, `X-ERPC-Duration` = slowest sub-call, no `X-ERPC-Upstream`):
 
 | Header | Value | When |
 |---|---|---|
+| `X-ERPC-Version` | eRPC version string | always |
+| `X-ERPC-Commit` | git commit SHA | always |
 | `X-ERPC-Attempts` | total physical ops (upstream + cache) | always |
 | `X-ERPC-Upstream-Attempts` / `X-ERPC-Upstream-Retries` / `X-ERPC-Upstream-Hedges` | counters | always |
 | `X-ERPC-Network-Attempts` / `X-ERPC-Network-Retries` / `X-ERPC-Network-Hedges` | counters | always |

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -271,8 +271,11 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-ERPC-Version", common.ErpcVersion)
-		w.Header().Set("X-ERPC-Commit", common.ErpcCommitSha)
+		// executionHeaders:"off" suppresses all X-ERPC-* headers, including these.
+		if s.executionHeadersMode() != common.ExecutionHeadersOff {
+			w.Header().Set("X-ERPC-Version", common.ErpcVersion)
+			w.Header().Set("X-ERPC-Commit", common.ErpcCommitSha)
+		}
 
 		// Add custom response headers (resolved at startup with env var expansion)
 		for key, value := range s.resolvedResponseHeaders {

--- a/erpc/http_server_exec_headers_test.go
+++ b/erpc/http_server_exec_headers_test.go
@@ -50,6 +50,9 @@ func TestExecutionHeaders_All_FullTrace(t *testing.T) {
 	require.Equal(t, 200, statusCode)
 	assert.Contains(t, body, `"result":"0x42"`)
 
+	// Build-identity headers present when not 'off'.
+	assert.NotEmpty(t, headers["X-Erpc-Version"], "version header should be present when not 'off'")
+	assert.NotEmpty(t, headers["X-Erpc-Commit"], "commit header should be present when not 'off'")
 	// Summary counters always present.
 	assert.Equal(t, "MISS", headers["X-Erpc-Cache"])
 	assert.NotEmpty(t, headers["X-Erpc-Attempts"])
@@ -159,14 +162,8 @@ func TestExecutionHeaders_Off_NoDiagnosticHeaders(t *testing.T) {
 	require.Equal(t, 200, statusCode)
 
 	for k := range headers {
-		assert.False(t, strings.HasPrefix(k, "X-Erpc-Cache") ||
-			strings.HasPrefix(k, "X-Erpc-Upstream") ||
-			strings.HasPrefix(k, "X-Erpc-Attempts") ||
-			strings.HasPrefix(k, "X-Erpc-Duration") ||
-			strings.HasPrefix(k, "X-Erpc-Network-") ||
-			strings.HasPrefix(k, "X-Erpc-Consensus-"),
-			"diagnostic header %q must be suppressed in 'off' mode", k,
-		)
+		assert.Falsef(t, strings.HasPrefix(strings.ToLower(k), "x-erpc-"),
+			"no X-ERPC-* header may be emitted in 'off' mode, found %q", k)
 	}
 }
 


### PR DESCRIPTION
## Problem

`X-ERPC-Version` and `X-ERPC-Commit` are currently emitted unconditionally on every response, independent of `executionHeaders` mode. This is intentional and documented, but it means `executionHeaders: "off"` — which a user would reasonably expect to suppress the full `X-ERPC-*` surface — still leaks the build identity on every response.

For operators running hardened public-facing listeners, this is unintuitive: setting `"off"` to avoid advertising server internals doesn't suppress the version string or commit SHA, which are a precise build fingerprint. Web servers address this exact concern with `ServerTokens Off` / `server_tokens off`, and users coming from that mental model would expect `"off"` to cover it.

## Change

Gate `X-ERPC-Version` / `X-ERPC-Commit` on `executionHeadersMode() != ExecutionHeadersOff`, consistent with the rest of the `X-ERPC-*` surface. No behavior change for `"all"` (default) or `"summary"` modes.

Update docs (`directives.mdx`, `config/server.mdx`, `use-cases/how-it-works.mdx`) to reflect that these headers are now suppressed under `"off"`.

## Tests

- `TestExecutionHeaders_Off_NoDiagnosticHeaders`: replace the explicit header enumeration with a case-insensitive `x-erpc-` prefix check, so any future unconditional addition is caught without maintaining the list.
- `TestExecutionHeaders_All_FullTrace`: add assertions that `X-ERPC-Version` and `X-ERPC-Commit` are present when not in `"off"` mode.