### PR TITLE
refactor(erpc): consolidate evm architecture dispatch into one seam

### DIFF
--- a/erpc/architecture.go
+++ b/erpc/architecture.go
@@ -1,0 +1,170 @@
+package erpc
+
+import (
+	"context"
+
+	"github.com/erpc/erpc/architecture/evm"
+	"github.com/erpc/erpc/common"
+)
+
+// archBehavior is the single seam through which the per-request path reaches
+// architecture-specific logic. Every operation listed here was previously an
+// `if/switch n.cfg.Architecture == common.ArchitectureEvm` (or, worse, an
+// ungated `evm.*` call) scattered across networks.go / projects.go.
+//
+// EVM is the only architecture this build supports, and this seam does not
+// pretend otherwise: it is NOT a plugin framework and there is no registration
+// API. It exists so the EVM commitment is made in ONE place and applied
+// UNIFORMLY, instead of being restated (and half-applied) at a dozen call
+// sites. The member set is derived strictly from the call sites that exist
+// today — nothing speculative is declared here.
+//
+// The interface (rather than a struct of function fields) is deliberate: the
+// compiler then guarantees an architecture either implements every operation
+// the request path performs, or does not resolve at all. There is no
+// "partially implemented architecture" state to nil-check per member.
+type archBehavior interface {
+	// prepareRequest normalizes an incoming request before dispatch.
+	// Called from Network.prepareRequest.
+	prepareRequest(ctx context.Context, nr *common.NormalizedRequest) error
+
+	// applySafeBlockSource routes "safe"-tagged requests, before multiplexing
+	// and cache lookup. Called from Network.Forward.
+	applySafeBlockSource(ctx context.Context, n *Network, req *common.NormalizedRequest) error
+
+	// projectPreForward is the early, project-level (cache-affecting,
+	// upstream-agnostic) pre-forward hook. Called from PreparedProject.doForward.
+	projectPreForward(ctx context.Context, n *Network, nq *common.NormalizedRequest) (handled bool, resp *common.NormalizedResponse, err error)
+
+	// networkPreForward is the network-level pre-forward hook, executed after
+	// upstream selection so it can see the candidate list. Called from Network.Forward.
+	networkPreForward(ctx context.Context, n *Network, upstreams []common.Upstream, nq *common.NormalizedRequest) (handled bool, resp *common.NormalizedResponse, err error)
+
+	// networkPostForward is the network-level post-forward hook. Called from
+	// PreparedProject.doForward on every path (short-circuited and forwarded alike).
+	networkPostForward(ctx context.Context, n *Network, nq *common.NormalizedRequest, nr *common.NormalizedResponse, re error) (*common.NormalizedResponse, error)
+
+	// upstreamPreForward / upstreamPostForward wrap a single upstream attempt.
+	// Called from Network.doForward.
+	upstreamPreForward(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, skipCacheRead bool) (handled bool, resp *common.NormalizedResponse, err error)
+	upstreamPostForward(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, resp *common.NormalizedResponse, re error, skipCacheRead bool) (*common.NormalizedResponse, error)
+
+	// requestBlockNumber resolves the concrete block a request targets, or 0
+	// when it carries none (tags, hashes, unparseable params).
+	requestBlockNumber(ctx context.Context, req *common.NormalizedRequest) int64
+
+	// responseBlockNumber resolves the concrete block a response pertains to,
+	// or 0 when it carries none.
+	responseBlockNumber(ctx context.Context, resp *common.NormalizedResponse) int64
+
+	// checkUpstreamBlockAvailability gates one upstream attempt on the
+	// upstream's configured block-availability bounds.
+	checkUpstreamBlockAvailability(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool)
+
+	// eligibleUpstreamIDsForBoundary derives the block-availability lane for a
+	// single-block request, feeding the selection policy's per-boundary axis.
+	eligibleUpstreamIDsForBoundary(ctx context.Context, n *Network, method string, req *common.NormalizedRequest) []string
+
+	// enrichStatePoller feeds head observations from a served response back
+	// into the responding upstream's state poller.
+	enrichStatePoller(ctx context.Context, n *Network, method string, req *common.NormalizedRequest, resp *common.NormalizedResponse)
+}
+
+// evmBehavior implements archBehavior for `evm` networks. Most members are
+// straight delegations to architecture/evm; the three that need Network
+// internals (block-availability gating, boundary lanes, state-poller
+// enrichment) keep their bodies in networks.go next to the code they
+// collaborate with, and are wired in from here by receiver type.
+type evmBehavior struct{}
+
+// archBehaviorFor maps an architecture to its behavior, or nil when this build
+// has no implementation for it. Unsupported architectures are already rejected
+// at the construction edge (NetworksRegistry.prepareNetwork), so a nil here
+// means "a Network was assembled outside that edge" — every call site treats it
+// as "run no architecture-specific logic" rather than assuming EVM.
+func archBehaviorFor(architecture common.NetworkArchitecture) archBehavior {
+	switch architecture {
+	case common.ArchitectureEvm:
+		return evmBehavior{}
+	default:
+		return nil
+	}
+}
+
+// arch resolves this network's architecture behavior. Resolution is a two-case
+// switch returning a stateless zero-size value, so it is deliberately NOT
+// cached on the Network: a cached field would add construction-order coupling
+// (and a nil-field hazard for the package-internal tests that assemble
+// `&Network{...}` directly) without making any input resolve differently.
+//
+// Network.Architecture() is the single resolution rule — including its
+// "empty architecture with an evm block means evm" default — so the seam and
+// the network's own answer to "what architecture am I" can never disagree.
+func (n *Network) arch() archBehavior {
+	if n == nil || n.cfg == nil {
+		return nil
+	}
+	return archBehaviorFor(n.Architecture())
+}
+
+func (evmBehavior) prepareRequest(ctx context.Context, nr *common.NormalizedRequest) error {
+	jsonRpcReq, err := nr.JsonRpcRequest(ctx)
+	if err != nil {
+		return common.NewErrJsonRpcExceptionInternal(
+			0,
+			common.JsonRpcErrorParseException,
+			"failed to unmarshal json-rpc request",
+			err,
+			nil,
+		)
+	}
+	evm.NormalizeHttpJsonRpc(ctx, nr, jsonRpcReq)
+	return nil
+}
+
+func (evmBehavior) applySafeBlockSource(ctx context.Context, n *Network, req *common.NormalizedRequest) error {
+	return evm.ApplySafeBlockSource(ctx, n, req)
+}
+
+func (evmBehavior) projectPreForward(ctx context.Context, n *Network, nq *common.NormalizedRequest) (bool, *common.NormalizedResponse, error) {
+	return evm.HandleProjectPreForward(ctx, n, nq)
+}
+
+func (evmBehavior) networkPreForward(ctx context.Context, n *Network, upstreams []common.Upstream, nq *common.NormalizedRequest) (bool, *common.NormalizedResponse, error) {
+	return evm.HandleNetworkPreForward(ctx, n, upstreams, nq)
+}
+
+func (evmBehavior) networkPostForward(ctx context.Context, n *Network, nq *common.NormalizedRequest, nr *common.NormalizedResponse, re error) (*common.NormalizedResponse, error) {
+	return evm.HandleNetworkPostForward(ctx, n, nq, nr, re)
+}
+
+func (evmBehavior) upstreamPreForward(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, skipCacheRead bool) (bool, *common.NormalizedResponse, error) {
+	return evm.HandleUpstreamPreForward(ctx, n, u, req, skipCacheRead)
+}
+
+func (evmBehavior) upstreamPostForward(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, resp *common.NormalizedResponse, re error, skipCacheRead bool) (*common.NormalizedResponse, error) {
+	return evm.HandleUpstreamPostForward(ctx, n, u, req, resp, re, skipCacheRead)
+}
+
+// requestBlockNumber prefers the block number cached during normalization and
+// falls back to extracting it from the raw request (defensive: covers paths
+// that bypass json_rpc.go normalization, and methods whose params have not
+// been pre-cached yet).
+func (evmBehavior) requestBlockNumber(ctx context.Context, req *common.NormalizedRequest) int64 {
+	if v := req.EvmBlockNumber(); v != nil {
+		if n64, ok := v.(int64); ok && n64 > 0 {
+			return n64
+		}
+	}
+	if _, bn, err := evm.ExtractBlockReferenceFromRequest(ctx, req); err == nil && bn > 0 {
+		return bn
+	}
+	return 0
+}
+
+func (evmBehavior) responseBlockNumber(ctx context.Context, resp *common.NormalizedResponse) int64 {
+	if _, bn, err := evm.ExtractBlockReferenceFromResponse(ctx, resp); err == nil && bn > 0 {
+		return bn
+	}
+	return 0
+}

--- a/erpc/architecture_test.go
+++ b/erpc/architecture_test.go
@@ -1,0 +1,53 @@
+package erpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The seam's unknown-architecture fallthrough is the path worth pinning: before
+// consolidation some EVM hooks were gated on `== ArchitectureEvm` and others ran
+// unconditionally, so "what happens on a network this build has no behavior for"
+// had no single answer. These tests fix that answer once, at the seam, instead of
+// at a dozen call sites.
+
+func TestArchSeam_ResolvesOnlyKnownArchitectures(t *testing.T) {
+	require.NotNil(t, archBehaviorFor(common.ArchitectureEvm))
+	assert.Nil(t, archBehaviorFor(""))
+	assert.Nil(t, archBehaviorFor(common.NetworkArchitecture("not-a-real-architecture")))
+}
+
+func TestArchSeam_NetworkWithoutConfigHasNoBehavior(t *testing.T) {
+	assert.Nil(t, (*Network)(nil).arch())
+	assert.Nil(t, (&Network{}).arch())
+	assert.NotNil(t, (&Network{cfg: &common.NetworkConfig{Architecture: common.ArchitectureEvm}}).arch())
+}
+
+func TestArchSeam_UnsupportedArchitectureSkipsArchitectureSpecificSteps(t *testing.T) {
+	ctx := context.Background()
+	n := &Network{
+		networkId: "notreal:1",
+		cfg:       &common.NetworkConfig{Architecture: common.NetworkArchitecture("not-a-real-architecture")},
+	}
+	require.Nil(t, n.arch())
+
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x0000000000000000000000000000000000000000","0x1"]}`))
+
+	// prepareRequest is the one step that must fail loudly: a request nobody can
+	// normalize must never reach an upstream.
+	err := n.prepareRequest(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported architecture")
+
+	// Every other step fails open, exactly as the pre-consolidation
+	// `!= ArchitectureEvm` guards did.
+	skipErr, retryable := n.checkUpstreamBlockAvailability(ctx, nil, req, "eth_getBalance")
+	assert.NoError(t, skipErr)
+	assert.False(t, retryable)
+	assert.Nil(t, n.eligibleUpstreamIDsForBoundary(ctx, "eth_getBalance", req))
+	assert.NotPanics(t, func() { n.enrichStatePoller(ctx, "eth_blockNumber", req, nil) })
+}

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -947,8 +947,8 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	}
 
 	// Route safe-tagged requests before multiplexing and cache lookup.
-	if n.cfg.Architecture == common.ArchitectureEvm {
-		if err := evm.ApplySafeBlockSource(ctx, n, req); err != nil {
+	if arch := n.arch(); arch != nil {
+		if err := arch.applySafeBlockSource(ctx, n, req); err != nil {
 			common.SetTraceSpanError(forwardSpan, err)
 			return nil, err
 		}
@@ -1076,17 +1076,19 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 	}
 
 	// Network-level pre-forward (executed after upstream selection) for upstream-aware logic
-	if handled, resp, err := evm.HandleNetworkPreForward(ctx, n, upsList, req); handled {
-		if err != nil {
-			if mlx != nil {
-				mlx.Close(ctx, nil, err)
+	if arch := n.arch(); arch != nil {
+		if handled, resp, err := arch.networkPreForward(ctx, n, upsList, req); handled {
+			if err != nil {
+				if mlx != nil {
+					mlx.Close(ctx, nil, err)
+				}
+				return nil, err
 			}
-			return nil, err
+			if mlx != nil {
+				mlx.Close(ctx, resp, nil)
+			}
+			return resp, nil
 		}
-		if mlx != nil {
-			mlx.Close(ctx, resp, nil)
-		}
-		return resp, nil
 	}
 
 	// Future-block short-circuit: a concrete block number beyond every eligible
@@ -1544,10 +1546,8 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 
 		// Extract block number from successful response for block availability bounds check below.
 		var respBlockNumber int64
-		if n.cfg.Architecture == common.ArchitectureEvm {
-			if _, bn, err := evm.ExtractBlockReferenceFromResponse(ctx, resp); err == nil && bn > 0 {
-				respBlockNumber = bn
-			}
+		if arch := n.arch(); arch != nil {
+			respBlockNumber = arch.responseBlockNumber(ctx, resp)
 		}
 
 		// If response is not empty, but at least one upstream responded empty we track in a metric.
@@ -1609,20 +1609,8 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 }
 
 func (n *Network) prepareRequest(ctx context.Context, nr *common.NormalizedRequest) error {
-	switch n.Architecture() {
-	case common.ArchitectureEvm:
-		jsonRpcReq, err := nr.JsonRpcRequest(ctx)
-		if err != nil {
-			return common.NewErrJsonRpcExceptionInternal(
-				0,
-				common.JsonRpcErrorParseException,
-				"failed to unmarshal json-rpc request",
-				err,
-				nil,
-			)
-		}
-		evm.NormalizeHttpJsonRpc(ctx, nr, jsonRpcReq)
-	default:
+	arch := n.arch()
+	if arch == nil {
 		return common.NewErrJsonRpcExceptionInternal(
 			0,
 			common.JsonRpcErrorServerSideException,
@@ -1632,7 +1620,7 @@ func (n *Network) prepareRequest(ctx context.Context, nr *common.NormalizedReque
 		)
 	}
 
-	return nil
+	return arch.prepareRequest(ctx, nr)
 }
 
 func (n *Network) GetMethodMetrics(method string) common.TrackedMetrics {
@@ -1749,16 +1737,19 @@ func (n *Network) GetFinality(ctx context.Context, req *common.NormalizedRequest
 }
 
 func (n *Network) doForward(execSpanCtx context.Context, u common.Upstream, req *common.NormalizedRequest, skipCacheRead, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
-	switch n.cfg.Architecture {
-	case common.ArchitectureEvm:
-		if handled, resp, err := evm.HandleUpstreamPreForward(execSpanCtx, n, u, req, skipCacheRead); handled {
-			return evm.HandleUpstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
+	arch := n.arch()
+	if arch != nil {
+		if handled, resp, err := arch.upstreamPreForward(execSpanCtx, n, u, req, skipCacheRead); handled {
+			return arch.upstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
 		}
 	}
 
 	// If not handled, then fallback to the normal forward
 	resp, err := u.Forward(execSpanCtx, req, false, isHedgeAttempt)
-	return evm.HandleUpstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
+	if arch == nil {
+		return resp, err
+	}
+	return arch.upstreamPostForward(execSpanCtx, n, u, req, resp, err, skipCacheRead)
 }
 
 // methodHasDedicatedRangeAvailabilityHook reports whether a method enforces its own
@@ -1891,6 +1882,18 @@ func (n *Network) recordHedgeDiscard(
 	common.SetTraceSpanError(span, common.NewErrUpstreamHedgeCancelled(u.Id(), err))
 }
 
+// checkUpstreamBlockAvailability dispatches per-upstream block-availability
+// gating through the architecture seam. An architecture with no availability
+// model — and any network assembled without one — allows the request through,
+// which is the same fail-open answer this returned for non-EVM networks before.
+func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool) {
+	arch := n.arch()
+	if arch == nil {
+		return nil, false
+	}
+	return arch.checkUpstreamBlockAvailability(ctx, n, u, req, method)
+}
+
 // checkUpstreamBlockAvailability performs per-upstream gating for the request based on
 // the upstream's configured block availability bounds. It is invoked just before
 // forwarding to an upstream to avoid copying/filtering the list.
@@ -1917,10 +1920,7 @@ func (n *Network) recordHedgeDiscard(
 //
 // FAIL-OPEN BEHAVIOR: If we cannot determine the bounds or block number (e.g. state
 // poller not ready), we allow the request to proceed rather than blocking traffic.
-func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool) {
-	if n.cfg.Architecture != common.ArchitectureEvm {
-		return nil, false
-	}
+func (a evmBehavior) checkUpstreamBlockAvailability(ctx context.Context, n *Network, u common.Upstream, req *common.NormalizedRequest, method string) (error, bool) {
 	// Range methods (eth_getLogs, trace_filter, arbtrace_filter) enforce block
 	// availability via their own range-aware pre-forward hooks; gating them here on a
 	// single extracted block number would conflict with that.
@@ -1943,20 +1943,7 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 		return nil, false
 	}
 
-	// Prefer the cached block number from normalization. Fall back to extracting
-	// from the request (defensive: handles paths that bypass json_rpc.go's
-	// normalization, and methods whose params haven't been pre-cached yet).
-	var bn int64
-	if v := req.EvmBlockNumber(); v != nil {
-		if n64, ok := v.(int64); ok {
-			bn = n64
-		}
-	}
-	if bn <= 0 {
-		if _, x, ebn := evm.ExtractBlockReferenceFromRequest(ctx, req); ebn == nil && x > 0 {
-			bn = x
-		}
-	}
+	bn := a.requestBlockNumber(ctx, req)
 	if bn <= 0 {
 		// If still unknown, skip gating (fail-open)
 		return nil, false
@@ -1994,6 +1981,18 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 	return nil, false
 }
 
+// eligibleUpstreamIDsForBoundary dispatches boundary-lane derivation through
+// the architecture seam. An architecture with no block-availability model —
+// and any network assembled without one — yields no lane scoping, which is the
+// same answer this returned for non-EVM networks before.
+func (n *Network) eligibleUpstreamIDsForBoundary(ctx context.Context, method string, req *common.NormalizedRequest) []string {
+	arch := n.arch()
+	if arch == nil {
+		return nil
+	}
+	return arch.eligibleUpstreamIDsForBoundary(ctx, n, method, req)
+}
+
 // eligibleUpstreamIDsForBoundary derives the block-availability "lane" for a
 // single-block request: the IDs of upstreams whose configured availability
 // bounds can serve the request's block. It feeds the selection policy's
@@ -2002,8 +2001,8 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 // answer this block.
 //
 // It returns nil ("no lane scoping → use the full-pool wildcard slot") when:
-//   - the network isn't EVM, or the method has a dedicated range-availability
-//     hook (eth_getLogs / trace_filter, gated by CheckBlockRangeAvailability),
+//   - the method has a dedicated range-availability hook (eth_getLogs /
+//     trace_filter, gated by CheckBlockRangeAvailability),
 //   - the block number can't be resolved (e.g. eth_getBlockByHash carries a
 //     hash, not a number) — same fail-open as checkUpstreamBlockAvailability,
 //   - no upstream advertises any bound (a single implicit lane = everything), or
@@ -2013,26 +2012,14 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 // The eligibility predicate mirrors checkUpstreamBlockAvailability's use of
 // EvmBlockAvailabilityBounds so the lane membership and the per-upstream
 // availability gate never disagree about which upstreams can serve a block.
-func (n *Network) eligibleUpstreamIDsForBoundary(ctx context.Context, method string, req *common.NormalizedRequest) []string {
-	if n.cfg == nil || n.cfg.Architecture != common.ArchitectureEvm {
-		return nil
-	}
+func (a evmBehavior) eligibleUpstreamIDsForBoundary(ctx context.Context, n *Network, method string, req *common.NormalizedRequest) []string {
 	if methodHasDedicatedRangeAvailabilityHook(method) {
 		return nil
 	}
-	// Resolve the request's block number (cached at normalization, with a
-	// defensive extraction fallback) — mirrors checkUpstreamBlockAvailability.
-	var bn int64
-	if v := req.EvmBlockNumber(); v != nil {
-		if n64, ok := v.(int64); ok {
-			bn = n64
-		}
-	}
-	if bn <= 0 {
-		if _, x, ebn := evm.ExtractBlockReferenceFromRequest(ctx, req); ebn == nil && x > 0 {
-			bn = x
-		}
-	}
+	// Resolve the request's block number through the same seam resolver
+	// checkUpstreamBlockAvailability uses, so the lane and the per-upstream
+	// gate can never disagree about which block the request targets.
+	bn := a.requestBlockNumber(ctx, req)
 	if bn <= 0 {
 		return nil
 	}
@@ -2269,88 +2256,99 @@ func filterMethodEligible(ups []common.Upstream, method string) ([]common.Upstre
 	return eligible, dropped
 }
 
+// enrichStatePoller dispatches head-observation feedback through the
+// architecture seam. The span is opened unconditionally (as before) so the
+// trace shape does not depend on the architecture.
 func (n *Network) enrichStatePoller(ctx context.Context, method string, req *common.NormalizedRequest, resp *common.NormalizedResponse) {
 	ctx, span := common.StartDetailSpan(ctx, "Network.EnrichStatePoller")
 	defer span.End()
 
-	switch n.Architecture() {
-	case common.ArchitectureEvm:
-		// TODO Move the logic to evm package as a post-forward hook?
-		if method == "eth_getBlockByNumber" {
-			// Prefer the original block reference preserved by normalization.
-			// This stays "latest"/"finalized" even if params were interpolated to hex.
-			var blkTag string
-			if ref := req.EvmBlockRef(); ref != nil {
-				if s, ok := ref.(string); ok && (s == "latest" || s == "finalized") {
+	arch := n.arch()
+	if arch == nil {
+		return
+	}
+	arch.enrichStatePoller(ctx, n, method, req, resp)
+}
+
+// enrichStatePoller feeds head observations carried by a served response back
+// into the responding upstream's state poller.
+//
+// TODO Move the logic to evm package as a post-forward hook?
+func (evmBehavior) enrichStatePoller(ctx context.Context, n *Network, method string, req *common.NormalizedRequest, resp *common.NormalizedResponse) {
+	if method == "eth_getBlockByNumber" {
+		// Prefer the original block reference preserved by normalization.
+		// This stays "latest"/"finalized" even if params were interpolated to hex.
+		var blkTag string
+		if ref := req.EvmBlockRef(); ref != nil {
+			if s, ok := ref.(string); ok && (s == "latest" || s == "finalized") {
+				blkTag = s
+			}
+		}
+		if lg := n.logger; lg != nil && lg.GetLevel() <= zerolog.TraceLevel {
+			lg.Trace().
+				Str("blkTagFromEvmBlockRef", blkTag).
+				Interface("evmBlockRefRaw", req.EvmBlockRef()).
+				Msg("enrichStatePoller: resolved block tag from request EvmBlockRef")
+		}
+		// Fallback to inspecting the request param only if we couldn't resolve from EvmBlockRef
+		if blkTag == "" {
+			jrq, err := req.JsonRpcRequest(ctx)
+			if err != nil {
+				return
+			}
+			jrq.RLock()
+			if len(jrq.Params) > 0 {
+				if s, ok := jrq.Params[0].(string); ok && (s == "latest" || s == "finalized") {
 					blkTag = s
 				}
 			}
-			if lg := n.logger; lg != nil && lg.GetLevel() <= zerolog.TraceLevel {
-				lg.Trace().
-					Str("blkTagFromEvmBlockRef", blkTag).
-					Interface("evmBlockRefRaw", req.EvmBlockRef()).
-					Msg("enrichStatePoller: resolved block tag from request EvmBlockRef")
-			}
-			// Fallback to inspecting the request param only if we couldn't resolve from EvmBlockRef
-			if blkTag == "" {
-				jrq, err := req.JsonRpcRequest(ctx)
-				if err != nil {
-					return
-				}
-				jrq.RLock()
-				if len(jrq.Params) > 0 {
-					if s, ok := jrq.Params[0].(string); ok && (s == "latest" || s == "finalized") {
-						blkTag = s
-					}
-				}
-				jrq.RUnlock()
-				if lg := n.logger; lg != nil {
-					lg.Trace().
-						Str("blkTagFromParams", blkTag).
-						Msg("enrichStatePoller: resolved block tag from request params")
-				}
-			}
-			if blkTag == "" {
-				return
-			}
-			jrs, _ := resp.JsonRpcResponse(ctx)
-			bnh, err := jrs.PeekStringByPath(ctx, "number")
-			if err != nil {
-				return
-			}
-			blockNumber, err := common.HexToInt64(bnh)
-			if err != nil {
-				return
-			}
+			jrq.RUnlock()
 			if lg := n.logger; lg != nil {
 				lg.Trace().
-					Str("blkTag", blkTag).
-					Int64("blockNumber", blockNumber).
-					Str("method", method).
-					Msg("enrichStatePoller: suggesting block number to state poller")
+					Str("blkTagFromParams", blkTag).
+					Msg("enrichStatePoller: resolved block tag from request params")
 			}
-			if ups := resp.Upstream(); ups != nil {
-				if ups, ok := ups.(common.EvmUpstream); ok {
-					// These methods are non-blocking and handle async updates internally
-					switch blkTag {
-					case "finalized":
-						ups.EvmStatePoller().SuggestFinalizedBlock(blockNumber)
-					case "latest":
-						ups.EvmStatePoller().SuggestLatestBlock(blockNumber)
-					}
+		}
+		if blkTag == "" {
+			return
+		}
+		jrs, _ := resp.JsonRpcResponse(ctx)
+		bnh, err := jrs.PeekStringByPath(ctx, "number")
+		if err != nil {
+			return
+		}
+		blockNumber, err := common.HexToInt64(bnh)
+		if err != nil {
+			return
+		}
+		if lg := n.logger; lg != nil {
+			lg.Trace().
+				Str("blkTag", blkTag).
+				Int64("blockNumber", blockNumber).
+				Str("method", method).
+				Msg("enrichStatePoller: suggesting block number to state poller")
+		}
+		if ups := resp.Upstream(); ups != nil {
+			if ups, ok := ups.(common.EvmUpstream); ok {
+				// These methods are non-blocking and handle async updates internally
+				switch blkTag {
+				case "finalized":
+					ups.EvmStatePoller().SuggestFinalizedBlock(blockNumber)
+				case "latest":
+					ups.EvmStatePoller().SuggestLatestBlock(blockNumber)
 				}
 			}
-		} else if method == "eth_blockNumber" {
-			jrs, _ := resp.JsonRpcResponse(ctx)
-			bnh, err := jrs.PeekStringByPath(ctx)
+		}
+	} else if method == "eth_blockNumber" {
+		jrs, _ := resp.JsonRpcResponse(ctx)
+		bnh, err := jrs.PeekStringByPath(ctx)
+		if err == nil {
+			blockNumber, err := common.HexToInt64(bnh)
 			if err == nil {
-				blockNumber, err := common.HexToInt64(bnh)
-				if err == nil {
-					if ups := resp.Upstream(); ups != nil {
-						if ups, ok := ups.(common.EvmUpstream); ok {
-							// This method is non-blocking and handles async updates internally
-							ups.EvmStatePoller().SuggestLatestBlock(blockNumber)
-						}
+				if ups := resp.Upstream(); ups != nil {
+					if ups, ok := ups.(common.EvmUpstream); ok {
+						// This method is non-blocking and handles async updates internally
+						ups.EvmStatePoller().SuggestLatestBlock(blockNumber)
 					}
 				}
 			}

--- a/erpc/networks_registry.go
+++ b/erpc/networks_registry.go
@@ -2,7 +2,6 @@ package erpc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -298,13 +297,16 @@ func (nr *NetworksRegistry) prepareNetwork(nwCfg *common.NetworkConfig) (*Networ
 		return nil, err
 	}
 
+	// Construction edge: the ONE place that decides whether an architecture is
+	// supported. Everything downstream reaches architecture-specific logic via
+	// Network.arch(), never by re-testing the architecture value.
 	switch nwCfg.Architecture {
-	case "evm":
+	case common.ArchitectureEvm:
 		if nr.evmJsonRpcCache != nil {
 			network.cacheDal = nr.evmJsonRpcCache.WithProjectId(nr.project.Config.Id)
 		}
 	default:
-		return nil, errors.New("unknown network architecture")
+		return nil, fmt.Errorf("unsupported architecture: %s for network: %s", nwCfg.Architecture, nwCfg.NetworkId())
 	}
 	// Register alias for lazy-created networks to support alias-based routing
 	if nwCfg.Alias != "" {

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/architecture/evm/integrity"
 	"github.com/erpc/erpc/auth"
 	"github.com/erpc/erpc/common"
@@ -241,9 +240,11 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 			upstreamId = upstream.Id()
 		}
 
-		if _, bn, e := evm.ExtractBlockReferenceFromResponse(ctx, resp); e == nil && bn > 0 {
-			// Record block-range heatmap using dynamic buckets and human-readable labels
-			recordEvmBlockRangeHeatmap(ctx, p.Config.Id, network, method, nq, resp)
+		if arch := network.arch(); arch != nil {
+			if bn := arch.responseBlockNumber(ctx, resp); bn > 0 {
+				// Record block-range heatmap using dynamic buckets and human-readable labels
+				recordEvmBlockRangeHeatmap(ctx, p.Config.Id, network, method, nq, resp)
+			}
 		}
 		telemetry.CounterHandle(telemetry.MetricNetworkSuccessfulRequests,
 			p.Config.Id,
@@ -333,17 +334,20 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 }
 
 func (p *PreparedProject) doForward(ctx context.Context, network *Network, nq *common.NormalizedRequest) (*common.NormalizedResponse, error) {
-	switch network.cfg.Architecture {
-	case common.ArchitectureEvm:
+	arch := network.arch()
+	if arch != nil {
 		// Early, project-level pre-forward (cache-affecting, upstream-agnostic)
-		if handled, resp, err := evm.HandleProjectPreForward(ctx, network, nq); handled {
-			return evm.HandleNetworkPostForward(ctx, network, nq, resp, err)
+		if handled, resp, err := arch.projectPreForward(ctx, network, nq); handled {
+			return arch.networkPostForward(ctx, network, nq, resp, err)
 		}
 	}
 
 	// If not handled, then fallback to the normal forward
 	resp, err := network.Forward(ctx, nq)
-	return evm.HandleNetworkPostForward(ctx, network, nq, resp, err)
+	if arch == nil {
+		return resp, err
+	}
+	return arch.networkPostForward(ctx, network, nq, resp, err)
 }
 
 func (p *PreparedProject) AcquireRateLimitPermit(ctx context.Context, req *common.NormalizedRequest) error {


### PR DESCRIPTION
## Summary

`common.NetworkArchitecture` is a string with exactly one value (`"evm"`), but the `erpc` package spent that pretend-openness badly: EVM was hard-wired through ~10 scattered `if/switch == ArchitectureEvm` sites, **and** several EVM hooks ran outside those switches entirely. So the same request could be half-gated — `HandleUpstreamPreForward` behind an architecture check, `HandleUpstreamPostForward` unconditional two lines below.

This PR makes the EVM commitment **honest and consistent**: one internal seam (`erpc/architecture.go`), resolved from `cfg.Architecture`, holding exactly the operations the real call sites need. Every request-path site now dispatches through it. Behavior is unchanged.

This is deliberately **not** a plugin framework: no registry, no registration API, no config surface, no second architecture stubbed out. Adding one would be speculative abstraction — the thing the razor tells us not to do.

## The seam

`erpc/architecture.go` defines an unexported `archBehavior` interface with one implementation, `evmBehavior`, which delegates to `architecture/evm`:

| member | replaces |
| --- | --- |
| `prepareRequest` | `Network.prepareRequest`'s `switch` + `evm.NormalizeHttpJsonRpc` |
| `applySafeBlockSource` | `Network.Forward`'s `evm.ApplySafeBlockSource` gate |
| `projectPreForward` | `PreparedProject.doForward`'s `evm.HandleProjectPreForward` |
| `networkPreForward` | `Network.Forward`'s **ungated** `evm.HandleNetworkPreForward` |
| `networkPostForward` | `PreparedProject.doForward`'s **ungated** `evm.HandleNetworkPostForward` (both paths) |
| `upstreamPreForward` / `upstreamPostForward` | `Network.doForward` (post-forward was **ungated** on the fallback path) |
| `requestBlockNumber` | the block-number resolution duplicated verbatim in `checkUpstreamBlockAvailability` and `eligibleUpstreamIDsForBoundary` |
| `responseBlockNumber` | `evm.ExtractBlockReferenceFromResponse` in `Network.Forward` and in `PreparedProject.Forward`'s heatmap gate |
| `checkUpstreamBlockAvailability` | the `!= ArchitectureEvm` early return + EVM body |
| `eligibleUpstreamIDsForBoundary` | same |
| `enrichStatePoller` | the `switch n.Architecture()` wrapper + EVM body |

An **interface**, not a struct of function fields, so the compiler guarantees an architecture either implements every operation the request path performs or does not resolve at all — there is no partially-implemented state to nil-check per member.

The three members that need `Network` internals keep their bodies where they were (in `networks.go`), re-homed onto the `evmBehavior` receiver; `Network` keeps a thin same-named dispatcher so existing callers and package tests are untouched.

`erpc/projects.go` no longer imports `architecture/evm` at all, and after this change `grep -rn "evm.Handle" erpc/ upstream/` returns hits in **one file only** — `erpc/architecture.go`. All five request-path hooks are reachable from exactly one place.

### Construction edge unchanged

`NetworksRegistry.prepareNetwork` remains the single place that decides whether an architecture is supported, and stays a `switch`. Only two cosmetics there: the bare string `"evm"` became `common.ArchitectureEvm`, and the error message now matches the one `prepareRequest` produces.

## Razor rationale (arXiv:2301.12987)

- The previous shape was the worst of both worlds: speculative **form** (an open-looking architecture string) plus inconsistent **gating** that would silently misfire the moment a second architecture existed. It shrank the extension without buying generality.
- Weakened by **deleting** structure, not adding it: one dispatch point replaces ten restatements of the same predicate; one `requestBlockNumber` replaces two verbatim copies; no new layer, no new config, no registry.
- **The unknown-architecture fallthrough is now the primary path, and it is tested** (`erpc/architecture_test.go`). Previously "what happens on a network this build has no behavior for" had no single answer — some steps skipped EVM, some ran it anyway. Now it has exactly one answer, decided at the seam.
- **Weak ≠ vague**: every observed case is still decided exactly. `prepareRequest` still fails loudly (a request nobody can normalize must never be dispatched); every other step still fails open, exactly as its `!= ArchitectureEvm` guard did.
- Deliberate non-commitment: `arch()` resolves per call rather than caching into a `Network` field. The lookup is a two-case switch returning a zero-size value, so a cached field would buy nothing and would add construction-order coupling plus a nil-field hazard for the package-internal tests that assemble `&Network{...}` directly.

## Why the hook-gating fix is a no-op

Four calls that previously ran regardless of architecture are now gated exactly like their pre-forward counterparts: `HandleNetworkPostForward` (both paths in `PreparedProject.doForward`), `HandleUpstreamPostForward` (the fallback path in `Network.doForward`), `HandleNetworkPreForward`, and the block-range heatmap's block-ref extraction.

`archBehaviorFor` returns non-nil exactly when the architecture is `evm`, and every network that can reach the request path is `evm`:

1. `NewNetwork` defaults an empty `Architecture` to `common.ArchitectureEvm`.
2. `NetworksRegistry.prepareNetwork` rejects anything other than `evm` before the network is stored, so it is never reachable by a request.
3. `NetworkConfig.NetworkId()` returns `""` when `Architecture` is empty, so an architecture-less network cannot be addressed at all.
4. At the client edge, `http_server.go` rejects a request whose URL carries an architecture `common.IsValidArchitecture` does not accept — and that function accepts only `evm`.

So the gate is true for every request that exists today, and each of those four calls still runs on exactly the same requests as before. The gate only changes what would happen for a network with no behavior — which today cannot exist. The suite agrees.

One related detail: sites that read `n.cfg.Architecture` raw and sites that read `n.Architecture()` now share one rule (`n.Architecture()`, nil-config-safe). These differ only for a network with an empty `Architecture` and a non-nil `Evm` block, which `NewNetwork` makes unreachable and `NetworkId()` makes unaddressable.

## Not in this PR

Explicit inventory of EVM commitments this PR deliberately leaves alone, so the remaining surface is visible rather than implied:

- **`common/request.go`** — `EvmBlockRef` / `EvmBlockNumber` live on the shared request type. The seam reads them; it does not move them.
- **`common/network.go`** — the `Evm*` methods on the `common.Network` interface (`EvmHighestLatestBlockNumber`, `EvmHighestFinalizedBlockNumber`, `EvmLeaderUpstream`) and their `// TODO Move to EvmNetwork interface?`. Also `common.Upstream.EvmBlockAvailabilityBounds` and the `common.EvmUpstream` assertions the seam bodies still perform.
- **`architecture/evm/` internals** — call sites only.
- **`upstream/`** — `upstream.go`, `upstream_executor.go` and `registry.go` import `architecture/evm` directly. Upstream-side consolidation is a follow-up.
- **`erpc/network_executor.go`** — `evm.IsNonRetryableWriteMethod` at the retry policy. Untouched on purpose (concurrent work nearby).
- **`Network.enrichStatePoller`'s inline `"eth_getBlockByNumber"` / `"eth_blockNumber"` strings** and its `TODO Move the logic to evm package as a post-forward hook?`. The body moved onto the seam's receiver; the hook migration is explicitly a separate change.
- **`Network.GetFinality` and `Network.tryShortCircuitFutureBlock`** still call `evm.ExtractBlockReference*` directly. Both consume the block *ref* string as well as the number, which no other site needs — adding a `blockRef` member for them would be a commitment today's data does not force. Left in place.
- **Served-tip helpers** on `Network` (`gatherEvmTipInputsForMethod`, `servedTip`, `guaranteedMethodFloor`, `observeServedTipMetrics`) — explicitly EVM-named machinery over `evm.ServedTipInput` / `evm.PickServedTip`.
- **`erpc/healthcheck.go`** architecture switches — they match a URL segment / config to chain ids, not per-request dispatch, and call no EVM hook.
- **`common.NewErrUnknownNetworkArchitecture`** is defined in `common/errors.go` and used nowhere. Adopting it at the construction edge would change that path's error type and HTTP status, so it stays unused here.

## Test plan

- `make fmt` — clean (`gofmt -l erpc/` empty). Pre-existing gofmt drift in `common/request.go`, `thirdparty/satelink.go`, `thirdparty/satelink_test.go` was deliberately left alone.
- `go build ./...` — clean. `go vet ./erpc/...` — only the pre-existing `query_executor_test.go:341` `copies lock value` warning, present on `main`.
- Full `test-fast` shard set (consensus / network / httpserver / integrity / container-cache / catch-all / `TestHttp_`) plus `./cmd/...` and all non-`erpc` packages.
- New `erpc/architecture_test.go` pins the seam's unknown-architecture fallthrough: only `evm` resolves; a config-less or unknown-architecture network resolves to no behavior; `prepareRequest` errors while availability gating, boundary lanes and state-poller enrichment fail open.
- No new config, no new metrics, no docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
