### PR TITLE
fix(evm): cover eth_getProof/eth_simulateV1/debug_traceCall in state-proven boundary

### DIFF
--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -104,7 +104,8 @@ func HandleUpstreamPreForward(ctx context.Context, n common.Network, u common.Up
 		return false, nil, err
 	}
 
-	switch strings.ToLower(method) {
+	methodLower := strings.ToLower(method)
+	switch methodLower {
 	case "eth_getlogs":
 		return upstreamPreForward_eth_getLogs(ctx, n, u, r)
 	case "eth_chainid":
@@ -113,10 +114,14 @@ func HandleUpstreamPreForward(ctx context.Context, n common.Network, u common.Up
 		return upstreamPreForward_trace_filter(ctx, n, u, r)
 	case "eth_queryblocks", "eth_querytransactions", "eth_querylogs", "eth_querytraces", "eth_querytransfers":
 		return upstreamPreForward_eth_query(ctx, n, u, r)
-	case "eth_call", "eth_getbalance", "eth_getcode", "eth_getstorageat",
-		"eth_gettransactioncount", "eth_estimategas":
-		return upstreamPreForward_stateBoundary(ctx, n, u, r, method)
 	default:
+		// The state-proven boundary protects a CLASS (methods answered from the
+		// state trie at a block), not a list copied to this call site. The class
+		// is defined once, in common.IsEvmStateQueryMethod, so a method joining
+		// it cannot be gated in one place and forgotten in another.
+		if common.IsEvmStateQueryMethod(methodLower) {
+			return upstreamPreForward_stateBoundary(ctx, n, u, r, method)
+		}
 		return false, nil, nil
 	}
 }
@@ -141,8 +146,10 @@ func upstreamPreForward_stateBoundary(ctx context.Context, n common.Network, u c
 	}
 	_, blockNumber, err := ExtractBlockReferenceFromRequest(ctx, r)
 	if err != nil || blockNumber <= 0 {
-		// Tags (latest/pending) and unparseable refs are not gated here: the
-		// proven boundary is a statement about a CONCRETE height.
+		// Tags (latest/pending), unparseable refs, and requests whose height the
+		// method config cannot locate are not gated here: the proven boundary is
+		// a statement about a CONCRETE height, so with no height there is nothing
+		// to compare and the request goes out as it does today.
 		return false, nil, nil
 	}
 	eu, ok := u.(common.EvmUpstream)

--- a/architecture/evm/integrity_stateprobe_test.go
+++ b/architecture/evm/integrity_stateprobe_test.go
@@ -208,6 +208,97 @@ func TestStateBoundaryGate(t *testing.T) {
 	})
 }
 
+// The boundary protects a CLASS of methods — everything answered from the state
+// trie at a block — and the routing switch is where a member gets forgotten: an
+// ungated state method reaches the upstream with no proof at all, which is the
+// silent-wrong-data case the gate exists to prevent. Every case here goes
+// through the public hook entry point, so dropping a method from the dispatch
+// fails this test rather than silently disabling the protection for it.
+//
+// The params are written the way a client sends them (block parameter in its
+// real position, later arguments present), so a wrong ReqRefs position shows up
+// as an ungated request instead of passing by accident.
+func TestStateBoundaryGate_StateMethodCoverage(t *testing.T) {
+	const proven = int64(0x0f0)
+
+	cases := []struct {
+		method string
+		params string // %s is where the block parameter goes
+	}{
+		// Already covered before this test existed — pinned so the six cannot
+		// regress while the class is being widened.
+		{"eth_call", `[{"to":"0x1234"},"%s"]`},
+		{"eth_getBalance", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
+		{"eth_getCode", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
+		{"eth_getStorageAt", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","0x0","%s"]`},
+		{"eth_getTransactionCount", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
+		{"eth_estimateGas", `[{"to":"0x1234"},"%s"]`},
+		// The state trie itself: block is the THIRD param, after the storage keys.
+		{"eth_getProof", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x00"],"%s"]`},
+		// EVM execution at a block, exactly like eth_call: block is the SECOND param.
+		{"eth_simulateV1", `[{"blockStateCalls":[{"calls":[{"to":"0x1234"}]}]},"%s"]`},
+		// Same, with a trailing tracer config the extraction must not mistake
+		// for the block parameter.
+		{"debug_traceCall", `[{"to":"0x1234"},"%s",{"tracer":"callTracer"}]`},
+	}
+
+	mkReq := func(method, params, block string) *common.NormalizedRequest {
+		return common.NewNormalizedRequest([]byte(fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}`,
+			method, fmt.Sprintf(params, block))))
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			n := &mockNetwork{}
+			n.On("Id").Return("evm:7777").Maybe()
+			stateProbers.Store("evm:7777", &stateProber{})
+			defer stateProbers.Delete("evm:7777")
+			u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: proven}
+
+			// Below the proven head: the upstream demonstrably holds this state.
+			handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0xe0"), false)
+			assert.False(t, handled, "a block the upstream has PROVEN must pass through")
+			assert.NoError(t, err)
+
+			// Above the proven head: no proof covers it, so refuse and let
+			// retry/consensus route to an upstream that can prove it.
+			handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0x100"), false)
+			assert.True(t, handled, "an unproven block must not be forwarded ungated")
+			require.Error(t, err)
+			assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable), err.Error())
+			assert.Contains(t, err.Error(), tc.method, "the refusal must name the method it refused")
+
+			// A tag names no concrete height, so there is nothing to compare it
+			// against — unchanged from before this method joined the class.
+			handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "latest"), false)
+			assert.False(t, handled, "tag requests are not gated (the boundary is about concrete heights)")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// Widening the class must not pull in chain-data methods: those read blocks,
+// receipts and logs, which a node with stale STATE still answers correctly, and
+// they have their own availability enforcement.
+func TestStateBoundaryGate_ChainDataMethodsStayUngated(t *testing.T) {
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x100",false]}`,
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts","params":["0x100"]}`,
+		`{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":["0x100"]}`,
+		`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["0xdead"]}`,
+	} {
+		n := &mockNetwork{}
+		n.On("Id").Return("evm:7777").Maybe()
+		stateProbers.Store("evm:7777", &stateProber{})
+		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 0x0f0}
+		handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, common.NewNormalizedRequest([]byte(body)), false)
+		stateProbers.Delete("evm:7777")
+		assert.False(t, handled, body)
+		assert.NoError(t, err, body)
+	}
+}
+
 // gateUpstream lets a test dictate the proven head and route the assert through
 // the real StateProven semantics (refuse above proven, allow at/below).
 type gateUpstream struct {

--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -190,11 +190,40 @@ type EvmProbeEarliestInfo struct {
 // IsEvmStateQueryMethod reports whether a method reads the STATE TRIE at a
 // block (as opposed to chain data like blocks/receipts/logs). These are the
 // methods a node can silently answer from older state, so they are the ones
-// the state-proven boundary applies to.
+// the state-proven boundary applies to (architecture/evm/hooks.go).
+//
+// Membership is a two-part test, and BOTH parts must hold:
+//
+//  1. the method's answer is a function of the state trie at the requested
+//     block (a balance, a slot, code, an account proof, or an EVM execution in
+//     that block's context) — a node with stale state answers it wrongly while
+//     reporting a current head; and
+//  2. the requested block is resolvable from the request through the method's
+//     ReqRefs (common/defaults.go), because a boundary that cannot name a
+//     height cannot enforce one.
+//
+// This list is an enumeration over an open set, so its unmatched path is the
+// one that matters: an unlisted state method is simply NOT gated (fail-open,
+// exactly today's behavior for it). Adding a method here can only ever refuse
+// or divert traffic the proven head does not cover, so extend it whenever parts
+// 1 and 2 both hold. Known state-reading methods still absent:
+//
+//   - eth_createAccessList, debug_traceCallMany — no method config at all, so
+//     part 2 fails and gating them would be inert until they get one.
+//   - trace_call — its block parameter is the second OR third argument
+//     depending on the client, and on the variant where trace types occupy the
+//     second argument the extraction errors out, so the gate would be inert for
+//     exactly those requests. Pin the position first.
+//   - the arbtrace_call family — parts 1 and 2 both hold; left out only to keep
+//     this change to the methods the gap review named.
 func IsEvmStateQueryMethod(methodLower string) bool {
 	switch methodLower {
 	case "eth_call", "eth_getbalance", "eth_getcode", "eth_getstorageat",
-		"eth_gettransactioncount", "eth_estimategas":
+		"eth_gettransactioncount", "eth_estimategas",
+		// eth_getProof IS the state trie (params[2] is the block); eth_simulateV1
+		// (params[1]) and debug_traceCall (params[1]) execute the EVM against the
+		// state at the requested block exactly like eth_call does.
+		"eth_getproof", "eth_simulatev1", "debug_tracecall":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

The state-proven boundary (`upstreamPreForward_stateBoundary`) refuses to send a state query to an upstream whose **proven** head does not cover the requested block. It exists because a node can answer `eth_call`/`eth_getBalance` from *older* state while reporting a current head — a well-formed response with the wrong answer, which nothing else in eRPC can see.

Its routing switch in `HandleUpstreamPreForward` listed six methods and fell through to "no gate" for everything else. Three methods that are answered from the state trie at a block were therefore reaching upstreams with **no proof at all**:

| Method | Why it is in the class | Block parameter |
|---|---|---|
| `eth_getProof` | *is* the state trie (account + storage proof at a block) | `params[2]` |
| `eth_simulateV1` | executes the EVM against the state at a block | `params[1]` |
| `debug_traceCall` | executes the EVM against the state at a block, like `eth_call` | `params[1]` |

This PR gates all three, and removes the duplicated method list.

## What changed

- **`common/architecture_evm.go`** — `IsEvmStateQueryMethod` was **dead code** (zero callers) that duplicated the switch's six-method list. It is now the single definition of the protected class, extended with the three methods, and its doc comment states the two-part membership test (answer is a function of the state trie at the requested block **and** the block is resolvable via the method's `ReqRefs`), plus which state-reading methods remain out and why.
- **`architecture/evm/hooks.go`** — the switch's hand-copied list is deleted; the `default` branch consults `common.IsEvmStateQueryMethod`. One place defines the class, so a method can no longer be gated in one file and forgotten in another. The six already-gated methods dispatch exactly as before.
- **Tests** — `TestStateBoundaryGate_StateMethodCoverage` (all nine methods, through the public hook entry point) and `TestStateBoundaryGate_ChainDataMethodsStayUngated`.
- **No change to `common/defaults.go`.** See below.

## Razor rationale

An enumerated list is acceptable when its unmatched path is safe. Here the unmatched path of a **safety gate fails open**: an unlisted state method is forwarded with no proof, silently. That inverts the rule — the fallthrough is the primary path and it is the unsafe one, so the enumeration has to actually cover the class it claims to protect.

The change weakens by **deleting** structure rather than adding it: two lists become one predicate, and the predicate is stated as a *criterion* (state-trie read + resolvable height) rather than as a bare set, so the next method is a one-line addition against a written test instead of a rediscovery of the same gap. Nothing speculative is added — no new config surface, no new abstraction layer.

Adding a member to this class is monotone in the safe direction: it can only refuse or divert a request that the upstream's proven head does not cover, and refusal is a retryable `ErrUpstreamBlockUnavailable` that routes to an upstream which *can* prove the height.

## Caching semantics — unchanged, and no method-table edit was needed

The concern going in was that `common/defaults.go`'s method tables also drive caching, so adding `ReqRefs` to reach the block could make these methods newly cacheable. **That turned out to be unnecessary: all three already have entries in `DefaultWithBlockCacheMethods`** (`eth_getProof: ThirdParam`, `eth_simulateV1: SecondParam`, `debug_traceCall: SecondParam`), and those positions already match the JSON-RPC spec. So:

- `common/defaults.go` is untouched → cache eligibility, cache keys, TTLs and finality are byte-identical for every method.
- The boundary calls `ExtractBlockReferenceFromRequest`, which for these methods was **already** being computed on the normal request path — `NormalizeHttpJsonRpc` (via `Network.prepareRequest`) walks the same `ReqRefs` for tag interpolation before the upstream pre-forward hook ever runs. No new parsing commitment, no new failure mode.
- The gate is also inert unless the integrity **state prober** is running for the network (`integrity.stateProbe.enabled`, itself requiring `follow`), which is off by default.

> One correction to the original problem statement: it listed `debug_traceCall`'s block as `params[2]`. Per the geth API (`debug_traceCall(callObject, blockNrOrHash, config)`) it is `params[1]`, which is what `defaults.go` already encodes and what `erpc/networks_interpolation_test.go` asserts. The new test sends a trailing tracer config so a wrong position would surface as an ungated request rather than a silent pass.

## The gate's own fallthrough (unchanged, documented)

When `ExtractBlockReferenceFromRequest` returns an error or `blockNumber <= 0`, the boundary returns "not handled" and the request is forwarded **ungated**. That covers:

1. **Block tags** — `latest`/`pending`/`safe` name no concrete height. (In production `latest`/`finalized` are usually already interpolated to hex before this hook, so tagged state calls generally *are* gated.)
2. **Unparseable refs** — any `ReqRefs` position that fails to parse aborts the whole extraction with an error → ungated.
3. **No resolvable height** — a method with no entry in the method tables, or a param shape the refs do not match.

There is also a **case-sensitivity** wrinkle worth knowing: dispatch lowercases the method, but `getMethodConfig` looks the method up by exact case. A client sending `ETH_CALL` would be dispatched to the boundary and then resolve no block ref → ungated. This is pre-existing and affects the original six identically; it is not addressed here.

The comment at that branch now names all three cases explicitly.

## Evaluated and deliberately not done: "reads EVM state" as per-method metadata

Folding the property into `common.CacheMethodConfig` (so `networks[].methods.definitions` could extend the class without a code change) was evaluated and rejected for this PR:

- It is a **config schema change** — `CacheMethodConfig` is serialized to YAML/JSON and generated into `typescript/config/src/generated.ts`.
- More importantly, it would put a **safety** property inside an **operator-overridable cache** structure. `getMethodConfig` takes a network's `methods.definitions[method]` **wholesale** and never merges it with the defaults, so an operator overriding `eth_call` purely to tune caching would silently drop its `stateQuery: true` and disable the protection — reintroducing exactly the fail-open failure this PR closes, in a place nobody would look.
- No existing field can derive the property (`ReqRefs` presence is equally true of `eth_getBlockByNumber`), so there is no zero-schema derivation either.

If per-method extensibility is wanted later, the right shape is a separate, additive list on the integrity/state-probe config (e.g. `stateProbe.additionalStateMethods`) that only ever **adds** to the built-in class — not a field an unrelated override can remove.

## Docs

No page under `docs/pages/` documents the state-proven boundary. `integrity.mdx` documents `level` / `checks` / `invalidBehavior` / `observeOnly` / `profiles` / `reorgWindow`, but `integrity.stateProbe` and `integrity.follow` (its prerequisite) are absent from the config-schema table, the edge cases and observability — as are `erpc_upstream_state_probe_total`, `erpc_upstream_state_proven_block` and `erpc_upstream_state_proven_lag`. So there is no "covered methods" list to extend. Documenting the state prober end-to-end is a self-contained follow-up rather than a rider on a gate fix.

## Test plan

- `TestStateBoundaryGate_StateMethodCoverage` — table over all nine state methods, driven through `HandleUpstreamPreForward` (the switch is where a member gets forgotten, so the test exercises the public entry point, not the boundary function). Each method asserts three things: a block **at/below** the proven head passes through; a block **above** it is refused with a retryable `ErrUpstreamBlockUnavailable` naming the method; a tag is not gated. Params are written as a client sends them (real block position, later arguments present).
- `TestStateBoundaryGate_ChainDataMethodsStayUngated` — `eth_getBlockByNumber`, `eth_getBlockReceipts`, `debug_traceBlockByNumber`, `eth_getTransactionReceipt` stay ungated: stale *state* does not make those wrong, and they have their own availability enforcement.
- **Mutation-checked**: with the three methods removed from `IsEvmStateQueryMethod`, the three new subtests fail on exactly the "an unproven block must not be forwarded ungated" assertion while the six pre-existing ones still pass — the test proves the fix, not the plumbing.
- Existing `TestStateBoundaryGate` / `TestStateProber` unchanged and green.

Verification: `gofmt` clean on the touched files, `go vet ./architecture/evm/... ./common/...` clean, `go test ./architecture/evm/... ./common/...` green, `make test-fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
