### PR TITLE
fix(evm): carry upstream attribution to synthesized eth_blockNumber response

### DIFF
--- a/architecture/evm/eth_blockNumber.go
+++ b/architecture/evm/eth_blockNumber.go
@@ -148,6 +148,9 @@ func networkPostForward_eth_blockNumber(ctx context.Context, network common.Netw
 	corrected := common.NewNormalizedResponse().
 		WithRequest(nq).
 		WithJsonRpcResponse(jrr)
+	if ups != nil {
+		corrected.SetUpstream(ups)
+	}
 	if nr.FromCache() {
 		// Preserve cache attribution: the value was upgraded in-memory and no
 		// upstream call was made to produce this response.


### PR DESCRIPTION
## Summary

- When `eth_blockNumber` synthesizes a corrected response (e.g. promoting a `safe`/`finalized` block to the highest seen), the `upstream` field on the response was not being set — causing the response to appear as a cache miss even when it originated from an upstream call.
- Added a nil-guard to set `upstream` on the synthesized response when an upstream reference is available.

## Test plan

- [ ] Verify that `eth_blockNumber` responses synthesized from an upstream result correctly carry the upstream attribution
- [ ] Confirm cache-miss metrics are not incorrectly incremented for upstream-sourced block number responses
- [ ] Check that cache-attributed responses still preserve their `FromCache()` attribution unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)