### PR TITLE
fix(deps): pin postcss to 8.5.18 to fix sourceMappingURL path traversal

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,9 @@
 	"pnpm": {
 		"ignoredBuiltDependencies": [
 			"sharp"
-		]
+		],
+		"overrides": {
+			"postcss": "8.5.18"
+		}
 	}
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: 8.5.18
+
 importers:
 
   .:
@@ -2136,8 +2139,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prism-react-renderer@2.4.1:
@@ -4940,7 +4943,7 @@ snapshots:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.18
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.27.7)(react@18.3.1)
@@ -5086,7 +5089,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  postcss@8.4.31:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1


### PR DESCRIPTION
## Summary
- Next.js bundles its own exact `postcss` version internally (`8.4.31` as of `next@15.5.19`), so bumping `next` alone doesn't change it
- Adds a pnpm `overrides` entry pinning `postcss` to `8.5.18` in `docs/package.json`, fixing [GHSA-r28c-9q8g-f849](https://github.com/postcss/postcss/security/advisories/GHSA-r28c-9q8g-f849): path traversal in previous source map auto-loading via `sourceMappingURL`, which could disclose the contents of arbitrary `.map` files reachable via `../` traversal (or an absolute path when `from` is unset)

## Test plan
- [x] `pnpm install` in `docs/` regenerates the lockfile with `postcss@8.5.18` resolved
- [x] `pnpm build` in `docs/` completes successfully