### PR TITLE
fix(server): apply gzip to streamed JSON-RPC responses (first-write threshold bug)

### DIFF
--- a/erpc/http_gzip_e2e_test.go
+++ b/erpc/http_gzip_e2e_test.go
@@ -1,0 +1,190 @@
+package erpc
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gzipE2ECfg builds a full-stack config: real HTTP server, one EVM upstream
+// (rpc1.localhost, mocked by gock), enableGzip on, and a finalized-block
+// memory cache so the #990 "cache HIT served uncompressed" symptom is
+// reproducible end to end.
+func gzipE2ECfg() *common.Config {
+	return &common.Config{
+		Server: &common.ServerConfig{
+			MaxTimeout: common.Duration(10 * time.Second).Ptr(),
+			EnableGzip: util.BoolPtr(true),
+			ListenV4:   util.BoolPtr(true),
+		},
+		Database: &common.DatabaseConfig{
+			EvmJsonRpcCache: &common.CacheConfig{
+				Connectors: []*common.ConnectorConfig{
+					{
+						Id:     "mem",
+						Driver: common.DriverMemory,
+						Memory: &common.MemoryConnectorConfig{
+							MaxItems: 100_000, MaxTotalSize: "1GB",
+						},
+					},
+				},
+				Policies: []*common.CachePolicyConfig{
+					{
+						Network:   "*",
+						Method:    "*",
+						Finality:  common.DataFinalityStateFinalized,
+						Connector: "mem",
+						TTL:       common.FixedDuration(5 * time.Minute),
+					},
+				},
+			},
+		},
+		Projects: []*common.ProjectConfig{
+			{
+				Id: "test_project",
+				Networks: []*common.NetworkConfig{
+					{
+						Architecture: common.ArchitectureEvm,
+						Evm:          &common.EvmNetworkConfig{ChainId: 123},
+						Failsafe: []*common.FailsafeConfig{
+							{Retry: &common.RetryPolicyConfig{MaxAttempts: 2}},
+						},
+					},
+				},
+				Upstreams: []*common.UpstreamConfig{
+					{
+						Id: "rpc1", Type: common.UpstreamTypeEvm,
+						Endpoint: "http://rpc1.localhost",
+						Evm:      &common.EvmUpstreamConfig{ChainId: 123},
+					},
+				},
+			},
+		},
+		RateLimiters: &common.RateLimiterConfig{},
+	}
+}
+
+// TestHttpServer_Gzip_E2E_StreamedJsonRpc is the end-to-end regression for
+// https://github.com/erpc/erpc/issues/990. It boots the real HTTP server over
+// a TCP socket and drives a real HTTP client, so the response travels the full
+// production path: routing -> upstream client -> NormalizedResponse.WriteTo ->
+// JsonRpcResponse.WriteTo (envelope prefix write, then the large result write)
+// -> gzipHandler/conditionalGzipWriter -> the wire.
+//
+// Setting Accept-Encoding: gzip explicitly disables Go's transparent
+// decompression, so the test observes the actual Content-Encoding header and
+// the raw compressed bytes on the wire.
+func TestHttpServer_Gzip_E2E_StreamedJsonRpc(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	gock.EnableNetworking()
+	gock.NetworkingFilter(func(req *http.Request) bool {
+		// Real call for the client<->server hop (localhost); intercept upstream.
+		return strings.Split(req.URL.Host, ":")[0] == "localhost"
+	})
+	util.SetupMocksForEvmStatePoller()
+
+	// A large finalized block (0x386053 << finalized tip 0x11117777), shaped
+	// like the multi-MB payloads #990 is about. ~130KB, far above the 1KB
+	// compressionThreshold, streamed after the ~22-byte envelope prefix.
+	const sentinel = "0xda7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7ada7a"
+	txs := make([]string, 0, 2000)
+	for i := range 2000 {
+		txs = append(txs, fmt.Sprintf(`"%s%04x"`, sentinel[:60], i))
+	}
+	bigResult := fmt.Sprintf(
+		`{"number":"0x386053","hash":"%s","transactions":[%s]}`,
+		sentinel, strings.Join(txs, ","),
+	)
+	expectedBody := `{"jsonrpc":"2.0","id":1,"result":` + bigResult + `}`
+
+	gock.New("http://rpc1.localhost").
+		Post("").
+		Persist().
+		Filter(func(r *http.Request) bool {
+			b := util.SafeReadBody(r)
+			return strings.Contains(b, "eth_getBlockByNumber") && strings.Contains(b, "0x386053")
+		}).
+		Reply(200).
+		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":` + bigResult + `}`))
+
+	sendRequest, _, _, shutdown, _ := createServerTestFixtures(gzipE2ECfg(), t)
+	defer shutdown()
+
+	reqBody := `{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x386053",false],"id":1}`
+
+	// First call: served from upstream (cache MISS).
+	status, headers, raw := sendRequest(reqBody, map[string]string{"Accept-Encoding": "gzip"}, nil)
+	require.Equal(t, http.StatusOK, status, "body: %.200s", raw)
+	assert.Equal(t, "gzip", headers["Content-Encoding"], "large JSON-RPC response must be gzip-compressed (issue #990)")
+	assert.Equal(t, "Accept-Encoding", headers["Vary"])
+
+	decoded := gunzipE2E(t, raw)
+	assert.Equal(t, expectedBody, decoded, "decompressed body must equal the full JSON-RPC response")
+	assert.Less(t, len(raw), len(decoded), "wire bytes must be smaller than the uncompressed payload")
+	t.Logf("MISS: wire=%d bytes, decompressed=%d bytes, ratio=%.3f, x-erpc-cache=%q",
+		len(raw), len(decoded), float64(len(raw))/float64(len(decoded)), headers["X-Erpc-Cache"])
+
+	// Second call: served from the finalized-block cache (HIT). #990 explicitly
+	// reported cache hits going out uncompressed; assert the HIT path compresses
+	// too. The HIT re-serializes through the same WriteTo -> gzip path.
+	status2, headers2, raw2 := sendRequest(reqBody, map[string]string{"Accept-Encoding": "gzip"}, nil)
+	require.Equal(t, http.StatusOK, status2)
+	assert.Equal(t, "HIT", headers2["X-Erpc-Cache"], "second identical finalized request should be a cache hit")
+	assert.Equal(t, "gzip", headers2["Content-Encoding"], "cache-HIT large response must also be gzip-compressed (issue #990)")
+	assert.Equal(t, expectedBody, gunzipE2E(t, raw2))
+}
+
+// TestHttpServer_Gzip_E2E_SmallResponseUncompressed confirms the CPU-saving
+// behavior is preserved end to end: sub-threshold responses stay plain.
+func TestHttpServer_Gzip_E2E_SmallResponseUncompressed(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	gock.EnableNetworking()
+	gock.NetworkingFilter(func(req *http.Request) bool {
+		return strings.Split(req.URL.Host, ":")[0] == "localhost"
+	})
+	util.SetupMocksForEvmStatePoller()
+
+	gock.New("http://rpc1.localhost").
+		Post("").
+		Persist().
+		Filter(func(r *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(r), "eth_getBalance")
+		}).
+		Reply(200).
+		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+
+	sendRequest, _, _, shutdown, _ := createServerTestFixtures(gzipE2ECfg(), t)
+	defer shutdown()
+
+	status, headers, body := sendRequest(
+		`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`,
+		map[string]string{"Accept-Encoding": "gzip"}, nil,
+	)
+	require.Equal(t, http.StatusOK, status, "body: %s", body)
+	assert.Empty(t, headers["Content-Encoding"], "small responses must stay uncompressed")
+	assert.Equal(t, "Accept-Encoding", headers["Vary"])
+	assert.Contains(t, body, `"result":"0x1"`)
+}
+
+func gunzipE2E(t *testing.T, s string) string {
+	t.Helper()
+	zr, err := gzip.NewReader(bytes.NewReader([]byte(s)))
+	require.NoError(t, err)
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	return string(out)
+}

--- a/erpc/http_gzip_test.go
+++ b/erpc/http_gzip_test.go
@@ -1,0 +1,181 @@
+package erpc
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gzipTestClient performs a request against a gzipHandler-wrapped handler and
+// returns the raw (non-auto-decompressed) response.
+func gzipTestRequest(t *testing.T, handler http.HandlerFunc, acceptGzip bool) (*http.Response, []byte) {
+	t.Helper()
+
+	srv := httptest.NewServer(gzipHandler(handler))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	if acceptGzip {
+		// Setting the header explicitly disables the transport's transparent
+		// decompression, so we can observe the wire representation.
+		req.Header.Set("Accept-Encoding", "gzip")
+	}
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, body
+}
+
+func gunzip(t *testing.T, b []byte) []byte {
+	t.Helper()
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	require.NoError(t, err)
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	return out
+}
+
+// Regression test for https://github.com/erpc/erpc/issues/990: JSON-RPC
+// responses are streamed via JsonRpcResponse.WriteTo as an explicit
+// WriteHeader followed by many small writes (envelope prefix first, large
+// result later). The compression decision must be based on cumulative size,
+// not the size of the first write.
+func TestGzipHandler_StreamedJsonRpcStyleResponseIsCompressed(t *testing.T) {
+	largeResult := strings.Repeat(`{"logIndex":"0x1","data":"0xdeadbeef"},`, 500) // ~19KB
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // JSON-RPC path calls WriteHeader before the body
+		// Mimic JsonRpcResponse.WriteTo: tiny envelope writes, then the payload.
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":`))
+		_, _ = w.Write([]byte(`1`))
+		_, _ = w.Write([]byte(`,"result":[`))
+		_, _ = w.Write([]byte(largeResult))
+		_, _ = w.Write([]byte(`]}`))
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", resp.Header.Get("Vary"))
+
+	expected := `{"jsonrpc":"2.0","id":1,"result":[` + largeResult + `]}`
+	assert.Equal(t, expected, string(gunzip(t, body)))
+	assert.Less(t, len(body), len(expected), "wire body should be smaller than the plain payload")
+}
+
+func TestGzipHandler_SmallResponseStaysUncompressed(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", resp.Header.Get("Vary"))
+	assert.Equal(t, `{"jsonrpc":"2.0","id":1,"result":"0x1"}`, string(body))
+}
+
+// Single large write (e.g. verbose /healthcheck) — the pre-existing behavior
+// that already worked must keep working.
+func TestGzipHandler_SingleLargeWriteIsCompressed(t *testing.T) {
+	payload := strings.Repeat("a", 4096)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, payload, string(gunzip(t, body)))
+}
+
+func TestGzipHandler_ExplicitStatusCodePreservedWhenCompressing(t *testing.T) {
+	payload := strings.Repeat("b", 8192)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"`))
+		_, _ = w.Write([]byte(payload))
+		_, _ = w.Write([]byte(`"}`))
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, `{"error":"`+payload+`"}`, string(gunzip(t, body)))
+}
+
+func TestGzipHandler_ClientWithoutGzipGetsPlainBody(t *testing.T) {
+	payload := strings.Repeat("c", 4096)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}
+
+	resp, body := gzipTestRequest(t, handler, false)
+
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", resp.Header.Get("Vary"))
+	assert.Equal(t, payload, string(body))
+}
+
+// A Flush before the threshold is reached commits the response to passthrough:
+// buffered bytes must reach the wire and later writes stay uncompressed.
+func TestGzipHandler_FlushBeforeThresholdCommitsPassthrough(t *testing.T) {
+	late := strings.Repeat("d", 4096)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("early"))
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(late))
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "early"+late, string(body))
+}
+
+func TestGzipHandler_HeaderOnlyResponseDeliversStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	assert.Empty(t, body)
+}
+
+// Cumulative accounting: many writes individually below the threshold must
+// still trigger compression once their total crosses it.
+func TestGzipHandler_ManySmallWritesCrossingThresholdCompress(t *testing.T) {
+	chunk := strings.Repeat("e", 100)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		for range 50 { // 5000 bytes total, 100 at a time
+			_, _ = w.Write([]byte(chunk))
+		}
+	}
+
+	resp, body := gzipTestRequest(t, handler, true)
+
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, strings.Repeat(chunk, 50), string(gunzip(t, body)))
+}

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1920,18 +1920,42 @@ func (s *HttpServer) Shutdown(logger *zerolog.Logger) error {
 }
 
 // conditionalGzipWriter wraps ResponseWriter and decides whether to compress
-// based on the first write size. This avoids buffering while still allowing
-// us to skip compression for small responses.
+// once enough body bytes have been observed. Writes (and any explicit status
+// code) are held back until the total body size reaches compressionThreshold,
+// at which point the response is committed as gzip; if the handler finishes or
+// flushes below the threshold, the buffered bytes are sent uncompressed.
+//
+// Buffering across writes (instead of deciding on the first write only) is
+// required because JSON-RPC responses are streamed in multiple small writes:
+// JsonRpcResponse.WriteTo emits the ~22-byte envelope prefix first, so a
+// first-write-only decision would permanently disable compression for every
+// JSON-RPC response regardless of total size (see issue #990).
+//
+// WriteHeader is deferred for the same reason: the JSON-RPC path calls
+// WriteHeader before streaming the body, and Content-Encoding must be set
+// before the header block is flushed to the client.
 type conditionalGzipWriter struct {
 	http.ResponseWriter
 	gzipWriter  *gzip.Writer
 	pool        *util.GzipWriterPool
 	decided     bool
 	compressing bool
+	buf         []byte // body bytes buffered while undecided
+	status      int    // deferred status code from WriteHeader, 0 if none
 }
 
 // Compile-time check that conditionalGzipWriter implements http.Flusher
 var _ http.Flusher = (*conditionalGzipWriter)(nil)
+
+// WriteHeader defers the status code until the compression decision is made,
+// so Content-Encoding can still be set when compression kicks in.
+func (w *conditionalGzipWriter) WriteHeader(statusCode int) {
+	if w.decided {
+		w.ResponseWriter.WriteHeader(statusCode)
+		return
+	}
+	w.status = statusCode
+}
 
 func (w *conditionalGzipWriter) Write(b []byte) (int, error) {
 	// If we've already decided, just pass through
@@ -1942,37 +1966,60 @@ func (w *conditionalGzipWriter) Write(b []byte) (int, error) {
 		return w.ResponseWriter.Write(b)
 	}
 
-	// First write - decide based on size
-	w.decided = true
-
-	// If the first chunk is small, assume the whole response is small
-	// This works well for RPC responses which are typically sent in one write
-	if len(b) < compressionThreshold {
-		// Skip compression for small responses
-		w.compressing = false
-		return w.ResponseWriter.Write(b)
+	// Enough cumulative bytes to justify compression: commit and route this
+	// write through gzip directly (avoids copying large payloads into buf).
+	if len(w.buf)+len(b) >= compressionThreshold {
+		if err := w.decide(true); err != nil {
+			return 0, err
+		}
+		return w.gzipWriter.Write(b)
 	}
 
-	// Large response, enable compression
-	w.compressing = true
-
-	// Set compression headers
-	w.ResponseWriter.Header().Del("Content-Length")
-	w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
-	w.ResponseWriter.Header().Set("Vary", "Accept-Encoding")
-	if ct := w.ResponseWriter.Header().Get("Content-Type"); ct == "" {
-		w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	// Still undecided: buffer and wait for more writes.
+	if w.buf == nil {
+		w.buf = make([]byte, 0, compressionThreshold)
 	}
-
-	// Initialize gzip writer
-	w.gzipWriter = w.pool.Get(w.ResponseWriter)
-
-	// Write the data
-	return w.gzipWriter.Write(b)
+	w.buf = append(w.buf, b...)
+	return len(b), nil
 }
 
-// Flush implements http.Flusher interface to support streaming responses
+// decide commits to compressing or not: it sets the relevant headers, sends
+// the deferred status code, and drains buffered bytes to the chosen sink.
+func (w *conditionalGzipWriter) decide(compress bool) error {
+	w.decided = true
+	w.compressing = compress
+
+	if compress {
+		w.ResponseWriter.Header().Del("Content-Length")
+		w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+		if ct := w.ResponseWriter.Header().Get("Content-Type"); ct == "" {
+			w.ResponseWriter.Header().Set("Content-Type", "application/json")
+		}
+		w.gzipWriter = w.pool.Get(w.ResponseWriter)
+	}
+	if w.status != 0 {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+
+	var err error
+	if len(w.buf) > 0 {
+		if compress {
+			_, err = w.gzipWriter.Write(w.buf)
+		} else {
+			_, err = w.ResponseWriter.Write(w.buf)
+		}
+		w.buf = nil
+	}
+	return err
+}
+
+// Flush implements http.Flusher interface to support streaming responses.
+// A flush while undecided means the handler wants the (sub-threshold)
+// buffered bytes on the wire now, so the response commits to passthrough.
 func (w *conditionalGzipWriter) Flush() {
+	if !w.decided {
+		_ = w.decide(false)
+	}
 	if w.compressing && w.gzipWriter != nil {
 		_ = w.gzipWriter.Flush()
 	}
@@ -1982,7 +2029,12 @@ func (w *conditionalGzipWriter) Flush() {
 	}
 }
 
+// Close finalizes the response. If the total body stayed below the threshold,
+// the buffered bytes (and any deferred status code) are sent uncompressed.
 func (w *conditionalGzipWriter) Close() error {
+	if !w.decided {
+		return w.decide(false)
+	}
 	if w.compressing && w.gzipWriter != nil {
 		err := w.gzipWriter.Close()
 		w.pool.Put(w.gzipWriter)
@@ -1996,13 +2048,18 @@ func gzipHandler(next http.Handler) http.Handler {
 	var gzPool = util.NewGzipWriterPool()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The response representation depends on Accept-Encoding, so caches
+		// must be told regardless of whether this response ends up compressed.
+		w.Header().Set("Vary", "Accept-Encoding")
+
 		// Check if client accepts gzip encoding
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		// Create conditional gzip response writer that decides on first write
+		// Create conditional gzip response writer that decides once enough
+		// body bytes have been seen (or the response completes/flushes).
 		gzw := &conditionalGzipWriter{
 			ResponseWriter: w,
 			pool:           gzPool,


### PR DESCRIPTION
Fixes #990

## Problem

With `enableGzip: true` (the default) and `Accept-Encoding: gzip`, large JSON-RPC responses are sent **uncompressed** — no `Content-Encoding`, no `Vary`, multi-MB `eth_getBlockReceipts`/`eth_getLogs` bodies transferred as plain JSON, including cache hits.

Two mechanisms conflict, exactly as diagnosed in #990:

1. **`conditionalGzipWriter` decided on the first write only.** `JsonRpcResponse.WriteTo` streams the response as many small writes, starting with the ~22-byte envelope prefix (`{"jsonrpc":"2.0","id":`). Since 22 < 1024 (`compressionThreshold`), compression was permanently disabled for **every** JSON-RPC response regardless of total size. (The `/healthcheck` path writes its body in one large write, which is why it still compressed — making the behavior extra confusing.)
2. **A second, latent header-ordering bug:** the JSON-RPC path calls `w.WriteHeader(statusCode)` *before* streaming the body (`http_server.go` single path and batch path). Headers flush at that point, so even a size-aware decision made later could never set `Content-Encoding` — and a hypothetical ≥1KB first write after an explicit `WriteHeader` would have emitted gzip bytes with **no** `Content-Encoding` header (corrupt response from the client's perspective).

## Change

`conditionalGzipWriter` now:

- **Buffers sub-threshold body writes** (bounded at 1KB) and decides on **cumulative** size: crossing `compressionThreshold` commits to gzip; completing or flushing below it commits to passthrough.
- **Defers the status code**: `WriteHeader` is recorded and forwarded only at decision time, so `Content-Encoding`/`Vary` land before the header block is flushed.
- **Bypasses the buffer for large writes** — when `len(buf)+len(b) >= threshold` the incoming slice goes straight through the gzip writer, so the single-large-write path (healthcheck) behaves exactly as before, with no copy. After the decision there is zero buffering, same as today.
- **`Flush()` while undecided commits passthrough** — buffered bytes must reach the wire, matching the previous streaming behavior for small chunks.
- **Sets `Vary: Accept-Encoding` on all responses** passing through the handler (compressed or not, gzip-accepting client or not), which shared caches require for correctness; #990 also flagged the missing `Vary`.

## Verification

- 8 end-to-end tests against a real `net/http` server (real header-flush semantics), including the exact #990 repro shape: explicit `WriteHeader` + streamed envelope prefix + large result → now `Content-Encoding: gzip`, body round-trips, wire size < plain size.
- Confirmed the two regression tests **fail against the previous implementation** (no `Content-Encoding`, plain body) and pass with this change.
- Small responses, explicit non-200 status codes, header-only responses (204), flush-then-write streaming, and no-`Accept-Encoding` clients are all covered.

## Related

Fixing this makes the compression CPU cost *real* for large responses that previously skipped gzip entirely. Companion PR #1011 swaps the gzip implementation to `klauspost/compress` (~2.9x faster) to keep that tax low.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all gzip-wrapped HTTP responses and changes header timing (deferred WriteHeader); behavior is well covered by tests but affects a hot path for every JSON-RPC response when gzip is enabled.
> 
> **Overview**
> Fixes **#990**: large JSON-RPC bodies (including cache hits) were sent uncompressed when clients sent `Accept-Encoding: gzip`, because `conditionalGzipWriter` chose compression on the **first** write only—the streamed envelope prefix is tiny, so gzip never engaged.
> 
> **`conditionalGzipWriter`** now buffers sub-threshold writes, decides on **cumulative** body size (1KB threshold), and **defers `WriteHeader`** until the decision so `Content-Encoding: gzip` can be set before headers flush. Early `Flush` commits to plain passthrough; large writes still bypass the buffer and go straight to gzip.
> 
> **`gzipHandler`** always sets **`Vary: Accept-Encoding`** on responses that pass through it.
> 
> New **unit** tests cover streamed JSON-RPC shape, small/large bodies, status codes, flush behavior, and clients without gzip; **e2e** tests hit the real HTTP stack for large MISS/HIT and small responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84678bee0c6c3fa2adfc7dc332fd4ed86894e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->