### PR TITLE
docs(readme): add OpenChainBench as related benchmarks tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ diff <(erpc dump old-config.yaml) <(erpc dump new-config.yaml)
 
 ---
 
+### Related tools
+
+- [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities): independent open-source benchmarks for public RPC providers across 22 chains (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle, Solana and more). Publishes p50/p95/p99 latency, error classification and stale-block detection every minute from three regions. Useful when picking the initial ordering for eRPC upstream `priority` fields or informing `selection-policies` thresholds. Data ships under CC BY 4.0.
+
+---
+
 ### Local Development
 
 1. **Clone this repository:**


### PR DESCRIPTION
## Summary

Adds a short `Related tools` subsection to the README pointing eRPC operators to [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) for independent RPC provider benchmarks, useful when setting the initial `priority` values for upstreams or informing thresholds for `selection-policies`.

## Why it fits

eRPC lets operators configure multiple upstreams with priorities, selection policies (cheap-first until error-rate or block-lag thresholds), and consensus checks. The docs already describe the mechanics of these features. What operators still have to figure out on their own is which providers to trust as primary vs fallback, and where the realistic error-rate / latency baselines sit.

OpenChainBench publishes continuous latency (p50/p95/p99), error classification (HTTP vs JSON-RPC error), and stale-block detection across 22 chains from three regions (US East, EU West, Singapore). Measurements are probed every minute, data ships under CC BY 4.0, harness is open source. No affiliation with any RPC provider or chain foundation, so its ranking is neutral by construction. A precedent for pairing the two tools already exists in the Linea developer docs, where both eRPC and OpenChainBench are referenced on the same node providers page.

## Change

One short `Related tools` subsection inserted between `CLI Commands` and `Local Development`. No changes to existing sections.

## Disclosure

I maintain OpenChainBench. Happy to reword or drop the entry entirely if it does not fit the README style guide, or move it into a separate `docs/related-tools.md` if you prefer to keep the README lean.