### PR TITLE
feat(auth): add allowClientDirectivesUsers to scope directive access by user identity

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -602,11 +602,12 @@ type ProjectConfig struct {
 	// erpc does NOT validate the header, so enable this ONLY when erpc is reachable
 	// solely by a trusted proxy that sets the header and strips any client copy —
 	// otherwise callers can spoof their own attribution. Default false.
-	TrustUserIdHeader     bool     `yaml:"trustUserIdHeader,omitempty" json:"trustUserIdHeader"`
-	ForwardHeaders        []string `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
-	AllowClientDirectives *string  `yaml:"allowClientDirectives,omitempty" json:"allowClientDirectives"`
-	IgnoreMethods         []string `yaml:"ignoreMethods,omitempty" json:"ignoreMethods"`
-	AllowMethods          []string `yaml:"allowMethods,omitempty" json:"allowMethods"`
+	TrustUserIdHeader          bool     `yaml:"trustUserIdHeader,omitempty" json:"trustUserIdHeader"`
+	ForwardHeaders             []string `yaml:"forwardHeaders,omitempty" json:"forwardHeaders"`
+	AllowClientDirectives      *string  `yaml:"allowClientDirectives,omitempty" json:"allowClientDirectives"`
+	AllowClientDirectivesUsers *string  `yaml:"allowClientDirectivesUsers,omitempty" json:"allowClientDirectivesUsers"`
+	IgnoreMethods              []string `yaml:"ignoreMethods,omitempty" json:"ignoreMethods"`
+	AllowMethods               []string `yaml:"allowMethods,omitempty" json:"allowMethods"`
 
 	// ScoreMetricsWindowSize is the tumbling window the per-upstream
 	// health tracker uses for its rolling counters (errorRate, p50/p70/

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -724,6 +724,79 @@ func TestEnrichFromHttp_AllowClientDirectives(t *testing.T) {
 	})
 }
 
+// applyUserDirectiveGate simulates the http_server logic for allowClientDirectivesUsers:
+// if usersPattern is set, only matching users get the directive matcher; everyone else is denied.
+func applyUserDirectiveGate(t *testing.T, req *NormalizedRequest, directiveMatcher MatcherFunc, usersPattern string) {
+	t.Helper()
+	if usersPattern == "" {
+		req.SetAllowClientDirectiveMatcher(directiveMatcher)
+		return
+	}
+	um, err := NewWildcardMatcher(usersPattern)
+	if err != nil {
+		t.Fatalf("bad users pattern %q: %v", usersPattern, err)
+	}
+	u := req.User()
+	if u == nil || !um(u.Id) {
+		req.SetAllowClientDirectiveMatcher(DenyAllClientDirectives)
+	} else {
+		req.SetAllowClientDirectiveMatcher(directiveMatcher)
+	}
+}
+
+func TestAllowClientDirectivesUsers(t *testing.T) {
+	t.Run("matching user gets directive matcher applied", func(t *testing.T) {
+		req := NewNormalizedRequest(nil)
+		req.SetUser(&User{Id: "ops-user"})
+		applyUserDirectiveGate(t, req, nil, "ops-*") // nil = allow all directives
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Cache-Read", "true")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+		dir := req.Directives()
+		if dir == nil || dir.SkipCacheRead != "true" {
+			t.Fatalf("expected SkipCacheRead=true for allowed user, got %v", dir)
+		}
+	})
+
+	t.Run("non-matching user blocked even if allowClientDirectives is wildcard", func(t *testing.T) {
+		req := NewNormalizedRequest(nil)
+		req.SetUser(&User{Id: "external-caller"})
+		applyUserDirectiveGate(t, req, nil, "ops-*") // nil = allow all, but user doesn't match
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Cache-Read", "true")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+		dir := req.Directives()
+		if dir != nil && dir.SkipCacheRead != "" {
+			t.Fatalf("expected SkipCacheRead blocked for non-allowed user, got %q", dir.SkipCacheRead)
+		}
+	})
+
+	t.Run("nil user blocked when users pattern is set", func(t *testing.T) {
+		req := NewNormalizedRequest(nil)
+		applyUserDirectiveGate(t, req, nil, "ops-*")
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Consensus", "true")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+		dir := req.Directives()
+		if dir != nil && dir.SkipConsensus {
+			t.Fatal("expected SkipConsensus blocked for nil user")
+		}
+	})
+
+	t.Run("no users pattern leaves directive matcher unchanged", func(t *testing.T) {
+		req := NewNormalizedRequest(nil)
+		// usersPattern="" means allowClientDirectivesUsers not configured → everyone uses directive matcher
+		applyUserDirectiveGate(t, req, DenyAllClientDirectives, "")
+		h := http.Header{}
+		h.Set("X-ERPC-Skip-Cache-Read", "true")
+		req.EnrichFromHttp(h, nil, UserAgentTrackingModeSimplified)
+		dir := req.Directives()
+		if dir != nil && dir.SkipCacheRead != "" {
+			t.Fatalf("expected SkipCacheRead blocked by directive matcher, got %q", dir.SkipCacheRead)
+		}
+	})
+}
+
 func newReqForUser() *NormalizedRequest {
 	return NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}`))
 }

--- a/common/validation.go
+++ b/common/validation.go
@@ -749,6 +749,11 @@ func (p *ProjectConfig) Validate(c *Config) error {
 			return fmt.Errorf("project.*.allowClientDirectives pattern is invalid: %w", err)
 		}
 	}
+	if p.AllowClientDirectivesUsers != nil && *p.AllowClientDirectivesUsers != "" {
+		if _, err := NewWildcardMatcher(*p.AllowClientDirectivesUsers); err != nil {
+			return fmt.Errorf("project.*.allowClientDirectivesUsers pattern is invalid: %w", err)
+		}
+	}
 	if p.RateLimitBudget != "" {
 		if !c.HasRateLimiterBudget(p.RateLimitBudget) {
 			return fmt.Errorf("project.*.rateLimitBudget '%s' does not exist in config.rateLimiters", p.RateLimitBudget)

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -684,7 +684,14 @@ func (s *HttpServer) createRequestHandler() http.Handler {
 					if project.Config.UserAgentMode != "" {
 						uaMode = project.Config.UserAgentMode
 					}
-					nq.SetAllowClientDirectiveMatcher(project.allowClientDirectiveMatcher)
+					directiveMatcher := project.allowClientDirectiveMatcher
+					if project.allowClientDirectivesUserMatcher != nil {
+						u := nq.User()
+						if u == nil || !project.allowClientDirectivesUserMatcher(u.Id) {
+							directiveMatcher = common.DenyAllClientDirectives
+						}
+					}
+					nq.SetAllowClientDirectiveMatcher(directiveMatcher)
 				}
 				nq.EnrichFromHttp(headers, queryArgs, uaMode)
 				rlg.Trace().Interface("directives", nq.Directives()).Msgf("applied request directives")

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -25,8 +25,9 @@ type PreparedProject struct {
 	rateLimitersRegistry        *upstream.RateLimitersRegistry
 	upstreamsRegistry           *upstream.UpstreamsRegistry
 	policyEngine                *policy.Engine
-	allowClientDirectiveMatcher common.MatcherFunc
-	cfgMu                       sync.RWMutex
+	allowClientDirectiveMatcher      common.MatcherFunc
+	allowClientDirectivesUserMatcher common.MatcherFunc
+	cfgMu                            sync.RWMutex
 }
 
 type ProjectHealthInfo struct {

--- a/erpc/projects_registry.go
+++ b/erpc/projects_registry.go
@@ -221,6 +221,13 @@ func (r *ProjectsRegistry) RegisterProject(prjCfg *common.ProjectConfig) (*Prepa
 			pp.allowClientDirectiveMatcher = matcher
 		}
 	}
+	if prjCfg.AllowClientDirectivesUsers != nil && *prjCfg.AllowClientDirectivesUsers != "" {
+		matcher, err := common.NewWildcardMatcher(*prjCfg.AllowClientDirectivesUsers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse AllowClientDirectivesUsers: %w", err)
+		}
+		pp.allowClientDirectivesUserMatcher = matcher
+	}
 	r.preparedProjects[prjCfg.Id] = pp
 
 	r.logger.Info().Msgf("registered project %s", prjCfg.Id)


### PR DESCRIPTION
## Summary

- Adds `allowClientDirectivesUsers` project config field (wildcard/boolean pattern, same syntax as `allowClientDirectives`)
- When set, only authenticated users whose ID matches the pattern receive the `allowClientDirectives` matcher; all other callers are denied directives entirely
- When not set, behavior is unchanged — all callers are governed by `allowClientDirectives` alone

**Example config:**
```yaml
allowClientDirectives: "*"               # which directives are allowed
allowClientDirectivesUsers: "ops-*|internal-gateway"  # who can use them
```

With the above, `ops-user` can send any `X-ERPC-*` header; `external-caller` is blocked regardless of `allowClientDirectives`.

## Changes

| File | Change |
|------|--------|
| `common/config.go` | New `AllowClientDirectivesUsers *string` field on `ProjectConfig` |
| `common/validation.go` | Pattern validation for the new field |
| `erpc/projects.go` | New `allowClientDirectivesUserMatcher MatcherFunc` on `PreparedProject` |
| `erpc/projects_registry.go` | Compile user pattern at startup |
| `erpc/http_server.go` | Apply user gate before setting directive matcher on each request |
| `common/request_test.go` | 4 new test cases covering all branches |

## Test plan

- [ ] `matching user gets directive matcher applied` — allowed user can use directives
- [ ] `non-matching user blocked even if allowClientDirectives is wildcard` — non-matching user denied
- [ ] `nil user blocked when users pattern is set` — unauthenticated caller denied
- [ ] `no users pattern leaves directive matcher unchanged` — existing behavior preserved when field is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)