### PR TITLE
fix(evm): collapse dead if/else in applyReorg followHead update

### DIFF
--- a/architecture/evm/integrity_chainview.go
+++ b/architecture/evm/integrity_chainview.go
@@ -304,11 +304,9 @@ func (c *chainView) applyReorg(ancestor int64, branch []*integrity.Header, numbe
 	if c.followBase == 0 || ancestor+1 < c.followBase {
 		c.followBase = ancestor + 1
 	}
-	if top := numbers[0]; top > c.followHead {
-		c.followHead = top
-	} else {
-		c.followHead = top
-	}
+	// Everything above the ancestor was dropped above, so the branch head is
+	// the new head unconditionally — it may move backwards on a deeper reorg.
+	c.followHead = numbers[0]
 	c.mu.Unlock()
 
 	telemetry.MetricIntegrityReorgDepth.WithLabelValues(c.projectId(), c.networkLabel(), c.group).


### PR DESCRIPTION
## What

In `chainView.applyReorg` (`architecture/evm/integrity_chainview.go`), the `followHead` update was:

```go
if top := numbers[0]; top > c.followHead {
    c.followHead = top
} else {
    c.followHead = top
}
```

Both branches assign the same value, so the conditional has no effect — it reads as if a `max()` guard was intended but isn't actually there.

## Why the unconditional assignment is correct

Everything above `ancestor` was already dropped from `canonical` earlier in the same function, and `numbers[0]` is the highest block in the branch (the reorg walk collects newest-first). So the branch head is unconditionally the new `followHead`, and it's fine for it to move backwards on a deeper reorg.

## Fix

Collapse to the unconditional assignment and add a comment explaining why, instead of leaving a no-op conditional that misleads readers into thinking there's a max/guard semantic here.