### PR TITLE
feat(admin): add allowMethods/denyMethods filtering to admin endpoint

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -254,10 +254,10 @@ type ForceTraceMatcher struct {
 }
 
 type AdminConfig struct {
-	Auth          *AuthConfig `yaml:"auth" json:"auth"`
-	CORS          *CORSConfig `yaml:"cors" json:"cors"`
-	AllowMethods  []string `yaml:"allowMethods,omitempty" json:"allowMethods,omitempty"`
-	IgnoreMethods []string `yaml:"ignoreMethods,omitempty" json:"ignoreMethods,omitempty"`
+	Auth         *AuthConfig `yaml:"auth" json:"auth"`
+	CORS         *CORSConfig `yaml:"cors" json:"cors"`
+	AllowMethods []string    `yaml:"allowMethods,omitempty" json:"allowMethods,omitempty"`
+	DenyMethods  []string    `yaml:"denyMethods,omitempty" json:"denyMethods,omitempty"`
 }
 
 type AliasingConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -254,8 +254,10 @@ type ForceTraceMatcher struct {
 }
 
 type AdminConfig struct {
-	Auth *AuthConfig `yaml:"auth" json:"auth"`
-	CORS *CORSConfig `yaml:"cors" json:"cors"`
+	Auth          *AuthConfig `yaml:"auth" json:"auth"`
+	CORS          *CORSConfig `yaml:"cors" json:"cors"`
+	AllowMethods  []string `yaml:"allowMethods,omitempty" json:"allowMethods,omitempty"`
+	IgnoreMethods []string `yaml:"ignoreMethods,omitempty" json:"ignoreMethods,omitempty"`
 }
 
 type AliasingConfig struct {

--- a/docs/pages/operation/admin.mdx
+++ b/docs/pages/operation/admin.mdx
@@ -117,6 +117,8 @@ All fields are under the top-level `admin:` key.
 | `admin.cors.exposedHeaders` | `[]string` | `nil` | Never set by defaults. When nil, `Access-Control-Expose-Headers` is omitted. Set explicitly if browser clients need to read custom eRPC response headers. |
 | `admin.cors.allowCredentials` | `*bool` | `false` (pointer) | Must stay `false` when `allowedOrigins: ["*"]` per CORS spec. Source: [`common/defaults.go:L2838-L2840`](https://github.com/erpc/erpc/blob/main/common/defaults.go#L2838-L2840) |
 | `admin.cors.maxAge` | `int` | `3600` | Preflight cache duration in seconds. `Access-Control-Max-Age` is emitted when `> 0`. Source: [`common/defaults.go:L2841-L2843`](https://github.com/erpc/erpc/blob/main/common/defaults.go#L2841-L2843) |
+| `admin.denyMethods` | `[]string` (wildcard) | `nil` | Blocks matching admin JSON-RPC methods before auth or upstream work. Wildcards (`*`, `?`) and boolean operators (`\|`, `&`, `!`) are supported. A blocked method returns JSON-RPC error `-32601` ("method not supported"). Evaluated before `allowMethods`. |
+| `admin.allowMethods` | `[]string` (wildcard) | `nil` | When set, only matching methods are served; all others are blocked. Also re-admits a method blocked by `denyMethods`. To build an allowlist: `denyMethods: ["*"]` + `allowMethods: ["erpc_listProjects"]`. **Note:** `allowMethods` alone is not an allowlist — without `denyMethods: ["*"]`, unmatched methods are still served. |
 
 ### Worked examples
 

--- a/docs/pages/operation/admin.mdx
+++ b/docs/pages/operation/admin.mdx
@@ -118,7 +118,7 @@ All fields are under the top-level `admin:` key.
 | `admin.cors.allowCredentials` | `*bool` | `false` (pointer) | Must stay `false` when `allowedOrigins: ["*"]` per CORS spec. Source: [`common/defaults.go:L2838-L2840`](https://github.com/erpc/erpc/blob/main/common/defaults.go#L2838-L2840) |
 | `admin.cors.maxAge` | `int` | `3600` | Preflight cache duration in seconds. `Access-Control-Max-Age` is emitted when `> 0`. Source: [`common/defaults.go:L2841-L2843`](https://github.com/erpc/erpc/blob/main/common/defaults.go#L2841-L2843) |
 | `admin.denyMethods` | `[]string` (wildcard) | `nil` | Blocks matching admin JSON-RPC methods before auth or upstream work. Wildcards (`*`, `?`) and boolean operators (`\|`, `&`, `!`) are supported. A blocked method returns JSON-RPC error `-32601` ("method not supported"). Evaluated before `allowMethods`. |
-| `admin.allowMethods` | `[]string` (wildcard) | `nil` | When set, only matching methods are served; all others are blocked. Also re-admits a method blocked by `denyMethods`. To build an allowlist: `denyMethods: ["*"]` + `allowMethods: ["erpc_listProjects"]`. **Note:** `allowMethods` alone is not an allowlist — without `denyMethods: ["*"]`, unmatched methods are still served. |
+| `admin.allowMethods` | `[]string` (wildcard) | `nil` | When set, only matching methods are served; all others are blocked. Also re-admits a method blocked by `denyMethods`. Example: `allowMethods: ["erpc_list*"]` restricts the admin endpoint to read-only list methods. |
 
 ### Worked examples
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -613,6 +613,30 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 
 				if isAdmin {
 					if s.adminCfg != nil {
+						if blocked, berr := isAdminMethodBlocked(s.adminCfg, method); berr != nil {
+							responses[index] = processErrorBody(&rlg, &startedAt, nq, berr, &common.TRUE)
+							common.EndRequestSpan(requestCtx, nil, berr)
+							return
+						} else if blocked {
+							jrr, _ := nq.JsonRpcRequest()
+							var reqId interface{}
+							jsonrpcVersion := "2.0"
+							if jrr != nil {
+								jsonrpcVersion = jrr.JSONRPC
+								reqId = jrr.ID
+							}
+							responses[index] = &HttpJsonRpcErrorResponse{
+								Jsonrpc: jsonrpcVersion,
+								Id:      reqId,
+								Error: map[string]interface{}{
+									"code":    int(common.JsonRpcErrorUnsupportedException),
+									"message": fmt.Sprintf("method not supported: %s", method),
+								},
+								Request: nq,
+							}
+							common.EndRequestSpan(requestCtx, nil, nil)
+							return
+						}
 						resp, err := s.erpc.AdminHandleRequest(requestCtx, nq)
 						if err != nil {
 							responses[index] = processErrorBody(&rlg, &startedAt, nq, err, &common.TRUE)
@@ -2196,4 +2220,46 @@ func stripAddrDecorations(s string) string {
 		return s[1 : len(s)-1]
 	}
 	return s
+}
+
+// isAdminMethodBlocked returns true when the admin config's IgnoreMethods/AllowMethods
+// rules prevent the given method from being handled.
+// IgnoreMethods is evaluated first; AllowMethods can re-admit a method that was ignored.
+func isAdminMethodBlocked(cfg *common.AdminConfig, method string) (bool, error) {
+	blocked := false
+	for _, pattern := range cfg.IgnoreMethods {
+		match, err := common.WildcardMatch(pattern, method)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			blocked = true
+			break
+		}
+	}
+	if blocked {
+		for _, pattern := range cfg.AllowMethods {
+			match, err := common.WildcardMatch(pattern, method)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	if len(cfg.AllowMethods) > 0 {
+		for _, pattern := range cfg.AllowMethods {
+			match, err := common.WildcardMatch(pattern, method)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	return false, nil
 }

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -2222,12 +2222,12 @@ func stripAddrDecorations(s string) string {
 	return s
 }
 
-// isAdminMethodBlocked returns true when the admin config's IgnoreMethods/AllowMethods
+// isAdminMethodBlocked returns true when the admin config's DenyMethods/AllowMethods
 // rules prevent the given method from being handled.
-// IgnoreMethods is evaluated first; AllowMethods can re-admit a method that was ignored.
+// DenyMethods is evaluated first; AllowMethods can re-admit a method that was denied.
 func isAdminMethodBlocked(cfg *common.AdminConfig, method string) (bool, error) {
 	blocked := false
-	for _, pattern := range cfg.IgnoreMethods {
+	for _, pattern := range cfg.DenyMethods {
 		match, err := common.WildcardMatch(pattern, method)
 		if err != nil {
 			return false, err

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -8277,3 +8277,221 @@ func TestHttpServer_DrainStampsConnectionClose(t *testing.T) {
 	resp = sendRequest()
 	require.True(t, resp.Close, "drain-window responses must carry Connection: close so pooled clients migrate before Shutdown")
 }
+
+func TestHttpServer_AdminMethodFilter(t *testing.T) {
+	const adminSecret = "test-secret"
+
+	newServer := func(t *testing.T, adminCfg *common.AdminConfig) (string, func()) {
+		t.Helper()
+		logger := log.Logger
+		ctx, cancel := context.WithCancel(context.Background())
+
+		cfg := &common.Config{
+			Server: &common.ServerConfig{
+				ListenV4: util.BoolPtr(true),
+			},
+			Admin: adminCfg,
+			Projects: []*common.ProjectConfig{
+				{
+					Id: "test_project",
+					Networks: []*common.NetworkConfig{
+						{
+							Architecture: common.ArchitectureEvm,
+							Evm:          &common.EvmNetworkConfig{ChainId: 1},
+						},
+					},
+					Upstreams: []*common.UpstreamConfig{
+						{
+							Type:     common.UpstreamTypeEvm,
+							Endpoint: "http://rpc1.localhost",
+							Evm:      &common.EvmUpstreamConfig{ChainId: 1},
+						},
+					},
+				},
+			},
+			RateLimiters: &common.RateLimiterConfig{},
+		}
+
+		ssr, err := data.NewSharedStateRegistry(ctx, &logger, &common.SharedStateConfig{
+			Connector: &common.ConnectorConfig{
+				Driver: "memory",
+				Memory: &common.MemoryConnectorConfig{MaxItems: 100_000, MaxTotalSize: "1GB"},
+			},
+		})
+		require.NoError(t, err)
+
+		erpcInstance, err := NewERPC(ctx, &logger, ssr, nil, cfg)
+		require.NoError(t, err)
+		erpcInstance.Bootstrap(ctx)
+
+		httpServer, err := NewHttpServer(ctx, &logger, cfg.Server, cfg.HealthCheck, cfg.Admin, erpcInstance)
+		require.NoError(t, err)
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		go func() {
+			_ = httpServer.serverV4.Serve(listener)
+		}()
+		time.Sleep(50 * time.Millisecond)
+
+		return fmt.Sprintf("http://127.0.0.1:%d", port), func() {
+			httpServer.serverV4.Shutdown(ctx) //nolint:errcheck
+			cancel()
+		}
+	}
+
+	callAdmin := func(t *testing.T, baseURL, method string) (int, map[string]interface{}) {
+		t.Helper()
+		body := strings.NewReader(fmt.Sprintf(`{"jsonrpc":"2.0","method":%q,"params":[{"projectId":"test_project"}],"id":1}`, method))
+		req, err := http.NewRequest("POST", baseURL+"/admin", body)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-erpc-secret-token", adminSecret)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		var result map[string]interface{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		return resp.StatusCode, result
+	}
+
+	secretAuth := &common.AuthConfig{
+		Strategies: []*common.AuthStrategyConfig{
+			{
+				Type:   common.AuthTypeSecret,
+				Secret: &common.SecretStrategyConfig{Value: adminSecret},
+			},
+		},
+	}
+
+	t.Run("no filter allows all methods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{Auth: secretAuth})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.False(t, hasError, "expected no error for erpc_listCordoned with no filter")
+	})
+
+	t.Run("ignoreMethods blocks exact match", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:          secretAuth,
+			IgnoreMethods: []string{"erpc_listCordoned"},
+		})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status, "blocked methods return 200 with JSON-RPC error")
+		errObj, hasError := result["error"]
+		assert.True(t, hasError, "expected error for blocked method")
+		errMap, _ := errObj.(map[string]interface{})
+		assert.Contains(t, errMap["message"], "method not supported")
+	})
+
+	t.Run("ignoreMethods wildcard blocks matching methods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:          secretAuth,
+			IgnoreMethods: []string{"erpc_*Cordoned"},
+		})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		errObj, hasError := result["error"]
+		assert.True(t, hasError)
+		errMap, _ := errObj.(map[string]interface{})
+		assert.Contains(t, errMap["message"], "method not supported")
+	})
+
+	t.Run("ignoreMethods does not block non-matching methods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:          secretAuth,
+			IgnoreMethods: []string{"erpc_cordonUpstream"},
+		})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.False(t, hasError, "erpc_listCordoned should not be blocked when only erpc_cordonUpstream is ignored")
+	})
+
+	t.Run("allowMethods restricts to listed methods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:         secretAuth,
+			AllowMethods: []string{"erpc_listCordoned"},
+		})
+		defer cleanup()
+
+		// listed method: allowed
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.False(t, hasError)
+
+		// unlisted method: blocked
+		status, result = callAdmin(t, baseURL, "erpc_cordonUpstream")
+		assert.Equal(t, http.StatusOK, status, "blocked methods return 200 with JSON-RPC error")
+		errObj, hasError := result["error"]
+		assert.True(t, hasError)
+		errMap, _ := errObj.(map[string]interface{})
+		assert.Contains(t, errMap["message"], "method not supported")
+	})
+
+	t.Run("allowMethods wildcard allows matching methods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:         secretAuth,
+			AllowMethods: []string{"erpc_list*"},
+		})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.False(t, hasError)
+
+		status, result = callAdmin(t, baseURL, "erpc_cordonUpstream")
+		assert.Equal(t, http.StatusOK, status, "blocked methods return 200 with JSON-RPC error")
+		errObj, hasError := result["error"]
+		assert.True(t, hasError)
+		errMap, _ := errObj.(map[string]interface{})
+		assert.Contains(t, errMap["message"], "method not supported")
+	})
+
+	t.Run("allowMethods re-admits method blocked by ignoreMethods", func(t *testing.T) {
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:          secretAuth,
+			IgnoreMethods: []string{"erpc_*"},
+			AllowMethods:  []string{"erpc_listCordoned"},
+		})
+		defer cleanup()
+
+		// explicitly allowed despite wildcard ignore
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.False(t, hasError)
+
+		// everything else still blocked
+		status, result = callAdmin(t, baseURL, "erpc_cordonUpstream")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError = result["error"]
+		assert.True(t, hasError)
+	})
+
+	t.Run("invalid pattern expression returns error", func(t *testing.T) {
+		// "|" with missing right operand is invalid in the WildcardMatch expression grammar
+		baseURL, cleanup := newServer(t, &common.AdminConfig{
+			Auth:          secretAuth,
+			IgnoreMethods: []string{"erpc_list*|"},
+		})
+		defer cleanup()
+
+		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
+		assert.Equal(t, http.StatusOK, status)
+		_, hasError := result["error"]
+		assert.True(t, hasError, "invalid pattern expression should propagate as a request error")
+	})
+}

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -1573,7 +1573,7 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 			// 	util.SetupMocksForEvmStatePoller()
 			// 	defer util.AssertNoPendingMocks(t, 0)
 
-			// 	cfg.Projects[0].Upstreams[0].IgnoreMethods = []string{}
+			// 	cfg.Projects[0].Upstreams[0].DenyMethods = []string{}
 
 			// 	// Set up test fixtures
 			// 	sendRequest, _, _, shutdown, _ := createServerTestFixtures(cfg, t)
@@ -1646,7 +1646,7 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 			// 	util.SetupMocksForEvmStatePoller()
 			// 	defer util.AssertNoPendingMocks(t, 1)
 
-			// 	cfg.Projects[0].Upstreams[0].IgnoreMethods = []string{"ignored_method"}
+			// 	cfg.Projects[0].Upstreams[0].DenyMethods = []string{"ignored_method"}
 
 			// 	// Set up test fixtures
 			// 	sendRequest, _, _, shutdown, _ := createServerTestFixtures(cfg, t)
@@ -7993,7 +7993,7 @@ func TestHttpServer_Evm_GetLogs_MemoryProfile(t *testing.T) {
 										Max:      common.Duration(10 * time.Second),
 									},
 								},
-								Retry:         &common.RetryPolicyConfig{MaxAttempts: 4, Delay: 0, EmptyResultAccept: []string{"eth_getLogs"}, EmptyResultMaxAttempts: 1},
+								Retry: &common.RetryPolicyConfig{MaxAttempts: 4, Delay: 0, EmptyResultAccept: []string{"eth_getLogs"}, EmptyResultMaxAttempts: 1},
 								Consensus: &common.ConsensusPolicyConfig{
 									AgreementThreshold:      2,
 									MaxParticipants:         4,
@@ -8375,10 +8375,10 @@ func TestHttpServer_AdminMethodFilter(t *testing.T) {
 		assert.False(t, hasError, "expected no error for erpc_listCordoned with no filter")
 	})
 
-	t.Run("ignoreMethods blocks exact match", func(t *testing.T) {
+	t.Run("denyMethods blocks exact match", func(t *testing.T) {
 		baseURL, cleanup := newServer(t, &common.AdminConfig{
-			Auth:          secretAuth,
-			IgnoreMethods: []string{"erpc_listCordoned"},
+			Auth:        secretAuth,
+			DenyMethods: []string{"erpc_listCordoned"},
 		})
 		defer cleanup()
 
@@ -8390,10 +8390,10 @@ func TestHttpServer_AdminMethodFilter(t *testing.T) {
 		assert.Contains(t, errMap["message"], "method not supported")
 	})
 
-	t.Run("ignoreMethods wildcard blocks matching methods", func(t *testing.T) {
+	t.Run("denyMethods wildcard blocks matching methods", func(t *testing.T) {
 		baseURL, cleanup := newServer(t, &common.AdminConfig{
-			Auth:          secretAuth,
-			IgnoreMethods: []string{"erpc_*Cordoned"},
+			Auth:        secretAuth,
+			DenyMethods: []string{"erpc_*Cordoned"},
 		})
 		defer cleanup()
 
@@ -8405,17 +8405,17 @@ func TestHttpServer_AdminMethodFilter(t *testing.T) {
 		assert.Contains(t, errMap["message"], "method not supported")
 	})
 
-	t.Run("ignoreMethods does not block non-matching methods", func(t *testing.T) {
+	t.Run("denyMethods does not block non-matching methods", func(t *testing.T) {
 		baseURL, cleanup := newServer(t, &common.AdminConfig{
-			Auth:          secretAuth,
-			IgnoreMethods: []string{"erpc_cordonUpstream"},
+			Auth:        secretAuth,
+			DenyMethods: []string{"erpc_cordonUpstream"},
 		})
 		defer cleanup()
 
 		status, result := callAdmin(t, baseURL, "erpc_listCordoned")
 		assert.Equal(t, http.StatusOK, status)
 		_, hasError := result["error"]
-		assert.False(t, hasError, "erpc_listCordoned should not be blocked when only erpc_cordonUpstream is ignored")
+		assert.False(t, hasError, "erpc_listCordoned should not be blocked when only erpc_cordonUpstream is denied")
 	})
 
 	t.Run("allowMethods restricts to listed methods", func(t *testing.T) {
@@ -8460,11 +8460,11 @@ func TestHttpServer_AdminMethodFilter(t *testing.T) {
 		assert.Contains(t, errMap["message"], "method not supported")
 	})
 
-	t.Run("allowMethods re-admits method blocked by ignoreMethods", func(t *testing.T) {
+	t.Run("allowMethods re-admits method blocked by denyMethods", func(t *testing.T) {
 		baseURL, cleanup := newServer(t, &common.AdminConfig{
-			Auth:          secretAuth,
-			IgnoreMethods: []string{"erpc_*"},
-			AllowMethods:  []string{"erpc_listCordoned"},
+			Auth:         secretAuth,
+			DenyMethods:  []string{"erpc_*"},
+			AllowMethods: []string{"erpc_listCordoned"},
 		})
 		defer cleanup()
 
@@ -8484,8 +8484,8 @@ func TestHttpServer_AdminMethodFilter(t *testing.T) {
 	t.Run("invalid pattern expression returns error", func(t *testing.T) {
 		// "|" with missing right operand is invalid in the WildcardMatch expression grammar
 		baseURL, cleanup := newServer(t, &common.AdminConfig{
-			Auth:          secretAuth,
-			IgnoreMethods: []string{"erpc_list*|"},
+			Auth:        secretAuth,
+			DenyMethods: []string{"erpc_list*|"},
 		})
 		defer cleanup()
 

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -250,7 +250,7 @@ export interface AdminConfig {
     auth?: AuthConfig;
     cors?: CORSConfig;
     allowMethods?: string[];
-    ignoreMethods?: string[];
+    denyMethods?: string[];
 }
 export interface AliasingConfig {
     rules: (AliasingRuleConfig | undefined)[];

--- a/typescript/config/lib/generated.d.ts
+++ b/typescript/config/lib/generated.d.ts
@@ -249,6 +249,8 @@ export interface ForceTraceMatcher {
 export interface AdminConfig {
     auth?: AuthConfig;
     cors?: CORSConfig;
+    allowMethods?: string[];
+    ignoreMethods?: string[];
 }
 export interface AliasingConfig {
     rules: (AliasingRuleConfig | undefined)[];

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -289,6 +289,8 @@ export interface ForceTraceMatcher {
 export interface AdminConfig {
   auth?: AuthConfig;
   cors?: CORSConfig;
+  allowMethods?: string[];
+  ignoreMethods?: string[];
 }
 export interface AliasingConfig {
   rules: (AliasingRuleConfig | undefined)[];
@@ -561,6 +563,18 @@ export interface ProjectConfig {
    * Configure user agent tracking at the project level
    */
   userAgentMode?: UserAgentTrackingMode;
+  /**
+   * TrustUserIdHeader makes erpc read the caller's user identity from the
+   * X-ERPC-User-Id request header (see common.HeaderUserId) and use it for the
+   * `user` metric/log label — but only when no auth strategy resolved a user
+   * (auth wins) and only for attribution (no rate-limit budget is derived).
+   * This is for deployments that authenticate callers in front of erpc (e.g. a
+   * gateway) and want per-user erpc telemetry without erpc performing auth.
+   * erpc does NOT validate the header, so enable this ONLY when erpc is reachable
+   * solely by a trusted proxy that sets the header and strips any client copy —
+   * otherwise callers can spoof their own attribution. Default false.
+   */
+  trustUserIdHeader?: boolean;
   forwardHeaders?: string[];
   allowClientDirectives?: string;
   ignoreMethods?: string[];
@@ -1042,7 +1056,11 @@ export interface ConsensusPolicyConfig {
  * `consensus.requiredParticipants`. `Tag` is a glob pattern (`*`, `?`)
  * matched against each upstream's `tags`; `MinParticipants` is the minimum
  * number of matching upstreams that must be in the consensus participant
- * set. A single upstream can satisfy multiple entries it matches.
+ * set (pool quota, best-effort). `MinAgreement` is the minimum number of
+ * matching upstreams that must be part of the WINNING response group
+ * (winner-composition quota, hard-enforced: a winner that does not satisfy
+ * it becomes a composition dispute regardless of disputeBehavior). A single
+ * upstream can satisfy multiple entries it matches.
  */
 export interface ConsensusRequiredParticipant {
   tag: string;

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -290,7 +290,7 @@ export interface AdminConfig {
   auth?: AuthConfig;
   cors?: CORSConfig;
   allowMethods?: string[];
-  ignoreMethods?: string[];
+  denyMethods?: string[];
 }
 export interface AliasingConfig {
   rules: (AliasingRuleConfig | undefined)[];


### PR DESCRIPTION
## Summary

- Adds `allowMethods` and `denyMethods` fields to `AdminConfig`, mirroring the existing consumer project config pattern
- Once the admin endpoint is enabled, operators can restrict access to a subset of methods (e.g. read-only `erpc_list*`) or block specific write operations without disabling the endpoint entirely
- `denyMethods` is evaluated first; `allowMethods` can re-admit a method that would otherwise be denied

## Motivation

The admin control plane exposes both read and write methods. Before this change, enabling the endpoint was all-or-nothing — any authenticated caller could invoke any method including destructive ones (`erpc_deleteApiKey`, `erpc_cordonUpstream`). Operators now have fine-grained control.

## Usage

```yaml
admin:
  auth:
    strategies:
      - type: secret
        secret:
          value: "your-secret"
  # Allow only read-only methods
  allowMethods:
    - erpc_list*
    - erpc_taxonomy
    - erpc_config
    - erpc_project
```

```yaml
# Or block specific write methods
admin:
  denyMethods:
    - erpc_deleteApiKey
    - erpc_cordonUpstream
    - erpc_uncordonUpstream
```

Both fields support wildcard patterns (e.g. `erpc_list*`). `allowMethods` takes precedence over `denyMethods` for the same method.

When a method is blocked the response matches the existing consumer-path shape:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": { "code": -32004, "message": "method not supported: erpc_cordonUpstream" }
}
```

## Changes

- `common/config.go` — added `AllowMethods`/`DenyMethods` to `AdminConfig`
- `erpc/http_server.go` — added `isAdminMethodBlocked` helper and filtering before `AdminHandleRequest`
- `erpc/http_server_test.go` — 7 integration tests

## Test plan

```bash
go test ./erpc/... -run TestHttpServer_AdminMethodFilter -v
```

- [x] No filter allows all methods
- [x] `denyMethods` blocks exact match
- [x] `denyMethods` wildcard blocks matching methods
- [x] `denyMethods` does not block non-matching methods
- [x] `allowMethods` restricts to listed methods only
- [x] `allowMethods` wildcard allows matching methods
- [x] `allowMethods` re-admits method blocked by `denyMethods`

🤖 Generated with [Claude Code](https://claude.com/claude-code)