### PR TITLE
feat(telemetry): counterDropLabels / counterLabelOverrides to bound counter cardinality

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -2785,6 +2785,27 @@ type MetricsConfig struct {
 	// Value is the list of label names to keep for that metric.
 	HistogramLabelOverrides map[string][]string `yaml:"histogramLabelOverrides,omitempty" json:"histogramLabelOverrides,omitempty"`
 
+	// CounterDropLabels removes these labels from every counter that carries
+	// caller-controlled dimensions (user, agent_name, attempt, composite,
+	// hedge, error). Histograms and gauges are unaffected; use
+	// HistogramDropLabels for the histogram side.
+	//
+	// Counters are usually the largest contributor to /metrics size, because a
+	// label like a client-supplied user-agent is unbounded and every tuple ever
+	// seen is re-emitted on every scrape. Dropping a label collapses the series
+	// that differed only in it — sums stay correct, but the dimension stops
+	// being queryable, so check what consumes it (billing/attribution
+	// pipelines, dashboards) before dropping.
+	CounterDropLabels []string `yaml:"counterDropLabels,omitempty" json:"counterDropLabels,omitempty"`
+
+	// CounterLabelOverrides re-adds labels for specific counters even if they
+	// appear in CounterDropLabels. Key is the metric Name (without the "erpc_"
+	// namespace prefix), e.g. "upstream_request_total". Value is the list of
+	// label names to keep for that metric. Use this to drop a label fleet-wide
+	// while preserving it on the one or two counters a downstream pipeline
+	// actually reads.
+	CounterLabelOverrides map[string][]string `yaml:"counterLabelOverrides,omitempty" json:"counterLabelOverrides,omitempty"`
+
 	// CounterIdleEvictionAfter bounds /metrics cardinality for hot-path
 	// counters whose label-sets are keyed by caller-controlled inputs
 	// (method, user, agentName, ...). Counter series idle for at least this

--- a/docs/pages/operation/cli.mdx
+++ b/docs/pages/operation/cli.mdx
@@ -210,6 +210,8 @@ pprof — build with `-tags pprof` to activate.
 | `metrics.histogramBuckets` | string | `""` (built-in defaults) | Comma-separated float64 bucket boundaries. Non-float values are rejected by validation. |
 | `metrics.histogramDropLabels` | []string | nil | Label names removed from every histogram to reduce cardinality. |
 | `metrics.histogramLabelOverrides` | map[string][]string | nil | Per-metric label keep-list; key is metric name without `erpc_` prefix. |
+| `metrics.counterDropLabels` | []string | nil | Label names removed from every counter carrying caller-controlled dimensions. Sums are preserved; the dimension is not. |
+| `metrics.counterLabelOverrides` | map[string][]string | nil | Per-metric label keep-list for counters; key is metric name without `erpc_` prefix. |
 
 **Environment variables**
 

--- a/docs/pages/operation/monitoring.mdx
+++ b/docs/pages/operation/monitoring.mdx
@@ -172,6 +172,8 @@ All fields under `metrics.` in the YAML root config. Struct: <SourceLink file="c
 | `metrics.histogramBuckets` | `string` | `""` → `[0.05, 0.5, 5, 30]` | Comma-separated float64 bucket boundaries for the 8 configurable `LabeledHistogram` instances: `upstream_request_duration_seconds`, `network_request_duration_seconds`, `consensus_duration_seconds`, `cache_set_success/error_duration_seconds`, `cache_get_success_hit/miss/error_duration_seconds`. Invalid float → warning + fallback to defaults. Source: <SourceLink file="telemetry/metrics.go" lines="731-736" /> |
 | `metrics.histogramDropLabels` | `[]string` | `nil` | Label names to drop from EVERY `LabeledHistogram`. Counters and gauges unaffected. Drop is permanent for the process lifetime — reconfiguring after first `SetHistogramBuckets` call panics. Common candidates: `user`, `agent_name`. Source: <SourceLink file="erpc/init.go" lines="53" /> |
 | `metrics.histogramLabelOverrides` | `map[string][]string` | `nil` | Per-metric overrides that re-add labels even if listed in `histogramDropLabels`. Key = metric name **without** `erpc_` prefix (e.g. `"network_request_duration_seconds"`). Value = labels to preserve for that metric. Source: <SourceLink file="erpc/init.go" lines="53" /> |
+| `metrics.counterDropLabels` | `[]string` | `nil` | Label names to drop from every counter carrying caller-controlled dimensions (`user`, `agent_name`, `attempt`, `composite`, `hedge`, `error`). Histograms and gauges unaffected. Sums are preserved — the series that differed only in the dropped label collapse into one — but the dimension stops being queryable, so verify nothing downstream groups by it first. Applied at `erpc.Init` via `SetCounterLabelFilter` + `RebuildFilteredCounters`. Source: <SourceLink file="erpc/init.go" lines="57-62" /> |
+| `metrics.counterLabelOverrides` | `map[string][]string` | `nil` | Per-metric overrides that re-add labels even if listed in `counterDropLabels`. Key = metric name **without** `erpc_` prefix (e.g. `"upstream_request_total"`). Lets you drop a label fleet-wide while keeping it on the one or two counters a billing/attribution pipeline actually reads. Source: <SourceLink file="erpc/init.go" lines="57-62" /> |
 | `metrics.counterIdleEvictionAfter` | `Duration` | `24h` | Idle threshold after which counter series emitted via `telemetry.CounterHandle` are evicted from the registry (`DeleteLabelValues`), bounding `/metrics` growth from caller-controlled label values (`method`, `user`, `agent_name`). `0` disables. Swept on the health tracker's sweep cadence. Source: <SourceLink file="erpc/init.go" lines="54-56" /> |
 
 **Hardcoded server constants (not configurable):**
@@ -321,8 +323,17 @@ and rate-limit events — but **two rules reference stale metric names** (`erpc_
   or clients — these two labels multiply every `LabeledHistogram`'s bucket count by the
   number of distinct values.
 - Managed Prometheus scrapers (Grafana Cloud, hosted Prometheus) typically cap the `/metrics`
-  response body at 10–64 MB. If scrape errors mention body size, add `category` to
-  `histogramDropLabels` too.
+  response body at 10–64 MB, and the cap is usually enforced on the response **whole**: past
+  it the scrape is rejected outright, so every series for that instance goes dark rather than
+  degrading. Counters — not histograms — are normally the bulk of a large payload, because an
+  unbounded label like a client-supplied user-agent is re-emitted on every scrape for the life
+  of the process. Reach for `counterDropLabels` (and `counterIdleEvictionAfter`) before
+  raising the scraper's limit; the label set is unbounded and will re-cross any new ceiling.
+- `counterDropLabels` is the counter-side twin of `histogramDropLabels`, with one important
+  difference: counter labels are more likely to be load-bearing downstream. `agent_name` or
+  `user` on a request counter often feeds billing or per-tenant attribution, so check
+  consumers before dropping and use `counterLabelOverrides` to spare the specific counters
+  that need it.
 - Never set `histogramDropLabels` after startup — the Prometheus registry rejects label-set
   changes and the process panics. Plan your drop list before first deploy.
 - Use `histogramLabelOverrides` to surgically restore a dropped label on exactly one

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -54,6 +54,12 @@ func Init(
 		if cfg.Metrics.CounterIdleEvictionAfter != nil {
 			telemetry.SetCounterIdleEvictionAfter(cfg.Metrics.CounterIdleEvictionAfter.Duration())
 		}
+		// Counters are built at package init, so installing the filter is only
+		// half the job — RebuildFilteredCounters re-creates them under it.
+		if len(cfg.Metrics.CounterDropLabels) > 0 || len(cfg.Metrics.CounterLabelOverrides) > 0 {
+			telemetry.SetCounterLabelFilter(cfg.Metrics.CounterDropLabels, cfg.Metrics.CounterLabelOverrides)
+			telemetry.RebuildFilteredCounters()
+		}
 	}
 	if err := telemetry.SetHistogramBuckets(bucketStr); err != nil {
 		logger.Warn().Err(err).Msg("failed to set histogram buckets, using defaults")

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -56,17 +56,16 @@ func Init(
 		}
 		// Counters are built unregistered at package init (Prometheus freezes
 		// a metric's label-set hash for the life of the registry, so we cannot
-		// register first and filter later). Install any filter here; registration
-		// happens below unconditionally so /metrics exposes them even when no
-		// drop list is configured.
+		// register first and filter later). Install any filter, then register
+		// once under it. Only when metrics config is present — processes that
+		// never scrape do not need these collectors on DefaultRegisterer, and
+		// tests that call Init without metrics must not freeze the full label
+		// set before a later Init can apply counterDropLabels.
 		if len(cfg.Metrics.CounterDropLabels) > 0 || len(cfg.Metrics.CounterLabelOverrides) > 0 {
 			telemetry.SetCounterLabelFilter(cfg.Metrics.CounterDropLabels, cfg.Metrics.CounterLabelOverrides)
 		}
+		telemetry.RebuildFilteredCounters()
 	}
-	// Register counters once under the current filter (empty = full schema).
-	// Safe to call with no metrics config — still need the collectors registered
-	// for any process that later enables scraping or Gather()-based checks.
-	telemetry.RebuildFilteredCounters()
 	if err := telemetry.SetHistogramBuckets(bucketStr); err != nil {
 		logger.Warn().Err(err).Msg("failed to set histogram buckets, using defaults")
 	}

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -54,13 +54,19 @@ func Init(
 		if cfg.Metrics.CounterIdleEvictionAfter != nil {
 			telemetry.SetCounterIdleEvictionAfter(cfg.Metrics.CounterIdleEvictionAfter.Duration())
 		}
-		// Counters are built at package init, so installing the filter is only
-		// half the job — RebuildFilteredCounters re-creates them under it.
+		// Counters are built unregistered at package init (Prometheus freezes
+		// a metric's label-set hash for the life of the registry, so we cannot
+		// register first and filter later). Install any filter here; registration
+		// happens below unconditionally so /metrics exposes them even when no
+		// drop list is configured.
 		if len(cfg.Metrics.CounterDropLabels) > 0 || len(cfg.Metrics.CounterLabelOverrides) > 0 {
 			telemetry.SetCounterLabelFilter(cfg.Metrics.CounterDropLabels, cfg.Metrics.CounterLabelOverrides)
-			telemetry.RebuildFilteredCounters()
 		}
 	}
+	// Register counters once under the current filter (empty = full schema).
+	// Safe to call with no metrics config — still need the collectors registered
+	// for any process that later enables scraping or Gather()-based checks.
+	telemetry.RebuildFilteredCounters()
 	if err := telemetry.SetHistogramBuckets(bucketStr); err != nil {
 		logger.Warn().Err(err).Msg("failed to set histogram buckets, using defaults")
 	}

--- a/erpc/init_test.go
+++ b/erpc/init_test.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
 	"github.com/h2non/gock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
 
@@ -175,4 +177,240 @@ func TestInit_InvalidHttpPort(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for Init to return an error")
 	}
+}
+
+// End-to-end: config.metrics.counterDropLabels is applied at Init, real request
+// traffic with distinct User-Agents increments package counters, and the
+// metrics HTTP scrape proves agent_name is gone on dropped counters while a
+// counterLabelOverrides keep-list still exposes it on the spared metric.
+func TestInit_CounterDropLabels_EndToEnd(t *testing.T) {
+	mainMutex.Lock()
+	defer mainMutex.Unlock()
+
+	// Isolate from other Init tests: Prometheus freezes dimHashesByName per
+	// registry for the life of the process, so a prior Init that registered
+	// the full label set would make counterDropLabels panic here. Swap in a
+	// fresh registry for both Registerer and Gatherer (promhttp.Handler reads
+	// DefaultGatherer).
+	reg := prometheus.NewRegistry()
+	prevReg := prometheus.DefaultRegisterer
+	prevGath := prometheus.DefaultGatherer
+	prometheus.DefaultRegisterer = reg
+	prometheus.DefaultGatherer = reg
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = prevReg
+		prometheus.DefaultGatherer = prevGath
+		// Clear the process-wide filter so a later Init sees the default
+		// (full schema). Do not RebuildFilteredCounters here — that would
+		// fight dimHashesByName on whatever registry is current.
+		telemetry.SetCounterLabelFilter(nil, nil)
+		telemetry.ResetHandleCache()
+	})
+
+	defer gock.Off()
+	defer gock.DisableNetworking()
+	defer gock.Clean()
+	defer gock.CleanUnmatchedRequest()
+
+	gock.EnableNetworking()
+	gock.NetworkingFilter(func(req *http.Request) bool {
+		return strings.Split(req.URL.Host, ":")[0] == "localhost"
+	})
+
+	util.SetupMocksForEvmStatePoller()
+	// Persist-reply every upstream POST so state-poller + client traffic both land.
+	gock.New("http://rpc1.localhost").
+		Persist().
+		Post("").
+		Reply(200).
+		JSON([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+
+	localHost := "localhost"
+	httpPort := rand.Intn(1000) + 2100
+	metricsPort := rand.Intn(1000) + 4100
+	baseURL := fmt.Sprintf("http://localhost:%d", httpPort)
+	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", metricsPort)
+
+	cfg := &common.Config{
+		LogLevel: "ERROR",
+		Server: &common.ServerConfig{
+			HttpHostV4: &localHost,
+			ListenV4:   util.BoolPtr(true),
+			HttpPortV4: &httpPort,
+		},
+		Metrics: &common.MetricsConfig{
+			Enabled: util.BoolPtr(true),
+			HostV4:  &localHost,
+			Port:    &metricsPort,
+			// Drop agent_name fleet-wide on counters, then spare the received
+			// counter so we can prove overrides still work end-to-end.
+			CounterDropLabels: []string{"agent_name"},
+			CounterLabelOverrides: map[string][]string{
+				"network_request_received_total": {"agent_name"},
+			},
+		},
+		Projects: []*common.ProjectConfig{
+			{
+				Id:            "main",
+				UserAgentMode: common.UserAgentTrackingModeRaw,
+				Upstreams: []*common.UpstreamConfig{
+					{
+						Id:       "good-evm-rpc",
+						Endpoint: "http://rpc1.localhost",
+						Type:     "evm",
+						Evm: &common.EvmUpstreamConfig{
+							ChainId: 123,
+						},
+					},
+				},
+				Networks: []*common.NetworkConfig{
+					{
+						Architecture: "evm",
+						Evm: &common.EvmNetworkConfig{
+							ChainId: 123,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Init(ctx, cfg, log.Logger)
+
+	// Wait until metrics port answers.
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for metrics to come up")
+		}
+		resp, err := http.Get(metricsURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	agents := []string{
+		"e2e-agent-alpha/1.0",
+		"e2e-agent-beta/2.0",
+		"e2e-agent-gamma/3.0",
+	}
+	for _, ua := range agents {
+		req, err := http.NewRequest(http.MethodPost, baseURL+"/main/evm/123", bytes.NewBufferString(
+			`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x1273c18","latest"]}`,
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", ua)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request with ua=%s: %v", ua, err)
+		}
+		body, _ := io.ReadAll(res.Body)
+		res.Body.Close()
+		if res.StatusCode != 200 {
+			t.Fatalf("expected 200 for ua=%s, got %d body=%s", ua, res.StatusCode, body)
+		}
+	}
+
+	// Scrape until the request counters appear (response path is async w.r.t. metrics).
+	var scrape string
+	for range 50 {
+		resp, err := http.Get(metricsURL)
+		if err != nil {
+			t.Fatalf("metrics scrape: %v", err)
+		}
+		b, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		scrape = string(b)
+		if strings.Contains(scrape, "erpc_network_successful_request_total{") &&
+			strings.Contains(scrape, "erpc_network_request_received_total{") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Dropped metric: successful_request must NOT carry agent_name, and the
+	// three UAs must collapse to a single series (sum preserved at ≥3).
+	successLines := metricSampleLines(scrape, "erpc_network_successful_request_total")
+	if len(successLines) == 0 {
+		t.Fatalf("no successful_request samples in scrape; first 800 bytes:\n%s", scrape[:min(800, len(scrape))])
+	}
+	for _, line := range successLines {
+		if strings.Contains(line, "agent_name=") {
+			t.Fatalf("agent_name should be dropped from successful_request, got: %s", line)
+		}
+	}
+	if len(successLines) != 1 {
+		t.Fatalf("expected 3 UAs to collapse to 1 successful_request series, got %d:\n%s",
+			len(successLines), strings.Join(successLines, "\n"))
+	}
+	if v := metricSampleValue(successLines[0]); v < 3 {
+		t.Fatalf("expected collapsed successful_request total ≥3, got %v from %s", v, successLines[0])
+	}
+
+	// Overridden metric: received_total keeps agent_name and has one series per UA.
+	recvLines := metricSampleLines(scrape, "erpc_network_request_received_total")
+	if len(recvLines) == 0 {
+		t.Fatal("no request_received samples in scrape")
+	}
+	seen := map[string]bool{}
+	for _, line := range recvLines {
+		if !strings.Contains(line, "agent_name=") {
+			t.Fatalf("override should keep agent_name on request_received, got: %s", line)
+		}
+		for _, ua := range agents {
+			if strings.Contains(line, `agent_name="`+ua+`"`) {
+				seen[ua] = true
+			}
+		}
+	}
+	for _, ua := range agents {
+		if !seen[ua] {
+			t.Fatalf("missing overridden series for ua=%s in:\n%s", ua, strings.Join(recvLines, "\n"))
+		}
+	}
+
+	// Dropped family also collapses on the upstream counter (no agent_name).
+	upLines := metricSampleLines(scrape, "erpc_upstream_request_total")
+	for _, line := range upLines {
+		if strings.Contains(line, "agent_name=") {
+			t.Fatalf("agent_name should be dropped from upstream_request_total, got: %s", line)
+		}
+	}
+	if len(upLines) == 0 {
+		t.Fatal("expected upstream_request_total samples after traffic")
+	}
+}
+
+func metricSampleLines(scrape, name string) []string {
+	var out []string
+	prefix := name + "{"
+	for _, line := range strings.Split(scrape, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func metricSampleValue(line string) float64 {
+	// "...} 3" or "...} 3.0"
+	i := strings.LastIndex(line, " ")
+	if i < 0 {
+		return 0
+	}
+	var v float64
+	fmt.Sscanf(line[i+1:], "%f", &v)
+	return v
 }

--- a/erpc/init_test.go
+++ b/erpc/init_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/util"
 	"github.com/h2non/gock"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
 
@@ -186,24 +185,18 @@ func TestInit_InvalidHttpPort(t *testing.T) {
 func TestInit_CounterDropLabels_EndToEnd(t *testing.T) {
 	mainMutex.Lock()
 	defer mainMutex.Unlock()
-
-	// Isolate from other Init tests: Prometheus freezes dimHashesByName per
-	// registry for the life of the process, so a prior Init that registered
-	// the full label set would make counterDropLabels panic here. Swap in a
-	// fresh registry for both Registerer and Gatherer (promhttp.Handler reads
-	// DefaultGatherer).
-	reg := prometheus.NewRegistry()
-	prevReg := prometheus.DefaultRegisterer
-	prevGath := prometheus.DefaultGatherer
-	prometheus.DefaultRegisterer = reg
-	prometheus.DefaultGatherer = reg
+	// Do NOT swap prometheus.DefaultRegisterer/Gatherer. Init calls
+	// SetHistogramBuckets which reassigns package-level histogram vars onto
+	// whichever Registerer is current; a private registry leaves the rest of
+	// the package observing collectors DefaultGatherer can no longer see
+	// (breaks TestUpstream_TimeoutPolicy/HistogramEmits under make test).
+	// Counters stay unregistered until an Init with metrics config runs, and
+	// this test is the one that first registers them — under the drop filter.
 	t.Cleanup(func() {
-		prometheus.DefaultRegisterer = prevReg
-		prometheus.DefaultGatherer = prevGath
-		// Clear the process-wide filter so a later Init sees the default
-		// (full schema). Do not RebuildFilteredCounters here — that would
-		// fight dimHashesByName on whatever registry is current.
-		telemetry.SetCounterLabelFilter(nil, nil)
+		// Filter is process-lifetime against DefaultRegisterer (dimHashesByName
+		// freezes the label set). Leave counters registered as-is; call sites
+		// still pass the full schema and LabeledCounter projects. Only clear
+		// the handle cache so nothing holds stale children.
 		telemetry.ResetHandleCache()
 	})
 

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -13,7 +13,7 @@ import (
 // Keyed by the Vec pointer plus the full labels key.
 
 type counterKey struct {
-	vec *prometheus.CounterVec
+	vec any // holds a comparable pointer (*prometheus.CounterVec or *LabeledCounter)
 	key string
 }
 
@@ -39,6 +39,13 @@ type gaugeKey struct {
 // *LabeledHistogram, so ObserverHandle can cache handles for either.
 type HistogramObservable interface {
 	WithLabelValues(labels ...string) prometheus.Observer
+}
+
+// CounterIncrementable is satisfied by both *prometheus.CounterVec and
+// *LabeledCounter, so CounterHandle can cache handles for either.
+type CounterIncrementable interface {
+	WithLabelValues(labels ...string) prometheus.Counter
+	DeleteLabelValues(labels ...string) bool
 }
 
 type observerKey struct {
@@ -84,8 +91,17 @@ var counterHandleCreateMu sync.Mutex
 // (CounterHandle(...).Inc()) rather than holding the returned Counter —
 // after an idle sweep evicts the series, a held child mutates an object
 // that is no longer collected.
-func CounterHandle(cv *prometheus.CounterVec, labels ...string) prometheus.Counter {
-	k := counterKey{vec: cv, key: labelsKey(labels)}
+func CounterHandle(cv CounterIncrementable, labels ...string) prometheus.Counter {
+	// Key on the POST-filter labels. Under a CounterLabelFilter several
+	// full-schema tuples collapse onto one underlying series; keying on the
+	// full tuple would create one cache entry per tuple sharing that series,
+	// and the idle sweep would then delete a series another live entry is
+	// still incrementing. Projecting first keeps it one entry per series.
+	keyLabels := labels
+	if lc, ok := cv.(*LabeledCounter); ok {
+		keyLabels = lc.ActiveLabelValues(labels)
+	}
+	k := counterKey{vec: cv, key: labelsKey(keyLabels)}
 	nowMs := time.Now().UnixMilli()
 	if v, ok := counterHandleCache.Load(k); ok {
 		h := v.(*cachedCounterHandle)
@@ -171,7 +187,7 @@ func sweepIdleCounterHandlesBefore(cutoffMs int64) int {
 		}
 		k := key.(counterKey)
 		counterHandleCache.Delete(key)
-		k.vec.DeleteLabelValues(v.(*cachedCounterHandle).vals...)
+		k.vec.(CounterIncrementable).DeleteLabelValues(v.(*cachedCounterHandle).vals...)
 		counterHandleCreateMu.Unlock()
 		evicted++
 		return true

--- a/telemetry/labeled_counter.go
+++ b/telemetry/labeled_counter.go
@@ -1,0 +1,213 @@
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// buildLabelSets normalizes the (dropLabels, keepOverrides) config pair into
+// the lookup shape both the histogram and counter filters use. Shared so the
+// two filters cannot drift in how they parse config.
+func buildLabelSets(dropLabels []string, keepOverrides map[string][]string) (map[string]struct{}, map[string]map[string]struct{}) {
+	drop := make(map[string]struct{}, len(dropLabels))
+	for _, l := range dropLabels {
+		if l = strings.TrimSpace(l); l != "" {
+			drop[l] = struct{}{}
+		}
+	}
+	overrides := make(map[string]map[string]struct{}, len(keepOverrides))
+	for metricName, keep := range keepOverrides {
+		metricName = strings.TrimSpace(metricName)
+		if metricName == "" {
+			continue
+		}
+		set := make(map[string]struct{}, len(keep))
+		for _, l := range keep {
+			if l = strings.TrimSpace(l); l != "" {
+				set[l] = struct{}{}
+			}
+		}
+		overrides[metricName] = set
+	}
+	return drop, overrides
+}
+
+// activeIndicesFor returns the positions of `schema` retained given a drop set
+// and the per-metric keep overrides.
+func activeIndicesFor(drop map[string]struct{}, keepOverrides map[string]map[string]struct{}, metricName string, schema []string) []int {
+	overrides := keepOverrides[metricName]
+	out := make([]int, 0, len(schema))
+	for i, l := range schema {
+		if _, dropped := drop[l]; dropped {
+			if _, kept := overrides[l]; !kept {
+				continue
+			}
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// CounterLabelFilter decides which labels a CounterVec exposes.
+//
+// Global `drop` removes labels from every counter built through
+// NewLabeledCounter; per-metric `keepOverrides` re-add labels for specific
+// metric names (the Prometheus Name without the namespace prefix, e.g.
+// "upstream_request_total").
+//
+// This is the counter-side twin of HistogramLabelFilter. Counters need their
+// own knob because dropping a label from a histogram only removes buckets,
+// while a counter label like a caller-supplied user-agent is frequently the
+// single largest contributor to /metrics size — and unlike histograms, some
+// counter labels are load-bearing for billing/attribution pipelines, so the
+// choice has to be made per deployment rather than baked in.
+type CounterLabelFilter struct {
+	drop          map[string]struct{}
+	keepOverrides map[string]map[string]struct{}
+}
+
+var (
+	counterFilterMu      sync.RWMutex
+	currentCounterFilter = &CounterLabelFilter{drop: map[string]struct{}{}}
+)
+
+// SetCounterLabelFilter installs the filter used by subsequent
+// NewLabeledCounter calls. Because the package-level counters are constructed
+// at init (before config is read), callers must follow this with
+// RebuildFilteredCounters to re-create them under the new filter — exactly the
+// SetHistogramLabelFilter + SetHistogramBuckets sequence.
+func SetCounterLabelFilter(dropLabels []string, keepOverrides map[string][]string) {
+	drop, overrides := buildLabelSets(dropLabels, keepOverrides)
+	counterFilterMu.Lock()
+	currentCounterFilter = &CounterLabelFilter{drop: drop, keepOverrides: overrides}
+	counterFilterMu.Unlock()
+}
+
+// activeIndices returns the positions from `schema` retained under the filter.
+func (f *CounterLabelFilter) activeIndices(metricName string, schema []string) []int {
+	return activeIndicesFor(f.drop, f.keepOverrides, metricName, schema)
+}
+
+// LabeledCounter wraps a prometheus.CounterVec whose label set is the
+// intersection of a canonical schema and the current CounterLabelFilter.
+// Call sites always pass values for the full schema (in schema order); the
+// wrapper forwards only the retained positions to the underlying Vec.
+//
+// Dropping a label collapses every series that differed only in that label
+// into one. The counters remain correct — their sums are preserved — but the
+// dropped dimension is no longer queryable. Check downstream consumers before
+// dropping a label that a billing or attribution pipeline groups by.
+type LabeledCounter struct {
+	opts       prometheus.CounterOpts
+	metricName string
+	schema     []string
+	activeIdx  []int
+	vec        *prometheus.CounterVec
+}
+
+// NewLabeledCounter creates a CounterVec honoring the current filter and
+// registers it with prometheus.DefaultRegisterer.
+func NewLabeledCounter(opts prometheus.CounterOpts, schema []string) *LabeledCounter {
+	return registerOrReuseCounter(newLabeledCounterUnregistered(opts, schema))
+}
+
+// newLabeledCounterUnregistered builds the counter without registering it, so
+// tests can use a private registry.
+func newLabeledCounterUnregistered(opts prometheus.CounterOpts, schema []string) *LabeledCounter {
+	counterFilterMu.RLock()
+	idx := currentCounterFilter.activeIndices(opts.Name, schema)
+	counterFilterMu.RUnlock()
+	active := make([]string, len(idx))
+	for i, j := range idx {
+		active[i] = schema[j]
+	}
+	return &LabeledCounter{
+		opts:       opts,
+		metricName: opts.Name,
+		schema:     schema,
+		activeIdx:  idx,
+		vec:        prometheus.NewCounterVec(opts, active),
+	}
+}
+
+// registerOrReuseCounter mirrors registerOrReuse for histograms: on a repeat
+// registration with an identical label set, return the already-registered
+// collector instead of panicking, which keeps the rebuild idempotent.
+func registerOrReuseCounter(lc *LabeledCounter) *LabeledCounter {
+	err := prometheus.Register(lc)
+	if err == nil {
+		return lc
+	}
+	if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		if existing, ok := are.ExistingCollector.(*LabeledCounter); ok {
+			return existing
+		}
+	}
+	panic(err)
+}
+
+// Rebuild re-creates this counter under the CURRENT filter, replacing the
+// registered collector. The old series are dropped with it — a filter change
+// is a cardinality change, so there is nothing meaningful to carry over.
+// Returns the replacement; callers must reassign their package-level var.
+func (lc *LabeledCounter) Rebuild() *LabeledCounter {
+	prometheus.DefaultRegisterer.Unregister(lc)
+	return NewLabeledCounter(lc.opts, lc.schema)
+}
+
+func (lc *LabeledCounter) Describe(ch chan<- *prometheus.Desc) { lc.vec.Describe(ch) }
+func (lc *LabeledCounter) Collect(ch chan<- prometheus.Metric) { lc.vec.Collect(ch) }
+func (lc *LabeledCounter) Reset()                              { lc.vec.Reset() }
+
+func (lc *LabeledCounter) assertArity(vals []string) {
+	if len(vals) != len(lc.schema) {
+		panic(fmt.Sprintf("labeled_counter: %s expected %d label values (%v), got %d",
+			lc.metricName, len(lc.schema), lc.schema, len(vals)))
+	}
+}
+
+// WithLabelValues accepts values for the FULL schema and filters internally to
+// the labels retained by the current filter. Panics on length mismatch to
+// surface miswired call sites immediately.
+func (lc *LabeledCounter) WithLabelValues(vals ...string) prometheus.Counter {
+	lc.assertArity(vals)
+	if len(lc.activeIdx) == len(lc.schema) {
+		return lc.vec.WithLabelValues(vals...)
+	}
+	return lc.vec.WithLabelValues(lc.project(vals)...)
+}
+
+// DeleteLabelValues removes the series for the given FULL-schema label set,
+// honoring the same convention as WithLabelValues. Returns true if a series
+// existed and was deleted. Used by the idle-counter sweep to release series
+// for label combinations that have gone quiet.
+func (lc *LabeledCounter) DeleteLabelValues(vals ...string) bool {
+	lc.assertArity(vals)
+	if len(lc.activeIdx) == len(lc.schema) {
+		return lc.vec.DeleteLabelValues(vals...)
+	}
+	return lc.vec.DeleteLabelValues(lc.project(vals)...)
+}
+
+// ActiveLabelValues projects full-schema values down to the retained subset, so
+// callers can key their own caches on the effective (post-filter) labels. This
+// is what lets multiple full-label tuples that now resolve to the same series
+// share one handle-cache entry instead of fighting over it.
+func (lc *LabeledCounter) ActiveLabelValues(vals []string) []string {
+	lc.assertArity(vals)
+	if len(lc.activeIdx) == len(lc.schema) {
+		return vals
+	}
+	return lc.project(vals)
+}
+
+func (lc *LabeledCounter) project(vals []string) []string {
+	active := make([]string, len(lc.activeIdx))
+	for i, idx := range lc.activeIdx {
+		active[i] = vals[idx]
+	}
+	return active
+}

--- a/telemetry/labeled_counter.go
+++ b/telemetry/labeled_counter.go
@@ -109,7 +109,11 @@ type LabeledCounter struct {
 }
 
 // NewLabeledCounter creates a CounterVec honoring the current filter and
-// registers it with prometheus.DefaultRegisterer.
+// registers it with prometheus.DefaultRegisterer. Prefer the package-level
+// counters (built unregistered at init, registered once via
+// RebuildFilteredCounters) for production metrics — Prometheus freezes a
+// metric's label-set hash for the life of the registry, so registering at
+// package init would make counterDropLabels impossible to apply later.
 func NewLabeledCounter(opts prometheus.CounterOpts, schema []string) *LabeledCounter {
 	return registerOrReuseCounter(newLabeledCounterUnregistered(opts, schema))
 }
@@ -149,13 +153,14 @@ func registerOrReuseCounter(lc *LabeledCounter) *LabeledCounter {
 	panic(err)
 }
 
-// Rebuild re-creates this counter under the CURRENT filter, replacing the
-// registered collector. The old series are dropped with it — a filter change
-// is a cardinality change, so there is nothing meaningful to carry over.
-// Returns the replacement; callers must reassign their package-level var.
+// Rebuild re-creates this counter under the CURRENT filter without registering
+// it. Prometheus freezes dimHashesByName for a metric's fqName even after
+// Unregister, so a label-set change cannot be applied by unregister+re-register
+// — the only safe path is the histogram one: build unregistered under the
+// filter, then register once. Returns the replacement; callers reassign their
+// package-level var, then registerOrReuseCounter.
 func (lc *LabeledCounter) Rebuild() *LabeledCounter {
-	prometheus.DefaultRegisterer.Unregister(lc)
-	return NewLabeledCounter(lc.opts, lc.schema)
+	return newLabeledCounterUnregistered(lc.opts, lc.schema)
 }
 
 func (lc *LabeledCounter) Describe(ch chan<- *prometheus.Desc) { lc.vec.Describe(ch) }

--- a/telemetry/labeled_counter_test.go
+++ b/telemetry/labeled_counter_test.go
@@ -1,0 +1,153 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// newTestLabeledCounter builds a LabeledCounter on a private registry under the
+// given filter, so tests never touch the global package metrics.
+func newTestLabeledCounter(t *testing.T, name string, schema []string, drop []string, overrides map[string][]string) *LabeledCounter {
+	t.Helper()
+	t.Cleanup(func() { SetCounterLabelFilter(nil, nil) })
+	t.Cleanup(ResetHandleCache)
+	SetCounterLabelFilter(drop, overrides)
+	lc := newLabeledCounterUnregistered(prometheus.CounterOpts{Name: name}, schema)
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(lc)
+	ResetHandleCache()
+	return lc
+}
+
+// Dropping a label collapses the series that differed only in it, and the
+// counter total is preserved — the sum is what stays correct, the dimension is
+// what is lost.
+func TestLabeledCounter_DropCollapsesSeriesAndPreservesSum(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_drop_total", []string{"network", "agent_name"}, []string{"agent_name"}, nil)
+
+	lc.WithLabelValues("evm:1", "agent-a").Inc()
+	lc.WithLabelValues("evm:1", "agent-b").Inc()
+	lc.WithLabelValues("evm:1", "agent-c").Inc()
+
+	if got := testutil.CollectAndCount(lc); got != 1 {
+		t.Fatalf("expected 3 agents to collapse to 1 series, got %d", got)
+	}
+	if got := testutil.ToFloat64(lc.vec.WithLabelValues("evm:1")); got != 3 {
+		t.Fatalf("expected collapsed counter to total 3, got %v", got)
+	}
+}
+
+// A per-metric override re-adds a dropped label for that metric only, so a
+// fleet-wide drop can spare the one counter a downstream pipeline reads.
+func TestLabeledCounter_OverrideKeepsLabelForNamedMetric(t *testing.T) {
+	schema := []string{"network", "agent_name"}
+	overrides := map[string][]string{"test_lc_kept_total": {"agent_name"}}
+
+	kept := newTestLabeledCounter(t, "test_lc_kept_total", schema, []string{"agent_name"}, overrides)
+	kept.WithLabelValues("evm:1", "agent-a").Inc()
+	kept.WithLabelValues("evm:1", "agent-b").Inc()
+	if got := testutil.CollectAndCount(kept); got != 2 {
+		t.Fatalf("override should preserve agent_name: expected 2 series, got %d", got)
+	}
+
+	// Same filter, a metric NOT named in the overrides still drops the label.
+	dropped := newLabeledCounterUnregistered(prometheus.CounterOpts{Name: "test_lc_other_total"}, schema)
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(dropped)
+	dropped.WithLabelValues("evm:1", "agent-a").Inc()
+	dropped.WithLabelValues("evm:1", "agent-b").Inc()
+	if got := testutil.CollectAndCount(dropped); got != 1 {
+		t.Fatalf("unnamed metric should drop agent_name: expected 1 series, got %d", got)
+	}
+}
+
+// Call sites keep passing the FULL schema; a wrong arity is a miswiring and
+// must fail loudly rather than silently mislabel a series.
+func TestLabeledCounter_PanicsOnArityMismatch(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_arity_total", []string{"network", "agent_name"}, []string{"agent_name"}, nil)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on short label list")
+		}
+	}()
+	lc.WithLabelValues("evm:1")
+}
+
+// CounterHandle must key on POST-filter labels. Two full tuples differing only
+// in a dropped label are the same underlying series, so they must share one
+// cache entry — otherwise the idle sweep can evict the series out from under a
+// tuple that is still being incremented.
+func TestCounterHandle_CollapsedTuplesShareOneCacheEntry(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_handle_total", []string{"network", "agent_name"}, []string{"agent_name"}, nil)
+
+	a := CounterHandle(lc, "evm:1", "agent-a")
+	b := CounterHandle(lc, "evm:1", "agent-b")
+	if a != b {
+		t.Fatal("collapsed tuples must resolve to the same cached child counter")
+	}
+
+	entries := 0
+	counterHandleCache.Range(func(_, _ any) bool { entries++; return true })
+	if entries != 1 {
+		t.Fatalf("expected 1 cache entry for collapsed tuples, got %d", entries)
+	}
+}
+
+// The regression this keying prevents: tuple A goes quiet while tuple B — the
+// same underlying series — stays hot. A sweep must not delete the live series.
+func TestCounterHandle_SweepKeepsSeriesLiveViaSiblingTuple(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_sweep_sibling_total", []string{"network", "agent_name"}, []string{"agent_name"}, nil)
+
+	CounterHandle(lc, "evm:1", "agent-a").Inc()
+	sleepMs(t)
+	cutoff := time.Now().UnixMilli()
+	sleepMs(t)
+	// agent-b refreshes the shared entry after the cutoff.
+	CounterHandle(lc, "evm:1", "agent-b").Inc()
+
+	if evicted := sweepIdleCounterHandlesBefore(cutoff); evicted != 0 {
+		t.Fatalf("expected 0 evicted while a sibling tuple is hot, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(lc); got != 1 {
+		t.Fatalf("live series must survive the sweep, got %d series", got)
+	}
+	if got := testutil.ToFloat64(lc.vec.WithLabelValues("evm:1")); got != 2 {
+		t.Fatalf("expected both increments retained, got %v", got)
+	}
+}
+
+// The sweep releases a filtered counter's series through the full-schema
+// DeleteLabelValues projection — the stored tuple is full-schema, the vec is
+// not, and the projection has to line up or nothing is deleted.
+func TestCounterHandle_SweepDeletesFilteredSeries(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_sweep_delete_total", []string{"network", "agent_name"}, []string{"agent_name"}, nil)
+
+	CounterHandle(lc, "evm:1", "agent-a").Inc()
+	if got := testutil.CollectAndCount(lc); got != 1 {
+		t.Fatalf("precondition: expected 1 series, got %d", got)
+	}
+	if evicted := sweepIdleCounterHandlesBefore(time.Now().UnixMilli() + 1000); evicted != 1 {
+		t.Fatalf("expected 1 evicted, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(lc); got != 0 {
+		t.Fatalf("expected series released from the vec, got %d", got)
+	}
+}
+
+// With no filter installed, a LabeledCounter is a pass-through: every schema
+// label is retained. Guards against the filter defaulting to "drop everything".
+func TestLabeledCounter_NoFilterRetainsFullSchema(t *testing.T) {
+	lc := newTestLabeledCounter(t, "test_lc_nofilter_total", []string{"network", "agent_name"}, nil, nil)
+
+	lc.WithLabelValues("evm:1", "agent-a").Inc()
+	lc.WithLabelValues("evm:1", "agent-b").Inc()
+	if got := testutil.CollectAndCount(lc); got != 2 {
+		t.Fatalf("unfiltered counter should keep both series, got %d", got)
+	}
+	if got := lc.ActiveLabelValues([]string{"evm:1", "agent-a"}); len(got) != 2 {
+		t.Fatalf("expected full projection, got %v", got)
+	}
+}

--- a/telemetry/labeled_histogram.go
+++ b/telemetry/labeled_histogram.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,48 +25,15 @@ var (
 // SetHistogramLabelFilter installs a filter used by subsequent NewLabeledHistogram
 // calls. Typically invoked once at startup from config, before SetHistogramBuckets.
 func SetHistogramLabelFilter(dropLabels []string, keepOverrides map[string][]string) {
-	f := &HistogramLabelFilter{
-		drop:          make(map[string]struct{}, len(dropLabels)),
-		keepOverrides: make(map[string]map[string]struct{}, len(keepOverrides)),
-	}
-	for _, l := range dropLabels {
-		l = strings.TrimSpace(l)
-		if l != "" {
-			f.drop[l] = struct{}{}
-		}
-	}
-	for metricName, keep := range keepOverrides {
-		metricName = strings.TrimSpace(metricName)
-		if metricName == "" {
-			continue
-		}
-		set := make(map[string]struct{}, len(keep))
-		for _, l := range keep {
-			l = strings.TrimSpace(l)
-			if l != "" {
-				set[l] = struct{}{}
-			}
-		}
-		f.keepOverrides[metricName] = set
-	}
+	drop, overrides := buildLabelSets(dropLabels, keepOverrides)
 	filterMu.Lock()
-	currentFilter = f
+	currentFilter = &HistogramLabelFilter{drop: drop, keepOverrides: overrides}
 	filterMu.Unlock()
 }
 
 // activeIndices returns the positions from `schema` retained under the filter.
 func (f *HistogramLabelFilter) activeIndices(metricName string, schema []string) []int {
-	overrides := f.keepOverrides[metricName]
-	out := make([]int, 0, len(schema))
-	for i, l := range schema {
-		if _, dropped := f.drop[l]; dropped {
-			if _, kept := overrides[l]; !kept {
-				continue
-			}
-		}
-		out = append(out, i)
-	}
-	return out
+	return activeIndicesFor(f.drop, f.keepOverrides, metricName, schema)
 }
 
 // LabeledHistogram wraps a prometheus.HistogramVec whose label set is the

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -10,37 +10,37 @@ import (
 )
 
 var (
-	MetricUnexpectedPanicTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUnexpectedPanicTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "unexpected_panic_total",
 		Help:      "Total number of unexpected panics.",
 	}, []string{"scope", "extra", "error"})
 
-	MetricUpstreamRequestTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamRequestTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_total",
 		Help:      "Total number of actual requests to upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "attempt", "composite", "finality", "user", "agent_name"})
 
-	MetricUpstreamErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamErrorTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_errors_total",
 		Help:      "Total number of errors for actual requests towards upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "error", "severity", "composite", "finality", "user", "agent_name"})
 
-	MetricUpstreamSkippedTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamSkippedTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_skipped_total",
 		Help:      "Total number of requests skipped by upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "user", "agent_name"})
 
-	MetricUpstreamMissingDataErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamMissingDataErrorTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_missing_data_error_total",
 		Help:      "Total number of requests where upstream is missing data or not synced yet.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "user", "agent_name"})
 
-	MetricUpstreamEmptyResponseTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamEmptyResponseTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_empty_response_total",
 		Help:      "Total number of empty responses from upstreams.",
@@ -454,38 +454,38 @@ var (
 		Help:      "Times a (network, check) hit the all-upstream failure signature (repeated exhaustion within the detector window) — a strong indicator the check is protocol-invalid for that chain rather than catching corruption.",
 	}, []string{"project", "network", "check"})
 
-	MetricNetworkEvmGetLogsSplitSuccess = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsSplitSuccess = newLabeledCounterUnregistered(prometheus.CounterOpts{
 
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_split_success_total",
 		Help:      "Total number of successful split eth_getLogs sub-requests (network-scoped).",
 	}, []string{"project", "network", "user", "agent_name"})
 
-	MetricNetworkEvmGetLogsSplitFailure = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsSplitFailure = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_split_failure_total",
 		Help:      "Total number of failed split eth_getLogs sub-requests (network-scoped).",
 	}, []string{"project", "network", "user", "agent_name"})
 
-	MetricNetworkEvmGetLogsForcedSplits = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsForcedSplits = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_forced_splits_total",
 		Help:      "Total number of eth_getLogs request splits by dimension (block_range, addresses, topics), network-scoped.",
 	}, []string{"project", "network", "dimension", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterSplitSuccess = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterSplitSuccess = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_split_success_total",
 		Help:      "Total number of successful split trace_filter/arbtrace_filter sub-requests (network-scoped).",
 	}, []string{"project", "network", "method", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterSplitFailure = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterSplitFailure = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_split_failure_total",
 		Help:      "Total number of failed split trace_filter/arbtrace_filter sub-requests (network-scoped).",
 	}, []string{"project", "network", "method", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterForcedSplits = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterForcedSplits = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_forced_splits_total",
 		Help:      "Total number of trace_filter/arbtrace_filter request splits by dimension (block_range, from_address, to_address), network-scoped.",
@@ -509,7 +509,7 @@ var (
 		Help:      "Number of times block head rolled back by a large number vs previous latest block returned by the same upstream.",
 	}, []string{"project", "vendor", "network", "upstream"})
 
-	MetricUpstreamWrongEmptyResponseTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricUpstreamWrongEmptyResponseTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_wrong_empty_response_total",
 		Help:      "Total number of times an upstream returned a wrong empty response even though other upstreams returned data.",
@@ -532,13 +532,13 @@ var (
 		Help:      "Total number of BDS pool connections force-closed by the stuck-call watchdog.",
 	}, []string{"project", "upstream"})
 
-	MetricNetworkRequestsReceived = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkRequestsReceived = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_request_received_total",
 		Help:      "Total number of requests received for a network.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
-	MetricNetworkMultiplexedRequests = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkMultiplexedRequests = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_multiplexed_request_total",
 		Help:      "Total number of multiplexed requests for a network.",
@@ -550,13 +550,13 @@ var (
 		Help:      "Total number of requests served from a configured static response without contacting any upstream.",
 	}, []string{"project", "network", "category"})
 
-	MetricNetworkHedgedRequestTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkHedgedRequestTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_hedged_request_total",
 		Help:      "Total number of hedged requests towards a network.",
 	}, []string{"project", "network", "upstream", "category", "attempt", "finality", "user", "agent_name"})
 
-	MetricNetworkHedgeDiscardsTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkHedgeDiscardsTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_hedge_discards_total",
 		Help:      "Total number of hedged requests discarded towards a network (i.e. attempt > 1 means wasted requests).",
@@ -630,19 +630,19 @@ var (
 		Help:      "Total circuit-breaker state transitions per upstream and direction (closed_to_open/half_open_to_open/half_open_to_closed/open_to_half_open).",
 	}, []string{"project", "upstream", "transition"})
 
-	MetricNetworkFailedRequests = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkFailedRequests = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_failed_request_total",
 		Help:      "Total number of failed requests for a network.",
 	}, []string{"project", "network", "category", "attempt", "error", "severity", "finality", "user", "agent_name"})
 
-	MetricNetworkSuccessfulRequests = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkSuccessfulRequests = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_successful_request_total",
 		Help:      "Total number of successful requests for a network.",
 	}, []string{"project", "network", "vendor", "upstream", "category", "attempt", "finality", "emptyish", "user", "agent_name"})
 
-	MetricRateLimitsTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricRateLimitsTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limits_total",
 		Help:      "Unified rate limiting events (remote limits and budget decisions).",
@@ -654,13 +654,13 @@ var (
 		Help:      "Maximum number of requests allowed per second for a rate limiter budget (including auto-tuner).",
 	}, []string{"budget", "method", "scope"})
 
-	MetricRateLimiterBudgetDecisionTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricRateLimiterBudgetDecisionTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limiter_budget_decision_total",
 		Help:      "[DEPRECATED] Replaced by rate_limits_total. Total number of local rate-limit decisions by budget.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name", "budget", "method", "scope", "decision"})
 
-	MetricRateLimiterFailopenTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricRateLimiterFailopenTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limiter_failopen_total",
 		Help:      "Total number of rate limiter fail-open events (requests allowed due to errors/timeouts).",
@@ -695,7 +695,7 @@ var (
 		Help:      "Total number of cache set operations.",
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheSetErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricCacheSetErrorTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_error_total",
 		Help:      "Total number of cache set errors.",
@@ -719,7 +719,7 @@ var (
 		Help:      "Total number of cache get misses.",
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricCacheGetErrorTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_error_total",
 		Help:      "Total number of cache get errors.",
@@ -791,38 +791,38 @@ var (
 		Help:      "Total number of shadow upstream responses that differ from the expected response.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "emptyish", "larger"})
 
-	MetricShadowResponseErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricShadowResponseErrorTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "shadow_response_error_total",
 		Help:      "Total number of shadow upstream requests that resulted in error.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "error"})
 
 	// Authentication metrics
-	MetricAuthFailedTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricAuthFailedTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "auth_failed_total",
 		Help:      "Total number of failed authentication attempts.",
 	}, []string{"project", "network", "strategy", "reason", "agent_name"})
 
-	MetricConsensusTotal = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusTotal = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_total",
 		Help:      "Total number of consensus operations attempted.",
 	}, []string{"project", "network", "category", "outcome", "finality", "user", "agent_name"})
 
-	MetricConsensusMisbehaviorDetected = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusMisbehaviorDetected = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_misbehavior_detected_total",
 		Help:      "Total number of times an upstream returned different data (not errors) than consensus.",
 	}, []string{"project", "network", "upstream", "category", "finality", "response_type", "larger_than_consensus", "user", "agent_name"})
 
-	MetricConsensusUpstreamPunished = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusUpstreamPunished = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_upstream_punished_total",
 		Help:      "Total number of times upstreams were punished.",
 	}, []string{"project", "network", "upstream", "user", "agent_name"})
 
-	MetricConsensusShortCircuit = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusShortCircuit = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_short_circuit_total",
 		Help:      "Total number of consensus rounds that short-circuited.",
@@ -833,37 +833,37 @@ var (
 	// participant returned. High rates indicate persistently slow
 	// upstreams dragging tail latency — operators can drop those
 	// upstreams or tighten the wait caps further.
-	MetricConsensusWaitCapped = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusWaitCapped = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_wait_capped_total",
 		Help:      "Total number of consensus rounds resolved early due to MaxWaitOnResult/MaxWaitOnEmpty firing.",
 	}, []string{"project", "network", "category", "trigger", "finality", "user", "agent_name"})
 
-	MetricConsensusErrors = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusErrors = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_errors_total",
 		Help:      "Total number of consensus errors by type.",
 	}, []string{"project", "network", "category", "error", "finality", "user", "agent_name"})
 
-	MetricConsensusUpstreamErrors = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusUpstreamErrors = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_upstream_errors_total",
 		Help:      "Total number of errors from upstreams during consensus operations.",
 	}, []string{"project", "network", "upstream", "category", "finality", "response_type", "error_code", "user", "agent_name"})
 
-	MetricConsensusPanics = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusPanics = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_panics_total",
 		Help:      "Total number of panic recoveries in consensus.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
-	MetricConsensusCancellations = NewLabeledCounter(prometheus.CounterOpts{
+	MetricConsensusCancellations = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_cancellations_total",
 		Help:      "Total number of context cancellations during consensus.",
 	}, []string{"project", "network", "category", "phase", "finality", "user", "agent_name"})
 
-	MetricNetworkEvmBlockRangeRequested = NewLabeledCounter(prometheus.CounterOpts{
+	MetricNetworkEvmBlockRangeRequested = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_block_range_requested_total",
 		Help:      "Total requests observed by block-number buckets for heatmap.",
@@ -1146,19 +1146,21 @@ func SetHistogramBuckets(bucketsStr string) error {
 }
 
 // RebuildFilteredCounters re-creates every counter that carries
-// caller-controlled labels (user, agent_name, attempt, composite, hedge,
-// error) under the current CounterLabelFilter, then clears the handle cache
-// because the underlying Vecs are new objects.
+// caller-controlled labels under the current CounterLabelFilter and registers
+// them with prometheus.DefaultRegisterer. Package counters are built
+// unregistered at init (before config is read); this is the step that both
+// applies the filter and exposes them on /metrics — the same two-step the
+// histogram side uses (SetHistogramLabelFilter + SetHistogramBuckets).
 //
-// Counters are constructed at package init, before config is read, so a filter
-// installed via SetCounterLabelFilter only takes effect once this runs. This is
-// the same two-step the histogram side uses: SetHistogramLabelFilter followed
-// by SetHistogramBuckets.
+// Must be called exactly once per process against a given DefaultRegisterer.
+// Prometheus freezes a metric's label-set hash for the life of the registry
+// (dimHashesByName survives Unregister), so a second call with a different
+// filter panics. Call it unconditionally from erpc.Init after any
+// SetCounterLabelFilter, even when the filter is empty, so the unregistered
+// init-time counters become scrapeable.
 //
-// Counters without caller-controlled labels are left alone: their cardinality
-// is bounded by deployment topology, so filtering them would add a foot-gun
-// (silently dropping a dimension an operator did not think was in scope)
-// without meaningfully shrinking /metrics.
+// Counters without caller-controlled labels stay as plain promauto CounterVecs
+// and are left alone: their cardinality is bounded by deployment topology.
 func RebuildFilteredCounters() {
 	MetricUnexpectedPanicTotal = MetricUnexpectedPanicTotal.Rebuild()
 	MetricUpstreamRequestTotal = MetricUpstreamRequestTotal.Rebuild()
@@ -1196,6 +1198,45 @@ func RebuildFilteredCounters() {
 	MetricConsensusPanics = MetricConsensusPanics.Rebuild()
 	MetricConsensusCancellations = MetricConsensusCancellations.Rebuild()
 	MetricNetworkEvmBlockRangeRequested = MetricNetworkEvmBlockRangeRequested.Rebuild()
+
+	// Register once under the (possibly filtered) label set. registerOrReuse
+	// keeps a second call with identical labels idempotent for tests.
+	MetricUnexpectedPanicTotal = registerOrReuseCounter(MetricUnexpectedPanicTotal)
+	MetricUpstreamRequestTotal = registerOrReuseCounter(MetricUpstreamRequestTotal)
+	MetricUpstreamErrorTotal = registerOrReuseCounter(MetricUpstreamErrorTotal)
+	MetricUpstreamSkippedTotal = registerOrReuseCounter(MetricUpstreamSkippedTotal)
+	MetricUpstreamMissingDataErrorTotal = registerOrReuseCounter(MetricUpstreamMissingDataErrorTotal)
+	MetricUpstreamEmptyResponseTotal = registerOrReuseCounter(MetricUpstreamEmptyResponseTotal)
+	MetricNetworkEvmGetLogsSplitSuccess = registerOrReuseCounter(MetricNetworkEvmGetLogsSplitSuccess)
+	MetricNetworkEvmGetLogsSplitFailure = registerOrReuseCounter(MetricNetworkEvmGetLogsSplitFailure)
+	MetricNetworkEvmGetLogsForcedSplits = registerOrReuseCounter(MetricNetworkEvmGetLogsForcedSplits)
+	MetricNetworkEvmTraceFilterSplitSuccess = registerOrReuseCounter(MetricNetworkEvmTraceFilterSplitSuccess)
+	MetricNetworkEvmTraceFilterSplitFailure = registerOrReuseCounter(MetricNetworkEvmTraceFilterSplitFailure)
+	MetricNetworkEvmTraceFilterForcedSplits = registerOrReuseCounter(MetricNetworkEvmTraceFilterForcedSplits)
+	MetricUpstreamWrongEmptyResponseTotal = registerOrReuseCounter(MetricUpstreamWrongEmptyResponseTotal)
+	MetricNetworkRequestsReceived = registerOrReuseCounter(MetricNetworkRequestsReceived)
+	MetricNetworkMultiplexedRequests = registerOrReuseCounter(MetricNetworkMultiplexedRequests)
+	MetricNetworkHedgedRequestTotal = registerOrReuseCounter(MetricNetworkHedgedRequestTotal)
+	MetricNetworkHedgeDiscardsTotal = registerOrReuseCounter(MetricNetworkHedgeDiscardsTotal)
+	MetricNetworkFailedRequests = registerOrReuseCounter(MetricNetworkFailedRequests)
+	MetricNetworkSuccessfulRequests = registerOrReuseCounter(MetricNetworkSuccessfulRequests)
+	MetricRateLimitsTotal = registerOrReuseCounter(MetricRateLimitsTotal)
+	MetricRateLimiterBudgetDecisionTotal = registerOrReuseCounter(MetricRateLimiterBudgetDecisionTotal)
+	MetricRateLimiterFailopenTotal = registerOrReuseCounter(MetricRateLimiterFailopenTotal)
+	MetricCacheSetErrorTotal = registerOrReuseCounter(MetricCacheSetErrorTotal)
+	MetricCacheGetErrorTotal = registerOrReuseCounter(MetricCacheGetErrorTotal)
+	MetricShadowResponseErrorTotal = registerOrReuseCounter(MetricShadowResponseErrorTotal)
+	MetricAuthFailedTotal = registerOrReuseCounter(MetricAuthFailedTotal)
+	MetricConsensusTotal = registerOrReuseCounter(MetricConsensusTotal)
+	MetricConsensusMisbehaviorDetected = registerOrReuseCounter(MetricConsensusMisbehaviorDetected)
+	MetricConsensusUpstreamPunished = registerOrReuseCounter(MetricConsensusUpstreamPunished)
+	MetricConsensusShortCircuit = registerOrReuseCounter(MetricConsensusShortCircuit)
+	MetricConsensusWaitCapped = registerOrReuseCounter(MetricConsensusWaitCapped)
+	MetricConsensusErrors = registerOrReuseCounter(MetricConsensusErrors)
+	MetricConsensusUpstreamErrors = registerOrReuseCounter(MetricConsensusUpstreamErrors)
+	MetricConsensusPanics = registerOrReuseCounter(MetricConsensusPanics)
+	MetricConsensusCancellations = registerOrReuseCounter(MetricConsensusCancellations)
+	MetricNetworkEvmBlockRangeRequested = registerOrReuseCounter(MetricNetworkEvmBlockRangeRequested)
 
 	// The Vecs above are new objects; cached child handles point at the old
 	// ones and would otherwise increment series that are no longer collected.

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -10,37 +10,37 @@ import (
 )
 
 var (
-	MetricUnexpectedPanicTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUnexpectedPanicTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "unexpected_panic_total",
 		Help:      "Total number of unexpected panics.",
 	}, []string{"scope", "extra", "error"})
 
-	MetricUpstreamRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamRequestTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_total",
 		Help:      "Total number of actual requests to upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "attempt", "composite", "finality", "user", "agent_name"})
 
-	MetricUpstreamErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_errors_total",
 		Help:      "Total number of errors for actual requests towards upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "error", "severity", "composite", "finality", "user", "agent_name"})
 
-	MetricUpstreamSkippedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamSkippedTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_skipped_total",
 		Help:      "Total number of requests skipped by upstreams.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "user", "agent_name"})
 
-	MetricUpstreamMissingDataErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamMissingDataErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_missing_data_error_total",
 		Help:      "Total number of requests where upstream is missing data or not synced yet.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "user", "agent_name"})
 
-	MetricUpstreamEmptyResponseTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamEmptyResponseTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_request_empty_response_total",
 		Help:      "Total number of empty responses from upstreams.",
@@ -454,37 +454,38 @@ var (
 		Help:      "Times a (network, check) hit the all-upstream failure signature (repeated exhaustion within the detector window) — a strong indicator the check is protocol-invalid for that chain rather than catching corruption.",
 	}, []string{"project", "network", "check"})
 
-	MetricNetworkEvmGetLogsSplitSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsSplitSuccess = NewLabeledCounter(prometheus.CounterOpts{
+
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_split_success_total",
 		Help:      "Total number of successful split eth_getLogs sub-requests (network-scoped).",
 	}, []string{"project", "network", "user", "agent_name"})
 
-	MetricNetworkEvmGetLogsSplitFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsSplitFailure = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_split_failure_total",
 		Help:      "Total number of failed split eth_getLogs sub-requests (network-scoped).",
 	}, []string{"project", "network", "user", "agent_name"})
 
-	MetricNetworkEvmGetLogsForcedSplits = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmGetLogsForcedSplits = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_get_logs_forced_splits_total",
 		Help:      "Total number of eth_getLogs request splits by dimension (block_range, addresses, topics), network-scoped.",
 	}, []string{"project", "network", "dimension", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterSplitSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterSplitSuccess = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_split_success_total",
 		Help:      "Total number of successful split trace_filter/arbtrace_filter sub-requests (network-scoped).",
 	}, []string{"project", "network", "method", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterSplitFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterSplitFailure = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_split_failure_total",
 		Help:      "Total number of failed split trace_filter/arbtrace_filter sub-requests (network-scoped).",
 	}, []string{"project", "network", "method", "user", "agent_name"})
 
-	MetricNetworkEvmTraceFilterForcedSplits = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmTraceFilterForcedSplits = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_trace_filter_forced_splits_total",
 		Help:      "Total number of trace_filter/arbtrace_filter request splits by dimension (block_range, from_address, to_address), network-scoped.",
@@ -508,7 +509,7 @@ var (
 		Help:      "Number of times block head rolled back by a large number vs previous latest block returned by the same upstream.",
 	}, []string{"project", "vendor", "network", "upstream"})
 
-	MetricUpstreamWrongEmptyResponseTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricUpstreamWrongEmptyResponseTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "upstream_wrong_empty_response_total",
 		Help:      "Total number of times an upstream returned a wrong empty response even though other upstreams returned data.",
@@ -531,13 +532,13 @@ var (
 		Help:      "Total number of BDS pool connections force-closed by the stuck-call watchdog.",
 	}, []string{"project", "upstream"})
 
-	MetricNetworkRequestsReceived = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkRequestsReceived = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_request_received_total",
 		Help:      "Total number of requests received for a network.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
-	MetricNetworkMultiplexedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkMultiplexedRequests = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_multiplexed_request_total",
 		Help:      "Total number of multiplexed requests for a network.",
@@ -549,13 +550,13 @@ var (
 		Help:      "Total number of requests served from a configured static response without contacting any upstream.",
 	}, []string{"project", "network", "category"})
 
-	MetricNetworkHedgedRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkHedgedRequestTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_hedged_request_total",
 		Help:      "Total number of hedged requests towards a network.",
 	}, []string{"project", "network", "upstream", "category", "attempt", "finality", "user", "agent_name"})
 
-	MetricNetworkHedgeDiscardsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkHedgeDiscardsTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_hedge_discards_total",
 		Help:      "Total number of hedged requests discarded towards a network (i.e. attempt > 1 means wasted requests).",
@@ -629,19 +630,19 @@ var (
 		Help:      "Total circuit-breaker state transitions per upstream and direction (closed_to_open/half_open_to_open/half_open_to_closed/open_to_half_open).",
 	}, []string{"project", "upstream", "transition"})
 
-	MetricNetworkFailedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkFailedRequests = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_failed_request_total",
 		Help:      "Total number of failed requests for a network.",
 	}, []string{"project", "network", "category", "attempt", "error", "severity", "finality", "user", "agent_name"})
 
-	MetricNetworkSuccessfulRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkSuccessfulRequests = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_successful_request_total",
 		Help:      "Total number of successful requests for a network.",
 	}, []string{"project", "network", "vendor", "upstream", "category", "attempt", "finality", "emptyish", "user", "agent_name"})
 
-	MetricRateLimitsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricRateLimitsTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limits_total",
 		Help:      "Unified rate limiting events (remote limits and budget decisions).",
@@ -653,13 +654,13 @@ var (
 		Help:      "Maximum number of requests allowed per second for a rate limiter budget (including auto-tuner).",
 	}, []string{"budget", "method", "scope"})
 
-	MetricRateLimiterBudgetDecisionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricRateLimiterBudgetDecisionTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limiter_budget_decision_total",
 		Help:      "[DEPRECATED] Replaced by rate_limits_total. Total number of local rate-limit decisions by budget.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name", "budget", "method", "scope", "decision"})
 
-	MetricRateLimiterFailopenTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricRateLimiterFailopenTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "rate_limiter_failopen_total",
 		Help:      "Total number of rate limiter fail-open events (requests allowed due to errors/timeouts).",
@@ -694,7 +695,7 @@ var (
 		Help:      "Total number of cache set operations.",
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheSetErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricCacheSetErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_set_error_total",
 		Help:      "Total number of cache set errors.",
@@ -718,7 +719,7 @@ var (
 		Help:      "Total number of cache get misses.",
 	}, []string{"project", "network", "category", "connector", "policy", "ttl"})
 
-	MetricCacheGetErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricCacheGetErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_get_error_total",
 		Help:      "Total number of cache get errors.",
@@ -790,38 +791,38 @@ var (
 		Help:      "Total number of shadow upstream responses that differ from the expected response.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "finality", "emptyish", "larger"})
 
-	MetricShadowResponseErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricShadowResponseErrorTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "shadow_response_error_total",
 		Help:      "Total number of shadow upstream requests that resulted in error.",
 	}, []string{"project", "vendor", "network", "upstream", "category", "error"})
 
 	// Authentication metrics
-	MetricAuthFailedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricAuthFailedTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "auth_failed_total",
 		Help:      "Total number of failed authentication attempts.",
 	}, []string{"project", "network", "strategy", "reason", "agent_name"})
 
-	MetricConsensusTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusTotal = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_total",
 		Help:      "Total number of consensus operations attempted.",
 	}, []string{"project", "network", "category", "outcome", "finality", "user", "agent_name"})
 
-	MetricConsensusMisbehaviorDetected = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusMisbehaviorDetected = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_misbehavior_detected_total",
 		Help:      "Total number of times an upstream returned different data (not errors) than consensus.",
 	}, []string{"project", "network", "upstream", "category", "finality", "response_type", "larger_than_consensus", "user", "agent_name"})
 
-	MetricConsensusUpstreamPunished = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusUpstreamPunished = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_upstream_punished_total",
 		Help:      "Total number of times upstreams were punished.",
 	}, []string{"project", "network", "upstream", "user", "agent_name"})
 
-	MetricConsensusShortCircuit = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusShortCircuit = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_short_circuit_total",
 		Help:      "Total number of consensus rounds that short-circuited.",
@@ -832,37 +833,37 @@ var (
 	// participant returned. High rates indicate persistently slow
 	// upstreams dragging tail latency — operators can drop those
 	// upstreams or tighten the wait caps further.
-	MetricConsensusWaitCapped = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusWaitCapped = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_wait_capped_total",
 		Help:      "Total number of consensus rounds resolved early due to MaxWaitOnResult/MaxWaitOnEmpty firing.",
 	}, []string{"project", "network", "category", "trigger", "finality", "user", "agent_name"})
 
-	MetricConsensusErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusErrors = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_errors_total",
 		Help:      "Total number of consensus errors by type.",
 	}, []string{"project", "network", "category", "error", "finality", "user", "agent_name"})
 
-	MetricConsensusUpstreamErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusUpstreamErrors = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_upstream_errors_total",
 		Help:      "Total number of errors from upstreams during consensus operations.",
 	}, []string{"project", "network", "upstream", "category", "finality", "response_type", "error_code", "user", "agent_name"})
 
-	MetricConsensusPanics = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusPanics = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_panics_total",
 		Help:      "Total number of panic recoveries in consensus.",
 	}, []string{"project", "network", "category", "finality", "user", "agent_name"})
 
-	MetricConsensusCancellations = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricConsensusCancellations = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "consensus_cancellations_total",
 		Help:      "Total number of context cancellations during consensus.",
 	}, []string{"project", "network", "category", "phase", "finality", "user", "agent_name"})
 
-	MetricNetworkEvmBlockRangeRequested = promauto.NewCounterVec(prometheus.CounterOpts{
+	MetricNetworkEvmBlockRangeRequested = NewLabeledCounter(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_evm_block_range_requested_total",
 		Help:      "Total requests observed by block-number buckets for heatmap.",
@@ -1142,6 +1143,63 @@ func SetHistogramBuckets(bucketsStr string) error {
 	ResetHandleCache()
 
 	return parseErr
+}
+
+// RebuildFilteredCounters re-creates every counter that carries
+// caller-controlled labels (user, agent_name, attempt, composite, hedge,
+// error) under the current CounterLabelFilter, then clears the handle cache
+// because the underlying Vecs are new objects.
+//
+// Counters are constructed at package init, before config is read, so a filter
+// installed via SetCounterLabelFilter only takes effect once this runs. This is
+// the same two-step the histogram side uses: SetHistogramLabelFilter followed
+// by SetHistogramBuckets.
+//
+// Counters without caller-controlled labels are left alone: their cardinality
+// is bounded by deployment topology, so filtering them would add a foot-gun
+// (silently dropping a dimension an operator did not think was in scope)
+// without meaningfully shrinking /metrics.
+func RebuildFilteredCounters() {
+	MetricUnexpectedPanicTotal = MetricUnexpectedPanicTotal.Rebuild()
+	MetricUpstreamRequestTotal = MetricUpstreamRequestTotal.Rebuild()
+	MetricUpstreamErrorTotal = MetricUpstreamErrorTotal.Rebuild()
+	MetricUpstreamSkippedTotal = MetricUpstreamSkippedTotal.Rebuild()
+	MetricUpstreamMissingDataErrorTotal = MetricUpstreamMissingDataErrorTotal.Rebuild()
+	MetricUpstreamEmptyResponseTotal = MetricUpstreamEmptyResponseTotal.Rebuild()
+	MetricNetworkEvmGetLogsSplitSuccess = MetricNetworkEvmGetLogsSplitSuccess.Rebuild()
+	MetricNetworkEvmGetLogsSplitFailure = MetricNetworkEvmGetLogsSplitFailure.Rebuild()
+	MetricNetworkEvmGetLogsForcedSplits = MetricNetworkEvmGetLogsForcedSplits.Rebuild()
+	MetricNetworkEvmTraceFilterSplitSuccess = MetricNetworkEvmTraceFilterSplitSuccess.Rebuild()
+	MetricNetworkEvmTraceFilterSplitFailure = MetricNetworkEvmTraceFilterSplitFailure.Rebuild()
+	MetricNetworkEvmTraceFilterForcedSplits = MetricNetworkEvmTraceFilterForcedSplits.Rebuild()
+	MetricUpstreamWrongEmptyResponseTotal = MetricUpstreamWrongEmptyResponseTotal.Rebuild()
+	MetricNetworkRequestsReceived = MetricNetworkRequestsReceived.Rebuild()
+	MetricNetworkMultiplexedRequests = MetricNetworkMultiplexedRequests.Rebuild()
+	MetricNetworkHedgedRequestTotal = MetricNetworkHedgedRequestTotal.Rebuild()
+	MetricNetworkHedgeDiscardsTotal = MetricNetworkHedgeDiscardsTotal.Rebuild()
+	MetricNetworkFailedRequests = MetricNetworkFailedRequests.Rebuild()
+	MetricNetworkSuccessfulRequests = MetricNetworkSuccessfulRequests.Rebuild()
+	MetricRateLimitsTotal = MetricRateLimitsTotal.Rebuild()
+	MetricRateLimiterBudgetDecisionTotal = MetricRateLimiterBudgetDecisionTotal.Rebuild()
+	MetricRateLimiterFailopenTotal = MetricRateLimiterFailopenTotal.Rebuild()
+	MetricCacheSetErrorTotal = MetricCacheSetErrorTotal.Rebuild()
+	MetricCacheGetErrorTotal = MetricCacheGetErrorTotal.Rebuild()
+	MetricShadowResponseErrorTotal = MetricShadowResponseErrorTotal.Rebuild()
+	MetricAuthFailedTotal = MetricAuthFailedTotal.Rebuild()
+	MetricConsensusTotal = MetricConsensusTotal.Rebuild()
+	MetricConsensusMisbehaviorDetected = MetricConsensusMisbehaviorDetected.Rebuild()
+	MetricConsensusUpstreamPunished = MetricConsensusUpstreamPunished.Rebuild()
+	MetricConsensusShortCircuit = MetricConsensusShortCircuit.Rebuild()
+	MetricConsensusWaitCapped = MetricConsensusWaitCapped.Rebuild()
+	MetricConsensusErrors = MetricConsensusErrors.Rebuild()
+	MetricConsensusUpstreamErrors = MetricConsensusUpstreamErrors.Rebuild()
+	MetricConsensusPanics = MetricConsensusPanics.Rebuild()
+	MetricConsensusCancellations = MetricConsensusCancellations.Rebuild()
+	MetricNetworkEvmBlockRangeRequested = MetricNetworkEvmBlockRangeRequested.Rebuild()
+
+	// The Vecs above are new objects; cached child handles point at the old
+	// ones and would otherwise increment series that are no longer collected.
+	ResetHandleCache()
 }
 
 // registerOrReuse registers lh with prometheus.DefaultRegisterer. If a

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -53,9 +53,32 @@ export interface AdaptiveDuration {
 export const UpstreamTypeEvm: UpstreamType = "evm";
 export type EvmUpstream = 
     Upstream;
+/**
+ * EvmStateProvenReader is the OPTIONAL, separately-asserted surface for the
+ * state-proven boundary (see the integrity state prober). Deliberately NOT part
+ * of EvmUpstream: that interface is implemented outside this repo, and widening
+ * it broke every existing implementor — the chainId suggest-gate silently
+ * degraded when its upstream stopped satisfying the assertion. Optional
+ * capabilities are asserted narrowly, never added to the core interface.
+ */
+export type EvmStateProvenReader = any;
+/**
+ * EvmStateProvenWriter is the prober-facing half.
+ */
+export type EvmStateProvenWriter = any;
 export type AvailbilityConfidence = number /* int */;
 export const AvailbilityConfidenceBlockHead: AvailbilityConfidence = 1;
 export const AvailbilityConfidenceFinalized: AvailbilityConfidence = 2;
+/**
+ * AvailbilityConfidenceStateProven gates on the state-PROVEN head rather
+ * than the claimed head: the highest block for which the integrity state
+ * probe verified the upstream truly executes in that block's context /
+ * holds its state trie. Nodes sometimes answer state queries (eth_call,
+ * eth_getBalance, ...) from OLDER state while their reported head is
+ * current; this confidence exists so routing for state methods can refuse
+ * to outrun proof. Falls back to blockHead while nothing is proven yet.
+ */
+export const AvailbilityConfidenceStateProven: AvailbilityConfidence = 3;
 export type EvmNodeType = string;
 export const EvmNodeTypeUnknown: EvmNodeType = "unknown";
 export const EvmNodeTypeFull: EvmNodeType = "full";
@@ -580,6 +603,11 @@ export interface ProjectConfig {
   ignoreMethods?: string[];
   allowMethods?: string[];
   /**
+   * Integrity is the project-wide data-integrity configuration. It applies to
+   * all networks; each network may override it with its own integrity block.
+   */
+  integrity?: IntegrityConfig;
+  /**
    * ScoreMetricsWindowSize is the tumbling window the per-upstream
    * health tracker uses for its rolling counters (errorRate, p50/p70/
    * p95 latency, throttledRate, misbehaviorRate). At each tick the
@@ -808,6 +836,11 @@ export interface ShadowUpstreamConfig {
   sampleRate?: number /* float64 */;
   ignoreFields?: { [key: string]: string[]};
 }
+/**
+ * Deprecated: UpstreamIntegrityConfig is a non-functional legacy stub (never
+ * read at runtime). Configure data integrity via the network `integrity` block.
+ * Retained only so existing YAML still parses.
+ */
 export interface UpstreamIntegrityConfig {
   eth_getBlockReceipts?: UpstreamIntegrityEthGetBlockReceiptsConfig;
 }
@@ -876,6 +909,10 @@ export interface EvmUpstreamConfig {
    * misleading and causes circuit breaker false positives.
    */
   skipSyncingCheck?: boolean;
+  /**
+   * Deprecated: never read at runtime. Configure data integrity via the network
+   * `integrity` block instead. Retained only so existing YAML still parses.
+   */
   integrity?: UpstreamIntegrityConfig;
   /**
    * @deprecated: use blockAvailability bounds instead; kept for config back-compat only
@@ -924,6 +961,16 @@ export interface EvmAvailabilityBoundConfig {
 export interface FailsafeConfig {
   matchMethod?: string;
   matchFinality?: DataFinalityState[];
+  /**
+   * MatchRequestKind scopes this policy by who issued the request:
+   * "user" (client traffic), "internal" (erpc's own auxiliary fetches, e.g.
+   * the integrity module's canonical corroboration), or ""/"*" for both.
+   * This is what lets an operator give INTERNAL canonical fetches a
+   * consensus policy (quorum-verified ground truth, deduplicated to ~once
+   * per block by the ChainView) while user data methods rely on integrity
+   * validation instead of per-request fan-out.
+   */
+  matchRequestKind?: 'user' | 'internal' | '*';
   retry?: RetryPolicyConfig;
   circuitBreaker?: CircuitBreakerPolicyConfig;
   timeout?: TimeoutPolicyConfig;
@@ -1142,6 +1189,11 @@ export interface S3FlushConfig {
    */
   region?: string;
   /**
+   * Custom S3 endpoint URL for S3-compatible providers (Tigris, MinIO, R2, …).
+   * Empty = real AWS S3. When set, path-style addressing is used.
+   */
+  endpoint?: string;
+  /**
    * AWS credentials config (optional). If not specified, uses standard AWS credential chain:
    * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
    * 2. IAM role (for EC2/ECS/EKS)
@@ -1211,6 +1263,11 @@ export interface NetworkConfig {
   methods?: MethodsConfig;
   multiplexing?: boolean;
   staticResponses?: (StaticResponseConfig | undefined)[];
+  /**
+   * Integrity overrides the project-wide data-integrity configuration for this
+   * network. Merges over the project block (network wins).
+   */
+  integrity?: IntegrityConfig;
 }
 /**
  * StaticResponseConfig declares a canned JSON-RPC response for a specific
@@ -1255,48 +1312,30 @@ export interface DirectiveDefaultsConfig {
   enforceGetLogsBlockRange?: boolean;
   enforceNonNullTaggedBlocks?: boolean;
   /**
-   * ValidateTransactionsRoot: checks transactionsRoot vs transaction count consistency.
-   * Defaults to true. Disable for non-standard chains that use unusual trie roots.
+   * --- Deprecated data-integrity validation flags ---
+   * Deprecated: data integrity is now configured via the `integrity` block
+   * (projects[].integrity / networks[].integrity). These per-check flags are
+   * retained only so existing YAML still parses. At startup the flags that map
+   * to a current check are translated into `integrity.checks` by
+   * migrateLegacyIntegrityChecks (an explicit `integrity` block wins per check);
+   * they are NOT read at runtime. The receipt-count / expected-block /
+   * receipt-to-transaction flags have no equivalent in the new model and are
+   * accepted but ignored. See docs/pages/config/failsafe/integrity.mdx.
    */
   validateTransactionsRoot?: boolean;
-  /**
-   * Validation: Header Field Lengths
-   */
   validateHeaderFieldLengths?: boolean;
-  /**
-   * Validation: Transactions (for eth_getBlockByNumber/Hash with full txs)
-   */
   validateTransactionFields?: boolean;
   validateTransactionBlockInfo?: boolean;
-  /**
-   * Validation: Receipts & Logs
-   */
   enforceLogIndexStrictIncrements?: boolean;
   validateTxHashUniqueness?: boolean;
   validateTransactionIndex?: boolean;
   validateLogFields?: boolean;
-  /**
-   * Validation: Bloom Filter (simplified to 2 checks)
-   * ValidateLogsBloomEmptiness: if logs exist, bloom must not be zero; if bloom is non-zero, logs must exist
-   */
   validateLogsBloomEmptiness?: boolean;
-  /**
-   * ValidateLogsBloomMatch: recalculate bloom from logs and verify it matches the provided bloom
-   */
   validateLogsBloomMatch?: boolean;
-  /**
-   * Validation: Receipt-to-Transaction Cross-Validation (requires GroundTruthTransactions in library-mode)
-   */
   validateReceiptTransactionMatch?: boolean;
   validateContractCreation?: boolean;
-  /**
-   * Validation: numeric checks
-   */
   receiptsCountExact?: number /* int64 */;
   receiptsCountAtLeast?: number /* int64 */;
-  /**
-   * Validation: Expected Ground Truths
-   */
   validationExpectedBlockHash?: string;
   validationExpectedBlockNumber?: number /* int64 */;
 }
@@ -1502,6 +1541,20 @@ export interface SelectionPolicyConfig {
    * genuinely (method, finality)-specific health.
    */
   evalScope?: EvalScope | "network" | "network-method" | "network-finality" | "network-method-finality";
+  /**
+   * EvalPerBoundary scopes selection-policy evaluation by block-availability
+   * "lane" — the set of upstreams whose configured block range can actually
+   * serve the request's block. Unlike EvalPerMethod / EvalPerFinality this is
+   * deliberately NOT folded into EvalScope: it must not change the
+   * health-tracker grain (boundary is a decision/pool axis, not a metrics
+   * axis), so the engine reads it directly as an orthogonal slot dimension.
+   * When on, a request whose block excludes some upstream is evaluated
+   * against a lane-scoped pool — an upstream that cannot serve the range is
+   * absent from the pool (a capability fact), distinct from the policy's
+   * soft health-based deprioritization. Default off. Pointer-typed so a
+   * future SetDefaults can distinguish "absent" from "explicitly false".
+   */
+  evalPerBoundary?: boolean;
   evalTimeout?: Duration;
   /**
    * EvalFunc is the per-tick evaluation function. In YAML it's a JS
@@ -1656,6 +1709,28 @@ export interface MetricsConfig {
    */
   histogramLabelOverrides?: { [key: string]: string[]};
   /**
+   * CounterDropLabels removes these labels from every counter that carries
+   * caller-controlled dimensions (user, agent_name, attempt, composite,
+   * hedge, error). Histograms and gauges are unaffected; use
+   * HistogramDropLabels for the histogram side.
+   * Counters are usually the largest contributor to /metrics size, because a
+   * label like a client-supplied user-agent is unbounded and every tuple ever
+   * seen is re-emitted on every scrape. Dropping a label collapses the series
+   * that differed only in it — sums stay correct, but the dimension stops
+   * being queryable, so check what consumes it (billing/attribution
+   * pipelines, dashboards) before dropping.
+   */
+  counterDropLabels?: string[];
+  /**
+   * CounterLabelOverrides re-adds labels for specific counters even if they
+   * appear in CounterDropLabels. Key is the metric Name (without the "erpc_"
+   * namespace prefix), e.g. "upstream_request_total". Value is the list of
+   * label names to keep for that metric. Use this to drop a label fleet-wide
+   * while preserving it on the one or two counters a downstream pipeline
+   * actually reads.
+   */
+  counterLabelOverrides?: { [key: string]: string[]};
+  /**
    * CounterIdleEvictionAfter bounds /metrics cardinality for hot-path
    * counters whose label-sets are keyed by caller-controlled inputs
    * (method, user, agentName, ...). Counter series idle for at least this
@@ -1676,6 +1751,184 @@ export interface RateLimitStoreConfig {
   redis?: RedisConnectorConfig;
   cacheKeyPrefix?: string;
   nearLimitRatio?: number /* float32 */;
+}
+
+//////////
+// source: config_integrity.go
+
+/**
+ * IntegrityHeaderModeOff ignores per-request integrity headers entirely.
+ */
+export const IntegrityHeaderModeOff = "off";
+/**
+ * IntegrityHeaderModeProfiles lets a request select only a named profile.
+ */
+export const IntegrityHeaderModeProfiles = "profiles";
+/**
+ * IntegrityHeaderModeFull lets a request set a level / per-check overrides.
+ */
+export const IntegrityHeaderModeFull = "full";
+/**
+ * IntegritySettings is the reusable body of an integrity configuration: the
+ * front-door level plus the axes (checks / budget) and the per-finality
+ * verdict. The top-level/per-network blocks and every named profile share this
+ * shape — only IntegrityConfig adds the header surface and profiles on top.
+ */
+export interface IntegritySettings {
+  /**
+   * Level is the front-door preset: off | intrinsic | corroborated | authoritative.
+   */
+  level?: string;
+  /**
+   * Checks overrides individual checks by their catalog id (enable/disable,
+   * params, per-check failure mode).
+   */
+  checks?: { [key: string]: IntegrityCheckConfig | undefined};
+  /**
+   * Budget caps the canonical force-fetches the authoritative tier issues.
+   */
+  budget?: IntegrityBudgetConfig;
+  /**
+   * InvalidBehavior is the per-finality verdict for reorg-sensitive checks,
+   * where invalid data is ambiguously a node bug or a reorg. Deterministic
+   * checks ignore it and always reject.
+   */
+  invalidBehavior?: IntegrityInvalidBehaviorConfig;
+  /**
+   * ReorgWindow is how many blocks back from the tip the integrity ChainView
+   * keeps a number→hash pin + header and tracks reorgs (default 32). Raise for
+   * deep-reorg chains (e.g. polygon 256).
+   */
+  reorgWindow?: number /* int */;
+  /**
+   * ObserveOnly runs every enabled check but never lets a verdict touch the
+   * response: violations that WOULD have been rejected are recorded with the
+   * outcome "would_reject" and served anyway. This is the safe way to enable
+   * integrity on a network for the first time — it reveals both bad upstream
+   * data AND the module's own gaps on that chain at zero request risk, and
+   * the would_reject rate is exactly the client-facing cost enforcement
+   * would incur.
+   * It is ABSOLUTE and overrides everything else, including a per-check
+   * onFailure: reject and invalidBehavior — so a future release adding a new
+   * check cannot start rejecting on an observe-only network. Deterministic
+   * checks are covered too, which invalidBehavior alone cannot do (they
+   * ignore it by design).
+   */
+  observeOnly?: boolean;
+  /**
+   * StateProbe proves, per upstream, that the node actually holds the state
+   * trie it claims: on each new followed block, probe every upstream with an
+   * execution-context call (and eth_getProof where supported) verified
+   * against the follower's verified header, and advance that upstream's
+   * state-proven head only on success. Routing for state methods (eth_call,
+   * eth_getBalance, ...) then refuses to outrun proof. Requires follow to be
+   * enabled (the verified header is the trust anchor). Off by default.
+   */
+  stateProbe?: IntegrityStateProbeConfig;
+  /**
+   * Follow turns the ChainView into an actual chain follower: it walks the
+   * chain forward block by block, requires each block to name its
+   * predecessor's hash, and reconciles reorgs by finding the common ancestor.
+   * Off by default — it costs one eth_getBlockByNumber per block per network.
+   */
+  follow?: IntegrityFollowConfig;
+  /**
+   * MisbehaviorsDestination durably archives every integrity catch (reject or
+   * soft-flag) as a JSONL record — same file/S3 destination shape as the
+   * consensus policy's misbehaviorsDestination. Catches are rare, so the
+   * volume is low; the archive is the forensic record metrics can't carry.
+   */
+  misbehaviorsDestination?: MisbehaviorsDestinationConfig;
+}
+/**
+ * IntegrityFollowConfig configures the ChainView chain follower.
+ * Following gives the module a CONTIGUOUS, parent-linked view of the chain
+ * instead of the sparse scatter of heights that client traffic happens to
+ * touch. That is what lets it answer "is this block canonical" from a verified
+ * chain rather than from whichever source was observed first, and it is the
+ * precondition for any check that compares consecutive headers.
+ */
+export interface IntegrityFollowConfig {
+  /**
+   * Enabled turns the follower on for this network. Default false.
+   */
+  enabled?: boolean;
+  /**
+   * Interval is how often to check for new blocks (default 1s). Keep it below
+   * the chain's block time or the follower will run a step behind.
+   */
+  interval?: Duration;
+  /**
+   * MaxBlocksPerTick bounds catch-up work per tick (default 16), so a
+   * follower starting far behind converges steadily instead of bursting.
+   */
+  maxBlocksPerTick?: number /* int */;
+}
+/**
+ * IntegrityStateProbeConfig configures the per-upstream state-trie probes.
+ */
+export interface IntegrityStateProbeConfig {
+  /**
+   * Enabled turns the probes on. Default false.
+   */
+  enabled?: boolean;
+  /**
+   * Interval is the minimum time between probes of the same upstream
+   * (default 2s) — a bound on probe cost, not a schedule; probes fire on
+   * followed-block arrival.
+   */
+  interval?: Duration;
+}
+/**
+ * IntegrityConfig is an IntegritySettings plus the per-request header-control
+ * surface and the named profiles a request may select. It lives at the project
+ * level (applies to all networks) and the network level (overrides).
+ */
+export interface IntegrityConfig {
+  integritysettings: IntegritySettings;
+  /**
+   * HeaderMode controls whether/how per-request X-ERPC-Integrity headers may
+   * adjust integrity: off | profiles | full. Defaults to off.
+   */
+  headerMode?: string;
+  /**
+   * Profiles are named settings an operator defines; a request may select one
+   * by name via header when HeaderMode permits.
+   */
+  profiles?: { [key: string]: IntegritySettings | undefined};
+}
+/**
+ * IntegrityCheckConfig overrides a single check by its catalog id.
+ */
+export interface IntegrityCheckConfig {
+  /**
+   * Enabled forces the check on/off; nil leaves the level's decision intact.
+   */
+  enabled?: boolean;
+  /**
+   * Params are check-specific knobs (e.g. bloom equality-vs-superset).
+   */
+  params?: { [key: string]: string};
+  /**
+   * OnFailure overrides this check's failure mode: reject | soft-flag.
+   */
+  onFailure?: string;
+}
+/**
+ * IntegrityBudgetConfig caps the authoritative tier's canonical fetches.
+ */
+export interface IntegrityBudgetConfig {
+  maxPerSecond?: number /* int */;
+  maxConcurrent?: number /* int */;
+}
+/**
+ * IntegrityInvalidBehaviorConfig is the per-finality verdict for reorg-sensitive
+ * checks: reject | soft-flag | off, split by whether the response's block is
+ * finalized.
+ */
+export interface IntegrityInvalidBehaviorConfig {
+  finalized?: string;
+  unfinalized?: string;
 }
 
 //////////


### PR DESCRIPTION
## Problem

Counters, not histograms, are usually what makes a large `/metrics` payload. A label whose value comes from the caller — a user-agent, an API-key-derived user id — is unbounded, and Prometheus re-emits every tuple ever observed on every scrape for the life of the process.

That matters more than raw size because managed scrapers enforce their body limit on the **whole** response: past the ceiling the scrape is rejected outright rather than truncated, so every `erpc_*` series for that instance goes dark while the process keeps serving traffic. Counter gaps are also unrecoverable after the fact — once the gap exceeds the staleness window, `rate()`/`increase()` break across it.

Two knobs already exist and neither closes this:

- `histogramDropLabels` only covers histograms.
- `counterIdleEvictionAfter` reclaims series once they go quiet, but cannot help while the tuples are being actively incremented — a burst of new label values outruns it by construction.

## Change

The counter-side twin of the histogram pair:

```yaml
metrics:
  counterDropLabels: ['agent_name']
  counterLabelOverrides:
    upstream_request_total: ['agent_name']   # keep it where a pipeline reads it
```

Dropping a label collapses the series that differed only in it. **Sums stay correct; the dimension stops being queryable.** That trade is deployment-specific — counter labels are more likely than histogram labels to be load-bearing for billing or per-tenant attribution — which is why this is config rather than a baked-in default, and why `counterLabelOverrides` exists to spare individual counters.

## Implementation

Mirrors the existing histogram path so there's one shape to learn:

- `LabeledCounter` mirrors `LabeledHistogram` — canonical schema, active-index projection, full-schema call sites.
- `CounterHandle` now takes a `CounterIncrementable` interface, exactly as `ObserverHandle` takes `HistogramObservable`, so both `*prometheus.CounterVec` and `*LabeledCounter` work and **no call site changes**.
- `RebuildFilteredCounters` mirrors `SetHistogramBuckets`: package counters are built at init, before config is read, so installing a filter is only half the job.
- `buildLabelSets` / `activeIndicesFor` are now shared by both filters so their config parsing can't drift.

### One subtlety worth review attention

Under a filter, several full-schema tuples collapse onto one series, so `CounterHandle` keys its cache on the **post-filter** labels. Keying on the full tuple would create one cache entry per tuple over a shared series, and the idle sweep would then evict a series another live entry is still incrementing.

Both properties are covered by tests, and I verified they have teeth — removing the projection fails them:

```
--- FAIL: TestCounterHandle_CollapsedTuplesShareOneCacheEntry
    expected 1 cache entry for collapsed tuples, got 2
--- FAIL: TestCounterHandle_SweepKeepsSeriesLiveViaSiblingTuple
    expected 0 evicted while a sibling tuple is hot, got 1
```

## Scope

Applied to the 36 counters carrying caller-controlled labels (`user`, `agent_name`, `attempt`, `composite`, `hedge`, `error`). Counters bounded by deployment topology are deliberately left alone — filtering them would let an operator silently drop a dimension they didn't think was in scope, for no meaningful size win. Happy to widen if you'd prefer it uniform across all 80.

## Verification

- 7 new tests: collapse-preserves-sum, per-metric override, arity panic, shared cache entry, sweep-keeps-live-series, sweep-deletes-filtered-series, no-filter pass-through.
- `go test ./telemetry/... ./common/...` green.
- `go vet ./...` clean apart from one pre-existing finding in `erpc/query_executor_test.go` (untouched here).
- TypeScript config types regenerated with tygo; `docs/pages/operation/monitoring.mdx` and `cli.mdx` updated.