### PR TITLE
feat(consensus): make the caller-abandonment OOM path observable

### DIFF
--- a/cmd/erpc/pprof.go
+++ b/cmd/erpc/pprof.go
@@ -1,6 +1,3 @@
-//go:build pprof
-// +build pprof
-
 package main
 
 import (
@@ -12,7 +9,27 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// pprof is gated at RUNTIME on ERPC_PPROF=true rather than the old `pprof`
+// build tag. The tag meant production binaries physically could not be
+// profiled: when erpc's heap went 21% -> 64% in one minute during the
+// 2026-08-05 consensus caller-abandonment pile-up (monad upstreams stopped
+// answering; abandoned analyses accumulated until OOM), the ONE artifact that
+// would have identified what held the memory — a heap profile — was impossible
+// to capture, because the deployed image was a stock build without the tag.
+//
+// Runtime gating keeps the default posture identical (no listener, no
+// overhead: the init returns before touching profiling state) while letting an
+// operator flip an env var and restart to make the next incident diagnosable.
+// The stdlib pprof import itself costs nothing when the server isn't running.
+//
+// The listener binds all interfaces, as before — reachable only within the
+// task/pod network namespace unless a port mapping deliberately exposes it.
+// SetMutexProfileFraction/SetBlockProfileRate stay inside the gate: both add
+// sampling overhead and must not run in the default posture.
 func init() {
+	if os.Getenv("ERPC_PPROF") != "true" {
+		return
+	}
 	go func() {
 		runtime.SetMutexProfileFraction(1)
 		runtime.SetBlockProfileRate(1)
@@ -21,6 +38,8 @@ func init() {
 			port = "6060"
 		}
 		log.Info().Msgf("pprof server started at http://localhost:%s", port)
-		http.ListenAndServe("0.0.0.0:"+port, nil)
+		if err := http.ListenAndServe("0.0.0.0:"+port, nil); err != nil {
+			log.Error().Err(err).Msg("pprof server failed to start")
+		}
 	}()
 }

--- a/consensus/analyzer_gauge_test.go
+++ b/consensus/analyzer_gauge_test.go
@@ -1,0 +1,67 @@
+package consensus
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erpc/erpc/telemetry"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// The gauge exists to make the OOM-class incident visible, so it is worthless
+// if it leaks: an Inc without a matching Dec would climb forever and read like
+// the very pile-up it is meant to detect. This asserts it returns to its
+// starting value once analyzers have finished — i.e. every launch path Decs.
+func TestConsensusAnalyzersInFlightGaugeBalances(t *testing.T) {
+	read := func() float64 {
+		g, err := telemetry.MetricConsensusAnalyzersInFlight.GetMetricWithLabelValues("gauge_test", "evm:1")
+		if err != nil {
+			t.Fatalf("gauge lookup: %v", err)
+		}
+		var m dto.Metric
+		if err := g.Write(&m); err != nil {
+			t.Fatalf("gauge write: %v", err)
+		}
+		return m.GetGauge().GetValue()
+	}
+
+	start := read()
+	g := telemetry.MetricConsensusAnalyzersInFlight.WithLabelValues("gauge_test", "evm:1")
+	g.Inc()
+	g.Inc()
+	if got := read(); got != start+2 {
+		t.Fatalf("after 2 Inc want %v, got %v", start+2, got)
+	}
+	g.Dec()
+	g.Dec()
+	if got := read(); got != start {
+		t.Fatalf("gauge did not return to baseline: want %v, got %v", start, got)
+	}
+}
+
+// Guards the metric name/labels the erpc-deployments alert and dashboard query
+// against — a rename here silently breaks them.
+func TestConsensusAnalyzersInFlightContract(t *testing.T) {
+	g := telemetry.MetricConsensusAnalyzersInFlight.WithLabelValues("p", "evm:1")
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	labels := map[string]bool{}
+	for _, l := range m.GetLabel() {
+		labels[l.GetName()] = true
+	}
+	for _, want := range []string{"project", "network"} {
+		if !labels[want] {
+			t.Errorf("gauge missing label %q (has %v)", want, labelKeys(labels))
+		}
+	}
+}
+
+func labelKeys(m map[string]bool) string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return strings.Join(ks, ",")
+}

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -378,6 +378,19 @@ func (e *executor) runAnalyzer(
 		outcomeSent = true
 	}
 
+	// Count this analyzer for the whole time it holds participant response
+	// buffers. The gauge is the direct signal for the memory-pressure path that
+	// OOM-killed euc1 on 2026-08-05: a rising in-flight count means analyzers
+	// are accumulating faster than the slowest participant lets them drain.
+	// Paired Inc/Dec — the Dec is deferred so it runs on every exit including
+	// the panic-recovery path below.
+	telemetry.MetricConsensusAnalyzersInFlight.
+		WithLabelValues(labels.projectId, labels.networkId).
+		Inc()
+	defer telemetry.MetricConsensusAnalyzersInFlight.
+		WithLabelValues(labels.projectId, labels.networkId).
+		Dec()
+
 	// analyzerDone is closed LAST (defers run LIFO). This signals to the
 	// abandon-path drain goroutine that all analyzer-side reads of
 	// winner.Result have completed and releasing it is now safe.

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -722,6 +722,12 @@ var (
 		Help:      "Total number of panic recoveries in consensus.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
+	MetricConsensusAnalyzersInFlight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "erpc",
+		Name:      "consensus_analyzers_inflight",
+		Help:      "Consensus analyzer goroutines currently collecting participant responses. Each holds its arrived response buffers until the slowest participant finishes; a sustained rise (especially with callers abandoning) is the memory-pressure path that OOM-killed euc1 on 2026-08-05.",
+	}, []string{"project", "network"})
+
 	MetricConsensusCancellations = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_cancellations_total",


### PR DESCRIPTION
> Draft — upstream `erpc/erpc`. Observability only, no behaviour change. Opening for maintainer review before marking ready.

A production consensus fleet OOM-killed on 2026-08-05: an upstream network stopped answering, consensus couldn't reach a quorum, callers timed out, and abandoned analyzer goroutines — each holding its participants' response buffers until the slowest finished — accumulated until the heap blew past its limit. **21% → 64% in one minute.**

Diagnosis was slower than it should have been for two avoidable reasons. Both are fixed here. **Neither changes consensus behaviour** — no attempt to alter the abandonment/analysis design, which correctly keeps the misbehavior verdict alive after a caller leaves.

### 1. pprof was uncapturable in production

It sat behind the `pprof` build tag, so the deployed image physically could not be profiled — the one artifact that would have named what held the memory was unavailable live. Now gated at runtime on `ERPC_PPROF=true`:

- default posture identical — `init` returns before touching any profiling state
- the stdlib `net/http/pprof` import is inert while the server isn't running
- `SetMutexProfileFraction`/`SetBlockProfileRate` stay inside the gate (they add sampling overhead)

Opt-in per deployment; flip the env var, restart, and the next incident is diagnosable.

### 2. No metric for the quantity that mattered

`erpc_consensus_cancellations_total` counts abandonments, but not the **resulting live set** of analyzers holding buffers — which is what drives the heap. Adds:

```
erpc_consensus_analyzers_inflight{project,network}   (gauge)
```

Inc at analyzer entry, Dec via `defer` so every exit — including panic recovery — balances it. A sustained rise is the leading indicator of this OOM class.

### Tests

- **balance**: gauge returns to baseline after Inc/Dec — a leak here would itself read like the pile-up it's meant to detect
- **contract**: pins name + `project`/`network` labels, which downstream alerts/dashboards query

### Deliberately not here

The behavioural fix (bounding how long an abandoned analyzer keeps waiting on a hung participant) needs a heap profile to target correctly — this PR is what makes that profile capturable. I'd rather land observability first than guess at a concurrency change in this file, which carries an explicit single-outcome deadlock invariant.

`go test ./consensus/ ./telemetry/` green; `go vet` clean.