### PR TITLE
perf(server): use klauspost/compress gzip for the HTTP body path

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1,7 +1,6 @@
 package erpc
 
 import (
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -26,6 +25,7 @@ import (
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
+	"github.com/klauspost/compress/gzip"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"

--- a/util/gzip_pool.go
+++ b/util/gzip_pool.go
@@ -1,10 +1,14 @@
 package util
 
 import (
-	"compress/flate"
-	"compress/gzip"
 	"io"
 	"sync"
+
+	// klauspost/compress produces standard RFC 1952 gzip streams but is
+	// substantially faster than compress/gzip; this pool sits on the hot
+	// per-request HTTP serving path, so compression CPU is paid per response.
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
 )
 
 // eofReader is used to reset gzip readers without allocating bufio.Reader

--- a/util/gzip_pool_test.go
+++ b/util/gzip_pool_test.go
@@ -1,0 +1,147 @@
+package util
+
+import (
+	"bytes"
+	stdgzip "compress/gzip"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syntheticJsonRpcPayload builds a payload shaped like a large eth_getLogs /
+// block-receipts JSON-RPC result, which is the dominant class of responses
+// the HTTP gzip path compresses in production.
+func syntheticJsonRpcPayload(entries int) []byte {
+	var sb strings.Builder
+	sb.WriteString(`{"jsonrpc":"2.0","id":1,"result":[`)
+	for i := range entries {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb,
+			`{"address":"0x%040x","topics":["0x%064x","0x%064x"],"data":"0x%0128x","blockNumber":"0x%x","transactionHash":"0x%064x","logIndex":"0x%x","removed":false}`,
+			i, i*7, i*13, i*104729, 21000000+i, i*31, i%300)
+	}
+	sb.WriteString(`]}`)
+	return []byte(sb.String())
+}
+
+// The pool writer must produce standard RFC 1952 gzip streams that stdlib
+// readers (i.e. any HTTP client) can decode, and the pool reader must decode
+// streams produced by stdlib writers (i.e. any upstream server).
+func TestGzipPools_InteropWithStdlib(t *testing.T) {
+	payload := syntheticJsonRpcPayload(50)
+
+	t.Run("pool writer -> stdlib reader", func(t *testing.T) {
+		wp := NewGzipWriterPool()
+		var buf bytes.Buffer
+		zw := wp.Get(&buf)
+		_, err := zw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		wp.Put(zw)
+
+		zr, err := stdgzip.NewReader(&buf)
+		require.NoError(t, err)
+		out, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		assert.Equal(t, payload, out)
+	})
+
+	t.Run("stdlib writer -> pool reader", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := stdgzip.NewWriter(&buf)
+		_, err := zw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+
+		rp := NewGzipReaderPool()
+		zr, err := rp.GetReset(&buf)
+		require.NoError(t, err)
+		out, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		rp.Put(zr)
+		assert.Equal(t, payload, out)
+	})
+}
+
+// Reused pooled writers/readers must keep producing valid streams after Reset.
+func TestGzipPools_ReuseAfterPut(t *testing.T) {
+	wp := NewGzipWriterPool()
+	rp := NewGzipReaderPool()
+
+	for i := range 3 {
+		payload := syntheticJsonRpcPayload(10 + i)
+
+		var buf bytes.Buffer
+		zw := wp.Get(&buf)
+		_, err := zw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		wp.Put(zw)
+
+		zr, err := rp.GetReset(&buf)
+		require.NoError(t, err)
+		out, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		rp.Put(zr)
+		assert.Equal(t, payload, out, "roundtrip %d", i)
+	}
+}
+
+// BenchmarkGzipWriterPool_CompressJsonRpc measures the in-process CPU cost of
+// compressing a large JSON-RPC response body — the per-request tax paid on the
+// HTTP serving hop when enableGzip is on.
+func BenchmarkGzipWriterPool_CompressJsonRpc(b *testing.B) {
+	payload := syntheticJsonRpcPayload(2500) // ~1MB
+	pool := NewGzipWriterPool()
+
+	var sized bytes.Buffer
+	zw := pool.Get(&sized)
+	_, _ = zw.Write(payload)
+	_ = zw.Close()
+	pool.Put(zw)
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		zw := pool.Get(io.Discard)
+		_, _ = zw.Write(payload)
+		_ = zw.Close()
+		pool.Put(zw)
+	}
+	// Report the compression ratio so speed can be weighed against size.
+	// (Must run after the loop: ResetTimer deletes user-reported metrics.)
+	b.ReportMetric(float64(sized.Len())/float64(len(payload)), "ratio")
+}
+
+// BenchmarkGzipReaderPool_DecompressJsonRpc measures the cost of decompressing
+// a gzipped upstream response body, which also runs in-process per request.
+func BenchmarkGzipReaderPool_DecompressJsonRpc(b *testing.B) {
+	payload := syntheticJsonRpcPayload(2500) // ~1MB
+	var compressed bytes.Buffer
+	zw := stdgzip.NewWriter(&compressed)
+	_, _ = zw.Write(payload)
+	_ = zw.Close()
+	data := compressed.Bytes()
+
+	pool := NewGzipReaderPool()
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		zr, err := pool.GetReset(bytes.NewReader(data))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, zr); err != nil {
+			b.Fatal(err)
+		}
+		pool.Put(zr)
+	}
+}


### PR DESCRIPTION
## Context

Gzip work runs in-process on the hot serving path, in both directions:

- compressing HTTP responses to clients (`enableGzip` defaults to true), and
- decompressing gzipped upstream responses / request bodies (unavoidable — the body must be parsed).

Compression cost is CPU-bound and scales with response size, so large `eth_getLogs`/block-receipt payloads make it a per-request tax that competes with request routing for CPU under load.

Not every deployment has a mesh/CDN layer to offload to, so the in-process cost is worth cheapening on its own. This matters more once #1010 lands (fixes #990 — today gzip effectively never fires on the JSON-RPC path; after that fix, large responses actually get compressed and the CPU cost becomes real).

## Change

Swap the pooled gzip reader/writer in `util/gzip_pool.go` (and the one type import in `erpc/http_server.go`) from stdlib `compress/gzip`+`compress/flate` to `github.com/klauspost/compress/gzip`+`flate`:

- Already a **direct dependency** (`v1.18.6`, used for zstd cache compression) — no go.mod change.
- Drop-in API (`NewReader`, `Reset`, `flate.Reader` fast-path for the pool's `eofReader`), same RFC 1952 wire format.
- Default compression level kept.

## Benchmarks

Apple M5, ~1.2MB synthetic `eth_getLogs`-shaped JSON payload (`go test ./util/ -bench BenchmarkGzip`):

| | stdlib | klauspost | delta |
|---|---|---|---|
| compress | 2.83 ms/op (435 MB/s) | 0.99 ms/op (1249 MB/s) | **~2.9x faster** |
| decompress | 585 µs/op (2107 MB/s) | 386 µs/op (3190 MB/s) | **~1.5x faster** |
| decompress allocs | 933 B, 17 allocs/op | 126 B, 4 allocs/op | −13 allocs |
| compression ratio | 0.0511 | 0.0520 | ~1.7% larger output |

The ratio cost is negligible against the CPU reduction for this workload class.

## Verification

- New interop tests: pool writer → stdlib `compress/gzip` reader (any HTTP client can decode) and stdlib writer → pool reader (any upstream's gzip decodes) round-trip byte-identically.
- Pooled reuse after `Put` keeps producing valid streams.
- `go build ./...`, `go test ./util/ ./clients/` green (clients package exercises the pools on the upstream request/response path).
- Benchmarks included in `util/gzip_pool_test.go` so the numbers are reproducible.

Note: trivially conflicts with #1010 on the `http_server.go` import line; either merges cleanly first.
