### PR TITLE
feat(telemetry): sweep idle counter series to bound /metrics cardinality

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -2705,6 +2705,17 @@ type MetricsConfig struct {
 	// "erpc_" namespace prefix), e.g. "network_request_duration_seconds".
 	// Value is the list of label names to keep for that metric.
 	HistogramLabelOverrides map[string][]string `yaml:"histogramLabelOverrides,omitempty" json:"histogramLabelOverrides,omitempty"`
+
+	// CounterIdleEvictionAfter bounds /metrics cardinality for hot-path
+	// counters whose label-sets are keyed by caller-controlled inputs
+	// (method, user, agentName, ...). Counter series idle for at least this
+	// duration are evicted from the Prometheus registry (DeleteLabelValues)
+	// by the health tracker's idle sweep; a series that becomes active again
+	// restarts at zero — the same semantics rate()/increase() consumers
+	// already handle across process restarts. Defaults to 24h (conservative:
+	// only clearly-dead label combinations are released). Set to 0 to
+	// disable eviction entirely.
+	CounterIdleEvictionAfter *Duration `yaml:"counterIdleEvictionAfter,omitempty" json:"counterIdleEvictionAfter,omitempty"`
 }
 
 // GetProjectConfig returns the project configuration by the specified project ID.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -768,6 +768,11 @@ func (m *MetricsConfig) SetDefaults() error {
 	if m.ErrorLabelMode == "" {
 		m.ErrorLabelMode = ErrorLabelModeCompact
 	}
+	if m.CounterIdleEvictionAfter == nil {
+		// Mirrors telemetry.DefaultCounterIdleEvictionAfter — conservative
+		// 24h so only clearly-dead label combinations are released.
+		m.CounterIdleEvictionAfter = Duration(24 * time.Hour).Ptr()
+	}
 
 	return nil
 }

--- a/docs/pages/operation/monitoring.mdx
+++ b/docs/pages/operation/monitoring.mdx
@@ -116,8 +116,15 @@ changing a registered metric's label set.
 
 An idle-eviction sweep runs every ~5 minutes and calls `DeleteLabelValues` on stale
 `erpc_upstream_request_duration_seconds` and `erpc_rate_limits_total` series to prevent
-cardinality runaway under method-flood attacks. Other high-cardinality metrics are bounded
-only by distinct (project, network, upstream, method) tuples.
+cardinality runaway under method-flood attacks. Counters emitted through
+`telemetry.CounterHandle` (upstream request/error totals, network success/hedge counters,
+etc.) are swept on the same cadence with their own, more conservative threshold —
+`metrics.counterIdleEvictionAfter`, default `24h` — so counter series whose label
+combinations go quiet (stale `method` × `user` × `agent_name` tuples) are eventually
+released instead of being re-emitted on every scrape for the process lifetime. A swept
+series that becomes active again restarts at zero, the same semantics as a process
+restart. Remaining high-cardinality metrics are bounded only by distinct
+(project, network, upstream, method) tuples.
 
 **`LabeledHistogram` label filtering.** `WithLabelValues` always receives the full canonical
 label set in schema order; the wrapper projects down to the active (post-filter) subset before
@@ -165,6 +172,7 @@ All fields under `metrics.` in the YAML root config. Struct: <SourceLink file="c
 | `metrics.histogramBuckets` | `string` | `""` → `[0.05, 0.5, 5, 30]` | Comma-separated float64 bucket boundaries for the 8 configurable `LabeledHistogram` instances: `upstream_request_duration_seconds`, `network_request_duration_seconds`, `consensus_duration_seconds`, `cache_set_success/error_duration_seconds`, `cache_get_success_hit/miss/error_duration_seconds`. Invalid float → warning + fallback to defaults. Source: <SourceLink file="telemetry/metrics.go" lines="731-736" /> |
 | `metrics.histogramDropLabels` | `[]string` | `nil` | Label names to drop from EVERY `LabeledHistogram`. Counters and gauges unaffected. Drop is permanent for the process lifetime — reconfiguring after first `SetHistogramBuckets` call panics. Common candidates: `user`, `agent_name`. Source: <SourceLink file="erpc/init.go" lines="53" /> |
 | `metrics.histogramLabelOverrides` | `map[string][]string` | `nil` | Per-metric overrides that re-add labels even if listed in `histogramDropLabels`. Key = metric name **without** `erpc_` prefix (e.g. `"network_request_duration_seconds"`). Value = labels to preserve for that metric. Source: <SourceLink file="erpc/init.go" lines="53" /> |
+| `metrics.counterIdleEvictionAfter` | `Duration` | `24h` | Idle threshold after which counter series emitted via `telemetry.CounterHandle` are evicted from the registry (`DeleteLabelValues`), bounding `/metrics` growth from caller-controlled label values (`method`, `user`, `agent_name`). `0` disables. Swept on the health tracker's sweep cadence. Source: <SourceLink file="erpc/init.go" lines="54-56" /> |
 
 **Hardcoded server constants (not configurable):**
 - Bind address: `":<port>"` (all interfaces) — <SourceLink file="erpc/init.go" lines="149" />

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -51,6 +51,9 @@ func Init(
 		}
 		// Must run before SetHistogramBuckets so the new Vecs are built with the filter applied.
 		telemetry.SetHistogramLabelFilter(cfg.Metrics.HistogramDropLabels, cfg.Metrics.HistogramLabelOverrides)
+		if cfg.Metrics.CounterIdleEvictionAfter != nil {
+			telemetry.SetCounterIdleEvictionAfter(cfg.Metrics.CounterIdleEvictionAfter.Duration())
+		}
 	}
 	if err := telemetry.SetHistogramBuckets(bucketStr); err != nil {
 		logger.Warn().Err(err).Msg("failed to set histogram buckets, using defaults")

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1508,7 +1508,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 			}
 			upstream := key.(*upstream.Upstream)
 			finality := req.Finality(ctx)
-			telemetry.MetricUpstreamWrongEmptyResponseTotal.WithLabelValues(
+			telemetry.CounterHandle(telemetry.MetricUpstreamWrongEmptyResponseTotal,
 				n.projectId,
 				upstream.VendorName(),
 				n.Label(),
@@ -1516,8 +1516,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 				method,
 				finality.String(),
 				req.UserId(),
-				req.AgentName(),
-			).Inc()
+				req.AgentName()).Inc()
 
 			// If the response block number is known, check if it falls outside
 			// this upstream's configured block availability range.
@@ -1789,12 +1788,11 @@ func (n *Network) handleBlockSkip(
 		attribute.Bool("skip_retryable", isRetryable),
 	)
 	finality := req.Finality(ctx)
-	telemetry.MetricUpstreamErrorTotal.WithLabelValues(
+	telemetry.CounterHandle(telemetry.MetricUpstreamErrorTotal,
 		n.projectId, u.VendorName(), n.Label(), u.Id(), method,
 		common.ErrorFingerprint(skipErr), string(common.SeverityInfo),
 		req.CompositeType(), finality.String(),
-		req.UserId(), req.AgentName(),
-	).Inc()
+		req.UserId(), req.AgentName()).Inc()
 	errToStore := skipErr
 	if !isRetryable {
 		errToStore = common.NewErrUpstreamRequestSkipped(skipErr, u.Id())

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -666,10 +666,12 @@ func (t *Tracker) sweepIdleObservers(cutoffMs int64) {
 	})
 
 	// Direct counter emissions (upstream/erpc hot paths) route through
-	// telemetry.CounterHandle; sweep their idle label-sets on the same
-	// threshold so caller-controlled label combinations (method, userId,
-	// agentName, ...) don't accumulate in the registry forever.
-	telemetry.SweepIdleCounterHandles(cutoffMs)
+	// telemetry.CounterHandle; sweep their idle label-sets so
+	// caller-controlled label combinations (method, userId, agentName, ...)
+	// don't accumulate in the registry forever. The counter sweep has its
+	// own, more conservative threshold (metrics.counterIdleEvictionAfter,
+	// default 24h) — only the cadence is shared with this observer sweep.
+	telemetry.SweepIdleCounterHandles()
 }
 
 // getUpsKeys expands a (upstream, method, finality) record into the

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -664,6 +664,12 @@ func (t *Tracker) sweepIdleObservers(cutoffMs int64) {
 		)
 		return true
 	})
+
+	// Direct counter emissions (upstream/erpc hot paths) route through
+	// telemetry.CounterHandle; sweep their idle label-sets on the same
+	// threshold so caller-controlled label combinations (method, userId,
+	// agentName, ...) don't accumulate in the registry forever.
+	telemetry.SweepIdleCounterHandles(cutoffMs)
 }
 
 // getUpsKeys expands a (upstream, method, finality) record into the

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -70,6 +70,15 @@ func labelsKey(labels []string) string {
 	return b.String()
 }
 
+// counterHandleCreateMu serializes CounterHandle's miss path (create +
+// cache-store) against sweep eviction (cache-delete + DeleteLabelValues).
+// Without it, a miss between the sweep's cache delete and its registry
+// delete would re-cache the still-registered child right before the sweep
+// removes it from the vec — leaving a hot cached handle whose increments
+// are never scraped again. The hit path stays lock-free: misses happen once
+// per label tuple per (re)birth, so the lock is off the hot path.
+var counterHandleCreateMu sync.Mutex
+
 // CounterHandle returns a cached child counter for the given labels and
 // refreshes its idle timestamp. Callers must re-fetch the handle per use
 // (CounterHandle(...).Inc()) rather than holding the returned Counter —
@@ -83,15 +92,24 @@ func CounterHandle(cv *prometheus.CounterVec, labels ...string) prometheus.Count
 		h.lastAccessedAtMs.Store(nowMs)
 		return h.counter
 	}
+	counterHandleCreateMu.Lock()
+	defer counterHandleCreateMu.Unlock()
+	// Re-check under the lock: another miss may have created the entry, or
+	// a sweep may have just evicted it (in which case WithLabelValues below
+	// creates a fresh series — never a doomed one, since eviction holds the
+	// same lock across cache-delete + registry-delete).
+	if v, ok := counterHandleCache.Load(k); ok {
+		h := v.(*cachedCounterHandle)
+		h.lastAccessedAtMs.Store(nowMs)
+		return h.counter
+	}
 	h := &cachedCounterHandle{
 		counter: cv.WithLabelValues(labels...),
 		vals:    append([]string(nil), labels...),
 	}
 	h.lastAccessedAtMs.Store(nowMs)
-	actual, _ := counterHandleCache.LoadOrStore(k, h)
-	ah := actual.(*cachedCounterHandle)
-	ah.lastAccessedAtMs.Store(nowMs)
-	return ah.counter
+	counterHandleCache.Store(k, h)
+	return h.counter
 }
 
 // DefaultCounterIdleEvictionAfter is the conservative default idle threshold
@@ -129,9 +147,13 @@ func SweepIdleCounterHandles() int {
 }
 
 // sweepIdleCounterHandlesBefore evicts cached counter handles not touched
-// since cutoffMs. Safe to call concurrently with CounterHandle: a racing
-// re-fetch recreates the series fresh at zero, which is the same semantics
-// as a process restart.
+// since cutoffMs. Cache delete and registry delete happen atomically with
+// respect to CounterHandle's miss path (counterHandleCreateMu), so a racing
+// re-fetch either lands before eviction (refreshing the timestamp, which the
+// under-lock re-check honors) or after it (recreating the series fresh at
+// zero — the same semantics as a process restart). A hit-path caller that
+// obtained the child just before eviction may lose the increments of that
+// single use; bounded, restart-equivalent.
 func sweepIdleCounterHandlesBefore(cutoffMs int64) int {
 	evicted := 0
 	counterHandleCache.Range(func(key, value any) bool {
@@ -139,9 +161,18 @@ func sweepIdleCounterHandlesBefore(cutoffMs int64) int {
 		if h.lastAccessedAtMs.Load() >= cutoffMs {
 			return true
 		}
+		counterHandleCreateMu.Lock()
+		// Re-check under the lock: a miss-path fetch may have refreshed or
+		// replaced the entry since the lock-free check above.
+		v, ok := counterHandleCache.Load(key)
+		if !ok || v.(*cachedCounterHandle).lastAccessedAtMs.Load() >= cutoffMs {
+			counterHandleCreateMu.Unlock()
+			return true
+		}
 		k := key.(counterKey)
 		counterHandleCache.Delete(key)
-		k.vec.DeleteLabelValues(h.vals...)
+		k.vec.DeleteLabelValues(v.(*cachedCounterHandle).vals...)
+		counterHandleCreateMu.Unlock()
 		evicted++
 		return true
 	})

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -13,6 +15,19 @@ import (
 type counterKey struct {
 	vec *prometheus.CounterVec
 	key string
+}
+
+// cachedCounterHandle pairs a child counter with the label tuple that
+// created it and an idle timestamp, so SweepIdleCounterHandles can evict
+// the cache entry AND release the underlying series via DeleteLabelValues.
+// Without the explicit delete, every label combination ever observed stays
+// in the Prometheus registry for the process lifetime (append-only model) —
+// which is unbounded for label-sets keyed by caller-controlled inputs
+// (method, userId, agentName, ...).
+type cachedCounterHandle struct {
+	counter          prometheus.Counter
+	vals             []string
+	lastAccessedAtMs atomic.Int64
 }
 
 type gaugeKey struct {
@@ -55,15 +70,52 @@ func labelsKey(labels []string) string {
 	return b.String()
 }
 
-// CounterHandle returns a cached child counter for the given labels.
+// CounterHandle returns a cached child counter for the given labels and
+// refreshes its idle timestamp. Callers must re-fetch the handle per use
+// (CounterHandle(...).Inc()) rather than holding the returned Counter —
+// after an idle sweep evicts the series, a held child mutates an object
+// that is no longer collected.
 func CounterHandle(cv *prometheus.CounterVec, labels ...string) prometheus.Counter {
 	k := counterKey{vec: cv, key: labelsKey(labels)}
+	nowMs := time.Now().UnixMilli()
 	if v, ok := counterHandleCache.Load(k); ok {
-		return v.(prometheus.Counter)
+		h := v.(*cachedCounterHandle)
+		h.lastAccessedAtMs.Store(nowMs)
+		return h.counter
 	}
-	c := cv.WithLabelValues(labels...)
-	actual, _ := counterHandleCache.LoadOrStore(k, c)
-	return actual.(prometheus.Counter)
+	h := &cachedCounterHandle{
+		counter: cv.WithLabelValues(labels...),
+		vals:    append([]string(nil), labels...),
+	}
+	h.lastAccessedAtMs.Store(nowMs)
+	actual, _ := counterHandleCache.LoadOrStore(k, h)
+	ah := actual.(*cachedCounterHandle)
+	ah.lastAccessedAtMs.Store(nowMs)
+	return ah.counter
+}
+
+// SweepIdleCounterHandles evicts cached counter handles not touched since
+// cutoffMs and deletes their label-sets from the parent CounterVec,
+// releasing the series from the Prometheus registry so /metrics stops
+// re-emitting stale label combinations. Driven by the health tracker's
+// idle sweep, at the same cadence and threshold as the observer sweep.
+// Returns the number of evicted series. Safe to call concurrently with
+// CounterHandle: a racing re-fetch recreates the series fresh at zero,
+// which is the same semantics as a process restart.
+func SweepIdleCounterHandles(cutoffMs int64) int {
+	evicted := 0
+	counterHandleCache.Range(func(key, value any) bool {
+		h := value.(*cachedCounterHandle)
+		if h.lastAccessedAtMs.Load() >= cutoffMs {
+			return true
+		}
+		k := key.(counterKey)
+		counterHandleCache.Delete(key)
+		k.vec.DeleteLabelValues(h.vals...)
+		evicted++
+		return true
+	})
+	return evicted
 }
 
 // GaugeHandle returns a cached child gauge for the given labels.

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -94,15 +94,45 @@ func CounterHandle(cv *prometheus.CounterVec, labels ...string) prometheus.Count
 	return ah.counter
 }
 
-// SweepIdleCounterHandles evicts cached counter handles not touched since
-// cutoffMs and deletes their label-sets from the parent CounterVec,
-// releasing the series from the Prometheus registry so /metrics stops
-// re-emitting stale label combinations. Driven by the health tracker's
-// idle sweep, at the same cadence and threshold as the observer sweep.
-// Returns the number of evicted series. Safe to call concurrently with
-// CounterHandle: a racing re-fetch recreates the series fresh at zero,
-// which is the same semantics as a process restart.
-func SweepIdleCounterHandles(cutoffMs int64) int {
+// DefaultCounterIdleEvictionAfter is the conservative default idle threshold
+// for counter series eviction: long enough that only clearly-dead label
+// combinations are released. Overridden via metrics.counterIdleEvictionAfter
+// (see common.MetricsConfig; wired in erpc/init.go via
+// SetCounterIdleEvictionAfter).
+const DefaultCounterIdleEvictionAfter = 24 * time.Hour
+
+var counterIdleEvictionAfterMs atomic.Int64
+
+func init() {
+	counterIdleEvictionAfterMs.Store(DefaultCounterIdleEvictionAfter.Milliseconds())
+}
+
+// SetCounterIdleEvictionAfter overrides the idle threshold for counter series
+// eviction. Zero (or negative) disables eviction entirely. Typically called
+// once at startup from config.
+func SetCounterIdleEvictionAfter(d time.Duration) {
+	counterIdleEvictionAfterMs.Store(d.Milliseconds())
+}
+
+// SweepIdleCounterHandles evicts cached counter handles idle for at least
+// the configured threshold (DefaultCounterIdleEvictionAfter unless overridden)
+// and deletes their label-sets from the parent CounterVec, releasing the
+// series from the Prometheus registry so /metrics stops re-emitting stale
+// label combinations. Driven by the health tracker's idle sweep cadence.
+// Returns the number of evicted series; no-op (0) when eviction is disabled.
+func SweepIdleCounterHandles() int {
+	afterMs := counterIdleEvictionAfterMs.Load()
+	if afterMs <= 0 {
+		return 0
+	}
+	return sweepIdleCounterHandlesBefore(time.Now().UnixMilli() - afterMs)
+}
+
+// sweepIdleCounterHandlesBefore evicts cached counter handles not touched
+// since cutoffMs. Safe to call concurrently with CounterHandle: a racing
+// re-fetch recreates the series fresh at zero, which is the same semantics
+// as a process restart.
+func sweepIdleCounterHandlesBefore(cutoffMs int64) int {
 	evicted := 0
 	counterHandleCache.Range(func(key, value any) bool {
 		h := value.(*cachedCounterHandle)

--- a/telemetry/handles_test.go
+++ b/telemetry/handles_test.go
@@ -38,7 +38,7 @@ func TestSweepIdleCounterHandles_EvictsIdleSeries(t *testing.T) {
 		t.Fatalf("precondition: expected 2 series, got %d", got)
 	}
 
-	evicted := SweepIdleCounterHandles(time.Now().UnixMilli() + 1000)
+	evicted := sweepIdleCounterHandlesBefore(time.Now().UnixMilli() + 1000)
 	if evicted != 2 {
 		t.Fatalf("expected 2 evicted, got %d", evicted)
 	}
@@ -55,7 +55,7 @@ func TestSweepIdleCounterHandles_RetainsActiveSeries(t *testing.T) {
 	CounterHandle(vec, "x", "1").Inc()
 	CounterHandle(vec, "y", "2").Inc()
 
-	if evicted := SweepIdleCounterHandles(time.Now().UnixMilli() - 60_000); evicted != 0 {
+	if evicted := sweepIdleCounterHandlesBefore(time.Now().UnixMilli() - 60_000); evicted != 0 {
 		t.Fatalf("expected 0 evicted with past cutoff, got %d", evicted)
 	}
 	if got := testutil.CollectAndCount(vec); got != 2 {
@@ -80,7 +80,7 @@ func TestCounterHandle_TouchRefreshPreventsEviction(t *testing.T) {
 	sleepMs(t)
 	CounterHandle(vec, "x", "1") // touch refreshes lastAccessedAtMs past cutoff
 
-	if evicted := SweepIdleCounterHandles(cutoff); evicted != 0 {
+	if evicted := sweepIdleCounterHandlesBefore(cutoff); evicted != 0 {
 		t.Fatalf("expected 0 evicted after touch refresh, got %d", evicted)
 	}
 	if got := testutil.CollectAndCount(vec); got != 1 {
@@ -97,7 +97,7 @@ func TestCounterHandle_RebirthAfterEvictionStartsAtZero(t *testing.T) {
 	h.Inc()
 	h.Inc()
 
-	if evicted := SweepIdleCounterHandles(time.Now().UnixMilli() + 1000); evicted != 1 {
+	if evicted := sweepIdleCounterHandlesBefore(time.Now().UnixMilli() + 1000); evicted != 1 {
 		t.Fatalf("expected 1 evicted, got %d", evicted)
 	}
 
@@ -125,7 +125,7 @@ func TestSweepIdleCounterHandles_PerEntryEvictionAcrossVecs(t *testing.T) {
 	CounterHandle(vecB, "x", "1").Inc()
 	CounterHandle(vecB, "y", "2").Inc() // B's entries are at/after cutoff
 
-	if evicted := SweepIdleCounterHandles(cutoff); evicted != 2 {
+	if evicted := sweepIdleCounterHandlesBefore(cutoff); evicted != 2 {
 		t.Fatalf("expected exactly 2 evicted (vec A only), got %d", evicted)
 	}
 	if got := testutil.CollectAndCount(vecA); got != 0 {
@@ -133,5 +133,42 @@ func TestSweepIdleCounterHandles_PerEntryEvictionAcrossVecs(t *testing.T) {
 	}
 	if got := testutil.CollectAndCount(vecB); got != 2 {
 		t.Fatalf("expected vec B untouched with 2 series, got %d", got)
+	}
+}
+
+// SetCounterIdleEvictionAfter(0) disables eviction: the public sweep returns
+// 0 and leaves the series registered, even for entries old enough that any
+// positive threshold would have evicted them.
+func TestSweepIdleCounterHandles_DisabledThresholdEvictsNothing(t *testing.T) {
+	t.Cleanup(func() { SetCounterIdleEvictionAfter(DefaultCounterIdleEvictionAfter) })
+	vec := newTestCounterVec(t, "test_sweep_disabled_total")
+
+	SetCounterIdleEvictionAfter(0)
+	CounterHandle(vec, "x", "1").Inc()
+	sleepMs(t) // old enough that a 1ms threshold would evict it
+
+	if evicted := SweepIdleCounterHandles(); evicted != 0 {
+		t.Fatalf("expected 0 evicted with eviction disabled, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected series retained with eviction disabled, got %d", got)
+	}
+}
+
+// The public no-arg sweep respects the configured threshold: with a 1ms
+// threshold, an entry idle for >=5ms is evicted and its series released.
+func TestSweepIdleCounterHandles_ConfiguredThresholdEvicts(t *testing.T) {
+	t.Cleanup(func() { SetCounterIdleEvictionAfter(DefaultCounterIdleEvictionAfter) })
+	vec := newTestCounterVec(t, "test_sweep_configured_total")
+
+	SetCounterIdleEvictionAfter(1 * time.Millisecond)
+	CounterHandle(vec, "x", "1").Inc()
+	time.Sleep(5 * time.Millisecond)
+
+	if evicted := SweepIdleCounterHandles(); evicted < 1 {
+		t.Fatalf("expected >=1 evicted past configured threshold, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 0 {
+		t.Fatalf("expected series released after threshold sweep, got %d", got)
 	}
 }

--- a/telemetry/handles_test.go
+++ b/telemetry/handles_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -170,5 +171,55 @@ func TestSweepIdleCounterHandles_ConfiguredThresholdEvicts(t *testing.T) {
 	}
 	if got := testutil.CollectAndCount(vec); got != 0 {
 		t.Fatalf("expected series released after threshold sweep, got %d", got)
+	}
+}
+
+// Regression stress test for the sweep/fetch orphan race: the old ordering in
+// sweepIdleCounterHandlesBefore deleted the cache entry BEFORE
+// vec.DeleteLabelValues, so a concurrent CounterHandle miss could re-cache the
+// still-registered child that the sweep then deregistered — a permanently
+// orphaned hot handle whose increments never reach the registry. The fix
+// serializes the miss path against eviction (counterHandleCreateMu).
+//
+// Invariant defended: after any sweep/fetch interleaving quiesces, an Inc()
+// through CounterHandle must be visible via vec.WithLabelValues on the same
+// label tuple. WithLabelValues on a swept tuple recreates the series at 0 —
+// fine; the invariant is DELTA visibility, not absolute counts.
+func TestCounterHandle_SweepRaceNeverOrphansHandles(t *testing.T) {
+	vec := newTestCounterVec(t, "test_sweep_race_orphan_total")
+	labels := []string{"x", "1"}
+	key := counterKey{vec: vec, key: labelsKey(labels)}
+
+	CounterHandle(vec, labels...).Inc() // seed the cache entry
+
+	for round := range 600 {
+		// Age the cached entry deterministically so the sweep sees it stale.
+		v, ok := counterHandleCache.Load(key)
+		if !ok {
+			t.Fatalf("round %d: cache entry missing before aging", round)
+		}
+		v.(*cachedCounterHandle).lastAccessedAtMs.Store(time.Now().UnixMilli() - 10_000)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			sweepIdleCounterHandlesBefore(time.Now().UnixMilli() - 5_000)
+		}()
+		go func() {
+			defer wg.Done()
+			CounterHandle(vec, labels...).Inc()
+		}()
+		wg.Wait()
+
+		// Orphan detector: an Inc through the cached handle must land on the
+		// vec's currently-registered child. If the race re-cached a
+		// deregistered child, `after` stays at `before`.
+		before := testutil.ToFloat64(vec.WithLabelValues(labels...))
+		CounterHandle(vec, labels...).Inc()
+		after := testutil.ToFloat64(vec.WithLabelValues(labels...))
+		if after != before+1 {
+			t.Fatalf("round %d: orphaned counter handle: before=%v after=%v — Inc through cached handle is invisible in the registry", round, before, after)
+		}
 	}
 }

--- a/telemetry/handles_test.go
+++ b/telemetry/handles_test.go
@@ -1,0 +1,137 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// newTestCounterVec builds a CounterVec on a private registry so tests never
+// touch the global package metrics.
+func newTestCounterVec(t *testing.T, name string) *prometheus.CounterVec {
+	t.Helper()
+	vec := prometheus.NewCounterVec(prometheus.CounterOpts{Name: name}, []string{"a", "b"})
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(vec)
+	ResetHandleCache()
+	t.Cleanup(ResetHandleCache)
+	return vec
+}
+
+// sleepMs guarantees time.Now().UnixMilli() strictly advances across the gap.
+func sleepMs(t *testing.T) {
+	t.Helper()
+	time.Sleep(3 * time.Millisecond)
+}
+
+// A future-cutoff sweep evicts every idle series from BOTH the cache and the
+// parent vec: DeleteLabelValues must release the registry series, not just
+// drop the cache entry.
+func TestSweepIdleCounterHandles_EvictsIdleSeries(t *testing.T) {
+	vec := newTestCounterVec(t, "test_sweep_evicts_total")
+
+	CounterHandle(vec, "x", "1").Inc()
+	CounterHandle(vec, "y", "2").Inc()
+	if got := testutil.CollectAndCount(vec); got != 2 {
+		t.Fatalf("precondition: expected 2 series, got %d", got)
+	}
+
+	evicted := SweepIdleCounterHandles(time.Now().UnixMilli() + 1000)
+	if evicted != 2 {
+		t.Fatalf("expected 2 evicted, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 0 {
+		t.Fatalf("expected 0 series after sweep, got %d — DeleteLabelValues did not release the series", got)
+	}
+}
+
+// A past-cutoff sweep evicts nothing: series stay in the registry and the
+// cached handle keeps incrementing the SAME series.
+func TestSweepIdleCounterHandles_RetainsActiveSeries(t *testing.T) {
+	vec := newTestCounterVec(t, "test_sweep_retains_total")
+
+	CounterHandle(vec, "x", "1").Inc()
+	CounterHandle(vec, "y", "2").Inc()
+
+	if evicted := SweepIdleCounterHandles(time.Now().UnixMilli() - 60_000); evicted != 0 {
+		t.Fatalf("expected 0 evicted with past cutoff, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 2 {
+		t.Fatalf("expected 2 series retained, got %d", got)
+	}
+
+	CounterHandle(vec, "x", "1").Inc()
+	if got := testutil.ToFloat64(CounterHandle(vec, "x", "1")); got != 2 {
+		t.Fatalf("expected same series to continue at 2, got %v", got)
+	}
+}
+
+// Re-fetching a handle refreshes its idle timestamp: a sweep with a cutoff
+// taken before the re-fetch must evict nothing, even though the series was
+// CREATED before that cutoff.
+func TestCounterHandle_TouchRefreshPreventsEviction(t *testing.T) {
+	vec := newTestCounterVec(t, "test_touch_refresh_total")
+
+	CounterHandle(vec, "x", "1").Inc() // created at t0
+	sleepMs(t)
+	cutoff := time.Now().UnixMilli() // t0 < cutoff: without a touch, evictable
+	sleepMs(t)
+	CounterHandle(vec, "x", "1") // touch refreshes lastAccessedAtMs past cutoff
+
+	if evicted := SweepIdleCounterHandles(cutoff); evicted != 0 {
+		t.Fatalf("expected 0 evicted after touch refresh, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected series to survive sweep, got %d series", got)
+	}
+}
+
+// After eviction, the same label tuple is reborn as a FRESH series starting
+// at zero — same semantics as a process restart.
+func TestCounterHandle_RebirthAfterEvictionStartsAtZero(t *testing.T) {
+	vec := newTestCounterVec(t, "test_rebirth_total")
+
+	h := CounterHandle(vec, "x", "1")
+	h.Inc()
+	h.Inc()
+
+	if evicted := SweepIdleCounterHandles(time.Now().UnixMilli() + 1000); evicted != 1 {
+		t.Fatalf("expected 1 evicted, got %d", evicted)
+	}
+
+	CounterHandle(vec, "x", "1").Inc()
+	if got := testutil.ToFloat64(CounterHandle(vec, "x", "1")); got != 1 {
+		t.Fatalf("expected reborn series at 1, got %v (old count resurrected?)", got)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected 1 series after rebirth, got %d", got)
+	}
+}
+
+// Eviction is per-entry, not cache-wide: stale entries of vec A are swept
+// while fresh entries of vec B survive, and the return value counts only
+// what was evicted.
+func TestSweepIdleCounterHandles_PerEntryEvictionAcrossVecs(t *testing.T) {
+	vecA := newTestCounterVec(t, "test_sweep_stale_total")
+	vecB := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_sweep_fresh_total"}, []string{"a", "b"})
+	prometheus.NewRegistry().MustRegister(vecB)
+
+	CounterHandle(vecA, "x", "1").Inc()
+	CounterHandle(vecA, "y", "2").Inc()
+	sleepMs(t)
+	cutoff := time.Now().UnixMilli() // A's entries are strictly older than cutoff
+	CounterHandle(vecB, "x", "1").Inc()
+	CounterHandle(vecB, "y", "2").Inc() // B's entries are at/after cutoff
+
+	if evicted := SweepIdleCounterHandles(cutoff); evicted != 2 {
+		t.Fatalf("expected exactly 2 evicted (vec A only), got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vecA); got != 0 {
+		t.Fatalf("expected vec A emptied, got %d series", got)
+	}
+	if got := testutil.CollectAndCount(vecB); got != 2 {
+		t.Fatalf("expected vec B untouched with 2 series, got %d", got)
+	}
+}

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -561,6 +561,18 @@ export interface ProjectConfig {
    * Configure user agent tracking at the project level
    */
   userAgentMode?: UserAgentTrackingMode;
+  /**
+   * TrustUserIdHeader makes erpc read the caller's user identity from the
+   * X-ERPC-User-Id request header (see common.HeaderUserId) and use it for the
+   * `user` metric/log label — but only when no auth strategy resolved a user
+   * (auth wins) and only for attribution (no rate-limit budget is derived).
+   * This is for deployments that authenticate callers in front of erpc (e.g. a
+   * gateway) and want per-user erpc telemetry without erpc performing auth.
+   * erpc does NOT validate the header, so enable this ONLY when erpc is reachable
+   * solely by a trusted proxy that sets the header and strips any client copy —
+   * otherwise callers can spoof their own attribution. Default false.
+   */
+  trustUserIdHeader?: boolean;
   forwardHeaders?: string[];
   allowClientDirectives?: string;
   ignoreMethods?: string[];
@@ -1042,7 +1054,11 @@ export interface ConsensusPolicyConfig {
  * `consensus.requiredParticipants`. `Tag` is a glob pattern (`*`, `?`)
  * matched against each upstream's `tags`; `MinParticipants` is the minimum
  * number of matching upstreams that must be in the consensus participant
- * set. A single upstream can satisfy multiple entries it matches.
+ * set (pool quota, best-effort). `MinAgreement` is the minimum number of
+ * matching upstreams that must be part of the WINNING response group
+ * (winner-composition quota, hard-enforced: a winner that does not satisfy
+ * it becomes a composition dispute regardless of disputeBehavior). A single
+ * upstream can satisfy multiple entries it matches.
  */
 export interface ConsensusRequiredParticipant {
   tag: string;
@@ -1588,6 +1604,18 @@ export interface MetricsConfig {
    * Value is the list of label names to keep for that metric.
    */
   histogramLabelOverrides?: { [key: string]: string[]};
+  /**
+   * CounterIdleEvictionAfter bounds /metrics cardinality for hot-path
+   * counters whose label-sets are keyed by caller-controlled inputs
+   * (method, user, agentName, ...). Counter series idle for at least this
+   * duration are evicted from the Prometheus registry (DeleteLabelValues)
+   * by the health tracker's idle sweep; a series that becomes active again
+   * restarts at zero — the same semantics rate()/increase() consumers
+   * already handle across process restarts. Defaults to 24h (conservative:
+   * only clearly-dead label combinations are released). Set to 0 to
+   * disable eviction entirely.
+   */
+  counterIdleEvictionAfter?: Duration;
 }
 /**
  * RateLimitStoreConfig defines where rate limit counters are stored

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -668,24 +668,12 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 					finality,
 				)
 			}
-			// TODO(memory): this and the matching MetricUpstreamErrorTotal /
-			// MetricUpstreamWrongEmptyResponseTotal / MetricUpstreamCanceledTotal
-			// sites in this file + erpc/networks.go all emit label-sets
-			// keyed by user-controlled inputs (method, finality, userId,
-			// agentName, etc.) WITHOUT going through a tracker cache, so
-			// the Prometheus registry accumulates one series per unique
-			// combo forever — even after the in-memory caches added in
-			// the 826df9f5 idle-sweep get cleared.
-			//
-			// The fix is parallel to the urdObsCache / remoteRateLimited
-			// pattern: wrap each WithLabelValues call in a cached*-style
-			// indirection that remembers the label tuple + a
-			// lastAccessedAtMs, then sweep on idle with
-			// MetricVec.DeleteLabelValues. Each direct call site needs the
-			// same retrofit. Out of scope for this PR — flagged for a
-			// follow-up titled "sweep direct Prom emissions in
-			// upstream/erpc hot paths".
-			telemetry.MetricUpstreamRequestTotal.WithLabelValues(
+			// These direct counter emissions carry label-sets keyed by
+			// caller-controlled inputs (method, finality, userId, agentName).
+			// They go through telemetry.CounterHandle so the health tracker's
+			// idle sweep can evict stale label combinations and release the
+			// series via DeleteLabelValues (see SweepIdleCounterHandles).
+			telemetry.CounterHandle(telemetry.MetricUpstreamRequestTotal,
 				u.ProjectId,
 				u.VendorName(),
 				u.NetworkLabel(),
@@ -695,8 +683,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 				nrq.CompositeType(),
 				finality.String(),
 				nrq.UserId(),
-				nrq.AgentName(),
-			).Inc()
+				nrq.AgentName()).Inc()
 			timer := u.metricsTracker.RecordUpstreamDurationStart(u, method, nrq.CompositeType(), finality, nrq.UserId())
 
 			preReqSpan.End()
@@ -762,7 +749,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						nrq.AgentName(),
 					).Inc()
 				} else if common.HasErrorCode(errCall, common.ErrCodeEndpointMissingData) {
-					telemetry.MetricUpstreamMissingDataErrorTotal.WithLabelValues(
+					telemetry.CounterHandle(telemetry.MetricUpstreamMissingDataErrorTotal,
 						u.ProjectId,
 						u.VendorName(),
 						u.NetworkLabel(),
@@ -770,8 +757,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						method,
 						finality.String(),
 						nrq.UserId(),
-						nrq.AgentName(),
-					).Inc()
+						nrq.AgentName()).Inc()
 				} else if common.HasErrorCode(errCall, common.ErrCodeEndpointRequestCanceled) {
 					// Cancelled request (hedge lost the race or client
 					// disconnected). Not attributable to upstream quality
@@ -798,7 +784,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						)
 					}
 					severity := common.ClassifySeverity(errCall)
-					telemetry.MetricUpstreamErrorTotal.WithLabelValues(
+					telemetry.CounterHandle(telemetry.MetricUpstreamErrorTotal,
 						u.ProjectId,
 						u.VendorName(),
 						u.NetworkLabel(),
@@ -809,8 +795,7 @@ func (u *Upstream) Forward(ctx context.Context, nrq *common.NormalizedRequest, b
 						nrq.CompositeType(),
 						finality.String(),
 						nrq.UserId(),
-						nrq.AgentName(),
-					).Inc()
+						nrq.AgentName()).Inc()
 				}
 
 				// Only ExecutionException (EVM revert) feeds the latency


### PR DESCRIPTION
## Problem

Several hot-path counters (`erpc_upstream_request_total`, `erpc_upstream_request_errors_total`, `erpc_network_successful_request_total`, hedge counters, …) carry label-sets keyed by caller-controlled inputs — `category` (method), `user`, and `agent_name`. Under `userAgentMode: 'raw'` (or any client population with diverse User-Agents), `agent_name` is unbounded, and Prometheus's registry is append-only: every label combination ever observed is re-emitted on every `/metrics` scrape for the process lifetime.

On a busy deployment this grows the scrape payload monotonically between restarts (we measured ~50k+ samples/hour of growth, with ~75% of `erpc_upstream_request_total` series idle over any 30-minute window). Past a threshold the target starts overrunning the collector's scrape timeout / size limit, and **all** metrics for that instance silently flatline while the process keeps serving traffic.

The codebase already solves this for tracker-owned metrics: the idle sweep added in 826df9f5 evicts stale entries from `urdObsCache` / `remoteRateLimitedCounterCache` and releases the series via `DeleteLabelValues`. The `TODO(memory)` comment in `upstream/upstream.go` explicitly flags the direct counter emissions as the remaining gap and sketches this exact fix.

## Change

- **`telemetry/handles.go`** — `CounterHandle` cache entries now carry the label tuple and a `lastAccessedAtMs` (refreshed per fetch, mirroring the tracker's `cachedObserver` pattern). New `SweepIdleCounterHandles(cutoffMs)` evicts idle entries and calls `DeleteLabelValues` on the parent vec, releasing the registry series.
- **`health/tracker.go`** — `sweepIdleObservers` additionally calls `SweepIdleCounterHandles`, so counter handles are swept on the existing cadence (`sweepEveryRotations`) and threshold (`idleEvictionAfter`, default 30 min, `0` disables — unchanged).
- **`upstream/upstream.go`, `erpc/networks.go`** — the five direct `WithLabelValues` emission sites named by the `TODO(memory)` comment now route through `telemetry.CounterHandle`, so they participate in the sweep. The TODO is retired.

No metric declarations, schemas, or label sets change. Call sites that already used `CounterHandle` (hedge counters, network success/failure/received) get sweep coverage with no diff.

## Semantics

- Eviction only fires for series idle ≥ `idleEvictionAfter` (default 30 min) — every increment was long since scraped. A series that becomes active again is recreated at zero: the same semantics as a process restart, which any `rate()`/`increase()` consumer already tolerates.
- Steady-state registry size now tracks *actual* request patterns instead of peak historical cardinality — same guarantee the tracker sweep already provides for its own metrics, extended to the direct emissions.
- Hot-path cost: one `time.Now().UnixMilli()` + one atomic store per increment on the cache-hit path.

## Tests

`telemetry/handles_test.go` (new): eviction releases registry series (`testutil.CollectAndCount` → 0), active series retained and continue the same child, bare re-fetch refreshes the idle timestamp, post-eviction rebirth starts at zero, and sweep is per-entry across vecs (returned count exact). Existing `./telemetry/...` and `./health/...` suites pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus counter lifecycle and scrape semantics (idle series reset to zero) on high-traffic request paths; incorrect eviction or the sweep/race fix could skew `rate()`/`increase()` or lose increments, but scope is observability only—not request routing or auth.
> 
> **Overview**
> Adds **`metrics.counterIdleEvictionAfter`** (default **24h**, **0** disables) so hot-path Prometheus counters keyed by caller-controlled labels (`method`, `user`, `agent_name`, etc.) can be dropped from the registry after going idle, instead of growing `/metrics` for the process lifetime.
> 
> **`telemetry.CounterHandle`** now tracks last access per label tuple, exposes **`SweepIdleCounterHandles`** / **`SetCounterIdleEvictionAfter`**, and uses a mutex on the create/evict path so sweeps cannot orphan cached counters that stop appearing in scrapes. The health tracker’s existing idle sweep also runs the counter sweep on the same cadence.
> 
> Direct **`WithLabelValues`** emissions on upstream request/error/missing-data counters in **`upstream/upstream.go`** and **`erpc/networks.go`** are switched to **`CounterHandle`** so they participate in eviction; docs and generated TS config types document the new knob. New tests in **`telemetry/handles_test.go`** cover eviction, retention, rebirth-at-zero, and sweep/race behavior.
> 
> Evicted series that become active again restart at **zero** (same as after a process restart).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7efee999912e328f0d535e8ebb89d164e71b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->