### PR TITLE
docs(agents): adopt the weakest-hypothesis design razor in agent guidelines

### DIFF
--- a/.cursor/rules/erpc.md
+++ b/.cursor/rules/erpc.md
@@ -2,6 +2,70 @@
 
 This project hosts **eRPC**, a fault-tolerant EVM RPC proxy with built-in caching, failover logic and a TypeScript CLI. The repository contains Go code for the server and TypeScript packages for tooling and configuration.
 
+## Design Razor: the Weakest Hypothesis, Not the Shortest
+
+Source: M. T. Bennett, *The Optimal Choice of Hypothesis Is the Weakest, Not
+the Shortest* (AGI-23; [arXiv:2301.12987](https://arxiv.org/abs/2301.12987)).
+The result in one line: among all hypotheses that EXACTLY account for what has
+been observed, the one most likely to also hold for unseen cases is the
+**weakest** — the one with the largest *extension* (the set of possibilities it
+still admits / inputs it still handles correctly). The paper proves weakness is
+necessary and sufficient to maximise the probability of generalising, while
+shortness/simplicity is neither. Its one-line razor: **"Explanations should be
+no more specific than necessary."**
+
+Generality is a property of a design's EXTENSION, not its FORM. "All things are
+blue crabs" is short and maximally overcommitted; a verbose pass-through can
+commit to almost nothing. A tidy regex or a clean enum is not evidence of
+generality.
+
+This razor is unusually load-bearing in eRPC because nearly every dimension we
+operate on is an open-ended set: chains, vendors, JSON-RPC methods, error
+shapes, response quirks, client behaviours. New members arrive weekly and
+UNANNOUNCED — the cost of an overcommitment here is silent misbehaviour on live
+traffic, not a compile error.
+
+Concretely, for every design and review in this repo:
+
+1. **The fallthrough is the primary path.** For any open set (methods, vendor
+   errors, response shapes, chains), much of tomorrow's traffic through your
+   code will be the case you did NOT enumerate. Design and test the
+   unknown-case default first; enumerated cases are optimisations layered on
+   top. A method table, error matcher, or chain special-case is acceptable only
+   when the unmatched path is safe, correct, and observable.
+2. **No unforced commitments.** Hard-coded `eth_*` method lists, vendor
+   error-string/regex matching, chain-ID special cases in core packages,
+   thresholds derived from "all chains/vendors we checked behave this way" —
+   each is a claim about ALL future members of an open set. If today's observed
+   data doesn't force the claim, don't make it.
+3. **Weaken by deleting structure, never by adding speculation.** Prefer
+   string + discovery over enum; kind + metadata over N parallel
+   structs/tables/endpoints; verbatim pass-through over interpretation; config
+   over code constants. Speculative abstraction (layers, hooks, options for
+   imagined futures) is not weakening — unexercised machinery is itself a
+   commitment. YAGNI governs form; the razor governs claims.
+4. **Weak ≠ vague.** The design must still decide every observed case exactly
+   (verified against real fixtures and tests), and open-ended inputs must still
+   resolve INTO a bounded, low-cardinality interface: any vendor error → one of
+   the finite normalized error codes; any method → one of the finite
+   cache/routing behaviours. Weakness in the claims, boundedness at the
+   interface.
+5. **Known invariants are data, not overreach.** True wire/protocol facts
+   (JSON-RPC 2.0 framing, hex-quantity encoding, chainId immutability) are
+   encoded as explicit, validated commitments at the edge — never smeared as
+   incidental assumptions through core logic. But measured behaviour is not an
+   invariant: N vendors or chains agreeing is an observation, not a law (a
+   traced-gas bound measured across six chains was later violated by EIP-3529
+   refunds on a seventh; the fix was deleting the bound, not adding an
+   exception). When reality violates a "bound", delete it — don't stack
+   exceptions.
+6. **No knobs for never-right behaviour.** A config flag whose one setting no
+   real use-case wants is added form with negative extension — fix the
+   semantics and delete the knob instead of shipping an opt-out for wrongness.
+7. **Review test.** For every design/PR ask: *what unseen-but-plausible input
+   does this silently mishandle, and what in today's observed data forces that
+   commitment?* If nothing forces it, weaken the design.
+
 ## Local Development
 
 ### Go code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,17 @@ it applies to all agents, not just Cursor.
 
 This file only repeats the bare minimum needed to bootstrap.
 
+## Design razor
+
+Among designs that exactly fit the observed cases, choose the WEAKEST — the
+one committing to the least beyond the data (Bennett,
+[arXiv:2301.12987](https://arxiv.org/abs/2301.12987): weakness, not
+shortness, predicts generalisation). Chains, vendors, methods, and error
+shapes are open-ended sets in this codebase: no unforced enums, method
+lists, or chain/vendor special-cases; the unknown-input fallthrough is the
+primary path — design and test it first. Full version with the review test:
+[`.cursor/rules/erpc.md`](.cursor/rules/erpc.md).
+
 ## Project
 
 - **eRPC** — fault-tolerant EVM RPC proxy with re-org-aware permanent caching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,40 @@
 # erpc — Claude Code Guide
 
 See [.cursor/rules/](.cursor/rules/) for all project rules and conventions.
+
+## Design razor: weakest hypothesis, not shortest
+
+Binding for all design and review work in this repo. From Bennett, AGI-23
+([arXiv:2301.12987](https://arxiv.org/abs/2301.12987)); full eRPC-tailored
+version in [.cursor/rules/erpc.md](.cursor/rules/erpc.md).
+
+Among designs that EXACTLY handle every observed case, prefer the one
+committing to the least beyond the data — "explanations should be no more
+specific than necessary". Generality lives in a design's extension (the unseen
+inputs it still handles correctly), not its form: short/tidy is provably
+neither necessary nor sufficient, and a compact regex or clean enum can be
+maximally overcommitted.
+
+eRPC's domain is open-ended sets (chains, vendors, methods, error shapes,
+client quirks), so:
+
+- The unknown-case fallthrough is the primary path — design and test it first;
+  enumerated cases (method tables, error matchers, chain special-cases) are
+  optimisations on top and only acceptable when the unmatched path is safe,
+  correct, and observable.
+- No unforced commitments: no hard-coded method lists, vendor error-string
+  matches, chain-ID special cases, or "all vendors we checked do X" thresholds
+  unless today's observed data forces them.
+- Weaken by DELETING structure (string + discovery over enum, kind + metadata
+  over parallel structs, pass-through over interpretation, config over code
+  constants) — never by adding speculative abstraction; unexercised machinery
+  is itself a commitment.
+- Weak ≠ vague: still decide every observed case exactly, and resolve open
+  inputs into bounded low-cardinality interfaces (normalized error codes,
+  finite behaviours).
+- Wire/protocol facts are explicit validated commitments at the edge; measured
+  behaviour of N chains/vendors is NOT an invariant — when reality violates a
+  bound, delete the bound rather than stacking exceptions.
+- Review test: what unseen-but-plausible input does this silently mishandle,
+  and what in today's data forces that commitment? If nothing forces it,
+  weaken the design.


### PR DESCRIPTION
## Summary

Encodes Bennett's razor — M. T. Bennett, *The Optimal Choice of Hypothesis Is the Weakest, Not the Shortest* (AGI-23, [arXiv:2301.12987](https://arxiv.org/abs/2301.12987)) — as a binding design/review principle for all AI agents (and humans) working on this repo.

The paper proves that among hypotheses which exactly fit the observed data, **weakness** (size of the extension — the set of unseen cases still handled correctly) is a necessary and sufficient proxy for generalisation, while shortness/simplicity (MDL) is neither; in its experiments the weakest model generalised at 1.1–5× the rate of the shortest. One-line form: *explanations should be no more specific than necessary.*

This matters unusually much for eRPC because nearly every dimension we operate on — chains, vendors, JSON-RPC methods, error shapes, client quirks — is an open-ended set whose new members arrive unannounced, so overcommitment shows up as silent misbehaviour on live traffic rather than a compile error.

## Changes

- **`.cursor/rules/erpc.md`** (canonical rules): full eRPC-tailored razor — the fallthrough is the primary path; no unforced commitments (method lists, error-string matches, chain special-cases, measured-behaviour thresholds); weaken by deleting structure, never by speculative abstraction; weak ≠ vague (exact on observed cases, bounded low-cardinality interfaces); wire-contract facts vs measured behaviour; no knobs for never-right behaviour; and the review test.
- **`CLAUDE.md`**: compact binding version auto-loaded by Claude Code sessions.
- **`AGENTS.md`**: bootstrap pointer for cross-tool agents.

## Test plan

Docs/agent-guidance only — no code or config schema changes; `make fmt`/`make test` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
