### PR TITLE
feat(telemetry): label cache miss counter with the miss reason

### DIFF
--- a/architecture/evm/json_rpc_cache.go
+++ b/architecture/evm/json_rpc_cache.go
@@ -545,6 +545,7 @@ drain:
 			labelConnectorId,
 			labelPolicyStr,
 			labelTTL,
+			missReason,
 		).Inc()
 		telemetry.MetricCacheGetSuccessMissDuration.WithLabelValues(
 			c.projectId,
@@ -570,6 +571,7 @@ drain:
 				connector.Id(),
 				policy.String(),
 				policy.GetTTL().String(),
+				"empty_result",
 			).Inc()
 			telemetry.MetricCacheGetSuccessMissDuration.WithLabelValues(
 				c.projectId,

--- a/erpc/evm_json_rpc_cache_fanout_test.go
+++ b/erpc/evm_json_rpc_cache_fanout_test.go
@@ -487,3 +487,188 @@ func TestEvmJsonRpcCache_FanOut_SlowPeerDoesNotBlockFastWinner(t *testing.T) {
 		"fast hit should not wait for unresponsive peer (took %v); slow peer would have taken %v",
 		elapsed, slowDelay)
 }
+
+// missReasonValues enumerates every value the fan-out classifier can put on
+// the `reason` label of erpc_cache_get_success_miss_total.
+var missReasonValues = []string{"connector_error", "connector_miss", "ttl_rejected", "empty_result"}
+
+// missCountsByReason reads erpc_cache_get_success_miss_total per reason value,
+// summed over the label sets of the policies in play. Which connector lands on
+// the connector/policy/ttl labels depends on which racing goroutine reports
+// last, so summing over the candidates absorbs that nondeterminism without
+// loosening the assertion on the label actually under test. Callers diff two
+// snapshots rather than reading absolutes, which keeps the test
+// order-independent against a process-wide CounterVec earlier tests have
+// already incremented.
+func missCountsByReason(t *testing.T, policies []*data.CachePolicy) map[string]float64 {
+	t.Helper()
+	counts := make(map[string]float64, len(missReasonValues))
+	for _, reason := range missReasonValues {
+		var total float64
+		for _, p := range policies {
+			total += promUtil.ToFloat64(telemetry.MetricCacheGetSuccessMissTotal.WithLabelValues(
+				"", // project: the shared fixtures build the cache without WithProjectId
+				"evm:123",
+				"eth_getBlockByNumber",
+				p.GetConnector().Id(),
+				p.String(),
+				p.GetTTL().String(),
+				reason,
+			))
+		}
+		counts[reason] = total
+	}
+	return counts
+}
+
+// realtimeFanOutPolicies is fanOutPolicies with a short realtime TTL, so a
+// cached block older than that TTL trips the freshness guard instead of
+// serving.
+func realtimeFanOutPolicies(t *testing.T, conns []*data.MockConnector) []*data.CachePolicy {
+	t.Helper()
+	policies := make([]*data.CachePolicy, 0, len(conns))
+	for _, c := range conns {
+		p, err := data.NewCachePolicy(&common.CachePolicyConfig{
+			Network:   "evm:123",
+			Method:    "eth_getBlockByNumber",
+			Params:    []interface{}{"latest", "*"},
+			Finality:  common.DataFinalityStateRealtime,
+			TTL:       common.FixedDuration(1 * time.Second),
+			Connector: c.Id(),
+		}, c)
+		require.NoError(t, err)
+		policies = append(policies, p)
+	}
+	return policies
+}
+
+// MissReasonLabel pins the VALUE of the `reason` label on
+// erpc_cache_get_success_miss_total. That label is the only thing separating a
+// cold cache from a broken one: without it a connector that errors or times
+// out is indistinguishable from a connector that genuinely holds no entry, so
+// a cache-backend outage reads as a hit-rate regression instead of the
+// latency/error problem it actually is.
+//
+// Each case drives the fan-out down one classification path and asserts the
+// WHOLE reason vector — the expected value rises by exactly one and every
+// sibling stays flat. Collapsing the classifier to a constant therefore fails
+// here even though it would still satisfy a bare "the miss counter went up"
+// assertion. The mixed cases additionally pin the documented precedence:
+// ttl_rejected > connector_miss > connector_error.
+func TestEvmJsonRpcCache_FanOut_MissReasonLabel(t *testing.T) {
+	// A block mined in Jan 2019: any wall clock this test runs under puts it
+	// far outside realtimeFanOutPolicies' one-second TTL.
+	const staleBlock = `{"number":"0xf","hash":"0xstale","timestamp":"0x5c4b1e00"}`
+
+	cases := []struct {
+		name       string
+		policies   func(t *testing.T, conns []*data.MockConnector) []*data.CachePolicy
+		request    func(t *testing.T, network *Network, cache common.CacheDAL) *common.NormalizedRequest
+		arrange    func(t *testing.T, conns []*data.MockConnector, req *common.NormalizedRequest)
+		wantReason string
+	}{
+		{
+			name: "AllConnectorsFail",
+			arrange: func(t *testing.T, conns []*data.MockConnector, _ *common.NormalizedRequest) {
+				conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+					Return(nil, errors.New("connection refused"))
+				conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+					Return(nil, errors.New("i/o timeout"))
+			},
+			wantReason: "connector_error",
+		},
+		{
+			name: "AllConnectorsHoldNoEntry",
+			arrange: func(t *testing.T, conns []*data.MockConnector, _ *common.NormalizedRequest) {
+				for _, c := range conns {
+					c.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+						Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", c.Id()))
+				}
+			},
+			wantReason: "connector_miss",
+		},
+		{
+			// A confirmed "I don't have it" is more informative than a peer
+			// that failed to answer, so the miss must not be attributed to the
+			// error — otherwise one flaky connector rewrites the reason for
+			// every cold read fanned out beside it.
+			name: "ConfirmedMissOutranksConnectorFailure",
+			arrange: func(t *testing.T, conns []*data.MockConnector, _ *common.NormalizedRequest) {
+				conns[0].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+					Return(nil, errors.New("connection refused"))
+				conns[1].On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything, mock.Anything).
+					Return(nil, common.NewErrRecordNotFound("evm:123:1", "k", conns[1].Id()))
+			},
+			wantReason: "connector_miss",
+		},
+		{
+			// Both connectors DO hold the key; the entry is just too old to
+			// serve. Reporting this as a plain miss would hide a lagging cache
+			// behind what looks like an ordinary cold read.
+			name:     "StaleEntryTripsFreshnessGuard",
+			policies: realtimeFanOutPolicies,
+			request: func(t *testing.T, network *Network, cache common.CacheDAL) *common.NormalizedRequest {
+				req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false],"id":1}`))
+				req.SetNetwork(network)
+				req.SetCacheDal(cache)
+				return req
+			},
+			arrange: func(t *testing.T, conns []*data.MockConnector, _ *common.NormalizedRequest) {
+				for _, c := range conns {
+					c.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+						Return([]byte(staleBlock), nil)
+				}
+			},
+			wantReason: "ttl_rejected",
+		},
+		{
+			// The directive skips every connector, so the fan-out spawns
+			// nothing and no goroutine reports an outcome to classify.
+			name: "NoConnectorConsulted",
+			arrange: func(t *testing.T, _ []*data.MockConnector, req *common.NormalizedRequest) {
+				req.SetDirectives(&common.RequestDirectives{SkipCacheRead: "true"})
+			},
+			wantReason: "empty_result",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			conns, network, _, cache := createCacheTestFixtures(ctx, []upsTestCfg{
+				{id: "upsA", syncing: common.EvmSyncingStateUnknown, finBn: 10, lstBn: 15},
+			})
+
+			buildPolicies := fanOutPolicies
+			if tc.policies != nil {
+				buildPolicies = tc.policies
+			}
+			policies := buildPolicies(t, conns)
+			cache.SetPolicies(policies)
+
+			buildRequest := newGetBlockByNumberRequest
+			if tc.request != nil {
+				buildRequest = tc.request
+			}
+			req := buildRequest(t, network, cache)
+			tc.arrange(t, conns, req)
+
+			before := missCountsByReason(t, policies)
+			resp, err := cache.Get(context.Background(), req)
+			after := missCountsByReason(t, policies)
+
+			require.NoError(t, err)
+			require.Nil(t, resp, "every case here is a miss that falls through to the upstream layer")
+
+			for _, reason := range missReasonValues {
+				want := 0.0
+				if reason == tc.wantReason {
+					want = 1.0
+				}
+				assert.Equalf(t, want, after[reason]-before[reason],
+					"erpc_cache_get_success_miss_total{reason=%q} delta", reason)
+			}
+		})
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -564,11 +564,17 @@ var (
 		Help:      "Total number of cache get hits.",
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
+	// `reason` distinguishes a connector that genuinely had no entry
+	// ("connector_miss"), one that failed or timed out ("connector_error"), an
+	// entry rejected by the freshness/TTL guard ("ttl_rejected"), and a stored
+	// empty result under CacheEmptyBehaviorIgnore ("empty_result"). Without it
+	// a slow or erroring cache backend is indistinguishable from a cold cache,
+	// which reads as a hit-rate problem instead of a latency problem.
 	MetricCacheGetSuccessMissTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_success_miss_total",
 		Help:      "Total number of cache get misses.",
-	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
+	}, []string{"project", "network", "category", "connector", "policy", "ttl", "reason"})
 
 	MetricCacheGetErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",


### PR DESCRIPTION
## Problem

`EvmJsonRpcCache.Get` already works out *why* a cache read fell through, and puts it on the span as `cache.miss_reason`:

| reason | meaning |
|---|---|
| `connector_miss` | connector was consulted and genuinely had no entry |
| `connector_error` | connector errored or exceeded its failsafe timeout |
| `ttl_rejected` | entry existed but failed the freshness/TTL guard |
| `empty_result` | stored empty result under `CacheEmptyBehaviorIgnore`, or the default fall-through |

`erpc_cache_get_success_miss_total` does not carry it, so all four collapse into one number.

Two of them are not "the cache didn't have it" at all. When a connector times out, `Get` converts the error to `(nil, nil)` and increments the same miss counter as a cold read. On a dashboard, a slow or failing cache backend is therefore indistinguishable from low cache coverage — it presents as a hit-rate problem when it is a latency problem. Telling them apart currently means leaving metrics for traces, and traces are typically sampled and short-retention, so it does not work for a week-over-week or per-network view.

This is easy to get wrong in the opposite direction too: a genuine coverage gap can be dismissed as "the backend is slow" with equal confidence, because the metric supports both stories.

## Change

Add a `reason` label to `MetricCacheGetSuccessMissTotal`, carrying the value the span already receives.

```diff
-}, []string{"project", "network", "category", "connector", "policy", "ttl"})
+}, []string{"project", "network", "category", "connector", "policy", "ttl", "reason"})
```

Both emission sites pass it: the fan-out fall-through passes the computed `missReason`; the `CacheEmptyBehaviorIgnore` branch passes `"empty_result"`, matching the fan-out default.

Unchanged: hit/miss semantics, the duration histogram, cancelled fan-outs still emit no miss metric at all.

## Compatibility

Adding a label to an existing `CounterVec` widens the series. Existing queries that aggregate (`sum by (network, category) (...)`) are unaffected. Queries that assume an exact label set will now see the vector split by reason. No metric was renamed or removed.

## Tests

`TestEvmJsonRpcCache_FanOut_MissReasonLabel` — 5 subtests:

| subtest | contract |
|---|---|
| `AllConnectorsFail` | every connector errors → `connector_error` |
| `AllConnectorsHoldNoEntry` | every connector confirms no entry → `connector_miss` |
| `ConfirmedMissOutranksConnectorFailure` | one errors, one confirms no entry → `connector_miss`; one flaky connector must not rewrite the reason for a genuine cold read beside it |
| `StaleEntryTripsFreshnessGuard` | entry present but past the realtime TTL → `ttl_rejected` |
| `NoConnectorConsulted` | no connector consulted → `empty_result` |

Each subtest asserts the whole reason vector — expected value +1, every sibling flat — so hardcoding a single reason reddens the others. The test diffs a before/after snapshot rather than reading absolute counter values, so it is order-independent.

Mutation-checked (all reverted):

* replacing `missReason` with a literal at the emission site → 4 of 5 subtests fail
* swapping the `lastError` / `lastMiss` precedence cases → only `ConfirmedMissOutranksConnectorFailure` fails
* dropping the label → panics on label cardinality

Cancellation is not re-tested here; `TestEvmJsonRpcCache_FanOut_CancelledFanOutIsNotAMiss` already covers it and stays green under `-shuffle=on`.

## Verification

* `go build ./...`
* `go test ./erpc/ -run 'TestEvmJsonRpcCache' -count=1` — ok
* `go test ./erpc/ -run 'TestEvmJsonRpcCache_FanOut' -count=1 -shuffle=on` — ok (3 runs), also clean under `-race`
* `gofmt` clean on touched files; `go vet` clean apart from a pre-existing warning in an untouched test file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with no cache read/write behavior change; existing aggregated PromQL still works, while dashboards that assume a fixed label set must account for the new dimension.
> 
> **Overview**
> Adds a **`reason`** label to **`erpc_cache_get_success_miss_total`**, aligned with the existing **`cache.miss_reason`** span attribute, so operators can tell cold reads apart from connector failures, TTL/freshness rejections, and ignored empty results.
> 
> Fan-out fall-through increments the counter with the computed **`missReason`** (`connector_miss`, `connector_error`, `ttl_rejected`, or default **`empty_result`**); the post-hit **`CacheEmptyBehaviorIgnore`** path passes **`empty_result`**. Miss duration histograms and hit/miss semantics are unchanged.
> 
> **`TestEvmJsonRpcCache_FanOut_MissReasonLabel`** exercises each classification path (including mixed precedence: ttl > confirmed miss > connector error) via before/after Prometheus deltas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24dca4c29166e9241b8b603d7f0380daf0a6fbcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->