### PR TITLE
feat(consensus): ordered acceptance policies with per-caller grade authorization

### DIFF
--- a/auth/registry.go
+++ b/auth/registry.go
@@ -82,9 +82,14 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 		// shared state (racing the handler's read) and would also leak the
 		// capability into the cache entry. The copy is allocated only when an
 		// operator actually configured the capability.
-		if user != nil && az.cfg.AllowClientDirectives != nil {
+		if user != nil && (az.cfg.AllowClientDirectives != nil || az.cfg.ConsensusPolicies != nil) {
 			stamped := *user
-			stamped.AllowClientDirectives = az.cfg.AllowClientDirectives
+			if az.cfg.AllowClientDirectives != nil {
+				stamped.AllowClientDirectives = az.cfg.AllowClientDirectives
+			}
+			if az.cfg.ConsensusPolicies != nil {
+				stamped.ConsensusPolicies = az.cfg.ConsensusPolicies
+			}
 			user = &stamped
 		}
 

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -87,8 +87,12 @@ func (r *AuthRegistry) Authenticate(ctx context.Context, req *common.NormalizedR
 			if az.cfg.AllowClientDirectives != nil {
 				stamped.AllowClientDirectives = az.cfg.AllowClientDirectives
 			}
+			// Union rather than overwrite: a strategy may already have
+			// derived grades from the caller's own claims (JWT roles). The
+			// strategy-level list is the baseline every caller of this
+			// strategy gets; claim grants add to it.
 			if az.cfg.ConsensusPolicies != nil {
-				stamped.ConsensusPolicies = az.cfg.ConsensusPolicies
+				stamped.ConsensusPolicies = unionPolicies(*az.cfg.ConsensusPolicies, user.ConsensusPolicies)
 			}
 			user = &stamped
 		}
@@ -131,4 +135,27 @@ func (r *AuthRegistry) FindDatabaseConnector(connectorId string) (data.Connector
 		}
 	}
 	return nil, fmt.Errorf("database connector with ID '%s' not found", connectorId)
+}
+
+// unionPolicies merges the strategy-level consensus grade baseline with any
+// grades the strategy derived from the caller's own claims. Order-independent
+// by construction, so a multi-role caller is served the union of its roles'
+// grades rather than whichever role matched first.
+func unionPolicies(baseline []string, derived *[]string) *[]string {
+	if derived == nil {
+		out := append([]string(nil), baseline...)
+		return &out
+	}
+	out := make([]string, 0, len(baseline)+len(*derived))
+	seen := make(map[string]struct{}, cap(out))
+	for _, group := range [][]string{baseline, *derived} {
+		for _, p := range group {
+			if _, dup := seen[p]; dup {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return &out
 }

--- a/auth/registry_consensus_roles_test.go
+++ b/auth/registry_consensus_roles_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// authenticateRoles runs a token carrying `roles` through the real registry
+// and returns the resolved caller.
+func authenticateRoles(t *testing.T, strategies []*common.AuthStrategyConfig, roles ...string) *common.User {
+	t.Helper()
+	logger := zerolog.Nop()
+	reg, err := NewAuthRegistry(context.Background(), &logger, "prj", &common.AuthConfig{Strategies: strategies}, nil)
+	require.NoError(t, err)
+
+	claimRoles := make([]interface{}, len(roles))
+	for i, r := range roles {
+		claimRoles[i] = r
+	}
+	token := signTestJWT(t, jwt.MapClaims{
+		"sub":   "caller",
+		"roles": claimRoles,
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	})
+
+	user, err := reg.Authenticate(context.Background(), nil, "eth_call", &AuthPayload{
+		Type: common.AuthTypeJwt,
+		Jwt:  &JwtPayload{Token: token},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	return user
+}
+
+// oneStrategyForEveryRole is the shape an operator with a single identity
+// provider actually writes: ONE strategy holding the JWKS/issuer config, with
+// grades granted from the role claim they already use for access control.
+func oneStrategyForEveryRole() []*common.AuthStrategyConfig {
+	baseline := []string{"standard"}
+	return []*common.AuthStrategyConfig{
+		{
+			Type:              common.AuthTypeJwt,
+			ConsensusPolicies: &baseline,
+			Jwt: &common.JwtStrategyConfig{
+				VerificationKeys:  map[string]string{"default": testJwtHMACSecret},
+				AllowedAlgorithms: []string{"HS256"},
+				ClaimMatchers:     map[string][]string{"roles": {"erpc:all"}},
+				ConsensusPoliciesByClaim: map[string]map[string][]string{
+					"roles": {"erpc:consensus-fallback": {"degraded"}},
+				},
+			},
+		},
+	}
+}
+
+func TestConsensusPolicies_GrantedFromClaims(t *testing.T) {
+	cfg := oneStrategyForEveryRole()
+
+	t.Run("baseline role gets only the strict grade", func(t *testing.T) {
+		user := authenticateRoles(t, cfg, "erpc:all")
+		assert.True(t, user.MayBeServedConsensusPolicy("standard"))
+		assert.False(t, user.MayBeServedConsensusPolicy("degraded"),
+			"a caller without the fallback role must not be served the relaxed grade")
+	})
+
+	t.Run("fallback role adds the relaxed grade on top of the baseline", func(t *testing.T) {
+		user := authenticateRoles(t, cfg, "erpc:all", "erpc:consensus-fallback")
+		assert.True(t, user.MayBeServedConsensusPolicy("standard"), "grants are additive, not replacing")
+		assert.True(t, user.MayBeServedConsensusPolicy("degraded"))
+	})
+
+	// The reason this exists at all: with one strategy per role, a token
+	// holding several roles resolved to whichever strategy was listed first,
+	// so the grade depended on config order. Claim grants are a union, so
+	// role order in the token — and strategy order in the config — cannot
+	// change the outcome.
+	t.Run("multi-role grant is order-independent", func(t *testing.T) {
+		a := authenticateRoles(t, cfg, "erpc:all", "erpc:consensus-fallback")
+		b := authenticateRoles(t, cfg, "erpc:consensus-fallback", "erpc:all")
+		assert.Equal(t, *a.ConsensusPolicies, *b.ConsensusPolicies,
+			"the same roles in a different order must grant the same grades")
+	})
+
+	t.Run("unknown role grants nothing beyond the baseline", func(t *testing.T) {
+		user := authenticateRoles(t, cfg, "erpc:all", "erpc:some-unrelated-role")
+		assert.True(t, user.MayBeServedConsensusPolicy("standard"))
+		assert.False(t, user.MayBeServedConsensusPolicy("degraded"))
+	})
+
+	t.Run("no claim mapping configured leaves the caller unrestricted", func(t *testing.T) {
+		// Existing configs must be unaffected: without either field the
+		// caller may be served any grade, exactly as before.
+		plain := []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeJwt,
+			Jwt: &common.JwtStrategyConfig{
+				VerificationKeys:  map[string]string{"default": testJwtHMACSecret},
+				AllowedAlgorithms: []string{"HS256"},
+			},
+		}}
+		user := authenticateRoles(t, plain, "erpc:all")
+		assert.Nil(t, user.ConsensusPolicies)
+		assert.True(t, user.MayBeServedConsensusPolicy("anything"))
+	})
+
+	t.Run("claim mapping configured but no role matches permits nothing", func(t *testing.T) {
+		// Distinct from "unset": the operator DID scope grades by role, so a
+		// caller whose roles grant none must not fall through to unrestricted.
+		scoped := []*common.AuthStrategyConfig{{
+			Type: common.AuthTypeJwt,
+			Jwt: &common.JwtStrategyConfig{
+				VerificationKeys:  map[string]string{"default": testJwtHMACSecret},
+				AllowedAlgorithms: []string{"HS256"},
+				ConsensusPoliciesByClaim: map[string]map[string][]string{
+					"roles": {"erpc:consensus-fallback": {"degraded"}},
+				},
+			},
+		}}
+		user := authenticateRoles(t, scoped, "erpc:all")
+		require.NotNil(t, user.ConsensusPolicies)
+		assert.Empty(t, *user.ConsensusPolicies)
+		assert.False(t, user.MayBeServedConsensusPolicy("standard"))
+	})
+}

--- a/auth/strategy_jwt.go
+++ b/auth/strategy_jwt.go
@@ -130,8 +130,50 @@ func (s *JwtStrategy) Authenticate(ctx context.Context, req *common.NormalizedRe
 			user.RateLimitBudget = s
 		}
 	}
+	if granted := grantedConsensusPolicies(claims, s.cfg.ConsensusPoliciesByClaim); granted != nil {
+		user.ConsensusPolicies = &granted
+	}
 
 	return user, nil
+}
+
+// grantedConsensusPolicies resolves the acceptance grades a token's claims
+// grant, unioned across every matching claim value so a caller holding
+// several roles gets all of their grades rather than whichever role happened
+// to be matched first. Returns nil when nothing is configured, leaving the
+// caller unrestricted (the strategy-level baseline still applies).
+func grantedConsensusPolicies(claims jwt.MapClaims, byClaim map[string]map[string][]string) []string {
+	if len(byClaim) == 0 {
+		return nil
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for claim, grants := range byClaim {
+		raw, ok := claims[claim]
+		if !ok {
+			continue
+		}
+		values, err := normalizeClaimToStrings(raw)
+		if err != nil {
+			continue
+		}
+		for _, v := range values {
+			for _, policy := range grants[v] {
+				if _, dup := seen[policy]; dup {
+					continue
+				}
+				seen[policy] = struct{}{}
+				out = append(out, policy)
+			}
+		}
+	}
+	if out == nil {
+		// Configured but nothing matched: an explicit empty grant, not
+		// "unrestricted". Returning nil here would silently widen a caller
+		// whose roles grant no grade into one allowed every grade.
+		return []string{}
+	}
+	return out
 }
 
 func (s *JwtStrategy) findVerificationKey(ctx context.Context, token *jwt.Token) (jwt.Keyfunc, error) {

--- a/common/config.go
+++ b/common/config.go
@@ -2877,6 +2877,34 @@ type JwtStrategyConfig struct {
 	// will be used to set the per-user RateLimitBudget override.
 	// Defaults to "rlm".
 	RateLimitBudgetClaimName string `yaml:"rateLimitBudgetClaimName,omitempty" json:"rateLimitBudgetClaimName,omitempty"`
+
+	// ConsensusPoliciesByClaim grants consensus acceptance grades based on the
+	// caller's own claims, so one strategy can serve every role of an identity
+	// provider instead of being cloned per role (which would duplicate the
+	// JWKS/issuer config, run one refresher per copy, and — because strategies
+	// resolve first-match-wins — make the grade of a multi-role token depend on
+	// config order rather than on its roles).
+	//
+	// Shape is claim name -> claim value -> granted grades:
+	//
+	//	consensusPolicies: ["standard"]        # baseline, on the strategy
+	//	jwt:
+	//	  claimMatchers:
+	//	    roles: ["erpc:all"]                # who may authenticate at all
+	//	  consensusPoliciesByClaim:
+	//	    roles:
+	//	      "erpc:consensus-fallback": ["degraded"]
+	//
+	// Grants are ADDITIVE and unioned across every matching claim value, on
+	// top of the strategy-level `consensusPolicies` baseline: a caller holding
+	// several roles is served the union of their grades, independent of
+	// ordering. There are no negative grants — a role cannot revoke a grade
+	// the baseline already allows, so the baseline should hold only what every
+	// caller of this strategy may receive.
+	//
+	// Claim values are matched against the same normalized string list as
+	// `claimMatchers` (bare string, string array, or SCIM-style objects).
+	ConsensusPoliciesByClaim map[string]map[string][]string `yaml:"consensusPoliciesByClaim,omitempty" json:"consensusPoliciesByClaim,omitempty"`
 }
 
 type SiweStrategyConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -1820,6 +1820,37 @@ type ConsensusPolicyConfig struct {
 	// handled by `lowParticipantsBehavior` / `agreementThreshold` exactly
 	// like any other low-participation tick. Empty (default) = disabled.
 	RequiredParticipants []*ConsensusRequiredParticipant `yaml:"requiredParticipants,omitempty" json:"requiredParticipants,omitempty"`
+
+	// AcceptancePolicies is an ORDERED list of named acceptance grades.
+	// Each entry states what the winning response group must look like for
+	// the round to be served under that grade. Evaluation walks the list
+	// top-down and stops at the first policy the round satisfies; the name
+	// of that policy is reported to the caller (`X-ERPC-Consensus-Policy`)
+	// and to metrics, so a relaxed answer is never silently indistinguishable
+	// from a strict one. When no policy is satisfied the round is a
+	// composition dispute.
+	//
+	// This lets an operator express "prefer a mixed internal+external
+	// agreement, but rather than hard-failing when the internal nodes are
+	// down or dissenting, serve an answer that several independent external
+	// providers agree on — and label it":
+	//
+	//	acceptancePolicies:
+	//	  - name: standard
+	//	    requiredAgreement:
+	//	      - { tag: "type:internal", minAgreement: 1 }
+	//	      - { tag: "type:external", minAgreement: 1 }
+	//	  - name: degraded
+	//	    requiredAgreement:
+	//	      - { tag: "type:external", minAgreement: 2 }
+	//
+	// Which callers may be served which grade is an authorization concern,
+	// configured per auth strategy (`consensusPolicies`), not here.
+	//
+	// Mutually exclusive with `requiredParticipants[].minAgreement`, which
+	// is the single-grade shorthand for the same mechanism. Empty (default)
+	// = disabled.
+	AcceptancePolicies []*ConsensusAcceptancePolicy `yaml:"acceptancePolicies,omitempty" json:"acceptancePolicies,omitempty"`
 }
 
 // ConsensusRequiredParticipant is one tag-quota entry for
@@ -1835,6 +1866,82 @@ type ConsensusRequiredParticipant struct {
 	Tag             string `yaml:"tag" json:"tag"`
 	MinParticipants int    `yaml:"minParticipants" json:"minParticipants"`
 	MinAgreement    int    `yaml:"minAgreement,omitempty" json:"minAgreement,omitempty"`
+}
+
+// ConsensusAcceptancePolicy is one named acceptance grade in
+// `consensus.acceptancePolicies`. A round is served under this policy when
+// the agreeing upstreams both reach `AgreementThreshold` and satisfy every
+// `RequiredAgreement` quota.
+type ConsensusAcceptancePolicy struct {
+	// Name identifies the grade. It is reported on the response
+	// (`X-ERPC-Consensus-Policy`) and in metrics, and is what auth
+	// strategies reference in their `consensusPolicies` allowlist, so it is
+	// an operator-facing contract — keep it stable.
+	Name string `yaml:"name" json:"name"`
+
+	// AgreementThreshold is the number of DISTINCT agreeing upstreams this
+	// grade requires. Defaults to the sum of its `RequiredAgreement`
+	// quotas, falling back to the policy-level `agreementThreshold` when
+	// the grade declares no quotas. A relaxed grade will usually want a
+	// lower threshold than the strict one — that is what lets it resolve a
+	// round too thin for the strict grade to ever win.
+	AgreementThreshold int `yaml:"agreementThreshold,omitempty" json:"agreementThreshold,omitempty"`
+
+	// RequiredAgreement constrains WHO must be among the agreeing
+	// upstreams. Empty means "any upstreams" — a pure count grade.
+	RequiredAgreement []*ConsensusAgreementQuota `yaml:"requiredAgreement,omitempty" json:"requiredAgreement,omitempty"`
+}
+
+// ConsensusAgreementQuota requires at least `MinAgreement` DISTINCT
+// upstreams matching `Tag` (a glob pattern, `*` / `?`, matched against each
+// upstream's `tags`) among the agreeing set. One upstream can satisfy every
+// quota it matches.
+type ConsensusAgreementQuota struct {
+	Tag          string `yaml:"tag" json:"tag"`
+	MinAgreement int    `yaml:"minAgreement" json:"minAgreement"`
+}
+
+func (p *ConsensusAcceptancePolicy) Copy() *ConsensusAcceptancePolicy {
+	if p == nil {
+		return nil
+	}
+	copied := *p
+	if p.RequiredAgreement != nil {
+		copied.RequiredAgreement = make([]*ConsensusAgreementQuota, len(p.RequiredAgreement))
+		for i, q := range p.RequiredAgreement {
+			if q == nil {
+				continue
+			}
+			qCopy := *q
+			copied.RequiredAgreement[i] = &qCopy
+		}
+	}
+	return &copied
+}
+
+// EffectiveAgreementThreshold is the number of distinct agreeing upstreams
+// this grade requires: its own explicit threshold, else the sum of its
+// quotas, else the policy-level fallback. Deriving from the quotas means the
+// common case needs no threshold at all — "1 internal + 1 external" already
+// says two upstreams must agree, and restating it as a separate number is
+// just a second place for the config to be wrong.
+func (p *ConsensusAcceptancePolicy) EffectiveAgreementThreshold(fallback int) int {
+	if p == nil {
+		return fallback
+	}
+	if p.AgreementThreshold > 0 {
+		return p.AgreementThreshold
+	}
+	sum := 0
+	for _, q := range p.RequiredAgreement {
+		if q != nil {
+			sum += q.MinAgreement
+		}
+	}
+	if sum > 0 {
+		return sum
+	}
+	return fallback
 }
 
 func (c *ConsensusPolicyConfig) Copy() *ConsensusPolicyConfig {
@@ -1879,6 +1986,13 @@ func (c *ConsensusPolicyConfig) Copy() *ConsensusPolicyConfig {
 			}
 			rpCopy := *rp
 			copied.RequiredParticipants[i] = &rpCopy
+		}
+	}
+
+	if c.AcceptancePolicies != nil {
+		copied.AcceptancePolicies = make([]*ConsensusAcceptancePolicy, len(c.AcceptancePolicies))
+		for i, p := range c.AcceptancePolicies {
+			copied.AcceptancePolicies[i] = p.Copy()
 		}
 	}
 
@@ -2664,6 +2778,31 @@ type AuthStrategyConfig struct {
 	// `trustUserIdHeader` (that path sets only Id — see
 	// NormalizedRequest.SetUserFromTrustedHeader).
 	AllowClientDirectives *string `yaml:"allowClientDirectives,omitempty" json:"allowClientDirectives,omitempty"`
+
+	// ConsensusPolicies, if set, restricts which consensus acceptance grades
+	// (`consensus.acceptancePolicies[].name`) may be served to callers
+	// authenticated by THIS strategy. A round resolved under a policy the
+	// caller is not allowed to receive is withheld and returned as a
+	// consensus composition dispute instead.
+	//
+	// This is how "who may accept a relaxed answer" is expressed — it is an
+	// authorization decision, so it lives beside allowMethods/rateLimitBudget
+	// rather than in the consensus config, and one deployment can serve
+	// strict and relaxed callers from a single endpoint:
+	//
+	//	- type: jwt          # settlement: strict grade only
+	//	  consensusPolicies: ["standard"]
+	//	- type: jwt          # indexers: may be served the relaxed grade
+	//	  consensusPolicies: ["standard", "degraded"]
+	//
+	// Left unset (nil) the caller may be served any configured grade, so
+	// existing configs are unaffected. An empty list is meaningful and
+	// distinct from unset: it permits nothing, which disables consensus
+	// grading for that caller entirely (every round becomes a dispute).
+	//
+	// Like AllowClientDirectives this travels on the User produced by the
+	// authenticating strategy, so `trustUserIdHeader` can never widen it.
+	ConsensusPolicies *[]string `yaml:"consensusPolicies,omitempty" json:"consensusPolicies,omitempty"`
 
 	Type     AuthType                `yaml:"type" json:"type" tstype:"TsAuthType"`
 	Network  *NetworkStrategyConfig  `yaml:"network,omitempty" json:"network,omitempty"`

--- a/common/exec_state.go
+++ b/common/exec_state.go
@@ -129,6 +129,11 @@ type ExecState struct {
 	ConsensusDisputes atomic.Int32
 	// ConsensusLowParticipants counts low-participant events.
 	ConsensusLowParticipants atomic.Int32
+	// consensusPolicy is the name of the consensus acceptance grade the
+	// round was served under (empty when consensus is off or ungraded).
+	// A pointer swap rather than a counter: it is written once by the
+	// analyzer and read by the response-header path on another goroutine.
+	consensusPolicy atomic.Pointer[string]
 
 	StartedAt time.Time
 
@@ -257,6 +262,10 @@ type ExecStateSnapshot struct {
 	ConsensusSlots           int
 	ConsensusDisputes        int
 	ConsensusLowParticipants int
+	// ConsensusPolicy is the consensus acceptance grade the round was
+	// served under; empty when consensus is off or no grades are
+	// configured.
+	ConsensusPolicy string
 
 	StartedAt time.Time
 }
@@ -301,8 +310,29 @@ func (s *ExecState) Snapshot() ExecStateSnapshot {
 		ConsensusSlots:           int(s.ConsensusSlots.Load()),
 		ConsensusDisputes:        int(s.ConsensusDisputes.Load()),
 		ConsensusLowParticipants: int(s.ConsensusLowParticipants.Load()),
+		ConsensusPolicy:          s.ConsensusPolicy(),
 		StartedAt:                s.StartedAt,
 	}
+}
+
+// SetConsensusPolicy records the acceptance grade the consensus round
+// resolved under. Last write wins; consensus resolves a request once.
+func (s *ExecState) SetConsensusPolicy(name string) {
+	if s == nil || name == "" {
+		return
+	}
+	s.consensusPolicy.Store(&name)
+}
+
+// ConsensusPolicy returns the recorded acceptance grade, or "" if none.
+func (s *ExecState) ConsensusPolicy() string {
+	if s == nil {
+		return ""
+	}
+	if p := s.consensusPolicy.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 // Apply sets the standard execution.* attributes on a span. Callers

--- a/common/user.go
+++ b/common/user.go
@@ -13,4 +13,26 @@ type User struct {
 	// the strategy that authenticated this user. Nil means "no strategy-level
 	// override" — the project-level pattern applies.
 	AllowClientDirectives *string
+
+	// ConsensusPolicies is the set of consensus acceptance grades this caller
+	// may be served, granted by the strategy that authenticated them. Nil
+	// means "no strategy-level restriction" — any configured grade may be
+	// served. A non-nil empty slice permits none.
+	ConsensusPolicies *[]string
+}
+
+// MayBeServedConsensusPolicy reports whether this caller is allowed to
+// receive a consensus result graded under the named acceptance policy.
+// A nil user (unauthenticated deployments, internal callers) and a user
+// without a strategy-level restriction may be served any grade.
+func (u *User) MayBeServedConsensusPolicy(name string) bool {
+	if u == nil || u.ConsensusPolicies == nil {
+		return true
+	}
+	for _, allowed := range *u.ConsensusPolicies {
+		if allowed == name {
+			return true
+		}
+	}
+	return false
 }

--- a/common/validation.go
+++ b/common/validation.go
@@ -1161,6 +1161,14 @@ func (f *FailsafeConfig) Validate() error {
 			return err
 		}
 	}
+	// Consensus was previously omitted here, which left every check in
+	// ConsensusPolicyConfig.Validate unreachable outside unit tests —
+	// misconfigurations reached runtime instead of failing startup.
+	if f.Consensus != nil {
+		if err := f.Consensus.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -1257,7 +1265,105 @@ func (c *ConsensusPolicyConfig) Validate() error {
 		}
 	}
 
+	if err := c.validateAcceptancePolicies(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// validateAcceptancePolicies checks the ordered acceptance-grade list. Beyond
+// the usual field checks it rejects two config shapes that would silently do
+// the wrong thing:
+//
+//   - Declaring both `acceptancePolicies` and a `requiredParticipants[].minAgreement`
+//     quota. Both express winner composition; having two sources would leave
+//     "which one wins" to implementation order.
+//   - A policy that is unreachable because an earlier, strictly more permissive
+//     policy always matches first. Order is the whole mechanism here, so an
+//     inverted list (relaxed before strict) is a misconfiguration that would
+//     quietly serve every round at the relaxed grade.
+func (c *ConsensusPolicyConfig) validateAcceptancePolicies() error {
+	if len(c.AcceptancePolicies) == 0 {
+		return nil
+	}
+	for i, rp := range c.RequiredParticipants {
+		if rp != nil && rp.MinAgreement > 0 {
+			return fmt.Errorf("consensus.acceptancePolicies cannot be combined with consensus.requiredParticipants[%d].minAgreement: both define winner composition — express every grade in acceptancePolicies, and keep requiredParticipants for participant selection (minParticipants) only", i)
+		}
+	}
+
+	seen := make(map[string]int, len(c.AcceptancePolicies))
+	thresholds := make([]int, len(c.AcceptancePolicies))
+	for i, p := range c.AcceptancePolicies {
+		if p == nil {
+			return fmt.Errorf("consensus.acceptancePolicies[%d] must not be null", i)
+		}
+		name := strings.TrimSpace(p.Name)
+		if name == "" {
+			return fmt.Errorf("consensus.acceptancePolicies[%d].name is required: the name is reported to callers and referenced by auth strategies", i)
+		}
+		if prev, dup := seen[name]; dup {
+			return fmt.Errorf("consensus.acceptancePolicies[%d].name %q duplicates acceptancePolicies[%d].name: names must be unique so auth allowlists and metrics are unambiguous", i, name, prev)
+		}
+		seen[name] = i
+
+		sum := 0
+		for j, q := range p.RequiredAgreement {
+			if q == nil {
+				return fmt.Errorf("consensus.acceptancePolicies[%d].requiredAgreement[%d] must not be null", i, j)
+			}
+			if strings.TrimSpace(q.Tag) == "" {
+				return fmt.Errorf("consensus.acceptancePolicies[%d].requiredAgreement[%d].tag is required", i, j)
+			}
+			if q.MinAgreement <= 0 {
+				return fmt.Errorf("consensus.acceptancePolicies[%d].requiredAgreement[%d].minAgreement must be greater than 0: a zero quota is expressed by omitting the entry", i, j)
+			}
+			sum += q.MinAgreement
+		}
+		if p.AgreementThreshold < 0 {
+			return fmt.Errorf("consensus.acceptancePolicies[%d].agreementThreshold must not be negative", i)
+		}
+		threshold := p.EffectiveAgreementThreshold(c.AgreementThreshold)
+		if threshold > c.MaxParticipants {
+			return fmt.Errorf("consensus.acceptancePolicies[%d] requires %d agreeing upstreams but maxParticipants is %d: this grade can never be satisfied", i, threshold, c.MaxParticipants)
+		}
+		if p.AgreementThreshold > 0 && p.AgreementThreshold < sum {
+			return fmt.Errorf("consensus.acceptancePolicies[%d].agreementThreshold (%d) is lower than the sum of its requiredAgreement quotas (%d): the quotas alone already require more agreeing upstreams", i, p.AgreementThreshold, sum)
+		}
+		thresholds[i] = threshold
+	}
+
+	// Reachability: a later policy is dead if some earlier policy is
+	// satisfied by every round that satisfies it — i.e. the earlier one asks
+	// for no more agreement and no stricter quota on any tag.
+	for i := 1; i < len(c.AcceptancePolicies); i++ {
+		for j := range i {
+			if thresholds[j] <= thresholds[i] && quotasSubsume(c.AcceptancePolicies[j], c.AcceptancePolicies[i]) {
+				return fmt.Errorf("consensus.acceptancePolicies[%d] (%q) is unreachable: acceptancePolicies[%d] (%q) is evaluated first and accepts everything this grade would — list grades strictest first", i, c.AcceptancePolicies[i].Name, j, c.AcceptancePolicies[j].Name)
+			}
+		}
+	}
+	return nil
+}
+
+// quotasSubsume reports whether policy `a` demands no more than `b` on every
+// tag b constrains, and constrains no tag b leaves free — meaning any agreeing
+// set satisfying b also satisfies a.
+func quotasSubsume(a, b *ConsensusAcceptancePolicy) bool {
+	for _, aq := range a.RequiredAgreement {
+		matched := false
+		for _, bq := range b.RequiredAgreement {
+			if bq.Tag == aq.Tag && bq.MinAgreement >= aq.MinAgreement {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 // Validate validates the MisbehaviorsDestinationConfig

--- a/consensus/acceptance_policy_test.go
+++ b/consensus/acceptance_policy_test.go
@@ -1,0 +1,619 @@
+package consensus
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The scenario every test below is a variation of: an operator wants a mixed
+// internal+external agreement, and would rather serve an answer two
+// independent externals agree on than hard-fail when the internal nodes are
+// absent or dissenting — provided the relaxed answer is labelled as such.
+func mixedThenExternalOnly() []*common.ConsensusAcceptancePolicy {
+	return []*common.ConsensusAcceptancePolicy{
+		{
+			Name: "standard",
+			RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:internal", MinAgreement: 1},
+				{Tag: "type:external", MinAgreement: 1},
+			},
+		},
+		{
+			Name: "degraded",
+			RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:external", MinAgreement: 2},
+			},
+		},
+	}
+}
+
+func cascadeConfig() *config {
+	return &config{
+		maxParticipants:         5,
+		agreementThreshold:      2,
+		acceptancePolicyConfigs: mixedThenExternalOnly(),
+	}
+}
+
+// grade selection -------------------------------------------------------------
+
+func TestAcceptance_StrictGradeWinsWhenMixedAgreementExists(t *testing.T) {
+	cfg := cascadeConfig()
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	// All three agree, so BOTH grades are satisfiable. Order must decide.
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+		resultFrom(t, ext2, "0xaa", 2),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error)
+	assert.Equal(t, "standard", winner.Policy,
+		"when both grades match, the strictest (first) one must be reported")
+}
+
+func TestAcceptance_FallsToRelaxedGradeWhenInternalAbsent(t *testing.T) {
+	// The availability case: internal nodes down/cordoned, two independent
+	// externals agree. Strict is unsatisfiable; the round is still served,
+	// and is labelled so the operator can tell it apart.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error, "two agreeing externals must satisfy the relaxed grade")
+	assert.Equal(t, "degraded", winner.Policy)
+}
+
+func TestAcceptance_FallsToRelaxedGradeWhenInternalDissents(t *testing.T) {
+	// The integrity case André raised: internal is UP but serving forked
+	// data while two externals agree. Strict cannot be met (the winning
+	// group holds no internal), so the relaxed grade serves — labelled.
+	// This is the behaviour a dispute-rate breaker cannot distinguish from
+	// the absent case; here it is decided per round from the votes.
+	cfg := cascadeConfig()
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xdead", 0), // forked
+		resultFrom(t, ext1, "0xaa", 1),
+		resultFrom(t, ext2, "0xaa", 2),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error)
+	assert.Equal(t, "degraded", winner.Policy)
+}
+
+func TestAcceptance_GenuineDisagreementStaysAPlainDispute(t *testing.T) {
+	// One internal and one external that disagree: no group reaches any
+	// grade's threshold, so the rules engine produces a plain dispute and
+	// the gate passes it through untouched. Converting it into a
+	// composition dispute would mask the real failure — the upstreams
+	// disagreed, which is not a composition problem.
+	cfg := cascadeConfig()
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xbb", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.NotNil(t, winner.Error)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusDispute),
+		"got: %v", winner.Error)
+	assert.False(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute))
+	assert.Empty(t, winner.Policy, "a disputed round is served under no grade")
+}
+
+func TestAcceptance_CountWinnerFailingEveryGradeIsCompositionDispute(t *testing.T) {
+	// Here a group DOES reach the threshold — two correlated externals
+	// agree — but the operator required an internal in the winner and only
+	// configured the strict grade. That is a composition failure, and must
+	// be labelled distinctly from a plain disagreement.
+	cfg := &config{
+		maxParticipants:    5,
+		agreementThreshold: 2,
+		acceptancePolicyConfigs: []*common.ConsensusAcceptancePolicy{
+			{Name: "standard", RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:internal", MinAgreement: 1},
+				{Tag: "type:external", MinAgreement: 1},
+			}},
+		},
+	}
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.NotNil(t, winner.Error)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute),
+		"got: %v", winner.Error)
+	assert.Empty(t, winner.Policy)
+}
+
+func TestAcceptance_RelaxedGradeResolvesRoundTooThinForStrict(t *testing.T) {
+	// The low-participants case. Strict needs 3 agreeing upstreams; only two
+	// externals answered at all. Without per-grade thresholds the rules
+	// engine would declare low-participants/dispute and the relaxed grade
+	// would never get a chance.
+	cfg := &config{
+		maxParticipants:    5,
+		agreementThreshold: 3,
+		acceptancePolicyConfigs: []*common.ConsensusAcceptancePolicy{
+			{
+				Name: "standard",
+				RequiredAgreement: []*common.ConsensusAgreementQuota{
+					{Tag: "type:internal", MinAgreement: 1},
+					{Tag: "type:external", MinAgreement: 2},
+				},
+			},
+			{
+				Name: "degraded",
+				RequiredAgreement: []*common.ConsensusAgreementQuota{
+					{Tag: "type:external", MinAgreement: 2},
+				},
+			},
+		},
+	}
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error, "relaxed grade needs only 2 agreeing upstreams, got: %v", winner.Error)
+	assert.Equal(t, "degraded", winner.Policy)
+}
+
+func TestAcceptance_GradeThresholdIsStillEnforced(t *testing.T) {
+	// The flip side of lowering the rules threshold: a single external must
+	// NOT be served just because the rules engine now nominates it. The
+	// relaxed grade's own bar (2 externals) still applies.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.NotNil(t, winner.Error, "one upstream cannot satisfy a grade requiring two")
+	assert.Empty(t, winner.Policy)
+}
+
+func TestAcceptance_DuplicateUpstreamCannotSatisfyGradeAlone(t *testing.T) {
+	// Hedge/retry can land twice on the same upstream. One node
+	// corroborating itself must not fill a minAgreement of 2.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.NotNil(t, winner.Error, "self-corroboration must not satisfy the relaxed grade")
+	assert.Empty(t, winner.Policy)
+}
+
+// caller authorization ---------------------------------------------------------
+
+func requestForUser(t *testing.T, user *common.User) *common.NormalizedRequest {
+	t.Helper()
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[]}`))
+	if user != nil {
+		req.SetUser(user)
+	}
+	return req
+}
+
+func TestAcceptance_CallerRestrictedToStrictGradeIsNotServedRelaxed(t *testing.T) {
+	// A settlement-grade caller: the round genuinely resolves at "degraded",
+	// but this caller may not accept that, so it gets the dispute instead.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+
+	strictOnly := &common.User{Id: "settlement", ConsensusPolicies: &[]string{"standard"}}
+	winner := winnerOfFor(cfg, requestForUser(t, strictOnly), analysis)
+
+	require.NotNil(t, winner.Error)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute),
+		"got: %v", winner.Error)
+	assert.Empty(t, winner.Policy)
+}
+
+func TestAcceptance_CallerAllowedRelaxedGradeIsServed(t *testing.T) {
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+
+	indexer := &common.User{Id: "indexer", ConsensusPolicies: &[]string{"standard", "degraded"}}
+	winner := winnerOfFor(cfg, requestForUser(t, indexer), analysis)
+
+	require.Nil(t, winner.Error, "got: %v", winner.Error)
+	assert.Equal(t, "degraded", winner.Policy)
+}
+
+func TestAcceptance_RestrictedCallerStillServedGradeItAllows(t *testing.T) {
+	// The restriction must not degrade the strict path: the same
+	// strict-only caller is served normally when the round earns "standard".
+	cfg := cascadeConfig()
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+	})
+
+	strictOnly := &common.User{Id: "settlement", ConsensusPolicies: &[]string{"standard"}}
+	winner := winnerOfFor(cfg, requestForUser(t, strictOnly), analysis)
+
+	require.Nil(t, winner.Error, "got: %v", winner.Error)
+	assert.Equal(t, "standard", winner.Policy)
+}
+
+func TestAcceptance_UnrestrictedCallerMayBeServedAnyGrade(t *testing.T) {
+	// Unset allowlist (and unauthenticated deployments) must behave exactly
+	// as before this feature existed.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+
+	for name, user := range map[string]*common.User{
+		"no user":         nil,
+		"no restriction":  {Id: "u"},
+		"explicit allows": {Id: "u", ConsensusPolicies: &[]string{"degraded"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			winner := winnerOfFor(cfg, requestForUser(t, user), analysis)
+			require.Nil(t, winner.Error, "got: %v", winner.Error)
+			assert.Equal(t, "degraded", winner.Policy)
+		})
+	}
+}
+
+func TestAcceptance_EmptyAllowlistPermitsNothing(t *testing.T) {
+	// An empty list is meaningful and distinct from unset.
+	cfg := cascadeConfig()
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+	})
+
+	denied := &common.User{Id: "denied", ConsensusPolicies: &[]string{}}
+	winner := winnerOfFor(cfg, requestForUser(t, denied), analysis)
+
+	require.NotNil(t, winner.Error)
+	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute))
+}
+
+// ordering invariants -----------------------------------------------------------
+
+func TestAcceptance_RelaxedWinDoesNotShortCircuitWhileStrictReachable(t *testing.T) {
+	// Timing must not decide the grade. Two externals agree early while an
+	// internal slot is still outstanding; cancelling here would serve
+	// "degraded" for a round that was about to earn "standard".
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+	int1 := taggedUpstream("internal-1", "type:internal")
+
+	partial := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+	provisional := winnerOf(cfg, partial)
+	require.Equal(t, "degraded", provisional.Policy)
+	require.True(t, partial.hasRemaining(), "a slot must still be outstanding for this test to mean anything")
+
+	e := newTestExecutor(cfg)
+	reason, ok := e.shouldShortCircuit(provisional, partial)
+	assert.False(t, ok, "must not cancel a strict-grade vote that can still arrive (reason=%s)", reason)
+
+	// The late internal vote upgrades the same round to the strict grade.
+	full := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+		resultFrom(t, int1, "0xaa", 2),
+	})
+	final := winnerOf(cfg, full)
+	require.Nil(t, final.Error)
+	assert.Equal(t, "standard", final.Policy, "late internal agreement must upgrade the grade")
+}
+
+func TestAcceptance_StrictWinMayShortCircuit(t *testing.T) {
+	// The converse of the deferral above: once the strictest grade is met
+	// and its lead is unassailable, the round is final and the remaining
+	// participant is cancelled as before. The relaxed-grade guard must not
+	// disable short-circuit generally.
+	cfg := &config{
+		maxParticipants:         3, // 2 answered, 1 outstanding -> lead 2 > 0+1
+		agreementThreshold:      2,
+		acceptancePolicyConfigs: mixedThenExternalOnly(),
+	}
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	partial := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, partial)
+	require.Equal(t, "standard", winner.Policy)
+	require.True(t, partial.hasRemaining(), "a slot must still be outstanding for this test to mean anything")
+
+	e := newTestExecutor(cfg)
+	_, ok := e.shouldShortCircuit(winner, partial)
+	assert.True(t, ok, "an unassailable strict-grade win should still short-circuit")
+}
+
+// compilation ---------------------------------------------------------------------
+
+func TestAcceptance_ShorthandCompilesToSingleStandardGrade(t *testing.T) {
+	// Configs written before named grades existed keep working, and report
+	// the implicit grade name.
+	cfg := &config{
+		maxParticipants:      3,
+		agreementThreshold:   2,
+		requiredParticipants: mixedQuota(1),
+	}
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaa", 0),
+		resultFrom(t, ext1, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error)
+	assert.Equal(t, defaultAcceptancePolicyName, winner.Policy)
+}
+
+func TestAcceptance_NoPoliciesConfiguredLeavesRoundUngraded(t *testing.T) {
+	// Opt-in: with no composition config at all the gate is a no-op and no
+	// grade is reported, so the header/metric stay absent.
+	cfg := &config{maxParticipants: 3, agreementThreshold: 2}
+	u1 := taggedUpstream("upstream-1")
+	u2 := taggedUpstream("upstream-2")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, u1, "0xaa", 0),
+		resultFrom(t, u2, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error)
+	assert.Empty(t, winner.Policy)
+}
+
+func TestAcceptance_CompileDerivesThresholdsAndLowersRulesBar(t *testing.T) {
+	cfg := &config{
+		maxParticipants:    5,
+		agreementThreshold: 4,
+		acceptancePolicyConfigs: []*common.ConsensusAcceptancePolicy{
+			// threshold derived from quotas: 1 + 2 = 3
+			{Name: "standard", RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:internal", MinAgreement: 1},
+				{Tag: "type:external", MinAgreement: 2},
+			}},
+			// explicit threshold wins over the derived sum
+			{Name: "degraded", AgreementThreshold: 2, RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:external", MinAgreement: 2},
+			}},
+		},
+	}
+	cfg.compile()
+
+	require.Len(t, cfg.acceptancePolicies, 2)
+	assert.Equal(t, 3, cfg.acceptancePolicies[0].threshold, "derived from the sum of quotas")
+	assert.Equal(t, 2, cfg.acceptancePolicies[1].threshold, "explicit threshold")
+	assert.Equal(t, 2, cfg.agreementThreshold,
+		"rules engine must run at the lowest grade's bar so thin rounds still nominate a candidate")
+
+	// Idempotent: a second compile must not lower the threshold again or
+	// duplicate the grades.
+	cfg.compile()
+	assert.Len(t, cfg.acceptancePolicies, 2)
+	assert.Equal(t, 2, cfg.agreementThreshold)
+}
+
+func TestAcceptance_GradeWithoutQuotasIsPureCountGrade(t *testing.T) {
+	cfg := &config{
+		maxParticipants:    5,
+		agreementThreshold: 3,
+		acceptancePolicyConfigs: []*common.ConsensusAcceptancePolicy{
+			{Name: "strict", RequiredAgreement: []*common.ConsensusAgreementQuota{
+				{Tag: "type:internal", MinAgreement: 1},
+				{Tag: "type:external", MinAgreement: 1},
+			}},
+			{Name: "any-two", AgreementThreshold: 2},
+		},
+	}
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xaa", 0),
+		resultFrom(t, ext2, "0xaa", 1),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error)
+	assert.Equal(t, "any-two", winner.Policy)
+}
+
+// exemptions ------------------------------------------------------------------------
+
+func TestAcceptance_SendRawTransactionExempt(t *testing.T) {
+	// A broadcast accepted by any node propagates network-wide, so winner
+	// composition proves nothing — the exemption must survive the cascade.
+	cfg := cascadeConfig()
+	ext1 := taggedUpstream("external-1", "type:external")
+
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, ext1, "0xhash", 0),
+	})
+	analysis.method = "eth_sendRawTransaction"
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error, "sendRawTransaction must not be composition-gated, got: %v", winner.Error)
+}
+
+// config validation ------------------------------------------------------------------
+
+func TestAcceptance_Validation(t *testing.T) {
+	base := func(policies ...*common.ConsensusAcceptancePolicy) *common.ConsensusPolicyConfig {
+		return &common.ConsensusPolicyConfig{
+			MaxParticipants:    5,
+			AgreementThreshold: 2,
+			AcceptancePolicies: policies,
+		}
+	}
+	quota := func(tag string, n int) *common.ConsensusAgreementQuota {
+		return &common.ConsensusAgreementQuota{Tag: tag, MinAgreement: n}
+	}
+
+	t.Run("valid strict-then-relaxed cascade is accepted", func(t *testing.T) {
+		cfg := base(mixedThenExternalOnly()...)
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("combining with requiredParticipants minAgreement is rejected", func(t *testing.T) {
+		// Two sources of winner composition would leave "which one wins" to
+		// implementation order.
+		cfg := base(mixedThenExternalOnly()...)
+		cfg.RequiredParticipants = []*common.ConsensusRequiredParticipant{
+			{Tag: "type:internal", MinParticipants: 1, MinAgreement: 1},
+		}
+		require.ErrorContains(t, cfg.Validate(), "cannot be combined")
+	})
+
+	t.Run("requiredParticipants without minAgreement still allowed alongside", func(t *testing.T) {
+		// Participant SELECTION is a separate concern and must remain usable.
+		cfg := base(mixedThenExternalOnly()...)
+		cfg.RequiredParticipants = []*common.ConsensusRequiredParticipant{
+			{Tag: "type:internal", MinParticipants: 1},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("missing name is rejected", func(t *testing.T) {
+		cfg := base(&common.ConsensusAcceptancePolicy{
+			RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:external", 2)},
+		})
+		require.ErrorContains(t, cfg.Validate(), "name is required")
+	})
+
+	t.Run("duplicate names are rejected", func(t *testing.T) {
+		// Names address grades in auth allowlists and metrics; duplicates
+		// would make both ambiguous.
+		cfg := base(
+			&common.ConsensusAcceptancePolicy{Name: "same", RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:internal", 2)}},
+			&common.ConsensusAcceptancePolicy{Name: "same", RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:external", 1)}},
+		)
+		require.ErrorContains(t, cfg.Validate(), "duplicates")
+	})
+
+	t.Run("empty quota tag is rejected", func(t *testing.T) {
+		cfg := base(&common.ConsensusAcceptancePolicy{
+			Name:              "standard",
+			RequiredAgreement: []*common.ConsensusAgreementQuota{quota("", 1)},
+		})
+		require.ErrorContains(t, cfg.Validate(), "tag is required")
+	})
+
+	t.Run("zero minAgreement quota is rejected", func(t *testing.T) {
+		cfg := base(&common.ConsensusAcceptancePolicy{
+			Name:              "standard",
+			RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:internal", 0)},
+		})
+		require.ErrorContains(t, cfg.Validate(), "must be greater than 0")
+	})
+
+	t.Run("grade requiring more than maxParticipants is rejected", func(t *testing.T) {
+		cfg := base(&common.ConsensusAcceptancePolicy{
+			Name:              "impossible",
+			RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:internal", 6)},
+		})
+		require.ErrorContains(t, cfg.Validate(), "can never be satisfied")
+	})
+
+	t.Run("threshold below its own quotas is rejected", func(t *testing.T) {
+		cfg := base(&common.ConsensusAcceptancePolicy{
+			Name:               "contradictory",
+			AgreementThreshold: 1,
+			RequiredAgreement: []*common.ConsensusAgreementQuota{
+				quota("type:internal", 1), quota("type:external", 1),
+			},
+		})
+		require.ErrorContains(t, cfg.Validate(), "lower than the sum")
+	})
+
+	t.Run("relaxed grade listed before strict is rejected as unreachable", func(t *testing.T) {
+		// Order IS the mechanism. An inverted list would quietly serve every
+		// round at the relaxed grade, defeating the point of the strict one.
+		cfg := base(
+			&common.ConsensusAcceptancePolicy{Name: "degraded", RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:external", 1)}},
+			&common.ConsensusAcceptancePolicy{Name: "standard", RequiredAgreement: []*common.ConsensusAgreementQuota{
+				quota("type:internal", 1), quota("type:external", 1),
+			}},
+		)
+		require.ErrorContains(t, cfg.Validate(), "unreachable")
+	})
+
+	t.Run("grades constraining different tags are both reachable", func(t *testing.T) {
+		// Neither subsumes the other: an internal-only round satisfies the
+		// first, an external-only round the second.
+		cfg := base(
+			&common.ConsensusAcceptancePolicy{Name: "internal-pair", RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:internal", 2)}},
+			&common.ConsensusAcceptancePolicy{Name: "external-pair", RequiredAgreement: []*common.ConsensusAgreementQuota{quota("type:external", 2)}},
+		)
+		require.NoError(t, cfg.Validate())
+	})
+}

--- a/consensus/analysis_test.go
+++ b/consensus/analysis_test.go
@@ -139,7 +139,7 @@ func TestConsensusWithExhaustedParticipants_StillReachesThreshold(t *testing.T) 
 
 	// determineWinner must return the agreed-upon revert, not a dispute.
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	winner := e.determineWinner(&lg, analysis)
+	winner := e.determineWinner(&lg, nil, analysis)
 
 	require.NotNil(t, winner)
 	assert.NotNil(t, winner.Error, "winner should be the consensus error (revert)")

--- a/consensus/composition_test.go
+++ b/consensus/composition_test.go
@@ -31,15 +31,24 @@ func errorFrom(ups common.Upstream, err error, index int) *execResult {
 	return &execResult{Err: err, Upstream: ups, Index: index}
 }
 
+// analyze and winnerOf compile the config first, exactly as the builder does
+// for production, so tests exercise the same derived acceptance grades.
 func analyze(cfg *config, responses []*execResult) *consensusAnalysis {
 	lg := zerolog.Nop()
+	cfg.compile()
 	return newConsensusAnalysis(&lg, context.Background(), cfg, responses)
 }
 
 func winnerOf(cfg *config, analysis *consensusAnalysis) *slotResult {
+	return winnerOfFor(cfg, nil, analysis)
+}
+
+// winnerOfFor is winnerOf with an explicit caller, for authorization cases.
+func winnerOfFor(cfg *config, req *common.NormalizedRequest, analysis *consensusAnalysis) *slotResult {
 	lg := zerolog.Nop()
+	cfg.compile()
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	return e.determineWinner(&lg, analysis)
+	return e.determineWinner(&lg, req, analysis)
 }
 
 // dedup ----------------------------------------------------------------------
@@ -311,7 +320,7 @@ func TestMinAgreement_ShortCircuitDeferredWhileRemaining(t *testing.T) {
 		resultFrom(t, ext1, "0xaa", 0),
 		resultFrom(t, ext2, "0xaa", 1),
 	})
-	provisional := e.determineWinner(&lg, partial)
+	provisional := e.determineWinner(&lg, nil, partial)
 	require.NotNil(t, provisional.Error)
 	require.True(t, common.HasErrorCode(provisional.Error, common.ErrCodeConsensusCompositionDispute))
 
@@ -324,7 +333,7 @@ func TestMinAgreement_ShortCircuitDeferredWhileRemaining(t *testing.T) {
 		resultFrom(t, ext2, "0xaa", 1),
 		resultFrom(t, internal, "0xaa", 2),
 	})
-	final := e.determineWinner(&lg, full)
+	final := e.determineWinner(&lg, nil, full)
 	require.Nil(t, final.Error)
 	require.NotNil(t, final.Result, "late internal agreement must convert the dispute into a win")
 }
@@ -401,7 +410,7 @@ func TestMinAgreement_CompositionDisputeDoesNotPunishDissenter(t *testing.T) {
 	})
 	lg := zerolog.Nop()
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	winner := e.determineWinner(&lg, analysis)
+	winner := e.determineWinner(&lg, nil, analysis)
 	require.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute))
 
 	e.trackAndPunishMisbehavingUpstreams(&lg, nil, metricsLabels{}, winner, analysis)
@@ -460,8 +469,8 @@ func TestQuota_DuplicateUpstreamCountsOnce(t *testing.T) {
 	// The wait-cap arming path checks quota coverage on the RAW pre-dedup
 	// response slice: one tagged upstream answering twice via hedge must
 	// not satisfy minAgreement: 2 by itself.
-	reqs := []*common.ConsensusRequiredParticipant{
-		{Tag: "type:internal", MinParticipants: 2, MinAgreement: 2},
+	quotas := []*common.ConsensusAgreementQuota{
+		{Tag: "type:internal", MinAgreement: 2},
 	}
 	int1 := taggedUpstream("internal-1", "type:internal")
 	int2 := taggedUpstream("internal-2", "type:internal")
@@ -470,11 +479,11 @@ func TestQuota_DuplicateUpstreamCountsOnce(t *testing.T) {
 		resultFrom(t, int1, "0xaa", 0),
 		resultFrom(t, int1, "0xaa", 1), // same upstream, second hedge leg
 	}
-	assert.False(t, resultsSatisfyAgreementQuotas(dup, reqs),
+	assert.False(t, resultsSatisfyQuotas(dup, quotas),
 		"one upstream answering twice must not count as two")
 
 	distinct := append(dup, resultFrom(t, int2, "0xaa", 2))
-	assert.True(t, resultsSatisfyAgreementQuotas(distinct, reqs))
+	assert.True(t, resultsSatisfyQuotas(distinct, quotas))
 }
 
 // config validation ------------------------------------------------------------
@@ -510,4 +519,12 @@ func TestMinAgreement_Validation(t *testing.T) {
 		}
 		require.NoError(t, cfg.Validate())
 	})
+}
+
+// newTestExecutor builds an executor over an already-compiled config, for
+// tests that call executor methods directly rather than through winnerOf.
+func newTestExecutor(cfg *config) *executor {
+	lg := zerolog.Nop()
+	cfg.compile()
+	return &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
 }

--- a/consensus/composition_test.go
+++ b/consensus/composition_test.go
@@ -528,3 +528,41 @@ func newTestExecutor(cfg *config) *executor {
 	cfg.compile()
 	return &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
 }
+
+// TestMinAgreement_BelowThresholdWinnerStillServed guards the pre-existing
+// shorthand semantics against the acceptance-grade rewrite.
+//
+// The composition gate checks WHO is in the winning group; deciding whether
+// enough upstreams agreed is the rules engine's job. Under
+// acceptMostCommonValidResult the rules engine deliberately returns a winner
+// below agreementThreshold, and such a winner was always served as long as it
+// satisfied the tag quotas. Re-checking the count inside the gate would turn
+// those rounds into composition disputes — a silent behavior change for
+// configs that combine minAgreement with a dispute behavior.
+func TestMinAgreement_BelowThresholdWinnerStillServed(t *testing.T) {
+	cfg := &config{
+		maxParticipants:       3,
+		agreementThreshold:    2,
+		disputeBehavior:       common.ConsensusDisputeBehaviorAcceptMostCommonValidResult,
+		preferLargerResponses: true,
+		requiredParticipants:  mixedQuota(1),
+	}
+	int1 := taggedUpstream("internal-1", "type:internal")
+	ext1 := taggedUpstream("external-1", "type:external")
+	ext2 := taggedUpstream("external-2", "type:external")
+
+	// Three-way disagreement: nothing reaches the threshold of 2. The
+	// internal node's response is the largest, so acceptMostCommon +
+	// preferLargerResponses elects it, and it satisfies the internal quota.
+	analysis := analyze(cfg, []*execResult{
+		resultFrom(t, int1, "0xaaaaaa", 0),
+		resultFrom(t, ext1, "0xbb", 1),
+		resultFrom(t, ext2, "0xcc", 2),
+	})
+	winner := winnerOf(cfg, analysis)
+
+	require.Nil(t, winner.Error,
+		"a below-threshold winner satisfying the tag quota must still be served, got: %v", winner.Error)
+	require.NotNil(t, winner.Result)
+	assert.Equal(t, defaultAcceptancePolicyName, winner.Policy)
+}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -33,7 +33,8 @@ func NewConsensus(cfg *common.ConsensusPolicyConfig, logger *zerolog.Logger) (*C
 		WithFireAndForget(cfg.FireAndForget).
 		WithMaxWaitOnResult(cfg.MaxWaitOnResult).
 		WithMaxWaitOnEmpty(cfg.MaxWaitOnEmpty).
-		WithRequiredParticipants(cfg.RequiredParticipants)
+		WithRequiredParticipants(cfg.RequiredParticipants).
+		WithAcceptancePolicies(cfg.AcceptancePolicies)
 
 	if cfg.MisbehaviorsDestination != nil {
 		b = b.WithMisbehaviorsDestination(cfg.MisbehaviorsDestination)

--- a/consensus/content_validation_error_test.go
+++ b/consensus/content_validation_error_test.go
@@ -50,7 +50,7 @@ func TestConsensus_ContentValidationErrorDoesNotDisputeMajority(t *testing.T) {
 	require.Equal(t, 2, analysis.validParticipants, "the content-validation error must not count as a valid participant")
 
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	winner := e.determineWinner(&lg, analysis)
+	winner := e.determineWinner(&lg, nil, analysis)
 
 	require.NotNil(t, winner)
 	require.Nil(t, winner.Error, "two honest agreeing upstreams must win, not ErrConsensusDispute")

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -374,6 +374,13 @@ func (e *executor) runAnalyzer(
 		if outcomeSent {
 			return
 		}
+		// Record the acceptance grade on the exact outcome being published,
+		// before the caller is released. Both publish paths (short-circuit
+		// and wait-all) funnel through here, so the reported grade can never
+		// be a stale provisional one from an earlier mid-collection pass.
+		if o.winner != nil {
+			originalReq.ExecState().SetConsensusPolicy(o.winner.Policy)
+		}
 		outcomeCh <- o // non-blocking: outcomeCh is buffered size 1
 		outcomeSent = true
 	}
@@ -471,24 +478,24 @@ func (e *executor) runAnalyzer(
 			return
 		}
 		// The caps mean "a usable answer is in hand; stragglers get this
-		// much longer". With minAgreement quotas, a response set that
-		// cannot yet satisfy the winner-composition quota is NOT a usable
-		// answer — arming the countdown off it would resolve the round
-		// before the required tagged upstream responds, converting every
-		// such round into a retryable composition dispute. Hold arming
-		// until the collected responses cover every quota tag with
-		// DISTINCT upstreams (resultsSatisfyAgreementQuotas dedupes by ID
-		// — the raw slice may hold the same upstream twice via hedge).
-		// Slot timeouts and the overall request timeout still bound the
-		// round. Deliberate ceiling: an errored or dissenting tagged
-		// response counts as coverage. When several tagged upstreams are
-		// in the round, an early tagged error/dissent can arm the cap and
-		// time out a slower tagged sibling that would have completed the
-		// quota — the failure is a retryable composition dispute, and the
-		// alternative (hold caps until a tagged vote joins the WINNER)
-		// would disable the caps on every genuine-disagreement round.
-		if anyAgreementQuota(e.config.requiredParticipants) &&
-			!resultsSatisfyAgreementQuotas(responses, e.config.requiredParticipants) {
+		// much longer". With acceptance quotas, a response set that cannot
+		// yet satisfy ANY configured grade is NOT a usable answer — arming
+		// the countdown off it would resolve the round before the required
+		// tagged upstream responds, converting every such round into a
+		// retryable composition dispute. Hold arming until the collected
+		// responses cover some grade's quota tags with DISTINCT upstreams
+		// (resultsSatisfyQuotas dedupes by ID — the raw slice may hold the
+		// same upstream twice via hedge). Slot timeouts and the overall
+		// request timeout still bound the round. Deliberate ceiling: an
+		// errored or dissenting tagged response counts as coverage. When
+		// several tagged upstreams are in the round, an early tagged
+		// error/dissent can arm the cap and time out a slower tagged
+		// sibling that would have completed the quota — the failure is a
+		// retryable composition dispute, and the alternative (hold caps
+		// until a tagged vote joins the WINNER) would disable the caps on
+		// every genuine-disagreement round.
+		if anyQuotaTag(e.config.acceptancePolicies) &&
+			!anyPolicyQuotasCovered(responses, e.config.acceptancePolicies) {
 			return
 		}
 		now := time.Now()
@@ -543,7 +550,7 @@ func (e *executor) runAnalyzer(
 		considerWaitCap(resp)
 
 		analysis = newConsensusAnalysis(e.logger, ctx, e.config, responses)
-		winner = e.determineWinner(lg, analysis)
+		winner = e.determineWinner(lg, originalReq, analysis)
 		if reason, ok := e.shouldShortCircuit(winner, analysis); ok {
 			shortCircuited = true
 			shortCircuitReason = reason
@@ -576,7 +583,7 @@ func (e *executor) runAnalyzer(
 	// final analysis and send the winner now.
 	if analysis == nil {
 		analysis = newConsensusAnalysis(e.logger, ctx, e.config, responses)
-		winner = e.determineWinner(lg, analysis)
+		winner = e.determineWinner(lg, originalReq, analysis)
 	}
 	if !shortCircuited {
 		// Short-circuit branch already marked winners; mark here only
@@ -825,10 +832,20 @@ func (e *executor) executeParticipant(
 func (e *executor) shouldShortCircuit(winner *slotResult, analysis *consensusAnalysis) (string, bool) {
 	// A composition dispute is provisional while more responses can still
 	// arrive: a later response may join the leading group (or grow another
-	// group) and satisfy the minAgreement quota. Never cancel remaining
-	// participants because of it — the final pass after collection decides.
+	// group) and satisfy a quota. Never cancel remaining participants
+	// because of it — the final pass after collection decides.
 	if winner != nil && winner.Error != nil && analysis.hasRemaining() &&
 		common.HasErrorCode(winner.Error, common.ErrCodeConsensusCompositionDispute) {
+		return "", false
+	}
+	// Same reasoning one step up the cascade: a win at a RELAXED grade is
+	// provisional while responses are outstanding, because a late vote can
+	// still complete a stricter grade. Cancelling here would serve a
+	// degraded answer that the round was about to earn honestly, making the
+	// grade depend on response timing rather than on what the upstreams
+	// actually agreed. Only the first (strictest) grade may short-circuit.
+	if winner != nil && winner.Policy != "" && analysis.hasRemaining() &&
+		!e.isStrictestPolicy(winner.Policy) {
 		return "", false
 	}
 	for _, rule := range shortCircuitRules {
@@ -883,7 +900,7 @@ func markWinningParticipants(req *common.NormalizedRequest, winner *slotResult, 
 	}
 }
 
-func (e *executor) determineWinner(lg *zerolog.Logger, analysis *consensusAnalysis) *slotResult {
+func (e *executor) determineWinner(lg *zerolog.Logger, req *common.NormalizedRequest, analysis *consensusAnalysis) *slotResult {
 	// Since we know R is *common.NormalizedResponse at runtime, we can safely work with it
 	// Evaluate rules in priority order
 	for _, rule := range consensusRules {
@@ -893,7 +910,7 @@ func (e *executor) determineWinner(lg *zerolog.Logger, analysis *consensusAnalys
 			lg.Debug().
 				Str("rule", rule.Description).
 				Msg("consensus rule matched")
-			return e.enforceWinnerComposition(lg, analysis, rule.Action(analysis))
+			return e.enforceAcceptancePolicy(lg, req, analysis, rule.Action(analysis))
 		}
 	}
 
@@ -904,12 +921,18 @@ func (e *executor) determineWinner(lg *zerolog.Logger, analysis *consensusAnalys
 	}
 }
 
-// enforceWinnerComposition applies the winner-composition quotas
-// (`requiredParticipants[].minAgreement`) to the winner produced by the
-// rules engine. This is the single enforcement point: every rule's output
-// flows through here, so no individual rule needs to be composition-aware.
+// enforceAcceptancePolicy grades the winner produced by the rules engine
+// against the ordered acceptance policies. This is the single enforcement
+// point: every rule's output flows through here, so no individual rule needs
+// to be composition-aware.
 //
-//   - Opt-in: no-op unless some entry sets minAgreement > 0.
+// The first grade the agreeing set satisfies — and that this caller is
+// authorized to be served — wins, and its name travels with the result. A
+// relaxed grade is therefore never silently indistinguishable from a strict
+// one, and ordering (strictest first) is what makes the strict grade
+// preferred rather than any runtime state.
+//
+//   - Opt-in: no-op unless at least one grade is configured.
 //   - eth_sendRawTransaction is exempt: a broadcast accepted by any node
 //     propagates network-wide, so winner composition proves nothing there
 //     (mirrors the dedicated first-success rule/short-circuit).
@@ -917,12 +940,13 @@ func (e *executor) determineWinner(lg *zerolog.Logger, analysis *consensusAnalys
 //     infrastructure-error groups pass through: they never assert data
 //     correctness, and converting one error into another would only mask
 //     the original failure.
-//   - A failing winner becomes ErrConsensusCompositionDispute. While
-//     responses are still outstanding the dispute is provisional — see the
-//     guard in shouldShortCircuit — because a later response can still
-//     complete the quota.
-func (e *executor) enforceWinnerComposition(lg *zerolog.Logger, analysis *consensusAnalysis, winner *slotResult) *slotResult {
-	if winner == nil || !anyAgreementQuota(e.config.requiredParticipants) {
+//   - When no grade matches the result becomes
+//     ErrConsensusCompositionDispute. While responses are still outstanding
+//     that dispute is provisional — see the guard in shouldShortCircuit —
+//     because a later response can still complete a quota.
+func (e *executor) enforceAcceptancePolicy(lg *zerolog.Logger, req *common.NormalizedRequest, analysis *consensusAnalysis, winner *slotResult) *slotResult {
+	policies := e.config.acceptancePolicies
+	if winner == nil || len(policies) == 0 {
 		return winner
 	}
 	if analysis.method == "eth_sendRawTransaction" {
@@ -932,51 +956,92 @@ func (e *executor) enforceWinnerComposition(lg *zerolog.Logger, analysis *consen
 	if g == nil || g.ResponseType == ResponseTypeInfrastructureError {
 		return winner
 	}
-	if resultsSatisfyAgreementQuotas(e.agreeingResults(analysis, g), e.config.requiredParticipants) {
-		return winner
-	}
-	// A quota tag matching zero participants in the ENTIRE round (not just
-	// the winning group) means the config is structurally unable to ever
-	// satisfy the quota right now — a typo'd tag or every tagged upstream
-	// down. That is an outage, not a routine dispute: escalate to Warn so
-	// operators see it without debug logging. Only when the round is
-	// complete (nothing can still arrive): this gate also runs on every
-	// mid-collection analysis, where a slower tagged upstream simply hasn't
-	// answered yet — warning there would fire on every healthy
-	// mixed-latency round.
-	for _, req := range e.config.requiredParticipants {
-		if req == nil || req.MinAgreement <= 0 {
+
+	agreeing := e.agreeingResults(analysis, g)
+	user := req.User()
+	var withheld []string
+	for _, p := range policies {
+		if !p.satisfiedBy(agreeing) {
 			continue
 		}
-		matchedAnywhere := false
-		for _, og := range analysis.groups {
-			for _, r := range og.Results {
-				if r != nil && r.Upstream != nil && upstreamMatchesTag(r.Upstream, req.Tag) {
-					matchedAnywhere = true
-					break
-				}
-			}
-			if matchedAnywhere {
-				break
-			}
+		// The round resolves at this grade. Whether THIS caller may receive
+		// it is a separate, authorization question: an unauthorized caller
+		// gets a dispute rather than a lower-graded answer, and evaluation
+		// stops here either way — a caller must never be served a grade
+		// weaker than the one the round actually achieved.
+		if !user.MayBeServedConsensusPolicy(p.name) {
+			withheld = append(withheld, p.name)
+			break
 		}
-		if !matchedAnywhere && !analysis.hasRemaining() {
-			lg.Warn().
-				Str("tag", req.Tag).
-				Int("minAgreement", req.MinAgreement).
-				Msg("minAgreement quota tag matched ZERO participants this round — check for a typo'd tag or unavailable tagged upstreams; consensus cannot succeed while this persists")
+		winner.Policy = p.name
+		return winner
+	}
+
+	e.warnOnStructurallyUnsatisfiableQuotas(lg, analysis, policies)
+
+	if len(withheld) > 0 {
+		lg.Debug().
+			Strs("withheldPolicies", withheld).
+			Msg("consensus resolved at an acceptance grade this caller is not authorized to receive")
+		return &slotResult{
+			Error: common.NewErrConsensusCompositionDispute(
+				fmt.Sprintf("consensus resolved under acceptance policy %q, which this caller is not authorized to be served", withheld[0]),
+				analysis.participants(),
+				nil,
+			),
 		}
 	}
+
 	lg.Debug().
 		Str("hash", g.Hash).
 		Int("count", g.Count).
-		Msg("winning group does not satisfy minAgreement composition quotas")
+		Msg("agreeing upstreams do not satisfy any configured acceptance policy")
 	return &slotResult{
 		Error: common.NewErrConsensusCompositionDispute(
-			"winning group does not satisfy requiredParticipants minAgreement quotas",
+			"agreeing upstreams do not satisfy any configured acceptance policy",
 			analysis.participants(),
 			nil,
 		),
+	}
+}
+
+// warnOnStructurallyUnsatisfiableQuotas escalates the case where a quota tag
+// matched ZERO participants in the ENTIRE round (not just the winning group):
+// a typo'd tag or every tagged upstream down means the grade cannot be
+// satisfied at all right now. That is an outage, not a routine dispute, so it
+// deserves Warn rather than debug-only visibility. Only reported once the
+// round is complete — this gate also runs on every mid-collection analysis,
+// where a slower tagged upstream simply has not answered yet, and warning
+// there would fire on every healthy mixed-latency round.
+func (e *executor) warnOnStructurallyUnsatisfiableQuotas(lg *zerolog.Logger, analysis *consensusAnalysis, policies []*acceptancePolicy) {
+	if analysis.hasRemaining() {
+		return
+	}
+	for _, p := range policies {
+		for _, q := range p.quotas {
+			if q == nil || q.MinAgreement <= 0 {
+				continue
+			}
+			matchedAnywhere := false
+			for _, og := range analysis.groups {
+				for _, r := range og.Results {
+					if r != nil && r.Upstream != nil && upstreamMatchesTag(r.Upstream, q.Tag) {
+						matchedAnywhere = true
+						break
+					}
+				}
+				if matchedAnywhere {
+					break
+				}
+			}
+			if !matchedAnywhere {
+				lg.Warn().
+					Str("policy", p.name).
+					Str("tag", q.Tag).
+					Int("minAgreement", q.MinAgreement).
+					Msg("acceptance policy quota tag matched ZERO participants this round — check for a typo'd tag or unavailable tagged upstreams; this grade cannot be satisfied while this persists")
+			}
+		}
 	}
 }
 
@@ -1586,6 +1651,13 @@ func (e *executor) recordMetricsAndTracing(req *common.NormalizedRequest, startT
 		common.SetTraceSpanError(span, result.Error)
 	} else {
 		span.SetStatus(codes.Ok, "Consensus successful")
+	}
+
+	if result != nil && result.Policy != "" {
+		telemetry.MetricConsensusPolicyServed.
+			WithLabelValues(labels.projectId, labels.networkId, labels.category, result.Policy, labels.userId, labels.agentName).
+			Inc()
+		span.SetAttributes(attribute.String("consensus.policy", result.Policy))
 	}
 
 	span.SetAttributes(

--- a/consensus/executor_race_test.go
+++ b/consensus/executor_race_test.go
@@ -540,7 +540,7 @@ func TestRace_TwoParticipants_OneInfraError_CorrectlyLowParticipants(t *testing.
 		"validParticipants=1 < threshold=2 is low-participants")
 
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	winner := e.determineWinner(&lg, analysis)
+	winner := e.determineWinner(&lg, nil, analysis)
 
 	require.NotNil(t, winner)
 	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusLowParticipants),
@@ -686,7 +686,7 @@ func TestRace_AllParticipantsReturnNil_LowParticipants(t *testing.T) {
 	}
 
 	e := &executor{consensusPolicy: &consensusPolicy{logger: &lg, config: cfg}}
-	winner := e.determineWinner(&lg, analysis)
+	winner := e.determineWinner(&lg, nil, analysis)
 
 	require.NotNil(t, winner)
 	assert.True(t, common.HasErrorCode(winner.Error, common.ErrCodeConsensusLowParticipants),

--- a/consensus/policy.go
+++ b/consensus/policy.go
@@ -28,6 +28,14 @@ type config struct {
 	maxWaitOnResult         *common.AdaptiveDuration
 	maxWaitOnEmpty          *common.AdaptiveDuration
 	requiredParticipants    []*common.ConsensusRequiredParticipant
+	// acceptancePolicyConfigs are the acceptance grades as configured;
+	// compile() turns them (or the requiredParticipants shorthand) into
+	// acceptancePolicies.
+	acceptancePolicyConfigs []*common.ConsensusAcceptancePolicy
+	// acceptancePolicies are the ordered acceptance grades in evaluation
+	// order. Nil = no composition requirement (gate is a no-op). Derived —
+	// always produced by compile(), never set directly.
+	acceptancePolicies []*acceptancePolicy
 }
 
 // builder is the internal builder used by NewConsensus.
@@ -107,9 +115,17 @@ func (b *builder) WithRequiredParticipants(v []*common.ConsensusRequiredParticip
 	return b
 }
 
+// WithAcceptancePolicies stores the raw acceptance grades. They are compiled
+// into evaluation order by config.compile().
+func (b *builder) WithAcceptancePolicies(v []*common.ConsensusAcceptancePolicy) *builder {
+	b.cfg.acceptancePolicyConfigs = v
+	return b
+}
+
 // build snapshots the config and constructs the runtime consensus policy.
 func (b *builder) build() *consensusPolicy {
 	hCopy := b.cfg
+	hCopy.compile()
 	log := hCopy.logger.With().Str("component", "consensus").Logger()
 
 	disputeLevel := hCopy.disputeLogLevel

--- a/consensus/quota.go
+++ b/consensus/quota.go
@@ -193,8 +193,19 @@ func buildAcceptancePolicies(
 	if !anyAgreementQuota(required) {
 		return nil
 	}
-	// Shorthand: one implicit grade carrying the minAgreement quotas, gated
-	// by the policy-level threshold exactly as before named grades existed.
+	// Shorthand: one implicit grade carrying the minAgreement quotas.
+	//
+	// threshold 0 (no count gate of its own) is deliberate and load-bearing
+	// for backward compatibility. Before named grades existed this gate
+	// checked WHO was in the winning group and nothing else — whether enough
+	// upstreams agreed was, and remains, the rules engine's decision. Under
+	// acceptMostCommonValidResult (and the block-head-leader behaviors) the
+	// rules engine deliberately elects a winner below agreementThreshold;
+	// re-checking the count here would turn those rounds into composition
+	// disputes for configs that have been running fine.
+	//
+	// Explicitly configured grades DO carry a threshold: a cascade needs to
+	// tell grades apart by count, and that config is opt-in.
 	quotas := make([]*common.ConsensusAgreementQuota, 0, len(required))
 	for _, rp := range required {
 		if rp == nil || rp.MinAgreement <= 0 {
@@ -204,7 +215,7 @@ func buildAcceptancePolicies(
 	}
 	return []*acceptancePolicy{{
 		name:      defaultAcceptancePolicyName,
-		threshold: agreementThreshold,
+		threshold: 0,
 		quotas:    quotas,
 	}}
 }

--- a/consensus/quota.go
+++ b/consensus/quota.go
@@ -112,42 +112,204 @@ func anyAgreementQuota(reqs []*common.ConsensusRequiredParticipant) bool {
 	return false
 }
 
-// resultsSatisfyAgreementQuotas reports whether the result set satisfies
-// every minAgreement entry: for each entry, at least minAgreement DISTINCT
-// upstreams must match the entry's tag. Distinctness is enforced here (not
-// assumed from dedupeByUpstream) because the wait-cap arming path passes the
-// raw pre-dedup response slice — a single tagged upstream answering twice
-// via hedge/retry must not satisfy a minAgreement of 2 by itself. Takes a
-// result slice (not a group) because the agreeing set can span multiple
-// hash groups — preferHighestValueFor counts agreement by numeric value,
-// and the same value with different encodings lands in different groups.
-func resultsSatisfyAgreementQuotas(results []*execResult, reqs []*common.ConsensusRequiredParticipant) bool {
-	for _, req := range reqs {
-		if req == nil || req.MinAgreement <= 0 {
+// anyPolicyQuotasCovered reports whether the collected results already cover
+// the tag quotas of at least one configured grade — i.e. some grade could
+// still be satisfied by what has arrived. Used by the wait-cap arming path,
+// which passes the RAW pre-dedup slice, so distinctness is enforced inside
+// resultsSatisfyQuotas rather than assumed.
+func anyPolicyQuotasCovered(results []*execResult, policies []*acceptancePolicy) bool {
+	for _, p := range policies {
+		if p != nil && resultsSatisfyQuotas(results, p.quotas) {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultAcceptancePolicyName is the grade reported when composition is
+// configured through the single-grade shorthand
+// (`requiredParticipants[].minAgreement`) rather than a named list.
+const defaultAcceptancePolicyName = "standard"
+
+// acceptancePolicy is the normalized runtime form of one acceptance grade.
+// Both config shapes — the ordered `acceptancePolicies` list and the
+// single-grade `requiredParticipants[].minAgreement` shorthand — are compiled
+// into this, so the executor has exactly one code path.
+type acceptancePolicy struct {
+	name string
+	// threshold is the number of DISTINCT agreeing upstreams this grade
+	// requires, already resolved (explicit > sum of quotas > policy-level).
+	threshold int
+	quotas    []*common.ConsensusAgreementQuota
+}
+
+// compile derives the ordered acceptance grades from whichever config shape
+// the operator used, and lowers the rules-engine threshold to the least
+// demanding grade.
+//
+// Keeping this on config (rather than in the builder) means derived state is
+// produced in exactly one place: any code path holding a config gets the same
+// grades, and the compiled list can never drift from the requiredParticipants
+// it was derived from. Idempotent.
+//
+// On the threshold: the rules engine only NOMINATES a candidate winner; each
+// grade's own threshold is enforced by the acceptance gate. Running the rules
+// at the lowest bar is what makes a relaxed grade reachable on a round too
+// thin for the strict grade to ever win — the case where internal nodes are
+// absent and only a couple of externals answered — without ever serving a
+// result below the bar of the grade it is served under.
+func (c *config) compile() {
+	if c == nil || c.acceptancePolicies != nil {
+		return
+	}
+	c.acceptancePolicies = buildAcceptancePolicies(c.acceptancePolicyConfigs, c.requiredParticipants, c.agreementThreshold)
+	if lowest := lowestAcceptanceThreshold(c.acceptancePolicies); lowest > 0 && lowest < c.agreementThreshold {
+		c.agreementThreshold = lowest
+	}
+}
+
+// buildAcceptancePolicies compiles the configured grades into evaluation
+// order. Returns nil when no composition requirement is configured at all,
+// which leaves the gate a no-op — the feature stays opt-in.
+func buildAcceptancePolicies(
+	policies []*common.ConsensusAcceptancePolicy,
+	required []*common.ConsensusRequiredParticipant,
+	agreementThreshold int,
+) []*acceptancePolicy {
+	if len(policies) > 0 {
+		out := make([]*acceptancePolicy, 0, len(policies))
+		for _, p := range policies {
+			if p == nil {
+				continue
+			}
+			out = append(out, &acceptancePolicy{
+				name:      p.Name,
+				threshold: p.EffectiveAgreementThreshold(agreementThreshold),
+				quotas:    p.RequiredAgreement,
+			})
+		}
+		return out
+	}
+	if !anyAgreementQuota(required) {
+		return nil
+	}
+	// Shorthand: one implicit grade carrying the minAgreement quotas, gated
+	// by the policy-level threshold exactly as before named grades existed.
+	quotas := make([]*common.ConsensusAgreementQuota, 0, len(required))
+	for _, rp := range required {
+		if rp == nil || rp.MinAgreement <= 0 {
+			continue
+		}
+		quotas = append(quotas, &common.ConsensusAgreementQuota{Tag: rp.Tag, MinAgreement: rp.MinAgreement})
+	}
+	return []*acceptancePolicy{{
+		name:      defaultAcceptancePolicyName,
+		threshold: agreementThreshold,
+		quotas:    quotas,
+	}}
+}
+
+// lowestAcceptanceThreshold is the smallest agreement count any configured
+// grade would accept. Zero when no grade is configured, leaving the caller's
+// policy-level threshold untouched.
+func lowestAcceptanceThreshold(policies []*acceptancePolicy) int {
+	lowest := 0
+	for _, p := range policies {
+		if p == nil || p.threshold <= 0 {
+			continue
+		}
+		if lowest == 0 || p.threshold < lowest {
+			lowest = p.threshold
+		}
+	}
+	return lowest
+}
+
+// distinctUpstreams counts unique upstream IDs in a result set. The agreeing
+// set can contain the same upstream twice (hedge/retry duplicates survive on
+// the raw pre-dedup path), and a node corroborating itself must not count as
+// two votes toward any threshold.
+func distinctUpstreams(results []*execResult) int {
+	var seen map[string]struct{}
+	n := 0
+	for _, r := range results {
+		if r == nil || r.Upstream == nil {
+			continue
+		}
+		id := r.Upstream.Id()
+		if seen == nil {
+			seen = make(map[string]struct{}, len(results))
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		n++
+	}
+	return n
+}
+
+// satisfiedBy reports whether an agreeing set meets this grade: enough
+// distinct upstreams overall, and enough distinct upstreams per tag quota.
+func (p *acceptancePolicy) satisfiedBy(agreeing []*execResult) bool {
+	if p == nil {
+		return false
+	}
+	if p.threshold > 0 && distinctUpstreams(agreeing) < p.threshold {
+		return false
+	}
+	return resultsSatisfyQuotas(agreeing, p.quotas)
+}
+
+// resultsSatisfyQuotas reports whether the result set contains at least
+// MinAgreement DISTINCT upstreams matching each quota's tag.
+func resultsSatisfyQuotas(results []*execResult, quotas []*common.ConsensusAgreementQuota) bool {
+	for _, q := range quotas {
+		if q == nil || q.MinAgreement <= 0 {
 			continue
 		}
 		matched := 0
 		var seen map[string]struct{}
 		for _, r := range results {
-			if r == nil || r.Upstream == nil || !upstreamMatchesTag(r.Upstream, req.Tag) {
+			if r == nil || r.Upstream == nil || !upstreamMatchesTag(r.Upstream, q.Tag) {
 				continue
 			}
 			id := r.Upstream.Id()
 			if seen == nil {
-				seen = make(map[string]struct{}, req.MinAgreement)
+				seen = make(map[string]struct{}, q.MinAgreement)
 			}
 			if _, dup := seen[id]; dup {
 				continue
 			}
 			seen[id] = struct{}{}
 			matched++
-			if matched >= req.MinAgreement {
+			if matched >= q.MinAgreement {
 				break
 			}
 		}
-		if matched < req.MinAgreement {
+		if matched < q.MinAgreement {
 			return false
 		}
 	}
 	return true
+}
+
+// anyQuotaTag reports whether any configured grade constrains composition at
+// all. A pure count-only cascade needs no tag-coverage handling in the
+// wait-cap path.
+func anyQuotaTag(policies []*acceptancePolicy) bool {
+	for _, p := range policies {
+		if p != nil && len(p.quotas) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// isStrictestPolicy reports whether name is the first configured grade —
+// the one no other grade is preferred over. Only a win at this grade is
+// final while responses are still outstanding.
+func (e *executor) isStrictestPolicy(name string) bool {
+	policies := e.config.acceptancePolicies
+	return len(policies) == 0 || policies[0].name == name
 }

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -13,4 +13,9 @@ import (
 type slotResult struct {
 	Result *common.NormalizedResponse
 	Error  error
+	// Policy is the name of the acceptance grade the round resolved under,
+	// empty when no acceptance policy is configured. Carried on the result
+	// so the short-circuit guard can prefer a stricter grade that is still
+	// achievable, and so the served grade can be reported to the caller.
+	Policy string
 }

--- a/docs/pages/config/failsafe/consensus.mdx
+++ b/docs/pages/config/failsafe/consensus.mdx
@@ -154,10 +154,18 @@ consensus:
 
 auth:
   strategies:
-    - type: jwt              # settlement services: strict grade only
-      consensusPolicies: ["standard"]
-    - type: jwt              # indexers: may accept the relaxed grade
-      consensusPolicies: ["standard", "degraded"]
+    # ONE strategy per identity provider. Grades come from the role claim the
+    # deployment already uses, unioned across every role the caller holds —
+    # cloning this block per role would duplicate the JWKS config and make a
+    # multi-role caller's grade depend on strategy order.
+    - type: jwt
+      consensusPolicies: ["standard"]        # baseline for every caller here
+      jwt:
+        claimMatchers:
+          roles: ["erpc:all"]                # who may authenticate at all
+        consensusPoliciesByClaim:
+          roles:
+            "erpc:consensus-fallback": ["degraded"]
 ```
 
 Alert on `rate(erpc_consensus_policy_served_total{policy="degraded"}[5m]) > 0` to be paged on the first relaxed round, rather than after a failure-rate window has accumulated.
@@ -238,6 +246,7 @@ All fields under `networks[].failsafe[].consensus.` (or project-level `failsafe[
 | `acceptancePolicies[].agreementThreshold` | int | `sum(requiredAgreement[].minAgreement)`, else the policy-level `agreementThreshold` | Distinct agreeing upstreams this grade requires. A relaxed grade normally wants a lower value than the strict one — that is what lets it resolve a round too thin for the strict grade to ever win (e.g. only 2 externals answered while the internal node is down). Cannot be lower than the sum of its own quotas. The rules engine runs at the LOWEST configured grade's threshold so such a round still nominates a candidate; each grade's own threshold is then enforced by the acceptance gate, so nothing is ever served below the bar of the grade it is served under. |
 | `acceptancePolicies[].requiredAgreement` | `[]*ConsensusAgreementQuota` | `[]` | `{tag, minAgreement}` entries constraining WHO must be among the agreeing upstreams. Empty = a pure count grade. Distinctness is enforced: one upstream answering twice via hedge cannot satisfy `minAgreement: 2`. |
 | `auth.strategies[].consensusPolicies` | `[]string` | `nil` (unrestricted) | Allowlist of grade names this strategy's callers may be served. A round resolving at a grade the caller may not receive is withheld as `ErrConsensusCompositionDispute` — never downgraded to a weaker grade. Unset = any grade; empty list = none. Travels on the authenticated `User`, so `trustUserIdHeader` can never widen it. |
+| `auth.strategies[].jwt.consensusPoliciesByClaim` | `map[string]map[string][]string` | `nil` | Grants grades from the caller's own claims — `claim -> value -> grades` — so ONE strategy serves every role of an identity provider instead of being cloned per role. Grants are additive and unioned across every matching value on top of the strategy-level `consensusPolicies` baseline, so a caller holding several roles gets the union of their grades regardless of ordering. Cloning strategies instead would duplicate the JWKS config and, because strategies resolve first-match-wins, make a multi-role caller's grade depend on config order. No negative grants: keep in the baseline only what every caller of the strategy may receive. Configured but no value matched = permits nothing (distinct from unset, which is unrestricted). |
 | `punishMisbehavior` | \*PunishMisbehaviorConfig | `nil` (disabled) | Enables cordon punishment for persistent misbehavior. |
 | `punishMisbehavior.disputeThreshold` | uint | **Required** &gt;0 | Token bucket capacity per `disputeWindow`. No `SetDefaults` entry — must be explicitly set; omitting is a startup validation error. |
 | `punishMisbehavior.disputeWindow` | Duration | **Required** &gt;0 | Token bucket window. Validated at startup AND guarded at runtime: `<= 0` silently disables punishment with a debug log. |

--- a/docs/pages/config/failsafe/consensus.mdx
+++ b/docs/pages/config/failsafe/consensus.mdx
@@ -132,6 +132,36 @@ https://docs.erpc.cloud/config/failsafe/consensus.llms.txt`}
 
 **Collection and analysis loop.** The `runAnalyzer` goroutine reads responses from a buffered channel. After each response it calls `newConsensusAnalysis` (classify, hash, deduplicate by upstream, group) and `determineWinner` (apply 24 priority-ordered rules). Responses are deduplicated by upstream ID before grouping — hedge/retry can reselect an upstream that already answered for another slot, and one node must not vote twice toward `agreementThreshold`; the best-ranked response per upstream keeps the vote (valid result &gt; consensus-valid error &gt; infrastructure error). If `shouldShortCircuit` returns true, the outcome is sent immediately and remaining requests are cancelled (or left running in fire-and-forget mode). After all participants respond — or a wait-cap deadline fires — the final outcome is sent to the caller's select.
 
+**Acceptance grading.** Every rule's winner flows through one gate, `enforceAcceptancePolicy`, before it is returned. When `acceptancePolicies` (or the `requiredParticipants[].minAgreement` shorthand) is configured, the gate walks the grades in order and serves the round under the first one whose threshold AND tag quotas the agreeing upstreams satisfy, stamping that grade name onto the result. Nothing here is stateful: the grade is a pure function of the votes in THIS round, so recovery needs no probe traffic or breaker reset — the moment a strict-grade vote arrives, the strict grade evaluates first again. Two properties keep the ordering honest: a win at any non-first grade is provisional while responses are outstanding (short-circuit is suppressed, exactly like a provisional composition dispute), so a relaxed answer is never served merely because a strict vote was slower; and the rules engine runs at the LOWEST grade's threshold so a round too thin for the strict grade still nominates a candidate, while each grade's own threshold is re-checked at the gate. If no grade matches, the winner becomes `ErrConsensusCompositionDispute`.
+
+**Caller authorization.** Grade names are also an authorization surface: `auth.strategies[].consensusPolicies` allowlists which grades a strategy's callers may be served. When a round resolves at a grade the caller may not receive, the gate stops and returns a composition dispute rather than continuing down the list — a caller is never quietly handed a weaker grade than the round achieved. This keeps strict and relaxed callers on one endpoint, and because the allowlist travels on the authenticated `User`, `trustUserIdHeader` cannot widen it.
+
+```yaml
+# Prefer a mixed internal+external agreement; if the internal nodes are down
+# or dissenting, serve what two independent externals agree on — labelled,
+# and only to callers allowed to accept it.
+consensus:
+  maxParticipants: 5
+  agreementThreshold: 2
+  acceptancePolicies:
+    - name: standard
+      requiredAgreement:
+        - { tag: "type:internal", minAgreement: 1 }
+        - { tag: "type:external", minAgreement: 1 }
+    - name: degraded
+      requiredAgreement:
+        - { tag: "type:external", minAgreement: 2 }
+
+auth:
+  strategies:
+    - type: jwt              # settlement services: strict grade only
+      consensusPolicies: ["standard"]
+    - type: jwt              # indexers: may accept the relaxed grade
+      consensusPolicies: ["standard", "degraded"]
+```
+
+Alert on `rate(erpc_consensus_policy_served_total{policy="degraded"}[5m]) > 0` to be paged on the first relaxed round, rather than after a failure-rate window has accumulated.
+
 **Response classification.** Each response is classified into one of four types: `ResponseTypeNonEmpty` (successful non-null result), `ResponseTypeEmpty` (successful but null/empty result), `ResponseTypeConsensusError` (JSON-RPC execution exception, client exception, unsupported, or missing-data), `ResponseTypeInfrastructureError` (all other errors including `ErrUpstreamsExhausted`). Infrastructure errors are excluded from `validParticipants`. `ErrUpstreamsExhausted` is always infra even when it wraps execution exceptions via the shared `ErrorsByUpstream` map. (<SourceLink file="consensus/analysis.go" lines="333-344" />) Specific error-code mappings: `ErrCodeEndpointExecutionException` (EVM revert, code 3) → `ConsensusError`; `ErrCodeEndpointClientSideException`, `ErrCodeEndpointUnsupported`, `ErrCodeEndpointMissingData` → `ConsensusError`; all other errors (timeout, network, server 500) → `InfrastructureError`; nil JSON-RPC response on a successful response object → `InfrastructureError` with hash `"error:generic"`. A successful response where `IsResultEmptyish` returns true → `ResponseTypeEmpty`.
 
 **Hashing.** Non-error responses are hashed via `JsonRpcResponse.CanonicalHash()` or `CanonicalHashWithIgnoredFields(fields)` when `ignoreFields` is configured for the method. Errors are hashed via `errorToConsensusHash`: JSON-RPC exceptions hash as `"jsonrpc:<normalized_code>"`; standard errors hash as their code; unknown errors hash as `"error:generic"`. Within each hash group, `LargestResult` tracks the member with the highest `CachedResponseSize`; the winner returns `group.LargestResult`, not the first response. (<SourceLink file="consensus/analysis.go" lines="102-117" />)
@@ -203,6 +233,11 @@ All fields under `networks[].failsafe[].consensus.` (or project-level `failsafe[
 | `requiredParticipants[].tag` | string | **Required** | Glob pattern matched against `upstream.tags[]`. Empty tag is a startup validation error. |
 | `requiredParticipants[].minParticipants` | int | **Required; no default** | Must be &gt; 0 and ≤ `maxParticipants`. Omitting or setting 0 is a startup validation error — not a silent no-op. |
 | `requiredParticipants[].minAgreement` | int | `0` (disabled) | Minimum matching upstreams that must be in the **winning** group. Unlike `minParticipants` (best-effort pool quota), this is hard-enforced: a count-winner that fails it becomes `ErrConsensusCompositionDispute` (`dispute_composition` outcome), regardless of `disputeBehavior`. Must be ≤ `minParticipants`. While responses are outstanding the dispute is provisional — short-circuit is suppressed so a late response can still complete the quota. `eth_sendRawTransaction` is exempt. The wait caps (`maxWaitOnResult`/`maxWaitOnEmpty`) are quota-aware: they start counting down only once collected responses cover every `minAgreement` tag (a tagged upstream's error counts as coverage), so fast correlated upstreams cannot time out a slower quota-tagged upstream; until coverage the round is bounded by per-upstream and request timeouts. A quota tag matching zero participants in a round logs at Warn — check for a typo'd tag or unavailable tagged upstreams. |
+| `acceptancePolicies` | `[]*ConsensusAcceptancePolicy` | `[]` (disabled) | ORDERED list of named acceptance grades, evaluated top-down; the first grade the agreeing upstreams satisfy is the one the round is served under, and its name is returned in `X-ERPC-Consensus-Policy` and counted in `erpc_consensus_policy_served_total{policy}`. When no grade matches, the round is `ErrConsensusCompositionDispute`. Mutually exclusive with `requiredParticipants[].minAgreement` (the single-grade shorthand, reported as the grade `standard`); configuring both is a startup validation error. Ordering is the whole mechanism — a grade that an earlier grade already subsumes is rejected at startup as unreachable, so grades must be listed strictest first. |
+| `acceptancePolicies[].name` | string | **Required** | Grade name, reported to callers and referenced by `auth.strategies[].consensusPolicies`. Must be unique. Operator-facing contract — keep it stable. |
+| `acceptancePolicies[].agreementThreshold` | int | `sum(requiredAgreement[].minAgreement)`, else the policy-level `agreementThreshold` | Distinct agreeing upstreams this grade requires. A relaxed grade normally wants a lower value than the strict one — that is what lets it resolve a round too thin for the strict grade to ever win (e.g. only 2 externals answered while the internal node is down). Cannot be lower than the sum of its own quotas. The rules engine runs at the LOWEST configured grade's threshold so such a round still nominates a candidate; each grade's own threshold is then enforced by the acceptance gate, so nothing is ever served below the bar of the grade it is served under. |
+| `acceptancePolicies[].requiredAgreement` | `[]*ConsensusAgreementQuota` | `[]` | `{tag, minAgreement}` entries constraining WHO must be among the agreeing upstreams. Empty = a pure count grade. Distinctness is enforced: one upstream answering twice via hedge cannot satisfy `minAgreement: 2`. |
+| `auth.strategies[].consensusPolicies` | `[]string` | `nil` (unrestricted) | Allowlist of grade names this strategy's callers may be served. A round resolving at a grade the caller may not receive is withheld as `ErrConsensusCompositionDispute` — never downgraded to a weaker grade. Unset = any grade; empty list = none. Travels on the authenticated `User`, so `trustUserIdHeader` can never widen it. |
 | `punishMisbehavior` | \*PunishMisbehaviorConfig | `nil` (disabled) | Enables cordon punishment for persistent misbehavior. |
 | `punishMisbehavior.disputeThreshold` | uint | **Required** &gt;0 | Token bucket capacity per `disputeWindow`. No `SetDefaults` entry — must be explicitly set; omitting is a startup validation error. |
 | `punishMisbehavior.disputeWindow` | Duration | **Required** &gt;0 | Token bucket window. Validated at startup AND guarded at runtime: `<= 0` silently disables punishment with a debug log. |

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1239,6 +1239,12 @@ func writeCounterHeaders(st *common.ExecState, w http.ResponseWriter) {
 	if snap.ConsensusLowParticipants > 0 {
 		setInt(w, "X-ERPC-Consensus-Low-Participants", snap.ConsensusLowParticipants)
 	}
+	// The acceptance grade is emitted whenever consensus graded the round,
+	// including on the error paths, so a caller can always tell a strict
+	// answer from a relaxed one without inspecting logs or metrics.
+	if snap.ConsensusPolicy != "" {
+		w.Header().Set("X-ERPC-Consensus-Policy", snap.ConsensusPolicy)
+	}
 }
 
 // writeResponseMetadataHeaders emits X-ERPC-Cache, X-ERPC-Upstream,

--- a/erpc/http_server_consensus_policy_test.go
+++ b/erpc/http_server_consensus_policy_test.go
@@ -1,0 +1,281 @@
+package erpc
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/internal/policy"
+	"github.com/erpc/erpc/util"
+	"github.com/h2non/gock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	consensusPolicySettlementToken = "settlement-token"
+	consensusPolicyIndexerToken    = "indexer-token"
+)
+
+// consensusPolicyYAML is the operator-facing shape of the feature, loaded
+// through the real config loader so the YAML keys themselves are covered —
+// a Go-struct-only test would pass even if a `yaml:` tag were wrong.
+//
+// The deployment: one internal node and two external providers. Callers
+// prefer an answer both kinds of node agree on, but rather than hard-fail
+// when the internal node is absent or wrong, an answer two independent
+// externals agree on is served — labelled `degraded`, and only to callers
+// whose role permits it.
+const consensusPolicyYAML = `
+logLevel: warn
+server:
+  maxTimeout: 10s
+projects:
+  - id: test_project
+    auth:
+      strategies:
+        - type: secret
+          consensusPolicies: ["standard"]
+          secret:
+            id: settlement
+            value: settlement-token
+        - type: secret
+          consensusPolicies: ["standard", "degraded"]
+          secret:
+            id: indexer
+            value: indexer-token
+    networks:
+      - architecture: evm
+        evm:
+          chainId: 123
+        failsafe:
+          - consensus:
+              maxParticipants: 3
+              agreementThreshold: 2
+              punishMisbehavior: null
+              # Generous caps so the assertions describe grading, not a race
+              # with the default ~5ms straggler cap.
+              maxWaitOnResult: 3s
+              maxWaitOnEmpty: 3s
+              acceptancePolicies:
+                - name: standard
+                  requiredAgreement:
+                    - tag: "type:internal"
+                      minAgreement: 1
+                    - tag: "type:external"
+                      minAgreement: 1
+                - name: degraded
+                  requiredAgreement:
+                    - tag: "type:external"
+                      minAgreement: 2
+    upstreams:
+      - id: internal1
+        type: evm
+        endpoint: http://rpc1.localhost
+        tags: ["type:internal"]
+        evm:
+          chainId: 123
+        jsonRpc:
+          supportsBatch: false
+      - id: external1
+        type: evm
+        endpoint: http://rpc2.localhost
+        tags: ["type:external"]
+        evm:
+          chainId: 123
+        jsonRpc:
+          supportsBatch: false
+      - id: external2
+        type: evm
+        endpoint: http://rpc3.localhost
+        tags: ["type:external"]
+        evm:
+          chainId: 123
+        jsonRpc:
+          supportsBatch: false
+rateLimiters: {}
+`
+
+// startConsensusPolicyServer boots the server from the YAML above and pins a
+// deterministic upstream order, so every consensus round draws all three
+// nodes instead of racing the selection policy's background evaluation.
+func startConsensusPolicyServer(t *testing.T) (
+	func(body string, headers map[string]string, queryParams map[string]string) (int, map[string]string, string),
+	func(),
+) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "erpc.yaml", []byte(consensusPolicyYAML), 0o644))
+	cfg, err := common.LoadConfig(fs, "erpc.yaml", &common.DefaultOptions{})
+	require.NoError(t, err, "the documented YAML shape must load and validate")
+
+	sendRequest, _, _, shutdown, erpcInstance := createServerTestFixtures(cfg, t)
+	prj, err := erpcInstance.GetProject("test_project")
+	require.NoError(t, err)
+	policy.OverrideAllForTest(prj.policyEngine, "internal1", "external1", "external2")
+	return sendRequest, shutdown
+}
+
+// mockConsensusUpstream persists a canned eth_getBlockNumber result for one
+// upstream. Persisted because consensus fans out and the state poller probes
+// independently; single-use mocks would race.
+func mockConsensusUpstream(host, result string) {
+	gock.New("http://" + host + ".localhost").
+		Post("/").
+		Persist().
+		Filter(func(request *http.Request) bool {
+			return strings.Contains(util.SafeReadBody(request), "eth_getBlockNumber")
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": result})
+}
+
+// TestHttpServer_ConsensusAcceptancePolicies drives the whole path — YAML
+// load, auth, consensus fan-out, acceptance grading, header emission — for
+// the two situations that motivated the feature.
+func TestHttpServer_ConsensusAcceptancePolicies(t *testing.T) {
+	const body = `{"jsonrpc":"2.0","method":"eth_getBlockNumber","params":[],"id":1}`
+
+	// The happy path: all three nodes agree, so the strict grade is met and
+	// even the strictest caller is served normally.
+	t.Run("StrictGradeWhenInternalAgrees", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		mockConsensusUpstream("rpc1", "0xaaaaaa")
+		mockConsensusUpstream("rpc2", "0xaaaaaa")
+		mockConsensusUpstream("rpc3", "0xaaaaaa")
+
+		sendRequest, shutdown := startConsensusPolicyServer(t)
+		defer shutdown()
+
+		status, headers, respBody := sendRequest(body, map[string]string{
+			"X-ERPC-Secret-Token": consensusPolicySettlementToken,
+		}, nil)
+
+		require.Equal(t, http.StatusOK, status)
+		assert.Contains(t, respBody, "0xaaaaaa")
+		assert.Equal(t, "standard", headers["X-Erpc-Consensus-Policy"],
+			"a mixed internal+external agreement must be served and labelled as the strict grade")
+	})
+
+	// The case André raised: the internal node is UP but serving forked
+	// data while the two externals agree. A dispute-rate circuit breaker
+	// cannot tell this apart from the internal node being down; here it is
+	// decided from the votes of this single round.
+	t.Run("RelaxedGradeWhenInternalDissents", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		mockConsensusUpstream("rpc1", "0xbbbbbb") // forked: same payload size, so this tests grading not preferLargerResponses
+		mockConsensusUpstream("rpc2", "0xaaaaaa")
+		mockConsensusUpstream("rpc3", "0xaaaaaa")
+
+		sendRequest, shutdown := startConsensusPolicyServer(t)
+		defer shutdown()
+
+		// A caller whose role permits the relaxed grade is served, and can
+		// see from the header that the answer is relaxed.
+		t.Run("AllowedCallerIsServedAndLabelled", func(t *testing.T) {
+			status, headers, respBody := sendRequest(body, map[string]string{
+				"X-ERPC-Secret-Token": consensusPolicyIndexerToken,
+			}, nil)
+
+			require.Equal(t, http.StatusOK, status)
+			assert.Contains(t, respBody, "0xaaaaaa",
+				"two agreeing externals must resolve the round")
+			assert.Equal(t, "degraded", headers["X-Erpc-Consensus-Policy"],
+				"the relaxed answer must be labelled, never indistinguishable from a strict one")
+		})
+
+		// The same round, same votes, a stricter caller: withheld rather
+		// than downgraded. This is what removes the need for a second
+		// endpoint per policy.
+		t.Run("StrictCallerIsWithheldNotDowngraded", func(t *testing.T) {
+			_, headers, respBody := sendRequest(body, map[string]string{
+				"X-ERPC-Secret-Token": consensusPolicySettlementToken,
+			}, nil)
+
+			// erpc reports JSON-RPC level failures in the body, so the
+			// error code is the assertion that matters, not the HTTP status.
+			assert.Contains(t, respBody, "ErrConsensusCompositionDispute",
+				"a settlement-grade caller must be refused, not downgraded")
+			assert.NotContains(t, respBody, `"result"`,
+				"the relaxed answer must not leak to a caller barred from that grade")
+			assert.Empty(t, headers["X-Erpc-Consensus-Policy"],
+				"no grade was served to this caller")
+		})
+	})
+
+	// The availability case: the internal node is unreachable entirely.
+	// Recovery needs no breaker reset — the grade is recomputed per round.
+	t.Run("RelaxedGradeWhenInternalUnreachable", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		gock.New("http://rpc1.localhost").
+			Post("/").
+			Persist().
+			Filter(func(request *http.Request) bool {
+				return strings.Contains(util.SafeReadBody(request), "eth_getBlockNumber")
+			}).
+			Reply(500).
+			JSON(map[string]interface{}{"error": "internal node down"})
+		mockConsensusUpstream("rpc2", "0xaaaaaa")
+		mockConsensusUpstream("rpc3", "0xaaaaaa")
+
+		sendRequest, shutdown := startConsensusPolicyServer(t)
+		defer shutdown()
+
+		status, headers, respBody := sendRequest(body, map[string]string{
+			"X-ERPC-Secret-Token": consensusPolicyIndexerToken,
+		}, nil)
+
+		require.Equal(t, http.StatusOK, status)
+		assert.Contains(t, respBody, "0xaaaaaa")
+		assert.Equal(t, "degraded", headers["X-Erpc-Consensus-Policy"])
+	})
+}
+
+// TestHttpServer_ConsensusAcceptancePolicies_ConfigRejection covers the
+// startup guard for the ordering mistake that would silently defeat the
+// feature: listing the relaxed grade first makes the strict grade dead code,
+// so every round would be served relaxed.
+func TestHttpServer_ConsensusAcceptancePolicies_ConfigRejection(t *testing.T) {
+	invertedYAML := strings.Replace(consensusPolicyYAML, `
+              acceptancePolicies:
+                - name: standard
+                  requiredAgreement:
+                    - tag: "type:internal"
+                      minAgreement: 1
+                    - tag: "type:external"
+                      minAgreement: 1
+                - name: degraded
+                  requiredAgreement:
+                    - tag: "type:external"
+                      minAgreement: 2`, `
+              acceptancePolicies:
+                - name: degraded
+                  requiredAgreement:
+                    - tag: "type:external"
+                      minAgreement: 1
+                - name: standard
+                  requiredAgreement:
+                    - tag: "type:internal"
+                      minAgreement: 1
+                    - tag: "type:external"
+                      minAgreement: 1`, 1)
+	require.NotEqual(t, consensusPolicyYAML, invertedYAML, "replacement must have applied")
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "erpc.yaml", []byte(invertedYAML), 0o644))
+	_, err := common.LoadConfig(fs, "erpc.yaml", &common.DefaultOptions{})
+
+	require.Error(t, err, "an unreachable grade must fail startup, not serve silently")
+	assert.Contains(t, err.Error(), "unreachable")
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -828,6 +828,17 @@ var (
 		Help:      "Total number of consensus rounds that short-circuited.",
 	}, []string{"project", "network", "category", "reason", "finality", "user", "agent_name"})
 
+	// MetricConsensusPolicyServed counts consensus rounds by the acceptance
+	// grade they resolved under. Operators alert on the first round served
+	// at a relaxed grade — that is the signal that the strict composition
+	// could not be met, available immediately rather than after a rate
+	// window has accumulated.
+	MetricConsensusPolicyServed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "consensus_policy_served_total",
+		Help:      "Total number of consensus rounds served, by acceptance policy.",
+	}, []string{"project", "network", "category", "policy", "user", "agent_name"})
+
 	// MetricConsensusWaitCapped counts consensus rounds resolved early
 	// because maxWaitOnResult / maxWaitOnEmpty fired before every
 	// participant returned. High rates indicate persistently slow

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1128,6 +1128,34 @@ export interface ConsensusPolicyConfig {
    * like any other low-participation tick. Empty (default) = disabled.
    */
   requiredParticipants?: (ConsensusRequiredParticipant | undefined)[];
+  /**
+   * AcceptancePolicies is an ORDERED list of named acceptance grades.
+   * Each entry states what the winning response group must look like for
+   * the round to be served under that grade. Evaluation walks the list
+   * top-down and stops at the first policy the round satisfies; the name
+   * of that policy is reported to the caller (`X-ERPC-Consensus-Policy`)
+   * and to metrics, so a relaxed answer is never silently indistinguishable
+   * from a strict one. When no policy is satisfied the round is a
+   * composition dispute.
+   * This lets an operator express "prefer a mixed internal+external
+   * agreement, but rather than hard-failing when the internal nodes are
+   * down or dissenting, serve an answer that several independent external
+   * providers agree on — and label it":
+   * 	acceptancePolicies:
+   * 	  - name: standard
+   * 	    requiredAgreement:
+   * 	      - { tag: "type:internal", minAgreement: 1 }
+   * 	      - { tag: "type:external", minAgreement: 1 }
+   * 	  - name: degraded
+   * 	    requiredAgreement:
+   * 	      - { tag: "type:external", minAgreement: 2 }
+   * Which callers may be served which grade is an authorization concern,
+   * configured per auth strategy (`consensusPolicies`), not here.
+   * Mutually exclusive with `requiredParticipants[].minAgreement`, which
+   * is the single-grade shorthand for the same mechanism. Empty (default)
+   * = disabled.
+   */
+  acceptancePolicies?: (ConsensusAcceptancePolicy | undefined)[];
 }
 /**
  * ConsensusRequiredParticipant is one tag-quota entry for
@@ -1144,6 +1172,45 @@ export interface ConsensusRequiredParticipant {
   tag: string;
   minParticipants: number /* int */;
   minAgreement?: number /* int */;
+}
+/**
+ * ConsensusAcceptancePolicy is one named acceptance grade in
+ * `consensus.acceptancePolicies`. A round is served under this policy when
+ * the agreeing upstreams both reach `AgreementThreshold` and satisfy every
+ * `RequiredAgreement` quota.
+ */
+export interface ConsensusAcceptancePolicy {
+  /**
+   * Name identifies the grade. It is reported on the response
+   * (`X-ERPC-Consensus-Policy`) and in metrics, and is what auth
+   * strategies reference in their `consensusPolicies` allowlist, so it is
+   * an operator-facing contract — keep it stable.
+   */
+  name: string;
+  /**
+   * AgreementThreshold is the number of DISTINCT agreeing upstreams this
+   * grade requires. Defaults to the sum of its `RequiredAgreement`
+   * quotas, falling back to the policy-level `agreementThreshold` when
+   * the grade declares no quotas. A relaxed grade will usually want a
+   * lower threshold than the strict one — that is what lets it resolve a
+   * round too thin for the strict grade to ever win.
+   */
+  agreementThreshold?: number /* int */;
+  /**
+   * RequiredAgreement constrains WHO must be among the agreeing
+   * upstreams. Empty means "any upstreams" — a pure count grade.
+   */
+  requiredAgreement?: (ConsensusAgreementQuota | undefined)[];
+}
+/**
+ * ConsensusAgreementQuota requires at least `MinAgreement` DISTINCT
+ * upstreams matching `Tag` (a glob pattern, `*` / `?`, matched against each
+ * upstream's `tags`) among the agreeing set. One upstream can satisfy every
+ * quota it matches.
+ */
+export interface ConsensusAgreementQuota {
+  tag: string;
+  minAgreement: number /* int */;
 }
 export type MisbehaviorsDestinationType = string;
 export const MisbehaviorsDestinationTypeFile: MisbehaviorsDestinationType = "file";
@@ -1606,6 +1673,28 @@ export interface AuthStrategyConfig {
    * NormalizedRequest.SetUserFromTrustedHeader).
    */
   allowClientDirectives?: string;
+  /**
+   * ConsensusPolicies, if set, restricts which consensus acceptance grades
+   * (`consensus.acceptancePolicies[].name`) may be served to callers
+   * authenticated by THIS strategy. A round resolved under a policy the
+   * caller is not allowed to receive is withheld and returned as a
+   * consensus composition dispute instead.
+   * This is how "who may accept a relaxed answer" is expressed — it is an
+   * authorization decision, so it lives beside allowMethods/rateLimitBudget
+   * rather than in the consensus config, and one deployment can serve
+   * strict and relaxed callers from a single endpoint:
+   * 	- type: jwt          # settlement: strict grade only
+   * 	  consensusPolicies: ["standard"]
+   * 	- type: jwt          # indexers: may be served the relaxed grade
+   * 	  consensusPolicies: ["standard", "degraded"]
+   * Left unset (nil) the caller may be served any configured grade, so
+   * existing configs are unaffected. An empty list is meaningful and
+   * distinct from unset: it permits nothing, which disables consensus
+   * grading for that caller entirely (every round becomes a dispute).
+   * Like AllowClientDirectives this travels on the User produced by the
+   * authenticating strategy, so `trustUserIdHeader` can never widen it.
+   */
+  consensusPolicies?: string[];
   type: TsAuthType;
   network?: NetworkStrategyConfig;
   secret?: SecretStrategyConfig;
@@ -2146,6 +2235,12 @@ export interface ExecStateSnapshot {
   consensusslots: number /* int */;
   consensusdisputes: number /* int */;
   consensuslowparticipants: number /* int */;
+  /**
+   * ConsensusPolicy is the consensus acceptance grade the round was
+   * served under; empty when consensus is off or no grades are
+   * configured.
+   */
+  consensuspolicy: string;
   startedat: any /* time.Time */;
 }
 
@@ -2212,6 +2307,13 @@ export interface User {
    * override" — the project-level pattern applies.
    */
   allowclientdirectives?: string;
+  /**
+   * ConsensusPolicies is the set of consensus acceptance grades this caller
+   * may be served, granted by the strategy that authenticated them. Nil
+   * means "no strategy-level restriction" — any configured grade may be
+   * served. A non-nil empty slice permits none.
+   */
+  consensuspolicies?: string[];
 }
 
 //////////

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1752,6 +1752,31 @@ export interface JwtStrategyConfig {
    * Defaults to "rlm".
    */
   rateLimitBudgetClaimName?: string;
+  /**
+   * ConsensusPoliciesByClaim grants consensus acceptance grades based on the
+   * caller's own claims, so one strategy can serve every role of an identity
+   * provider instead of being cloned per role (which would duplicate the
+   * JWKS/issuer config, run one refresher per copy, and — because strategies
+   * resolve first-match-wins — make the grade of a multi-role token depend on
+   * config order rather than on its roles).
+   * Shape is claim name -> claim value -> granted grades:
+   * 	consensusPolicies: ["standard"]        # baseline, on the strategy
+   * 	jwt:
+   * 	  claimMatchers:
+   * 	    roles: ["erpc:all"]                # who may authenticate at all
+   * 	  consensusPoliciesByClaim:
+   * 	    roles:
+   * 	      "erpc:consensus-fallback": ["degraded"]
+   * Grants are ADDITIVE and unioned across every matching claim value, on
+   * top of the strategy-level `consensusPolicies` baseline: a caller holding
+   * several roles is served the union of their grades, independent of
+   * ordering. There are no negative grants — a role cannot revoke a grade
+   * the baseline already allows, so the baseline should hold only what every
+   * caller of this strategy may receive.
+   * Claim values are matched against the same normalized string list as
+   * `claimMatchers` (bare string, string array, or SCIM-style objects).
+   */
+  consensusPoliciesByClaim?: { [key: string]: { [key: string]: string[]}};
 }
 export interface SiweStrategyConfig {
   allowedDomains: string[];


### PR DESCRIPTION
Implements the design discussed in #1039, as an alternative to the circuit-breaker approach in #1013.

## Problem

`requiredParticipants[].minAgreement` (#1008) lets an operator require that the winning group contain nodes they trust — say one internal node and one external provider. It has no answer for what happens when the internal nodes are down, out of sync, or serving forked data: every request fails until someone manually repoints clients, which in a regulated deployment needs security approval and takes time.

The obvious fix — count composition disputes, relax the quotas once the rate crosses a threshold — cannot distinguish **"internal is down"** from **"internal is disagreeing"**. The second case is the feature working as intended: if the externals consistently contradict the internal node, a rate-triggered breaker hands consensus to exactly the parties `minAgreement` was built to check. It also makes consensus stateful (window, threshold, probe sampling, reset semantics), and everything it infers from history is already visible in the votes of the current round.

## Approach

An ORDERED list of named acceptance grades, evaluated against the same vote set, per request, statelessly:

```yaml
consensus:
  maxParticipants: 5
  agreementThreshold: 2
  acceptancePolicies:
    - name: standard
      requiredAgreement:
        - { tag: "type:internal", minAgreement: 1 }
        - { tag: "type:external", minAgreement: 1 }
    - name: degraded
      requiredAgreement:
        - { tag: "type:external", minAgreement: 2 }
```

The first grade the agreeing upstreams satisfy is the one the round is served under, and **its name travels with the answer** — `X-ERPC-Consensus-Policy` on the response, and a `policy` label on the new `erpc_consensus_policy_served_total`. A relaxed answer is never indistinguishable from a strict one, and you can page on the first degraded round instead of waiting for a failure-rate window to accumulate:

```
rate(erpc_consensus_policy_served_total{policy="degraded"}[5m]) > 0
```

Recovery needs no probe traffic and no breaker reset: the grade is a pure function of this round's votes, so the moment a strict-grade vote arrives, the strict grade evaluates first again.

## Authorization

Which callers may accept which grade is an authorization question, so it lives on the auth strategy rather than in the consensus block:

```yaml
auth:
  strategies:
    - type: jwt                                    # settlement: strict only
      consensusPolicies: ["standard"]
    - type: jwt                                    # indexers: may accept relaxed
      consensusPolicies: ["standard", "degraded"]
```

A round resolving at a grade the caller may not receive is **withheld as a composition dispute, never downgraded** — so strict and relaxed callers share one endpoint. Like `allowClientDirectives`, the grant travels on the authenticated `User`, so `trustUserIdHeader` cannot widen it, and clients need no configuration.

## Two properties that keep the ordering honest

- **The rules engine runs at the lowest grade's threshold**, so a round too thin for the strict grade still nominates a candidate; each grade's own threshold is then re-checked at the gate, so nothing is served below the bar of the grade it is served under. This is what makes the relaxed grade reachable when only two externals answered at all.
- **A win at any non-first grade is provisional** while responses are outstanding — short-circuit is suppressed exactly as for a provisional composition dispute — so a relaxed answer is never served merely because a strict vote was slower. Grade must not depend on response timing.

Enforcement stays a single gate (`enforceAcceptancePolicy`), so every rule — threshold, `preferHighestValueFor`, `preferLargerResponses`, dispute behaviors — is covered by construction. `eth_sendRawTransaction` stays exempt; synthesized and infra-error winners pass through untouched.

## Compatibility

Both config shapes compile to the same runtime list, so the executor has one code path and `requiredParticipants[].minAgreement` keeps working unchanged (reported as the grade `standard`). Setting both is rejected at startup, as is a grade made unreachable by an earlier one — ordering is the whole mechanism, and an inverted list would quietly serve every round at the relaxed grade.

Unset everywhere, behavior is identical to before.

**Drive-by fix:** `ConsensusPolicyConfig.Validate()` was never called from `FailsafeConfig.Validate()`, which left every consensus config check — including the ones added in #1008 — unreachable outside unit tests. Misconfigurations reached runtime instead of failing startup. Now wired in.

## Tests

24 unit tests: grade selection (strict preferred when both match; relaxed on absent internal; relaxed on dissenting internal; genuine disagreement stays a plain dispute; count-winner failing every grade is a composition dispute), per-grade thresholds resolving thin rounds while still enforcing their own bar, hedge self-corroboration not filling a quota, caller authorization both directions, short-circuit deferral plus its late-vote upgrade, shorthand compilation, and 11 validation cases.

End-to-end through the real HTTP server **from a YAML config** — so the documented keys themselves are covered — asserting the served grade for an agreeing round, a forked internal node, and an unreachable internal node, including a strict caller refused the same round an indexer is served.

Also verified against a locally running binary with three fake nodes:

| scenario | indexer (`standard`+`degraded`) | settlement (`standard` only) |
|---|---|---|
| all nodes agree | 200 `policy=standard` | 200 `policy=standard` |
| internal forked (up, dissenting) | 200 `policy=degraded` | `ErrConsensusCompositionDispute` |
| internal down | 200 `policy=degraded` | `ErrConsensusCompositionDispute` |
| internal recovered | 200 `policy=standard` | 200 `policy=standard` |

Misordered grades fail startup:

```
consensus.acceptancePolicies[1] ("standard") is unreachable: acceptancePolicies[0]
("degraded") is evaluated first and accepts everything this grade would —
list grades strictest first
```

Full `consensus`, `common`, `auth`, `telemetry` and `erpc` suites pass.

## What this deliberately does not add

No `fallbackTrigger`, `fallbackWindow`, `fallbackThreshold`, `fallbackProbeRate`, or `fallbackAllowedUsers`. The one behavior not carried over from #1013 is "relax only after N minutes of sustained failure" — if a degraded answer is acceptable at minute 6 of an incident it was acceptable at minute 1, and if it is not acceptable, time does not make it so. Operators who want a human approval gate can deploy without the relaxed grade and add it during an incident; config reload already exists.

Refs #1004, #1008, #1013, #1039
cc @andreclaro @aramalipoor
