### PR TITLE
fix(evm): make singleflight doOnce panic-safe

### DIFF
--- a/architecture/evm/integrity_chainview.go
+++ b/architecture/evm/integrity_chainview.go
@@ -93,12 +93,14 @@ func doOnce[T any](mu *sync.Mutex, inflight map[string]*flight[T], key string, f
 	inflight[key] = f
 	mu.Unlock()
 
-	f.val, f.ok = fn()
+	defer func() {
+		mu.Lock()
+		delete(inflight, key)
+		mu.Unlock()
+		f.wg.Done()
+	}()
 
-	mu.Lock()
-	delete(inflight, key)
-	mu.Unlock()
-	f.wg.Done()
+	f.val, f.ok = fn()
 	return f.val, f.ok
 }
 


### PR DESCRIPTION
## What

`doOnce` in `architecture/evm/integrity_chainview.go` coalesces concurrent fetches for the same key (singleflight). The inflight-map cleanup (`delete(inflight, key)`) and `f.wg.Done()` only ran after a normal return from `fn()`.

## Bug

If `fn()` panics, cleanup never runs:
- every goroutine already blocked in `f.wg.Wait()` hangs forever (`Wait` takes no context, so nothing can rescue it)
- every *future* call for the same key joins the same dead `flight` and blocks too — the key is permanently poisoned until process restart

This is reachable, not just theoretical: callers typically recover panics at a higher layer so the process keeps running while leaking a stuck goroutine + a permanently-stuck key.

## Fix

Move the map-delete + `wg.Done()` into a `defer`, so cleanup runs on both the normal path and a panic.