### PR TITLE
fix(ratelimit): give each rule its own counter

### DIFF
--- a/upstream/ratelimiter_budget.go
+++ b/upstream/ratelimiter_budget.go
@@ -58,6 +58,22 @@ type RateLimiterBudget struct {
 
 type RateLimitRule struct {
 	Config *common.RateLimitRuleConfig
+
+	// key isolates this rule's counter from other rules in the budget. The envoy
+	// cache key excludes the limit value, so overlapping rules would otherwise
+	// share one counter and each increment it.
+	key string
+}
+
+// ruleKeyFor returns a stable identity for a rule. Two byte-identical rules map
+// to the same key, which is correct: they are the same limit. Resolved once at
+// construction so an autotuned MaxCount does not move the key mid-window.
+func ruleKeyFor(c *common.RateLimitRuleConfig) string {
+	scope := c.ScopeString()
+	if scope == "" {
+		scope = "global"
+	}
+	return fmt.Sprintf("method:%s scope:%s maxCount:%d period:%s", c.Method, scope, c.MaxCount, c.Period)
 }
 
 func (b *RateLimiterBudget) GetRulesByMethod(method string) ([]*RateLimitRule, error) {
@@ -266,8 +282,12 @@ func (b *RateLimiterBudget) evaluateRule(ctx context.Context, rule *RateLimitRul
 		return true // Fail-open when no cache is available
 	}
 
-	// Build descriptor entries
-	entries := []*pb_struct.RateLimitDescriptor_Entry{{Key: "method", Value: method}}
+	// Build descriptor entries. "rule" gives each rule its own counter; without it
+	// rules resolving to the same {method, scope} at the same period collide.
+	entries := []*pb_struct.RateLimitDescriptor_Entry{
+		{Key: "rule", Value: rule.key},
+		{Key: "method", Value: method},
+	}
 	if rule.Config.PerIP && clientIP != "" && clientIP != "n/a" {
 		entries = append(entries, &pb_struct.RateLimitDescriptor_Entry{Key: "ip", Value: clientIP})
 	}

--- a/upstream/ratelimiter_budget_bench_test.go
+++ b/upstream/ratelimiter_budget_bench_test.go
@@ -54,16 +54,15 @@ func buildBenchBudget(numRules int, perUser, perIP, perNetwork bool) *RateLimite
 
 	rules := make([]*RateLimitRule, numRules)
 	for i := 0; i < numRules; i++ {
-		rules[i] = &RateLimitRule{
-			Config: &common.RateLimitRuleConfig{
-				Method:     "eth_*", // Wildcard to match
-				MaxCount:   1_000_000_000,
-				Period:     common.RateLimitPeriodSecond,
-				PerUser:    perUser,
-				PerIP:      perIP,
-				PerNetwork: perNetwork,
-			},
+		cfg := &common.RateLimitRuleConfig{
+			Method:     "eth_*", // Wildcard to match
+			MaxCount:   1_000_000_000,
+			Period:     common.RateLimitPeriodSecond,
+			PerUser:    perUser,
+			PerIP:      perIP,
+			PerNetwork: perNetwork,
 		}
+		rules[i] = &RateLimitRule{Config: cfg, key: ruleKeyFor(cfg)}
 	}
 
 	logger := zerolog.Nop()
@@ -201,13 +200,12 @@ func buildBenchBudgetWithDelay(numRules int, delay time.Duration) *RateLimiterBu
 
 	rules := make([]*RateLimitRule, numRules)
 	for i := 0; i < numRules; i++ {
-		rules[i] = &RateLimitRule{
-			Config: &common.RateLimitRuleConfig{
-				Method:   "eth_*",
-				MaxCount: 1_000_000_000,
-				Period:   common.RateLimitPeriodSecond,
-			},
+		cfg := &common.RateLimitRuleConfig{
+			Method:   "eth_*",
+			MaxCount: 1_000_000_000,
+			Period:   common.RateLimitPeriodSecond,
 		}
+		rules[i] = &RateLimitRule{Config: cfg, key: ruleKeyFor(cfg)}
 	}
 
 	logger := zerolog.Nop()

--- a/upstream/ratelimiter_isolation_test.go
+++ b/upstream/ratelimiter_isolation_test.go
@@ -1,0 +1,93 @@
+package upstream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// Every rule in a budget must enforce its own limit against its own counter.
+//
+// The envoy cache key is derived from the domain, the descriptor entries and
+// the period bucket -- the limit value is not part of it. Two rules that
+// resolve to the same {method, scope} at the same period therefore produce an
+// identical key, and because each rule is evaluated with its own DoLimit call,
+// a single request increments that one shared counter once per overlapping
+// rule. The tightest limit then trips after MaxCount/N requests instead of
+// MaxCount.
+//
+// Here a catch-all rule and an exact-method rule both match eth_call, so each
+// request charges the shared counter twice and the 10-request ceiling is hit
+// after 5.
+func TestRateLimiterBudget_OverlappingRulesDoNotShareCounter(t *testing.T) {
+	logger := zerolog.Nop()
+	const method = "eth_call"
+
+	cfg := &common.RateLimiterConfig{
+		Store: &common.RateLimitStoreConfig{Driver: "memory"},
+		Budgets: []*common.RateLimitBudgetConfig{{
+			Id: "b",
+			Rules: []*common.RateLimitRuleConfig{
+				// Loose catch-all, far above anything this test sends.
+				{Method: "*", MaxCount: 1000, Period: common.RateLimitPeriodMinute},
+				// Tight per-method rule: this is the limit under test.
+				{Method: method, MaxCount: 10, Period: common.RateLimitPeriodMinute},
+			},
+		}},
+	}
+
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
+	require.NoError(t, err)
+	budget, err := registry.GetBudget("b")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	for i := 1; i <= 10; i++ {
+		ok, err := budget.TryAcquirePermit(ctx, "", nil, method, "", "", "", "upstream")
+		require.NoError(t, err)
+		require.True(t, ok, "request %d is within the per-method ceiling of 10 and must be allowed", i)
+	}
+
+	ok, err := budget.TryAcquirePermit(ctx, "", nil, method, "", "", "", "upstream")
+	require.NoError(t, err)
+	require.False(t, ok, "request 11 must exceed the per-method ceiling of 10")
+}
+
+// Two rules that differ only in MaxCount also collide on one counter: they
+// share a {method, scope} descriptor at the same period, so each request is
+// counted twice and the tighter of the two rules trips at half its ceiling.
+// The effective limit must be the tighter rule's MaxCount, not half of it.
+func TestRateLimiterBudget_SameMethodDifferentLimitsDoNotShareCounter(t *testing.T) {
+	logger := zerolog.Nop()
+	const method = "eth_getLogs"
+
+	cfg := &common.RateLimiterConfig{
+		Store: &common.RateLimitStoreConfig{Driver: "memory"},
+		Budgets: []*common.RateLimitBudgetConfig{{
+			Id: "b",
+			Rules: []*common.RateLimitRuleConfig{
+				{Method: method, MaxCount: 6, Period: common.RateLimitPeriodMinute},
+				{Method: method, MaxCount: 100, Period: common.RateLimitPeriodMinute},
+			},
+		}},
+	}
+
+	registry, err := NewRateLimitersRegistry(context.Background(), cfg, &logger)
+	require.NoError(t, err)
+	budget, err := registry.GetBudget("b")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	for i := 1; i <= 6; i++ {
+		ok, err := budget.TryAcquirePermit(ctx, "", nil, method, "", "", "", "upstream")
+		require.NoError(t, err)
+		require.True(t, ok, "request %d is within the tighter ceiling of 6 and must be allowed", i)
+	}
+
+	ok, err := budget.TryAcquirePermit(ctx, "", nil, method, "", "", "", "upstream")
+	require.NoError(t, err)
+	require.False(t, ok, "request 7 must exceed the tighter ceiling of 6")
+}

--- a/upstream/ratelimiter_leak_test.go
+++ b/upstream/ratelimiter_leak_test.go
@@ -81,15 +81,12 @@ func buildLeakTestBudget(t testing.TB, redisDelay, maxTimeout time.Duration, adm
 	)
 	cache := &blockingCache{inner: mem, delay: redisDelay, panicRate: panicRate}
 
-	rules := []*RateLimitRule{
-		{
-			Config: &common.RateLimitRuleConfig{
-				Method:   "*",
-				MaxCount: 1_000_000_000,
-				Period:   common.RateLimitPeriodSecond,
-			},
-		},
+	leakRuleCfg := &common.RateLimitRuleConfig{
+		Method:   "*",
+		MaxCount: 1_000_000_000,
+		Period:   common.RateLimitPeriodSecond,
 	}
+	rules := []*RateLimitRule{{Config: leakRuleCfg, key: ruleKeyFor(leakRuleCfg)}}
 
 	logger := zerolog.Nop()
 	registry := &RateLimitersRegistry{

--- a/upstream/ratelimiter_registry.go
+++ b/upstream/ratelimiter_registry.go
@@ -194,7 +194,7 @@ func (r *RateLimitersRegistry) initializeBudgets() {
 			r.logger.Debug().Msgf("preparing rate limiter rule: %v", rule)
 
 			budget.rulesMu.Lock()
-			budget.Rules = append(budget.Rules, &RateLimitRule{Config: rule})
+			budget.Rules = append(budget.Rules, &RateLimitRule{Config: rule, key: ruleKeyFor(rule)})
 			budget.rulesMu.Unlock()
 
 			scope := []string{}


### PR DESCRIPTION
## Problem

A budget's rules are mapped to envoy descriptors keyed by `{method, scope}` plus the period bucket. The limit value is deliberately not part of the cache key (`limiter.CacheKeyGenerator.GenerateCacheKey`), so two rules resolving to the same `{method, scope}` at the same period produce an **identical key**. Every rule is evaluated with its own `DoLimit` call, so a single request increments that one shared counter once per overlapping rule.

The tightest rule then trips at `maxCount / N`, where N is the number of overlapping rules.

This is easy to hit with the most common budget shape — a catch-all plus a per-method override:

```yaml
rules:
  - method: "*"
    maxCount: 1000
    period: minute
  - method: eth_call
    maxCount: 10        # actually blocks after 5
    period: minute
```

Two rules that differ only in `maxCount` collide the same way. The failure is silent: nothing logs, no metric distinguishes it, and the budget simply enforces a limit the operator never configured.

## Change

Add a stable per-rule discriminator as the first descriptor entry, so each rule gets its own counter and enforces its own limit.

The key is derived from the rule's `method`/`scope`/`maxCount`/`period` identity, so it is stable across restarts and identical on every replica sharing a Redis store. Two byte-identical rules still map to one key — that is correct, they are the same limit.

It is resolved **once at construction** rather than per evaluation. That matters because the auto-tuner mutates `maxCount` at runtime: recomputing the key on each call would move it mid-window every time the tuner adjusted, silently resetting the counter.

## Testing

Two regression tests, one per collision shape. Both fail at exactly half the configured ceiling before the change:

```
--- FAIL: TestRateLimiterBudget_OverlappingRulesDoNotShareCounter
    request 6 is within the per-method ceiling of 10 and must be allowed
--- FAIL: TestRateLimiterBudget_SameMethodDifferentLimitsDoNotShareCounter
    request 4 is within the tighter ceiling of 6 and must be allowed
```

The bench and leak tests construct `RateLimitRule` directly, so they now populate the key too — otherwise the benchmark understates descriptor size and the invariant "key is always set" would not hold.

Verified green: `upstream`, `common`, `auth`, `erpc`. `gofmt` and `go vet` clean.

## Notes

Descriptor entries are part of the cache key, so counters reset once on deploy. The window is brief and self-healing.

No config surface changes.
