### PR TITLE
docs(evm): correct indexMagnitude gating comment

### DIFF
--- a/architecture/evm/integrity/checks_index.go
+++ b/architecture/evm/integrity/checks_index.go
@@ -4,8 +4,9 @@ import "context"
 
 // indexMagnitude — no logIndex / transactionIndex may exceed a physically
 // possible block index. Catches 32-bit underflow garbage (e.g. 0xfffffff7 ==
-// 4294967287). This is an always-on sanity check for the receipt/log family;
-// it supersedes the standalone recursive walk that previously lived inline.
+// 4294967287). Replaces the standalone recursive walk that previously ran
+// unconditionally for the receipt/log family; it now runs only when integrity
+// checks are configured (LevelIntrinsic and above).
 func init() {
 	register(&Check{
 		ID:      "indexMagnitude",


### PR DESCRIPTION
## What

The doc comment on the `indexMagnitude` check (`architecture/evm/integrity/checks_index.go`) says:

> This is an always-on sanity check for the receipt/log family; it supersedes the standalone recursive walk that previously lived inline.

## Bug

That's not accurate as written. This check only runs through the integrity config gate: `resolveIntegrity` returns an empty `CheckSet` when `Config().Integrity == nil`, and `indexMagnitude` sits at `LevelIntrinsic`, so it also needs an explicit `integrity.level`. The walk it replaced ran unconditionally on the receipt/log family, so any deployment upgrading without a `network.integrity` block silently loses this protection — and the comment gives no hint that this happened.

## Fix

Correct the comment to state the actual gating (opt-in via integrity config, `LevelIntrinsic` and above), so the behavior change is documented rather than contradicted by the comment. No functional change.