### PR TITLE
feat(cost): expose X-ERPC-Network-Id and X-ERPC-Network-Alias

### DIFF
--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1347,6 +1347,18 @@ func isBillableItem(ctx context.Context, item interface{}) bool {
 //	                        Omitted when nothing accrued (e.g. pure cache hits).
 //	X-ERPC-Credits-Version: the eRPC version the built-in vendor tables
 //	                        shipped with; only alongside X-ERPC-Credits.
+//	X-ERPC-Network-Id:      canonical network id of the routed call
+//	                        (e.g. `evm:42161`).
+//	X-ERPC-Network-Alias:   its configured alias — the SAME value eRPC's own
+//	                        `network` metric label carries (NetworkLabel:
+//	                        alias when set, else the id), so a proxy in front
+//	                        can attribute usage per network without parsing
+//	                        bodies or re-deriving the network from the URL.
+//	                        Both are emitted only when every routed sub-call
+//	                        resolved to ONE network: a batch is addressed to a
+//	                        single network, so a disagreement means the value
+//	                        is not a fact about the response and is omitted
+//	                        rather than guessed.
 //
 // Early errors that never routed a request get no cost headers — there is
 // no routed call to account for.
@@ -1357,6 +1369,8 @@ func (s *HttpServer) writeCostHeaders(ctx context.Context, w http.ResponseWriter
 	billable := 0
 	methods := map[string]struct{}{}
 	credits := map[string]int64{} // "vendor:method" → units
+	networkId, networkAlias := "", ""
+	networkAmbiguous := false
 	for _, item := range items {
 		if isBillableItem(ctx, item) {
 			billable++
@@ -1364,6 +1378,17 @@ func (s *HttpServer) writeCostHeaders(ctx context.Context, w http.ResponseWriter
 		req := extractRequest(item)
 		if req == nil {
 			continue
+		}
+		// Network of the routed call. "n/a" is what NetworkId/NetworkLabel
+		// return when the network was never resolved (e.g. internal
+		// eth_chainId probes), so it is not a network and is skipped.
+		if id := req.NetworkId(); id != "" && id != "n/a" {
+			switch {
+			case networkId == "":
+				networkId, networkAlias = id, req.NetworkLabel()
+			case networkId != id:
+				networkAmbiguous = true
+			}
 		}
 		method, _ := req.Method()
 		if method != "" {
@@ -1379,6 +1404,12 @@ func (s *HttpServer) writeCostHeaders(ctx context.Context, w http.ResponseWriter
 	}
 	setInt(w, "X-ERPC-Calls", len(items))
 	setInt(w, "X-ERPC-Billable", billable)
+	if networkId != "" && !networkAmbiguous {
+		w.Header().Set("X-ERPC-Network-Id", networkId)
+		if networkAlias != "" && networkAlias != "n/a" {
+			w.Header().Set("X-ERPC-Network-Alias", networkAlias)
+		}
+	}
 	if len(methods) > 0 {
 		names := make([]string, 0, len(methods))
 		for m := range methods {

--- a/erpc/http_server_cost_test.go
+++ b/erpc/http_server_cost_test.go
@@ -118,3 +118,79 @@ func TestBatchExecHeaders_AggregateCountersAndPartialCache(t *testing.T) {
 	assert.Empty(t, h.Get("X-ERPC-Upstream"), "single-winner header has no batch meaning")
 	assert.Empty(t, h.Get("X-ERPC-Upstreams-Truncated"))
 }
+
+// routedResponseOnNetwork is routedResponse with the request bound to a
+// network, the way a real forward resolves one from the URL before routing.
+func routedResponseOnNetwork(t *testing.T, method, networkId, networkLabel string) *common.NormalizedResponse {
+	t.Helper()
+	resp := routedResponse(t, method)
+	req := resp.Request()
+	req.SetNetwork(&Network{networkId: networkId, networkLabel: networkLabel})
+	return resp
+}
+
+func TestCostHeaders_NetworkIdAndAlias(t *testing.T) {
+	enabled := true
+	s := costTestServer(&common.ServerConfig{CostHeaders: &enabled})
+
+	w := httptest.NewRecorder()
+	s.writeCostHeaders(context.Background(), w, []interface{}{
+		routedResponseOnNetwork(t, "eth_call", "evm:42161", "arbitrum-one"),
+	})
+
+	h := w.Header()
+	assert.Equal(t, "evm:42161", h.Get("X-ERPC-Network-Id"))
+	// The alias is exactly what eRPC's own `network` metric label carries, so a
+	// proxy attributing usage per network matches eRPC's numbers by construction.
+	assert.Equal(t, "arbitrum-one", h.Get("X-ERPC-Network-Alias"))
+}
+
+func TestCostHeaders_NetworkAliasFallsBackToId(t *testing.T) {
+	enabled := true
+	s := costTestServer(&common.ServerConfig{CostHeaders: &enabled})
+
+	// No configured alias: NetworkLabel falls back to the id, mirroring the
+	// metric label, so the header is still emitted (never empty).
+	w := httptest.NewRecorder()
+	s.writeCostHeaders(context.Background(), w, []interface{}{
+		routedResponseOnNetwork(t, "eth_call", "evm:1", ""),
+	})
+
+	h := w.Header()
+	assert.Equal(t, "evm:1", h.Get("X-ERPC-Network-Id"))
+	assert.Equal(t, "evm:1", h.Get("X-ERPC-Network-Alias"))
+}
+
+func TestCostHeaders_NetworkOmittedWhenUnresolved(t *testing.T) {
+	enabled := true
+	s := costTestServer(&common.ServerConfig{CostHeaders: &enabled})
+
+	// A request that never resolved a network (NetworkId "n/a") is not a
+	// network — emit nothing rather than the sentinel.
+	w := httptest.NewRecorder()
+	s.writeCostHeaders(context.Background(), w, []interface{}{routedResponse(t, "eth_chainId")})
+
+	h := w.Header()
+	assert.Empty(t, h.Get("X-ERPC-Network-Id"))
+	assert.Empty(t, h.Get("X-ERPC-Network-Alias"))
+	// The rest of the cost group is unaffected.
+	assert.Equal(t, "1", h.Get("X-ERPC-Calls"))
+}
+
+func TestCostHeaders_NetworkOmittedWhenBatchDisagrees(t *testing.T) {
+	enabled := true
+	s := costTestServer(&common.ServerConfig{CostHeaders: &enabled})
+
+	// A batch is addressed to ONE network, so a disagreement is not a fact
+	// about the response — omit rather than pick a side.
+	w := httptest.NewRecorder()
+	s.writeCostHeaders(context.Background(), w, []interface{}{
+		routedResponseOnNetwork(t, "eth_call", "evm:1", "mainnet"),
+		routedResponseOnNetwork(t, "eth_call", "evm:8453", "base"),
+	})
+
+	h := w.Header()
+	assert.Empty(t, h.Get("X-ERPC-Network-Id"))
+	assert.Empty(t, h.Get("X-ERPC-Network-Alias"))
+	assert.Equal(t, "2", h.Get("X-ERPC-Calls"))
+}


### PR DESCRIPTION
## Why

A proxy in front of eRPC can already meter per-customer usage from the cost headers (`X-ERPC-Calls` / `X-ERPC-Billable`), but it cannot say **which network** that usage was on.

Re-deriving it from the URL doesn't work reliably. The route pair is `{network}/{chainId}`, where `network` is often a *family* rather than a name — `/{project}/evm/1` is Ethereum mainnet, `/{project}/monad/10143` is Monad. A proxy would have to carry its own chainId→name table, keep it in sync with eRPC's network config, and it would *still* disagree with eRPC's own `network` metric label (`arbitrum-one` vs `arbitrum`, `mainnet` vs `ethereum`).

The network eRPC resolved is a fact eRPC already knows. This returns it.

## What

Two headers, emitted with the existing cost group:

| header | value |
|---|---|
| `X-ERPC-Network-Id` | canonical id, e.g. `evm:42161` |
| `X-ERPC-Network-Alias` | `NetworkLabel()` — configured alias when set, else the id |

The alias is deliberately `NetworkLabel()`: **byte-identical to what eRPC's own `network` metric label carries**, so a proxy's per-network attribution matches eRPC's numbers by construction rather than by convention.

## Semantics

- Emitted only when every routed sub-call resolved to **one** network. A batch is addressed to a single network, so a disagreement means the value isn't a fact about the response — omitted rather than guessed.
- A request that never resolved a network (`NetworkId` `"n/a"`, e.g. internal `eth_chainId` probes) emits neither header.
- `X-ERPC-Network-Alias` is never empty when present — `NetworkLabel()` falls back to the id.

## Scope

- **No new config.** Rides the existing `server.costHeaders` opt-in and is off by default with it. Deployments that haven't enabled the cost group see no change.
- No new files or subsystems — extends `writeCostHeaders` and its doc comment.
- 4 new tests (alias, alias-falls-back-to-id, unresolved-network, batch-disagreement); existing cost tests pass unchanged (their fixtures carry no network, so the headers are correctly absent).

## Note on overlap

#1016 also touches the cost-header path. This is additive and independent of the credit-unit work, but whichever lands second will want a trivial rebase in `writeCostHeaders`.
