### PR TITLE
fix(evm): served tip — bounds don't vote, regression guard, trajectory referee

### DIFF
--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -1,6 +1,12 @@
 package evm
 
-import "sort"
+import (
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
 
 // ServedTipInput is a single observation: an upstream's last-known tip block.
 // Callers are responsible for excluding syncing or cordoned upstreams BEFORE
@@ -88,4 +94,468 @@ func PickServedTip(tips []ServedTipInput) ServedTipPick {
 		Freshest: freshest,
 		Inputs:   len(heads),
 	}
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// PickServedTip is a snapshot of one instant, and so is every filter feeding
+// it: they all answer "what do the eligible upstreams say RIGHT NOW". That is
+// exactly the assumption a majority stall breaks. If N upstreams freeze inside
+// the lag-exclusion threshold (or a fleet-wide shared-counter freeze stalls the
+// lag metric itself), the majority IS the stale group, and the 2 upstreams that
+// genuinely have the chain's head are outvoted — no instantaneous rule can tell
+// that apart from a chain that simply stopped.
+//
+// One thing does distinguish them: what the network's head has been doing for
+// the last ten minutes. TipTrajectory records that track and lets the referee
+// answer "which of these groups is where the chain should be by now".
+//
+// STRUCTURAL LIMITS — this is deliberately NOT the stateful tip pipeline that
+// commit 7dee07c0 removed (a velocity gate plus a persisted monotonic clamp,
+// which reached an absorbing state where every live tip was rejected forever
+// and the served tip froze fleet-wide):
+//
+//   - ADVISORY, NEVER GENERATIVE. The referee only ever chooses among head
+//     values live upstreams are offering in this very evaluation. It cannot
+//     invent, remember, or extrapolate a servable block; the trajectory is used
+//     ONLY to rank the groups those upstreams form.
+//   - UPWARD-ONLY. It may raise the pick to a corroborated fresher group; it can
+//     never lower or hold one. A referee that cannot hold a value back cannot
+//     freeze a tip — the 7dee07c0 failure mode is unreachable, not merely
+//     unlikely. (Erring low is already the majority picker's job, and the
+//     regression guard's.)
+//   - SELF-LIMITING EVIDENCE. Samples are the plain MEDIAN of the live heads —
+//     never the served value, never the referee's own output. During a majority
+//     stall the tracker therefore keeps recording the stalled median, the fitted
+//     velocity decays, and the referee stops participating on its own after
+//     roughly half a window. Its intervention has a built-in expiry that no
+//     configuration can extend.
+//   - FAIL OPEN ON ANY UNCERTAINTY, and no shared state: everything below is
+//     per-process, in-memory, rebuilt from live observations after a restart.
+//     Per-pod independence is the point — a shared head counter is how the
+//     2026-08 celo trigger propagated fleet-wide in the first place.
+
+const (
+	// tipSampleInterval throttles recording to one sample per evaluation-with-
+	// this-much-elapsed. Fast enough that the default 10-minute window holds
+	// 120 samples, slow enough that the O(n log n) refit runs at most 0.2 Hz
+	// per network+axis while reads stay O(1).
+	tipSampleInterval = 5 * time.Second
+
+	// tipMinSamples is the smallest buffer the fit is computed over: below it
+	// a handful of points could define a "trajectory" on noise alone.
+	tipMinSamples = 30
+
+	// tipMaxSampleGap is how stale the freshest sample may be (as of the START
+	// of an evaluation) for the fit to still describe the present. A gap larger
+	// than this is where a halt or a burst hides, and extrapolating across it
+	// is guessing — the referee steps aside instead.
+	tipMaxSampleGap = time.Minute
+
+	// tipMinGroupSize is the corroboration rule: one witness is not evidence,
+	// however perfectly it matches the trajectory. A group must contain at
+	// least two upstreams to be electable.
+	tipMinGroupSize = 2
+
+	// tipToleranceSigmas (k) scales the window's OWN residual spread into the
+	// distance-from-expected a group may sit at and still count as
+	// on-trajectory. The spread is a median absolute residual, which for
+	// normal-ish noise is ≈0.67σ, so k=6 is ≈4σ: a chain that pauses and
+	// bursts widens its own gate automatically, while a metronomic chain keeps
+	// the floor (EvmServedTipConfig.MaxRegressionBlocks).
+	tipToleranceSigmas = 6.0
+
+	// tipClusterSeconds derives the cluster width from the fitted velocity:
+	// heads within this much CHAIN PROGRESS of each other are the same view of
+	// the head. 10s comfortably covers poller-interval skew and propagation
+	// between healthy providers, and is far below any stall worth correcting.
+	tipClusterSeconds = 10.0
+
+	// tipMinClusterWidth keeps sub-second-block chains (and a small fitted
+	// velocity generally) from splitting a healthy fleet into singletons.
+	tipMinClusterWidth = 16
+
+	// tipMaxClusterWidth is an overflow stop, not a tuning knob: an absurd
+	// fitted velocity must not produce an int64 conversion of a huge float. A
+	// too-wide cluster merges everything into one group, which can only make
+	// the referee defer.
+	tipMaxClusterWidth = int64(1) << 40
+
+	// tipMinBufferCapacity / tipMaxBufferCapacity bound the ring derived from
+	// the configured window (tipBufferCapacity).
+	tipMinBufferCapacity = 64
+	tipMaxBufferCapacity = 1024
+)
+
+// TipTrajectoryParams are the per-network knobs the referee reads on every
+// evaluation. They come straight from EvmServedTipConfig, so a config change
+// takes effect without rebuilding the tracker.
+type TipTrajectoryParams struct {
+	// Window is the minimum span of recorded history required before the
+	// referee may participate at all. <= 0 disables the tracker entirely:
+	// nothing is recorded and nothing is computed.
+	Window time.Duration
+
+	// ToleranceFloor is the minimum distance-from-expected a group may sit at
+	// and still be on-trajectory, in blocks (EvmServedTipConfig's
+	// MaxRegressionBlocks, defaulted by the caller). The observed residual
+	// spread can only widen the gate, never narrow it below this.
+	ToleranceFloor int64
+}
+
+// TipTrajectoryDecision is the referee's advice for one evaluation. Pick is
+// always a value the caller may serve as-is: the majority pick it passed in,
+// or a corroborated group's minimum.
+type TipTrajectoryDecision struct {
+	// Pick is the block to serve: the majority pick unless Overrode.
+	Pick int64
+
+	// Overrode reports that Pick differs from the majority pick — the only
+	// outcome that is an intervention, and the one worth an alert.
+	Overrode bool
+
+	// Declined reports the near miss: the group the trajectory elected sat
+	// ABOVE the majority pick — an override was on the table — and the referee
+	// refused it because the group was not close enough to where the head
+	// should be. It is the only other outcome worth counting, and like Overrode
+	// it is silent in steady state: a fleet in one cluster elects that cluster,
+	// and a fleet permanently split around its own median elects the median's
+	// group (the trajectory is fitted to the median, so no permanently-offset
+	// group is ever closer to it), so neither flag is set.
+	Declined bool
+
+	// Expected / Tolerance / VelocityPerSec describe the fit that produced the
+	// decision. Populated only once the confidence gate passes; for logs.
+	Expected       int64
+	Tolerance      int64
+	VelocityPerSec float64
+}
+
+// tipSample is one recorded observation of where the network's head was.
+type tipSample struct {
+	atMs int64
+	head int64
+}
+
+// tipFit is the robust linear fit over the buffer, recomputed on insertion and
+// read lock-free on every evaluation.
+type tipFit struct {
+	refMs   int64   // timestamp of the newest sample in the fit
+	refHead float64 // FITTED head at refMs (not the raw sample: one poisoned sample must not define the anchor)
+	vPerSec float64 // robust velocity, blocks/second
+	spread  float64 // median absolute residual around the fit, blocks
+	spanMs  int64   // newest − oldest sample timestamp
+	count   int
+}
+
+// expectedAt extrapolates the fit to an instant on the tracker's timeline.
+func (f *tipFit) expectedAt(nowMs int64) float64 {
+	return f.refHead + f.vPerSec*float64(nowMs-f.refMs)/1000
+}
+
+// confident is the gate: unless EVERY condition holds the referee is a no-op
+// and the caller's majority pick stands byte-identically. prevSampleAgeMs is
+// the age of the freshest sample as of the START of this evaluation — the
+// evaluation's own sample must not paper over a gap in the history.
+func (f *tipFit) confident(nowMs int64, prevSampleAgeMs int64, p TipTrajectoryParams) bool {
+	if f == nil || f.count < tipMinSamples {
+		return false
+	}
+	if f.spanMs < p.Window.Milliseconds() {
+		// Also the warm-up condition: an empty buffer after boot has no span.
+		return false
+	}
+	if prevSampleAgeMs > tipMaxSampleGap.Milliseconds() {
+		return false
+	}
+	if !(f.vPerSec > 0) || math.IsInf(f.vPerSec, 0) {
+		// A non-advancing (or NaN) fit describes a halted chain, where the
+		// majority pick is already the right answer.
+		return false
+	}
+	return !math.IsInf(f.refHead, 0) && !math.IsNaN(f.refHead) && nowMs >= f.refMs
+}
+
+// TipTrajectory is one network+axis's long-term head track: a ring of head
+// samples plus the robust fit over them. The zero value is ready to use and
+// allocates on first use; a tracker whose Window is <= 0 never allocates at
+// all.
+type TipTrajectory struct {
+	mu      sync.Mutex
+	samples []tipSample
+	next    int // ring write cursor
+	count   int
+
+	// ordered / slopes / resid are refit scratch, retained so the periodic fit
+	// allocates nothing after warm-up.
+	ordered []tipSample
+	slopes  []float64
+	resid   []float64
+
+	// base is the instant the first sample was recorded; every timestamp below
+	// is milliseconds since it, measured with time.Time's MONOTONIC reading.
+	// A velocity fit is exactly the thing an NTP step would corrupt (a wall
+	// clock that jumps injects a slope no chain ever had), so the timeline the
+	// fit lives on never touches wall time.
+	base         atomic.Pointer[time.Time]
+	lastSampleMs atomic.Int64
+	fit          atomic.Pointer[tipFit]
+}
+
+// SampleCount returns how many samples the tracker holds. Diagnostics and
+// tests only — the decision path never needs it.
+func (t *TipTrajectory) SampleCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// Observe records this evaluation's live-head median (throttled) and returns
+// the trajectory's advice for it.
+//
+// `tips` must be the LIVE head observations of this same evaluation (the
+// caller drops availability-bound-capped upstreams first — a serving range is
+// not a head), and `median` the plain majority pick over them. Both the sample
+// and the candidate groups come from those heads, so the referee's own output
+// never feeds back into its evidence.
+func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int64, p TipTrajectoryParams) TipTrajectoryDecision {
+	d := TipTrajectoryDecision{Pick: median}
+	if p.Window <= 0 || median <= 0 {
+		return d
+	}
+
+	nowMs, prevSampleAgeMs := t.record(now, median, p)
+
+	fit := t.fit.Load()
+	if !fit.confident(nowMs, prevSampleAgeMs, p) {
+		return d
+	}
+
+	heads := make([]int64, 0, len(tips))
+	for _, in := range tips {
+		if in.BlockNumber > 0 {
+			heads = append(heads, in.BlockNumber)
+		}
+	}
+	if len(heads) < tipMinGroupSize {
+		return d
+	}
+	sort.Slice(heads, func(i, j int) bool { return heads[i] > heads[j] })
+
+	expected := fit.expectedAt(nowMs)
+	tolerance := float64(p.ToleranceFloor)
+	if widened := tipToleranceSigmas * fit.spread; widened > tolerance {
+		tolerance = widened
+	}
+	d.Expected = int64(math.Round(expected))
+	d.Tolerance = int64(math.Round(tolerance))
+	d.VelocityPerSec = fit.vPerSec
+
+	// Single-linkage clustering over the descending heads: a gap wider than one
+	// cluster width starts a new group. Candidate groups are those with at
+	// least tipMinGroupSize members; the winner is the one whose MAX (its best
+	// claim about the head — using the min would penalise a wide group for its
+	// slowest member) sits closest to where the trajectory says the head is.
+	width := tipClusterWidth(fit.vPerSec)
+	bestDistance := math.Inf(1)
+	var bestMin int64
+	for i := 0; i < len(heads); {
+		j := i + 1
+		for j < len(heads) && heads[j-1]-heads[j] <= width {
+			j++
+		}
+		if j-i >= tipMinGroupSize {
+			groupMax, groupMin := heads[i], heads[j-1]
+			if distance := math.Abs(float64(groupMax) - expected); distance < bestDistance {
+				bestDistance, bestMin = distance, groupMin
+			}
+		}
+		i = j
+	}
+
+	if bestDistance > tolerance {
+		// No candidate group at all (+Inf), or the elected one is nowhere near
+		// the trajectory — nothing here is better evidence than the majority.
+		d.Declined = bestMin > median
+		return d
+	}
+	if bestMin <= median {
+		// UPWARD-ONLY (see the section comment): the referee exists to let a
+		// corroborated fresh minority outvote a stalled majority. Lowering or
+		// holding the tip is the majority picker's and the regression guard's
+		// job, and is the only direction from which a frozen tip is reachable.
+		return d
+	}
+
+	// Serve the group's MINIMUM: every member of a winning group already has
+	// that block, so the advertised tip stays servable by all of them — the
+	// same invariant the majority order statistic provides.
+	d.Pick = bestMin
+	d.Overrode = true
+	return d
+}
+
+// record appends a sample if at least tipSampleInterval has passed since the
+// last one. It returns `now` on the tracker's monotonic timeline, and the age
+// there of the previous freshest sample — the age BEFORE this evaluation's own
+// sample, so a gap in the history cannot be papered over by the sample that
+// notices it (a value past tipMaxSampleGap when there is no previous sample).
+//
+// The lock is taken only when a sample is actually due, so the per-request cost
+// is two atomic loads.
+func (t *TipTrajectory) record(now time.Time, head int64, p TipTrajectoryParams) (nowMs int64, prevAgeMs int64) {
+	staleSentinel := tipMaxSampleGap.Milliseconds() + 1
+
+	if base := t.base.Load(); base != nil {
+		nowMs = int64(now.Sub(*base) / time.Millisecond)
+		if last := t.lastSampleMs.Load(); nowMs-last < tipSampleInterval.Milliseconds() {
+			return nowMs, nowMs - last
+		}
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	base := t.base.Load()
+	if base == nil {
+		at := now
+		base = &at
+		t.base.Store(base)
+	}
+	nowMs = int64(now.Sub(*base) / time.Millisecond)
+
+	prevAgeMs = staleSentinel
+	if t.count > 0 {
+		last := t.lastSampleMs.Load()
+		if nowMs-last < tipSampleInterval.Milliseconds() {
+			return nowMs, nowMs - last
+		}
+		prevAgeMs = nowMs - last
+	}
+
+	if t.samples == nil {
+		t.samples = make([]tipSample, tipBufferCapacity(p.Window))
+	}
+	t.samples[t.next] = tipSample{atMs: nowMs, head: head}
+	t.next = (t.next + 1) % len(t.samples)
+	if t.count < len(t.samples) {
+		t.count++
+	}
+	t.lastSampleMs.Store(nowMs)
+	t.refit()
+
+	return nowMs, prevAgeMs
+}
+
+// refit recomputes the robust fit over the whole buffer. Called under t.mu, at
+// most once per tipSampleInterval.
+//
+// Velocity is the MEDIAN OF HALF-WINDOW-LAGGED SLOPES: slope_i between sample i
+// and sample i+n/2, median over the ~n/2 of them. Two properties matter here
+// and full Theil-Sen buys neither: every slope spans about half the window, so
+// per-sample noise is divided by a long baseline; and any single poisoned
+// sample enters at most two of the ~90 slopes, so the median never moves.
+// Theil-Sen's n²/2 pairs (≈16k at n=180) would cost a 128 KB sort per fit for
+// the same answer. The intercept is the median residual (the standard robust
+// intercept), and the spread is the median absolute residual around the
+// resulting line — the window's own noise, which is what widens the tolerance
+// for a chain that pauses and bursts.
+func (t *TipTrajectory) refit() {
+	n := t.count
+	if n < tipMinSamples {
+		t.fit.Store(nil)
+		return
+	}
+
+	// Materialise the ring chronologically.
+	ord := t.ordered[:0]
+	if t.count < len(t.samples) {
+		ord = append(ord, t.samples[:t.count]...)
+	} else {
+		ord = append(ord, t.samples[t.next:]...)
+		ord = append(ord, t.samples[:t.next]...)
+	}
+	t.ordered = ord
+
+	newest := ord[n-1]
+	lag := n / 2
+	slopes := t.slopes[:0]
+	for i := 0; i+lag < n; i++ {
+		dt := float64(ord[i+lag].atMs-ord[i].atMs) / 1000
+		if dt <= 0 {
+			continue
+		}
+		slopes = append(slopes, float64(ord[i+lag].head-ord[i].head)/dt)
+	}
+	t.slopes = slopes
+	if len(slopes) == 0 {
+		t.fit.Store(nil)
+		return
+	}
+	vPerSec := medianInPlace(slopes)
+
+	// Residuals in coordinates relative to the newest sample: seconds and
+	// blocks, never epoch milliseconds or 8-digit block numbers, so float64
+	// keeps full precision on chains of any height.
+	resid := t.resid[:0]
+	for _, s := range ord {
+		ts := float64(s.atMs-newest.atMs) / 1000
+		resid = append(resid, float64(s.head-newest.head)-vPerSec*ts)
+	}
+	t.resid = resid
+	intercept := medianInPlace(resid)
+	for i, r := range resid {
+		resid[i] = math.Abs(r - intercept)
+	}
+
+	t.fit.Store(&tipFit{
+		refMs:   newest.atMs,
+		refHead: float64(newest.head) + intercept,
+		vPerSec: vPerSec,
+		spread:  medianInPlace(resid),
+		spanMs:  newest.atMs - ord[0].atMs,
+		count:   n,
+	})
+}
+
+// tipBufferCapacity sizes the ring from the configured window: enough samples
+// to span it with headroom for jitter, so a window an operator raises still
+// becomes reachable instead of silently never satisfying the span gate. The
+// hard cap means windows beyond ~85 minutes can never be spanned, and would
+// stand the referee down permanently — see EvmServedTipConfig.TrajectoryWindow.
+func tipBufferCapacity(window time.Duration) int {
+	n := int(window/tipSampleInterval)*5/4 + 8
+	if n < tipMinBufferCapacity {
+		return tipMinBufferCapacity
+	}
+	if n > tipMaxBufferCapacity {
+		return tipMaxBufferCapacity
+	}
+	return n
+}
+
+// tipClusterWidth is how far apart two heads may be and still be one view of
+// the chain: tipClusterSeconds of chain progress, floored at
+// tipMinClusterWidth.
+func tipClusterWidth(vPerSec float64) int64 {
+	w := vPerSec * tipClusterSeconds
+	if !(w > tipMinClusterWidth) { // also catches NaN
+		return tipMinClusterWidth
+	}
+	if w > float64(tipMaxClusterWidth) {
+		return tipMaxClusterWidth
+	}
+	return int64(w)
+}
+
+// medianInPlace sorts xs and returns its median.
+func medianInPlace(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sort.Float64s(xs)
+	if n := len(xs); n%2 == 1 {
+		return xs[n/2]
+	}
+	return (xs[len(xs)/2-1] + xs[len(xs)/2]) / 2
 }

--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -353,6 +353,16 @@ type TipTrajectory struct {
 	next    int // ring write cursor
 	count   int
 
+	// window is the TipTrajectoryParams.Window the ring was sized for. The
+	// params are re-read on every evaluation (a config reload takes effect
+	// without rebuilding the tracker), but the ring is sized once — so a raised
+	// window would otherwise demand a span the existing ring can never hold, and
+	// the referee would stand down forever while looking configured. A change
+	// therefore rebuilds the ring and clears the fit and the dwell: the tracker
+	// re-warms from live observations, which is the same inert-then-confident
+	// path every process takes after a deploy.
+	window time.Duration
+
 	// ordered / slopes / resid are refit scratch, retained so the periodic fit
 	// allocates nothing after warm-up.
 	ordered []tipSample
@@ -639,8 +649,16 @@ func (t *TipTrajectory) record(now time.Time, head int64, p TipTrajectoryParams)
 		prevAgeMs = nowMs - last
 	}
 
-	if t.samples == nil {
+	if t.samples == nil || t.window != p.Window {
+		// First use, or the operator changed trajectoryWindow under a live
+		// process (see TipTrajectory.window): size the ring for the window in
+		// force and start the track again, since neither the old samples' span
+		// nor a fit over them describes the new configuration.
 		t.samples = make([]tipSample, tipBufferCapacity(p.Window))
+		t.window = p.Window
+		t.next, t.count = 0, 0
+		t.fit.Store(nil)
+		t.dwell.Store(nil)
 	}
 	t.samples[t.next] = tipSample{atMs: nowMs, head: head}
 	t.next = (t.next + 1) % len(t.samples)

--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -40,6 +40,12 @@ type ServedTipPick struct {
 
 	// Inputs is the number of valid (BlockNumber > 0) observations.
 	Inputs int
+
+	// Sorted is the valid inputs, DESCENDING by block number — the order
+	// statistic's own working slice, exposed so the trajectory referee can
+	// cluster the very same ballot without sorting it a second time. Nil when
+	// there are no valid inputs; never mutate it.
+	Sorted []ServedTipInput
 }
 
 // PickServedTip returns the freshest block number that a strict majority of
@@ -73,26 +79,31 @@ type ServedTipPick struct {
 // Examples (heads descending): N=1 → that head; N=2 → the LOWER (never
 // advertise a block only one upstream claims); N=3 → 2nd; N=4 → 3rd; N=5 → 3rd.
 func PickServedTip(tips []ServedTipInput) ServedTipPick {
-	heads := make([]int64, 0, len(tips))
+	// One sorted slice serves the whole evaluation: the order statistic here
+	// and the referee's clustering downstream (ServedTipPick.Sorted). The
+	// UpstreamIDs travel with it because group IDENTITY — not just the head
+	// values — is what the referee's dwell test is keyed on.
+	sorted := make([]ServedTipInput, 0, len(tips))
 	for _, t := range tips {
 		if t.BlockNumber > 0 {
-			heads = append(heads, t.BlockNumber)
+			sorted = append(sorted, t)
 		}
 	}
-	if len(heads) == 0 {
+	if len(sorted) == 0 {
 		return ServedTipPick{}
 	}
-	sort.Slice(heads, func(i, j int) bool { return heads[i] > heads[j] })
-	freshest := heads[0]
-	if len(heads) > 1 {
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].BlockNumber > sorted[j].BlockNumber })
+	freshest := sorted[0].BlockNumber
+	if len(sorted) > 1 {
 		// Corroborated freshest: a single rogue far-future tip must not be
 		// able to inflate the lag reference (see ServedTipPick.Freshest).
-		freshest = heads[1]
+		freshest = sorted[1].BlockNumber
 	}
 	return ServedTipPick{
-		Tip:      heads[len(heads)/2],
+		Tip:      sorted[len(sorted)/2].BlockNumber,
 		Freshest: freshest,
-		Inputs:   len(heads),
+		Inputs:   len(sorted),
+		Sorted:   sorted,
 	}
 }
 
@@ -130,6 +141,16 @@ func PickServedTip(tips []ServedTipInput) ServedTipPick {
 //     velocity decays, and the referee stops participating on its own after
 //     roughly half a window. Its intervention has a built-in expiry that no
 //     configuration can extend.
+//   - CORROBORATION IS EARNED OVER TIME, NOT IN AN INSTANT. Matching the
+//     trajectory in one sample is not evidence: during a chain halt the expected
+//     head SWEEPS upward through every fixed offset, so any static fork/pair sits
+//     "on trajectory" for as long as the sweep takes to cross it, and a routine
+//     15-second divergence puts a healthy pair "ahead" for one evaluation. Both
+//     were confirmed exploits of the instant test. A group must therefore hold
+//     its place — elected AND within tolerance — for a continuous tipDwellDuration
+//     before it may win, and must have ADVANCED its own head over that stretch at
+//     a fraction of the fitted velocity (tipDwellMinVelocityFraction). A frozen
+//     group can never satisfy the second condition, whatever the first says.
 //   - FAIL OPEN ON ANY UNCERTAINTY, and no shared state: everything below is
 //     per-process, in-memory, rebuilt from live observations after a restart.
 //     Per-pod independence is the point — a shared head counter is how the
@@ -146,16 +167,53 @@ const (
 	// a handful of points could define a "trajectory" on noise alone.
 	tipMinSamples = 30
 
-	// tipMaxSampleGap is how stale the freshest sample may be (as of the START
-	// of an evaluation) for the fit to still describe the present. A gap larger
-	// than this is where a halt or a burst hides, and extrapolating across it
-	// is guessing — the referee steps aside instead.
+	// tipMaxSampleGap is how large a hole the window may contain — both at its
+	// newest end (the age of the freshest sample as of the START of an
+	// evaluation) and ANYWHERE INSIDE it (tipFit.maxGapMs). A gap larger than
+	// this is where a halt or a burst hides, and a fit whose window straddles
+	// one is extrapolating across the very thing it cannot see: the residuals
+	// of the samples before the hole then pull the robust intercept up by a
+	// whole gap of chain progress, which is exactly how a rogue pair sitting at
+	// "where the head would be if the chain had not stopped" wins an election.
+	// Checking only the newest sample's age stood the referee down for a single
+	// evaluation — the next one, a millisecond later, extrapolated across the
+	// hole regardless. The gap must therefore leave the WINDOW before the fit
+	// counts as describing the present.
 	tipMaxSampleGap = time.Minute
 
 	// tipMinGroupSize is the corroboration rule: one witness is not evidence,
 	// however perfectly it matches the trajectory. A group must contain at
 	// least two upstreams to be electable.
+	//
+	// It stays 2 for a fleet of ANY size, deliberately: the whole point of the
+	// referee is that two upstreams which genuinely hold the chain's head must
+	// be able to outvote a larger stalled group, and scaling the requirement
+	// with the fleet would hand the stalled majority a veto in exactly the
+	// topology the referee exists for. What makes two trustworthy is not the
+	// count but the dwell and velocity conditions below: two witnesses that
+	// have tracked the network's own trajectory for half a minute, advancing
+	// their own heads while doing so.
 	tipMinGroupSize = 2
+
+	// tipDwellDuration is how long the elected group must hold its place —
+	// continuously within tolerance of the expected head — before it may
+	// outvote the majority. Six samples at the 5s throttle: long enough that a
+	// routine divergence (a 15s poller hiccup on half the fleet, the confirmed
+	// false-override shape) resolves before it can win, short enough that a
+	// genuine majority stall is corrected inside one block-explorer refresh.
+	tipDwellDuration = 30 * time.Second
+
+	// tipDwellMinVelocityFraction is the share of the fitted velocity the
+	// elected group must have delivered FROM ITS OWN HEAD over the dwell. It is
+	// a lower bound only — closeness to expected already bounds the group from
+	// above — and its job is to disqualify anything that is not moving: a fork,
+	// a wrong-chain pair, a frozen shared counter parked at a fixed offset. A
+	// static group's advance is 0 and the threshold is strictly positive
+	// whenever the referee is confident at all (confident() requires v > 0 and
+	// the dwell is ≥30s), so a static group can never be elected — not merely
+	// unlikely to be. Half the fitted velocity leaves room for a group that is
+	// catching up in bursts.
+	tipDwellMinVelocityFraction = 0.5
 
 	// tipToleranceSigmas (k) scales the window's OWN residual spread into the
 	// distance-from-expected a group may sit at and still count as
@@ -240,12 +298,13 @@ type tipSample struct {
 // tipFit is the robust linear fit over the buffer, recomputed on insertion and
 // read lock-free on every evaluation.
 type tipFit struct {
-	refMs   int64   // timestamp of the newest sample in the fit
-	refHead float64 // FITTED head at refMs (not the raw sample: one poisoned sample must not define the anchor)
-	vPerSec float64 // robust velocity, blocks/second
-	spread  float64 // median absolute residual around the fit, blocks
-	spanMs  int64   // newest − oldest sample timestamp
-	count   int
+	refMs    int64   // timestamp of the newest sample in the fit
+	refHead  float64 // FITTED head at refMs (not the raw sample: one poisoned sample must not define the anchor)
+	vPerSec  float64 // robust velocity, blocks/second
+	spread   float64 // median absolute residual around the fit, blocks
+	spanMs   int64   // newest − oldest sample timestamp
+	maxGapMs int64   // largest interval BETWEEN two consecutive samples in the window
+	count    int
 }
 
 // expectedAt extrapolates the fit to an instant on the tracker's timeline.
@@ -265,7 +324,11 @@ func (f *tipFit) confident(nowMs int64, prevSampleAgeMs int64, p TipTrajectoryPa
 		// Also the warm-up condition: an empty buffer after boot has no span.
 		return false
 	}
-	if prevSampleAgeMs > tipMaxSampleGap.Milliseconds() {
+	if prevSampleAgeMs > tipMaxSampleGap.Milliseconds() || f.maxGapMs > tipMaxSampleGap.Milliseconds() {
+		// Both ends of the same rule: the track must be unbroken up to now AND
+		// unbroken across the whole window it was fitted over (see
+		// tipMaxSampleGap). A hole inside the window stands the referee down
+		// until the hole has scrolled out of the ring.
 		return false
 	}
 	if !(f.vPerSec > 0) || math.IsInf(f.vPerSec, 0) {
@@ -300,6 +363,28 @@ type TipTrajectory struct {
 	base         atomic.Pointer[time.Time]
 	lastSampleMs atomic.Int64
 	fit          atomic.Pointer[tipFit]
+
+	// dwell is the current corroboration stretch: which group has been the
+	// elected one, since when, and where its head was then. nil = no stretch in
+	// progress. Immutable once stored, so a dwell that is simply CONTINUING
+	// costs one atomic load per evaluation and no write at all.
+	dwell atomic.Pointer[tipDwell]
+}
+
+// tipDwell is one continuous stretch during which the same group of upstreams
+// has been elected by the trajectory and has stayed within tolerance of the
+// expected head. Its fields are never mutated after the Store; a change of
+// group, a miss, or a loss of confidence replaces or clears the whole struct.
+type tipDwell struct {
+	// group is the order-independent identity of the group's MEMBERS
+	// (groupIdentity), not of their head values: a stretch belongs to a set of
+	// upstreams, and any change to that set starts a new one.
+	group uint64
+
+	// startMs is when the stretch began, and startHead the group's max head at
+	// that instant — the two ends of the velocity-agreement measurement.
+	startMs   int64
+	startHead int64
 }
 
 // SampleCount returns how many samples the tracker holds. Diagnostics and
@@ -313,14 +398,22 @@ func (t *TipTrajectory) SampleCount() int {
 // Observe records this evaluation's live-head median (throttled) and returns
 // the trajectory's advice for it.
 //
-// `tips` must be the LIVE head observations of this same evaluation (the
-// caller drops availability-bound-capped upstreams first — a serving range is
-// not a head), and `median` the plain majority pick over them. Both the sample
-// and the candidate groups come from those heads, so the referee's own output
-// never feeds back into its evidence.
-func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int64, p TipTrajectoryParams) TipTrajectoryDecision {
+// `sorted` must be ServedTipPick.Sorted for the LIVE head observations of this
+// same evaluation (the caller drops availability-bound-capped upstreams first —
+// a serving range is not a head), i.e. already filtered and DESCENDING, and
+// `median` the plain majority pick over them. Both the sample and the candidate
+// groups come from those heads, so the referee's own output never feeds back
+// into its evidence.
+func (t *TipTrajectory) Observe(now time.Time, sorted []ServedTipInput, median int64, p TipTrajectoryParams) TipTrajectoryDecision {
 	d := TipTrajectoryDecision{Pick: median}
 	if p.Window <= 0 || median <= 0 {
+		return d
+	}
+	if len(sorted) < tipMinGroupSize {
+		// Nothing here can ever produce a decision — no group of two can form —
+		// so nothing is recorded either. A single-upstream network (the majority
+		// of chains in a large deployment) therefore allocates no ring, runs no
+		// fit, and costs two comparisons per evaluation.
 		return d
 	}
 
@@ -328,19 +421,11 @@ func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int
 
 	fit := t.fit.Load()
 	if !fit.confident(nowMs, prevSampleAgeMs, p) {
+		// No confident fit means no elected group, so any stretch in progress is
+		// over: a group must re-earn its dwell once the referee can see again.
+		t.breakDwell()
 		return d
 	}
-
-	heads := make([]int64, 0, len(tips))
-	for _, in := range tips {
-		if in.BlockNumber > 0 {
-			heads = append(heads, in.BlockNumber)
-		}
-	}
-	if len(heads) < tipMinGroupSize {
-		return d
-	}
-	sort.Slice(heads, func(i, j int) bool { return heads[i] > heads[j] })
 
 	expected := fit.expectedAt(nowMs)
 	tolerance := float64(p.ToleranceFloor)
@@ -358,16 +443,18 @@ func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int
 	// slowest member) sits closest to where the trajectory says the head is.
 	width := tipClusterWidth(fit.vPerSec)
 	bestDistance := math.Inf(1)
-	var bestMin int64
-	for i := 0; i < len(heads); {
+	var bestMin, bestMax int64
+	var bestGroup uint64
+	for i := 0; i < len(sorted); {
 		j := i + 1
-		for j < len(heads) && heads[j-1]-heads[j] <= width {
+		for j < len(sorted) && sorted[j-1].BlockNumber-sorted[j].BlockNumber <= width {
 			j++
 		}
 		if j-i >= tipMinGroupSize {
-			groupMax, groupMin := heads[i], heads[j-1]
+			groupMax, groupMin := sorted[i].BlockNumber, sorted[j-1].BlockNumber
 			if distance := math.Abs(float64(groupMax) - expected); distance < bestDistance {
-				bestDistance, bestMin = distance, groupMin
+				bestDistance, bestMin, bestMax = distance, groupMin, groupMax
+				bestGroup = groupIdentity(sorted[i:j])
 			}
 		}
 		i = j
@@ -375,15 +462,31 @@ func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int
 
 	if bestDistance > tolerance {
 		// No candidate group at all (+Inf), or the elected one is nowhere near
-		// the trajectory — nothing here is better evidence than the majority.
+		// the trajectory — nothing here is better evidence than the majority,
+		// and whatever stretch was in progress just missed.
+		t.breakDwell()
 		d.Declined = bestMin > median
 		return d
 	}
+
+	// The elected group keeps (or starts) its dwell whether or not it is above
+	// the majority pick: in steady state the whole fleet is that group, and it
+	// arrives at a stall with its corroboration already earned.
+	corroborated := t.corroborate(nowMs, bestGroup, bestMax, fit.vPerSec)
+
 	if bestMin <= median {
 		// UPWARD-ONLY (see the section comment): the referee exists to let a
 		// corroborated fresh minority outvote a stalled majority. Lowering or
 		// holding the tip is the majority picker's and the regression guard's
 		// job, and is the only direction from which a frozen tip is reachable.
+		return d
+	}
+	if !corroborated {
+		// An override was on the table and the group has not held its place long
+		// enough (or has not moved its own head) to earn it — the same outcome,
+		// and the same counter, as a group that sits too far from the
+		// trajectory.
+		d.Declined = true
 		return d
 	}
 
@@ -393,6 +496,65 @@ func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int
 	d.Pick = bestMin
 	d.Overrode = true
 	return d
+}
+
+// corroborate reports whether `group` has EARNED the right to outvote the
+// majority, and keeps the dwell state that answers it.
+//
+// Two conditions, both measured over one continuous stretch of being the
+// elected group:
+//
+//   - it has been that group for at least tipDwellDuration. A chain halt sweeps
+//     the expected head upward through every fixed offset, so an instant match
+//     says only "the sweep is passing over this group right now";
+//   - its own head has advanced over the stretch by at least
+//     tipDwellMinVelocityFraction of what the fitted velocity says the chain
+//     produced. A fork, a wrong-chain pair, or a frozen counter parked at a
+//     plausible offset advances by nothing and can never pass.
+//
+// Concurrency: several serving goroutines may race here; the only outcomes are
+// "the stretch restarts" and "the stretch continues", and a restart is the
+// conservative direction (it can delay an override, never cause one).
+func (t *TipTrajectory) corroborate(nowMs int64, group uint64, groupMax int64, vPerSec float64) bool {
+	d := t.dwell.Load()
+	if d == nil || d.group != group || nowMs < d.startMs {
+		t.dwell.Store(&tipDwell{group: group, startMs: nowMs, startHead: groupMax})
+		return false
+	}
+	seconds := float64(nowMs-d.startMs) / 1000
+	if seconds < tipDwellDuration.Seconds() {
+		return false
+	}
+	return float64(groupMax-d.startHead) >= tipDwellMinVelocityFraction*vPerSec*seconds
+}
+
+// breakDwell ends any stretch in progress. Load-first, so the common case (no
+// stretch, or a fleet that has been in one cluster for hours) writes nothing.
+func (t *TipTrajectory) breakDwell() {
+	if t.dwell.Load() != nil {
+		t.dwell.Store(nil)
+	}
+}
+
+// groupIdentity fingerprints a group by its MEMBERS. The fold is commutative
+// (a sum of per-id FNV-1a hashes), so the identity is a property of the SET and
+// needs no sorting or allocation on the request path; the caller's slice is
+// already in head order, which is not the order the identity may depend on.
+func groupIdentity(group []ServedTipInput) uint64 {
+	const (
+		fnvOffset64 = uint64(14695981039346656037)
+		fnvPrime64  = uint64(1099511628211)
+	)
+	var sum uint64
+	for _, in := range group {
+		h := fnvOffset64
+		for i := 0; i < len(in.UpstreamID); i++ {
+			h ^= uint64(in.UpstreamID[i])
+			h *= fnvPrime64
+		}
+		sum += h
+	}
+	return sum
 }
 
 // record appends a sample if at least tipSampleInterval has passed since the
@@ -498,7 +660,13 @@ func (t *TipTrajectory) refit() {
 	// blocks, never epoch milliseconds or 8-digit block numbers, so float64
 	// keeps full precision on chains of any height.
 	resid := t.resid[:0]
-	for _, s := range ord {
+	var maxGapMs int64
+	for i, s := range ord {
+		if i > 0 {
+			if gap := s.atMs - ord[i-1].atMs; gap > maxGapMs {
+				maxGapMs = gap
+			}
+		}
 		ts := float64(s.atMs-newest.atMs) / 1000
 		resid = append(resid, float64(s.head-newest.head)-vPerSec*ts)
 	}
@@ -509,12 +677,13 @@ func (t *TipTrajectory) refit() {
 	}
 
 	t.fit.Store(&tipFit{
-		refMs:   newest.atMs,
-		refHead: float64(newest.head) + intercept,
-		vPerSec: vPerSec,
-		spread:  medianInPlace(resid),
-		spanMs:  newest.atMs - ord[0].atMs,
-		count:   n,
+		refMs:    newest.atMs,
+		refHead:  float64(newest.head) + intercept,
+		vPerSec:  vPerSec,
+		spread:   medianInPlace(resid),
+		spanMs:   newest.atMs - ord[0].atMs,
+		maxGapMs: maxGapMs,
+		count:    n,
 	})
 }
 

--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -540,25 +540,65 @@ func (t *TipTrajectory) breakDwell() {
 	}
 }
 
-// groupIdentity fingerprints a group by its MEMBERS. The fold is commutative
-// (a sum of per-id FNV-1a hashes), so the identity is a property of the SET and
-// needs no sorting or allocation on the request path; the caller's slice is
-// already in head order, which is not the order the identity may depend on.
+// tipGroupIDScratch is how many member ids groupIdentity can sort without
+// touching the heap. Real fleets are single digits; anything larger falls back
+// to an allocation rather than to a wrong answer.
+const tipGroupIDScratch = 32
+
+// groupIdentity fingerprints a group by its MEMBERS: the ids are sorted, then
+// hashed as one separated stream. Sorting is what makes the identity a property
+// of the SET while keeping the hash's avalanche intact.
+//
+// The obvious cheap alternative — a commutative fold, e.g. summing per-id
+// hashes — is structurally broken here, not merely weaker. FNV-1a's last step
+// is (h ^ c) * prime, so for two ids sharing a prefix the DIFFERENCE between
+// their hashes barely depends on that prefix; a fleet named with a shared
+// vendor prefix and a numeric suffix therefore collides on suffix swaps:
+// {prism-celo-1, nirvana-celo-2} and {prism-celo-2, nirvana-celo-1} folded to
+// the same number. A review found four such colliding pairs inside one
+// realistic 12-node fleet, and a collision here is not cosmetic — it lets a
+// DIFFERENT group inherit the dwell an earlier one earned, which is exactly the
+// corroboration the dwell exists to withhold.
+//
+// The caller's slice is in head order, so the sort works on a copy: a stack
+// array for any realistic fleet, and the request path stays lock-free (a shared
+// scratch buffer would have to be taken under the tracker's mutex, serialising
+// every evaluation to save an allocation that does not happen).
 func groupIdentity(group []ServedTipInput) uint64 {
 	const (
 		fnvOffset64 = uint64(14695981039346656037)
 		fnvPrime64  = uint64(1099511628211)
 	)
-	var sum uint64
+	var stack [tipGroupIDScratch]string
+	var ids []string
+	if len(group) <= len(stack) {
+		ids = stack[:0]
+	} else {
+		ids = make([]string, 0, len(group))
+	}
 	for _, in := range group {
-		h := fnvOffset64
-		for i := 0; i < len(in.UpstreamID); i++ {
-			h ^= uint64(in.UpstreamID[i])
+		ids = append(ids, in.UpstreamID)
+	}
+	// Insertion sort, not sort.Strings: the slices are tiny, and the interface
+	// conversion sort.Strings performs would force the scratch array onto the
+	// heap on every evaluation.
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {
+			ids[j-1], ids[j] = ids[j], ids[j-1]
+		}
+	}
+
+	h := fnvOffset64
+	for _, id := range ids {
+		for i := 0; i < len(id); i++ {
+			h ^= uint64(id[i])
 			h *= fnvPrime64
 		}
-		sum += h
+		// A separator, so {"ab","c"} and {"a","bc"} are different sets.
+		h ^= 0x1f
+		h *= fnvPrime64
 	}
-	return sum
+	return h
 }
 
 // record appends a sample if at least tipSampleInterval has passed since the

--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/erpc/erpc/common"
 )
 
 // ServedTipInput is a single observation: an upstream's last-known tip block.
@@ -160,8 +162,9 @@ const (
 	// tipSampleInterval throttles recording to one sample per evaluation-with-
 	// this-much-elapsed. Fast enough that the default 10-minute window holds
 	// 120 samples, slow enough that the O(n log n) refit runs at most 0.2 Hz
-	// per network+axis while reads stay O(1).
-	tipSampleInterval = 5 * time.Second
+	// per network+axis while reads stay O(1). It lives in common because the
+	// config validator derives the allowed trajectoryWindow range from it.
+	tipSampleInterval = common.ServedTipTrajectorySampleInterval
 
 	// tipMinSamples is the smallest buffer the fit is computed over: below it
 	// a handful of points could define a "trajectory" on noise alone.
@@ -240,9 +243,10 @@ const (
 	tipMaxClusterWidth = int64(1) << 40
 
 	// tipMinBufferCapacity / tipMaxBufferCapacity bound the ring derived from
-	// the configured window (tipBufferCapacity).
+	// the configured window (tipBufferCapacity). The cap is shared with the
+	// config validator, which rejects a window this ring could never span.
 	tipMinBufferCapacity = 64
-	tipMaxBufferCapacity = 1024
+	tipMaxBufferCapacity = common.ServedTipTrajectoryMaxSamples
 )
 
 // TipTrajectoryParams are the per-network knobs the referee reads on every

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -1,9 +1,13 @@
 package evm
 
 import (
+	"math"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The served-tip contract: PickServedTip returns the freshest block a strict
@@ -165,4 +169,295 @@ func TestPickServedTip_Scenario_HaltedChainHoldsHonestly(t *testing.T) {
 	frozen := tipsFromInts(500, 500, 499)
 	assert.Equal(t, int64(500), PickServedTip(frozen).Tip)
 	assert.Equal(t, PickServedTip(frozen), PickServedTip(frozen), "pure function: same inputs, same pick")
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// These pin the tracker's own mechanics: the fit it derives from a head track,
+// the confidence gate that keeps it inert, and the group election. The
+// end-to-end behaviour (which block a network actually serves) is pinned in
+// package erpc's networks_served_tip_test.go.
+
+// trajectoryParams is the referee's config as a network with default settings
+// supplies it: a 10-minute window and the 1024-block regression tolerance.
+func trajectoryParams() TipTrajectoryParams {
+	return TipTrajectoryParams{Window: 10 * time.Minute, ToleranceFloor: 1024}
+}
+
+// warmTrajectory feeds `samples` observations one tipSampleInterval apart,
+// advancing the head by `perSample` blocks each time, and returns the clock and
+// head it stopped at. Every sample goes through Observe, i.e. the same entry
+// point the request path uses.
+func warmTrajectory(tr *TipTrajectory, start time.Time, head int64, perSample int64, samples int) (time.Time, int64) {
+	now := start
+	for i := 0; i < samples; i++ {
+		tr.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		now = now.Add(tipSampleInterval)
+		head += perSample
+	}
+	return now, head
+}
+
+func TestTipTrajectory_FitRecoversVelocityAndExpectedHead(t *testing.T) {
+	var tr TipTrajectory
+	// 20 blocks/s (100 blocks per 5s sample), 130 samples ≈ 10m50s of history.
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+	fit := tr.fit.Load()
+	require.NotNil(t, fit)
+	assert.InDelta(t, 20.0, fit.vPerSec, 0.001, "robust velocity must recover the 20 blocks/s track")
+	assert.InDelta(t, 0.0, fit.spread, 0.001, "a perfectly linear track has no residual spread")
+
+	// The head the fit expects one sample-interval on is the next sample's.
+	assert.InDelta(t, float64(head), fit.expectedAt(int64(now.Sub(*tr.base.Load())/time.Millisecond)), 1.0)
+}
+
+func TestTipTrajectory_PoisonedSampleDoesNotMoveTheFit(t *testing.T) {
+	var tr TipTrajectory
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 60)
+	clean := tr.fit.Load()
+	require.NotNil(t, clean)
+
+	// One wrong-chain / garbage observation lands in the middle of the track.
+	tr.Observe(now, tipsFromInts(head), 999_999_999, trajectoryParams())
+	now, _ = warmTrajectory(&tr, now.Add(tipSampleInterval), head+100, 100, 70)
+
+	poisoned := tr.fit.Load()
+	require.NotNil(t, poisoned)
+	assert.InDelta(t, clean.vPerSec, poisoned.vPerSec, 0.001,
+		"a single poisoned sample must not move the median-of-lagged-slopes velocity")
+	assert.Less(t, poisoned.spread, float64(1024),
+		"nor may it inflate the residual spread past the tolerance floor")
+}
+
+func TestTipTrajectory_ConfidenceGate(t *testing.T) {
+	params := trajectoryParams()
+
+	t.Run("ColdBufferIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		now := time.Now()
+		for i := 0; i < tipMinSamples-1; i++ {
+			d := tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100, 999_000), 999_000, params)
+			require.False(t, d.Overrode, "sample %d: a cold tracker must never override", i)
+			now = now.Add(tipSampleInterval)
+		}
+		assert.Nil(t, tr.fit.Load(), "no fit below tipMinSamples")
+	})
+
+	t.Run("ShortWindowIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		// 60 samples = 5 minutes of span: enough points, not enough window.
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 60)
+		fit := tr.fit.Load()
+		require.NotNil(t, fit)
+		require.Less(t, fit.spanMs, params.Window.Milliseconds())
+
+		// A stalled majority + a fresh pair: the shape that WOULD be overridden.
+		d := tr.Observe(now, tipsFromInts(head, head, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		assert.False(t, d.Overrode, "span below the configured window must keep the referee inert")
+	})
+
+	t.Run("StaleTrackIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+		require.True(t, tr.fit.Load().spanMs >= params.Window.Milliseconds())
+
+		// Nothing evaluated for longer than the maximum gap: the fit no longer
+		// describes the present, whatever it says.
+		now = now.Add(tipMaxSampleGap + time.Second)
+		d := tr.Observe(now, tipsFromInts(head+1200, head+1200, head, head, head), head, params)
+		assert.False(t, d.Overrode, "a gap past tipMaxSampleGap must stand the referee down")
+	})
+
+	t.Run("HaltedChainIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		// A completely flat track: velocity 0, so there is no trajectory to be
+		// off. The majority pick is already the right answer for a halted chain.
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 0, 130)
+		require.NotNil(t, tr.fit.Load())
+		d := tr.Observe(now, tipsFromInts(head+5_000, head+5_000, head, head, head), head, params)
+		assert.False(t, d.Overrode, "v <= 0 must stand the referee down")
+	})
+
+	t.Run("DisabledRecordsNothing", func(t *testing.T) {
+		var tr TipTrajectory
+		off := TipTrajectoryParams{Window: 0, ToleranceFloor: 1024}
+		now := time.Now()
+		for i := 0; i < 200; i++ {
+			tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100), 1_000_000+int64(i)*100, off)
+			now = now.Add(tipSampleInterval)
+		}
+		assert.Zero(t, tr.SampleCount(), "trajectoryWindow: 0 must record nothing at all")
+		assert.Nil(t, tr.fit.Load())
+	})
+}
+
+func TestTipTrajectory_GroupElection(t *testing.T) {
+	params := trajectoryParams()
+
+	t.Run("StalledMajorityLosesToCorroboratedFreshPair", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// The stall: three heads freeze, two keep the track. The tracker keeps
+		// sampling the (frozen) majority median throughout — its evidence is
+		// never its own output.
+		frozen := head
+		for i := 0; i < 24; i++ {
+			now = now.Add(tipSampleInterval)
+			head += 100
+			tr.Observe(now, tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+		}
+
+		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+		assert.True(t, d.Overrode, "the on-trajectory pair must outvote the stalled majority")
+		assert.Equal(t, head, d.Pick, "the pick is the fresh group's MINIMUM — both members have it")
+		assert.False(t, d.Declined, "an override is not a near miss")
+	})
+
+	t.Run("SingletonIsNeverCorroboration", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		frozen := head
+		for i := 0; i < 24; i++ {
+			now = now.Add(tipSampleInterval)
+			head += 100
+			tr.Observe(now, tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+		}
+
+		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+		assert.False(t, d.Overrode,
+			"one upstream matching the trajectory perfectly is still one witness")
+		assert.Equal(t, frozen, d.Pick)
+	})
+
+	t.Run("NearMissIsDeclinedNotOverridden", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Everything is off the trajectory: the freshest pair is the closest
+		// group to where the head should be, but still further than the
+		// tolerance. The referee elects it and then refuses it — a near miss,
+		// which is the one non-override outcome worth counting.
+		d := tr.Observe(now, tipsFromInts(head+3_000, head+3_000, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		assert.False(t, d.Overrode)
+		assert.True(t, d.Declined, "a refused raise is the fallback outcome")
+		assert.Equal(t, head-20_000, d.Pick)
+	})
+
+	t.Run("RunawayPairIsOutsideTolerance", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Two upstreams jump far past where the chain can possibly be.
+		d := tr.Observe(now, tipsFromInts(head+500_000, head+500_000, head, head, head), head, params)
+		assert.False(t, d.Overrode, "a group that far off the trajectory must not win")
+		assert.Equal(t, head, d.Pick)
+	})
+
+	t.Run("UpwardOnly", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Three upstreams run ahead, two sit exactly on the trajectory: the
+		// on-trajectory group wins the election, but electing it would LOWER
+		// the majority pick, so the referee stands down instead.
+		d := tr.Observe(now, tipsFromInts(head+50_000, head+50_000, head+50_000, head, head), head+50_000, params)
+		assert.False(t, d.Overrode, "the referee may never lower or hold the pick")
+		assert.Equal(t, head+50_000, d.Pick)
+	})
+
+	t.Run("HealthyFleetIsOneGroupAndNeverIntervenes", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Normal propagation skew, well inside one cluster width.
+		heads := tipsFromInts(head, head-1, head-3, head-7, head-11)
+		median := PickServedTip(heads).Tip
+		d := tr.Observe(now, heads, median, params)
+		assert.False(t, d.Overrode)
+		assert.False(t, d.Declined, "a fleet in one cluster is not even a near miss")
+		assert.Equal(t, median, d.Pick)
+	})
+}
+
+func TestTipTrajectory_BurstyChainWidensItsOwnTolerance(t *testing.T) {
+	var steady, bursty TipTrajectory
+
+	_, _ = warmTrajectory(&steady, time.Now(), 1_000_000, 100, 130)
+
+	// Same average velocity, delivered in bursts: 9 samples of nothing, then a
+	// 1000-block batch (the L2-sequencer shape).
+	now, head := time.Now(), int64(1_000_000)
+	for i := 0; i < 130; i++ {
+		if i%10 == 9 {
+			head += 1000
+		}
+		bursty.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		now = now.Add(tipSampleInterval)
+	}
+
+	steadyFit, burstyFit := steady.fit.Load(), bursty.fit.Load()
+	require.NotNil(t, steadyFit)
+	require.NotNil(t, burstyFit)
+	assert.InDelta(t, steadyFit.vPerSec, burstyFit.vPerSec, 2.0,
+		"both tracks average the same velocity")
+	assert.Greater(t, burstyFit.spread*tipToleranceSigmas, float64(1024),
+		"a chain that pauses and bursts must widen its own tolerance past the floor")
+	assert.Less(t, steadyFit.spread*tipToleranceSigmas, float64(1024),
+		"a metronomic chain keeps the configured floor")
+}
+
+func TestTipTrajectory_SampleThrottleAndBufferBound(t *testing.T) {
+	var tr TipTrajectory
+	params := trajectoryParams()
+	now := time.Now()
+
+	// A hot request path: 500 evaluations inside one sample interval.
+	for i := 0; i < 500; i++ {
+		tr.Observe(now.Add(time.Duration(i)*time.Millisecond), tipsFromInts(1_000_000), 1_000_000, params)
+	}
+	assert.Equal(t, 1, tr.SampleCount(), "the throttle admits one sample per interval, whatever the QPS")
+
+	// And the ring never grows past the capacity derived from the window.
+	_, _ = warmTrajectory(&tr, now.Add(tipSampleInterval), 1_000_100, 100, 4_000)
+	assert.Equal(t, tipBufferCapacity(params.Window), tr.SampleCount())
+	assert.LessOrEqual(t, tr.fit.Load().spanMs, int64(tipBufferCapacity(params.Window))*tipSampleInterval.Milliseconds())
+}
+
+// The request path calls Observe from every serving goroutine at once, so the
+// throttle's double-checked lock, the refit and the lock-free fit read all have
+// to hold up under -race.
+func TestTipTrajectory_ConcurrentObserve(t *testing.T) {
+	var tr TipTrajectory
+	params := trajectoryParams()
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				head := int64(1_000_000 + i*100)
+				tr.Observe(start.Add(time.Duration(i)*tipSampleInterval), tipsFromInts(head, head-1), head, params)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Positive(t, tr.SampleCount())
+	assert.LessOrEqual(t, tr.SampleCount(), tipBufferCapacity(params.Window),
+		"the ring must stay bounded however many goroutines record into it")
+}
+
+func TestTipClusterWidth(t *testing.T) {
+	// Sub-second-block chains and slow chains alike keep the floor; a fast
+	// chain gets 10 seconds of its own progress.
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(0.083), "12s blocks → floor")
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(1), "1s blocks → floor")
+	assert.Equal(t, int64(40), tipClusterWidth(4), "250ms blocks → 10s of progress")
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(math.NaN()), "NaN must fall to the floor")
+	assert.Equal(t, tipMaxClusterWidth, tipClusterWidth(math.MaxFloat64), "no int64 overflow")
 }

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -196,9 +196,13 @@ func trajectoryParams() TipTrajectoryParams {
 // head it stopped at. Every sample goes through Observe, i.e. the same entry
 // point the request path uses.
 func warmTrajectory(tr *TipTrajectory, start time.Time, head int64, perSample int64, samples int) (time.Time, int64) {
+	return warmTrajectoryWith(tr, start, head, perSample, samples, trajectoryParams())
+}
+
+func warmTrajectoryWith(tr *TipTrajectory, start time.Time, head int64, perSample int64, samples int, p TipTrajectoryParams) (time.Time, int64) {
 	now := start
 	for i := 0; i < samples; i++ {
-		tr.Observe(now, ballot(head, head), head, trajectoryParams())
+		tr.Observe(now, ballot(head, head), head, p)
 		now = now.Add(tipSampleInterval)
 		head += perSample
 	}
@@ -709,6 +713,37 @@ func TestTipTrajectory_GapMustLeaveTheWindow(t *testing.T) {
 			"a pair sitting exactly where the gap-inflated fit expects the head must not win")
 		assert.Zero(t, d.Expected, "the fit is refused outright, so nothing is even compared to it")
 	})
+}
+
+// The params are re-read on every evaluation so a config reload takes effect
+// without rebuilding the tracker — but the ring was sized once, at first use. An
+// operator RAISING trajectoryWindow therefore asked for a span the existing ring
+// could never hold, and the referee stood down forever while looking configured.
+// A window change now rebuilds the ring and re-warms.
+func TestTipTrajectory_WindowChangeRebuildsTheRing(t *testing.T) {
+	var tr TipTrajectory
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+	require.NotNil(t, tr.fit.Load(), "precondition: warm and confident at the original window")
+	require.Greater(t, tr.SampleCount(), tipMinSamples)
+
+	// The same tracker, now asked for a window its ring cannot span.
+	raised := TipTrajectoryParams{Window: 30 * time.Minute, ToleranceFloor: 1024}
+	require.Greater(t, tipBufferCapacity(raised.Window), tipBufferCapacity(10*time.Minute),
+		"precondition: the raised window needs a bigger ring")
+
+	tr.Observe(now, ballot(head, head), head, raised)
+	assert.Equal(t, 1, tr.SampleCount(), "the track restarts on the new window")
+	assert.Nil(t, tr.fit.Load(), "and no fit from the old one survives it")
+	assert.Nil(t, tr.dwell.Load(), "nor any corroboration earned under it")
+
+	// Re-warming at the new window works — i.e. the referee comes back rather
+	// than standing down forever.
+	now, _ = warmTrajectoryWith(&tr, now.Add(tipSampleInterval), head+100, 100, 420, raised)
+	fit := tr.fit.Load()
+	require.NotNil(t, fit)
+	assert.GreaterOrEqual(t, fit.spanMs, raised.Window.Milliseconds(),
+		"the rebuilt ring can span the window the operator asked for")
+	_ = now
 }
 
 // A ballot that cannot form a group can never produce a decision, so it must not

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -509,89 +509,151 @@ func TestTipTrajectory_HaltSweepCannotElectAStaticGroup(t *testing.T) {
 	}
 }
 
-func TestTipTrajectory_DwellMustBeEarned(t *testing.T) {
+// stalledFleet drives a fleet in which `fresh` upstreams sit exactly on the
+// fitted trajectory and the rest are frozen `behind` blocks below it, evaluating
+// every tipSampleInterval and reporting the first elapsed time at which the
+// referee overrode (or -1). The elapsed times these tests assert on are ABSOLUTE
+// literals, deliberately: a dwell pinned in terms of tipDwellDuration is pinned
+// by nothing, since zeroing the constant would move the expectation with it.
+func stalledFleet(tr *TipTrajectory, now time.Time, head int64, behind int64, run time.Duration, fresh []string, frozenIDs []string) (firstOverride time.Duration, overrides int, at map[time.Duration]bool) {
 	p := trajectoryParams()
+	start := now
+	frozenHead := head - behind
+	firstOverride, at = -1, map[time.Duration]bool{}
+	for elapsed := time.Duration(0); elapsed <= run; elapsed += tipSampleInterval {
+		ins := make([]ServedTipInput, 0, len(fresh)+len(frozenIDs))
+		for _, id := range fresh {
+			ins = append(ins, in(id, head+int64(elapsed.Seconds())*20))
+		}
+		for _, id := range frozenIDs {
+			ins = append(ins, in(id, frozenHead))
+		}
+		pick := PickServedTip(ins)
+		d := tr.Observe(start.Add(elapsed), pick.Sorted, pick.Tip, p)
+		at[elapsed] = d.Overrode
+		if d.Overrode {
+			overrides++
+			if firstOverride < 0 {
+				firstOverride = elapsed
+			}
+		}
+	}
+	return firstOverride, overrides, at
+}
 
-	// The confirmed false-override shape: two of four upstreams pause for 15s
-	// (a poller hiccup, a vendor blip) and then catch up. Nothing is wrong with
-	// the fleet, and the divergence is over long before the dwell completes.
+func TestTipTrajectory_DwellMustBeEarned(t *testing.T) {
+	// A pair that is on the trajectory, corroborating each other, advancing at
+	// the chain's own velocity, and separated from the stalled majority from the
+	// VERY FIRST evaluation — i.e. nothing but elapsed time stands between it and
+	// an override. It must still wait.
+	t.Run("AnOnTrajectoryGroupStillWaits", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		_, _, at := stalledFleet(&tr, now, head, 3_000, 45*time.Second,
+			[]string{"u1", "u2"}, []string{"u3", "u4", "u5"})
+
+		for _, elapsed := range []time.Duration{0, 5 * time.Second, 15 * time.Second, 25 * time.Second} {
+			assert.False(t, at[elapsed],
+				"at %v the group has corroborated nothing yet — it has merely been right for %v", elapsed, elapsed)
+		}
+		assert.True(t, at[45*time.Second],
+			"but by 45s of holding that place it has earned the override the stall needs")
+	})
+
+	// The confirmed false-override shape, with the geometry taken out of the
+	// argument: the two clusters are further apart than one cluster width from
+	// the first sample, so nothing but the dwell prevents an override here.
 	t.Run("TransientDivergenceNeverWins", func(t *testing.T) {
 		var tr TipTrajectory
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
 
-		overrides := 0
-		paused := head
-		for k := 0; k < 3; k++ { // 15s of two-of-four divergence
-			head += 100
-			d := tr.Observe(now, ballotOf(
-				in("u1", head), in("u2", head),
-				in("u3", paused), in("u4", paused),
-			), paused, p)
-			if d.Overrode {
-				overrides++
-			}
-			now = now.Add(tipSampleInterval)
-		}
-		// The pair catches up: one cluster again.
-		head += 100
-		d := tr.Observe(now, ballotOf(in("u1", head), in("u2", head), in("u3", head), in("u4", head)), head, p)
-		assert.False(t, d.Overrode)
+		_, overrides, _ := stalledFleet(&tr, now, head, 1_000, 15*time.Second,
+			[]string{"u1", "u2"}, []string{"u3", "u4"})
 		assert.Zero(t, overrides,
-			"a 15-second divergence must not hand the tip to half the fleet")
-	})
+			"15 seconds of a two-of-four split must never hand the tip to half the fleet")
 
-	// The headline case still works — and only after the group has held its
-	// place for the dwell.
-	t.Run("StalledMajorityLosesOnlyAfterTheDwell", func(t *testing.T) {
-		var tr TipTrajectory
-		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
-		start := now
-
-		frozen := head
-		var firstOverride time.Duration = -1
-		for k := 0; k < 24; k++ {
-			head += 100
-			d := tr.Observe(now, ballotOf(
-				in("u1", head), in("u2", head),
-				in("u3", frozen), in("u4", frozen), in("u5", frozen),
-			), frozen, p)
-			if d.Overrode && firstOverride < 0 {
-				firstOverride = now.Sub(start)
-			}
-			now = now.Add(tipSampleInterval)
-		}
-		require.GreaterOrEqual(t, firstOverride, time.Duration(0),
-			"the corroborated fresh pair must still win a genuine majority stall")
-		assert.GreaterOrEqual(t, firstOverride, tipDwellDuration,
-			"and never before it has held its place for the dwell")
+		// And the fleet re-merging leaves nothing behind.
+		merged := head + 400
+		pick := PickServedTip([]ServedTipInput{in("u1", merged), in("u2", merged), in("u3", merged), in("u4", merged)})
+		d := tr.Observe(now.Add(20*time.Second), pick.Sorted, pick.Tip, trajectoryParams())
+		assert.False(t, d.Overrode)
 	})
 
 	// A group is a SET of upstreams, not a pair of head values: replacing a
-	// member restarts the corroboration from zero, because the new set has
-	// proven nothing.
+	// member restarts the corroboration, because the new set has proven nothing.
+	// This must reach the dwell's RESET branch (an existing stretch, different
+	// members), not its first-evaluation nil branch.
 	t.Run("MembershipChangeRestartsTheDwell", func(t *testing.T) {
 		var tr TipTrajectory
+		p := trajectoryParams()
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
 
-		frozen := head
-		stall := func(freshA, freshB string) TipTrajectoryDecision {
-			head += 100
-			d := tr.Observe(now, ballotOf(
-				in(freshA, head), in(freshB, head),
+		frozen := head - 3_000
+		stall := func(elapsed time.Duration, freshA, freshB string) TipTrajectoryDecision {
+			pick := PickServedTip([]ServedTipInput{
+				in(freshA, head+int64(elapsed.Seconds())*20), in(freshB, head+int64(elapsed.Seconds())*20),
 				in("u3", frozen), in("u4", frozen), in("u5", frozen),
-			), frozen, p)
-			now = now.Add(tipSampleInterval)
-			return d
+			})
+			return tr.Observe(now.Add(elapsed), pick.Sorted, pick.Tip, p)
 		}
-		for k := 0; k < 24; k++ {
-			stall("u1", "u2")
+		var elapsed time.Duration
+		for ; elapsed <= 60*time.Second; elapsed += tipSampleInterval {
+			stall(elapsed, "u1", "u2")
 		}
-		require.True(t, stall("u1", "u2").Overrode, "precondition: {u1,u2} has earned its override")
+		require.True(t, stall(elapsed, "u1", "u2").Overrode, "precondition: {u1,u2} has earned its override")
 
-		d := stall("u1", "u6")
+		earned := tr.dwell.Load()
+		require.NotNil(t, earned, "precondition: a stretch is in progress, so the swap hits the RESET branch")
+
+		elapsed += tipSampleInterval
+		d := stall(elapsed, "u1", "u6")
 		assert.False(t, d.Overrode, "a different set of upstreams starts a new dwell")
 		assert.True(t, d.Declined, "and the refusal is the fallback outcome, not silence")
+
+		restarted := tr.dwell.Load()
+		require.NotNil(t, restarted)
+		assert.NotEqual(t, earned.group, restarted.group, "the stretch belongs to the new member set")
+		assert.Greater(t, restarted.startMs, earned.startMs, "and it starts now, not when the old one did")
 	})
+}
+
+// A group's identity must survive being renamed by the fleet's own naming
+// convention. The commutative fold this replaced collided on suffix swaps —
+// nineteen colliding pairs inside one realistic twelve-node fleet — and a
+// collision lets a DIFFERENT set of upstreams inherit a dwell it never earned.
+func TestTipTrajectory_GroupIdentityDistinguishesSuffixSwaps(t *testing.T) {
+	a := []ServedTipInput{in("prism-celo-1", 10), in("nirvana-celo-2", 10)}
+	b := []ServedTipInput{in("prism-celo-2", 10), in("nirvana-celo-1", 10)}
+
+	assert.NotEqual(t, groupIdentity(a), groupIdentity(b),
+		"two different pairs of the same fleet must not share an identity")
+	assert.Equal(t, groupIdentity(a), groupIdentity([]ServedTipInput{a[1], a[0]}),
+		"but member ORDER must not change it — the identity is a property of the set")
+
+	// The consequence that matters: the earned dwell is not inherited.
+	var tr TipTrajectory
+	p := trajectoryParams()
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+	frozen := head - 3_000
+	stall := func(elapsed time.Duration, freshA, freshB string) TipTrajectoryDecision {
+		pick := PickServedTip([]ServedTipInput{
+			in(freshA, head+int64(elapsed.Seconds())*20), in(freshB, head+int64(elapsed.Seconds())*20),
+			in("quicknode-celo-1", frozen), in("quicknode-celo-2", frozen), in("quicknode-celo-3", frozen),
+		})
+		return tr.Observe(now.Add(elapsed), pick.Sorted, pick.Tip, p)
+	}
+	var elapsed time.Duration
+	for ; elapsed <= 60*time.Second; elapsed += tipSampleInterval {
+		stall(elapsed, "prism-celo-1", "nirvana-celo-2")
+	}
+	require.True(t, stall(elapsed, "prism-celo-1", "nirvana-celo-2").Overrode,
+		"precondition: {prism-celo-1, nirvana-celo-2} earned its override")
+
+	elapsed += tipSampleInterval
+	d := stall(elapsed, "prism-celo-2", "nirvana-celo-1")
+	assert.False(t, d.Overrode,
+		"the suffix-swapped pair is a different set and must earn its own dwell")
 }
 
 // The gap rule is about the WINDOW, not about the newest sample: standing the

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -487,7 +487,7 @@ func TestTipTrajectory_HaltSweepCannotElectAStaticGroup(t *testing.T) {
 		require.NotNil(t, tr.fit.Load(), "precondition: the referee is warm and confident")
 
 		rogue := frozen + ahead
-		overrides, elected := 0, 0
+		overrides, contended := 0, 0
 		for k := 0; k < 240; k++ { // 20 minutes of halt, sampled every 5s
 			d := tr.Observe(now, ballotOf(
 				in("r1", rogue), in("r2", rogue),
@@ -497,14 +497,15 @@ func TestTipTrajectory_HaltSweepCannotElectAStaticGroup(t *testing.T) {
 				overrides++
 			}
 			if d.Declined {
-				elected++
+				contended++
 			}
 			now = now.Add(tipSampleInterval)
 		}
 		assert.Zero(t, overrides,
 			"a static group cannot have produced the chain progress the fit describes, "+
 				"however close the sweeping expected head passes to it (offset +%d)", ahead)
-		t.Logf("offset +%-6d : 0 overrides, %d evaluations where the sweep put it on trajectory", ahead, elected)
+		t.Logf("offset +%-6d : 0 overrides, %d evaluations where the sweep made the static pair the ELECTED group",
+			ahead, contended)
 	}
 }
 

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -23,6 +23,13 @@ func tipsFromInts(blocks ...int64) []ServedTipInput {
 	return out
 }
 
+// ballot is what the network hands the referee: the pick's own descending,
+// zero-filtered slice (ServedTipPick.Sorted). Tests go through PickServedTip so
+// they exercise the same single sort the request path performs.
+func ballot(blocks ...int64) []ServedTipInput {
+	return PickServedTip(tipsFromInts(blocks...)).Sorted
+}
+
 func itoa(i int) string {
 	if i == 0 {
 		return "0"
@@ -191,7 +198,7 @@ func trajectoryParams() TipTrajectoryParams {
 func warmTrajectory(tr *TipTrajectory, start time.Time, head int64, perSample int64, samples int) (time.Time, int64) {
 	now := start
 	for i := 0; i < samples; i++ {
-		tr.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		tr.Observe(now, ballot(head, head), head, trajectoryParams())
 		now = now.Add(tipSampleInterval)
 		head += perSample
 	}
@@ -219,7 +226,7 @@ func TestTipTrajectory_PoisonedSampleDoesNotMoveTheFit(t *testing.T) {
 	require.NotNil(t, clean)
 
 	// One wrong-chain / garbage observation lands in the middle of the track.
-	tr.Observe(now, tipsFromInts(head), 999_999_999, trajectoryParams())
+	tr.Observe(now, ballot(head, head), 999_999_999, trajectoryParams())
 	now, _ = warmTrajectory(&tr, now.Add(tipSampleInterval), head+100, 100, 70)
 
 	poisoned := tr.fit.Load()
@@ -237,7 +244,7 @@ func TestTipTrajectory_ConfidenceGate(t *testing.T) {
 		var tr TipTrajectory
 		now := time.Now()
 		for i := 0; i < tipMinSamples-1; i++ {
-			d := tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100, 999_000), 999_000, params)
+			d := tr.Observe(now, ballot(1_000_000+int64(i)*100, 999_000), 999_000, params)
 			require.False(t, d.Overrode, "sample %d: a cold tracker must never override", i)
 			now = now.Add(tipSampleInterval)
 		}
@@ -253,7 +260,7 @@ func TestTipTrajectory_ConfidenceGate(t *testing.T) {
 		require.Less(t, fit.spanMs, params.Window.Milliseconds())
 
 		// A stalled majority + a fresh pair: the shape that WOULD be overridden.
-		d := tr.Observe(now, tipsFromInts(head, head, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		d := tr.Observe(now, ballot(head, head, head-20_000, head-20_000, head-20_000), head-20_000, params)
 		assert.False(t, d.Overrode, "span below the configured window must keep the referee inert")
 	})
 
@@ -265,7 +272,7 @@ func TestTipTrajectory_ConfidenceGate(t *testing.T) {
 		// Nothing evaluated for longer than the maximum gap: the fit no longer
 		// describes the present, whatever it says.
 		now = now.Add(tipMaxSampleGap + time.Second)
-		d := tr.Observe(now, tipsFromInts(head+1200, head+1200, head, head, head), head, params)
+		d := tr.Observe(now, ballot(head+1200, head+1200, head, head, head), head, params)
 		assert.False(t, d.Overrode, "a gap past tipMaxSampleGap must stand the referee down")
 	})
 
@@ -275,7 +282,7 @@ func TestTipTrajectory_ConfidenceGate(t *testing.T) {
 		// off. The majority pick is already the right answer for a halted chain.
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 0, 130)
 		require.NotNil(t, tr.fit.Load())
-		d := tr.Observe(now, tipsFromInts(head+5_000, head+5_000, head, head, head), head, params)
+		d := tr.Observe(now, ballot(head+5_000, head+5_000, head, head, head), head, params)
 		assert.False(t, d.Overrode, "v <= 0 must stand the referee down")
 	})
 
@@ -284,7 +291,7 @@ func TestTipTrajectory_ConfidenceGate(t *testing.T) {
 		off := TipTrajectoryParams{Window: 0, ToleranceFloor: 1024}
 		now := time.Now()
 		for i := 0; i < 200; i++ {
-			tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100), 1_000_000+int64(i)*100, off)
+			tr.Observe(now, ballot(1_000_000+int64(i)*100, 1_000_000+int64(i)*100), 1_000_000+int64(i)*100, off)
 			now = now.Add(tipSampleInterval)
 		}
 		assert.Zero(t, tr.SampleCount(), "trajectoryWindow: 0 must record nothing at all")
@@ -306,10 +313,10 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		for i := 0; i < 24; i++ {
 			now = now.Add(tipSampleInterval)
 			head += 100
-			tr.Observe(now, tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+			tr.Observe(now, ballot(head, head, frozen, frozen, frozen), frozen, params)
 		}
 
-		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+		d := tr.Observe(now.Add(time.Second), ballot(head, head, frozen, frozen, frozen), frozen, params)
 		assert.True(t, d.Overrode, "the on-trajectory pair must outvote the stalled majority")
 		assert.Equal(t, head, d.Pick, "the pick is the fresh group's MINIMUM — both members have it")
 		assert.False(t, d.Declined, "an override is not a near miss")
@@ -323,10 +330,10 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		for i := 0; i < 24; i++ {
 			now = now.Add(tipSampleInterval)
 			head += 100
-			tr.Observe(now, tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+			tr.Observe(now, ballot(head, frozen, frozen, frozen, frozen), frozen, params)
 		}
 
-		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+		d := tr.Observe(now.Add(time.Second), ballot(head, frozen, frozen, frozen, frozen), frozen, params)
 		assert.False(t, d.Overrode,
 			"one upstream matching the trajectory perfectly is still one witness")
 		assert.Equal(t, frozen, d.Pick)
@@ -340,7 +347,7 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		// group to where the head should be, but still further than the
 		// tolerance. The referee elects it and then refuses it — a near miss,
 		// which is the one non-override outcome worth counting.
-		d := tr.Observe(now, tipsFromInts(head+3_000, head+3_000, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		d := tr.Observe(now, ballot(head+3_000, head+3_000, head-20_000, head-20_000, head-20_000), head-20_000, params)
 		assert.False(t, d.Overrode)
 		assert.True(t, d.Declined, "a refused raise is the fallback outcome")
 		assert.Equal(t, head-20_000, d.Pick)
@@ -351,7 +358,7 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
 
 		// Two upstreams jump far past where the chain can possibly be.
-		d := tr.Observe(now, tipsFromInts(head+500_000, head+500_000, head, head, head), head, params)
+		d := tr.Observe(now, ballot(head+500_000, head+500_000, head, head, head), head, params)
 		assert.False(t, d.Overrode, "a group that far off the trajectory must not win")
 		assert.Equal(t, head, d.Pick)
 	})
@@ -363,7 +370,7 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		// Three upstreams run ahead, two sit exactly on the trajectory: the
 		// on-trajectory group wins the election, but electing it would LOWER
 		// the majority pick, so the referee stands down instead.
-		d := tr.Observe(now, tipsFromInts(head+50_000, head+50_000, head+50_000, head, head), head+50_000, params)
+		d := tr.Observe(now, ballot(head+50_000, head+50_000, head+50_000, head, head), head+50_000, params)
 		assert.False(t, d.Overrode, "the referee may never lower or hold the pick")
 		assert.Equal(t, head+50_000, d.Pick)
 	})
@@ -373,12 +380,11 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
 
 		// Normal propagation skew, well inside one cluster width.
-		heads := tipsFromInts(head, head-1, head-3, head-7, head-11)
-		median := PickServedTip(heads).Tip
-		d := tr.Observe(now, heads, median, params)
+		pick := PickServedTip(tipsFromInts(head, head-1, head-3, head-7, head-11))
+		d := tr.Observe(now, pick.Sorted, pick.Tip, params)
 		assert.False(t, d.Overrode)
 		assert.False(t, d.Declined, "a fleet in one cluster is not even a near miss")
-		assert.Equal(t, median, d.Pick)
+		assert.Equal(t, pick.Tip, d.Pick)
 	})
 }
 
@@ -394,7 +400,7 @@ func TestTipTrajectory_BurstyChainWidensItsOwnTolerance(t *testing.T) {
 		if i%10 == 9 {
 			head += 1000
 		}
-		bursty.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		bursty.Observe(now, ballot(head, head), head, trajectoryParams())
 		now = now.Add(tipSampleInterval)
 	}
 
@@ -416,7 +422,7 @@ func TestTipTrajectory_SampleThrottleAndBufferBound(t *testing.T) {
 
 	// A hot request path: 500 evaluations inside one sample interval.
 	for i := 0; i < 500; i++ {
-		tr.Observe(now.Add(time.Duration(i)*time.Millisecond), tipsFromInts(1_000_000), 1_000_000, params)
+		tr.Observe(now.Add(time.Duration(i)*time.Millisecond), ballot(1_000_000, 1_000_000), 1_000_000, params)
 	}
 	assert.Equal(t, 1, tr.SampleCount(), "the throttle admits one sample per interval, whatever the QPS")
 
@@ -441,7 +447,7 @@ func TestTipTrajectory_ConcurrentObserve(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < 200; i++ {
 				head := int64(1_000_000 + i*100)
-				tr.Observe(start.Add(time.Duration(i)*tipSampleInterval), tipsFromInts(head, head-1), head, params)
+				tr.Observe(start.Add(time.Duration(i)*tipSampleInterval), ballot(head, head-1), head, params)
 			}
 		}()
 	}
@@ -450,6 +456,212 @@ func TestTipTrajectory_ConcurrentObserve(t *testing.T) {
 	assert.Positive(t, tr.SampleCount())
 	assert.LessOrEqual(t, tr.SampleCount(), tipBufferCapacity(params.Window),
 		"the ring must stay bounded however many goroutines record into it")
+}
+
+// ─── Corroboration must be EARNED (dwell + velocity agreement) ───────────────
+//
+// Matching the trajectory in one instant is not evidence. These pin the two
+// exploits of the instant test, both confirmed by simulation against the first
+// version of the referee.
+
+// in / ballotOf build a ballot with EXPLICIT upstream ids, so a test can change
+// a group's MEMBERSHIP without changing any head value.
+func in(id string, blk int64) ServedTipInput { return ServedTipInput{UpstreamID: id, BlockNumber: blk} }
+func ballotOf(ins ...ServedTipInput) []ServedTipInput {
+	return PickServedTip(ins).Sorted
+}
+
+// A GENUINE chain halt, with no traffic gap at all: the process evaluates every
+// 5s, the honest majority is frozen at the last real head, and two upstreams sit
+// at a FIXED higher block (a fork, a wrong-chain pair, a shared counter frozen
+// mid-flight). Because the fitted trajectory keeps extrapolating, the expected
+// head SWEEPS upward through every fixed offset — so the static pair is "on
+// trajectory" for as long as the sweep takes to cross it. Measured against the
+// instant test, the +2000 pair won 74 of 240 halt evaluations, i.e. minutes of a
+// halted chain served from a fork.
+func TestTipTrajectory_HaltSweepCannotElectAStaticGroup(t *testing.T) {
+	for _, ahead := range []int64{2_000, 6_000, 20_000} {
+		var tr TipTrajectory
+		p := trajectoryParams()
+		now, frozen := warmTrajectory(&tr, time.Now(), 74_500_000, 100, 140)
+		require.NotNil(t, tr.fit.Load(), "precondition: the referee is warm and confident")
+
+		rogue := frozen + ahead
+		overrides, elected := 0, 0
+		for k := 0; k < 240; k++ { // 20 minutes of halt, sampled every 5s
+			d := tr.Observe(now, ballotOf(
+				in("r1", rogue), in("r2", rogue),
+				in("h1", frozen), in("h2", frozen), in("h3", frozen),
+			), frozen, p)
+			if d.Overrode {
+				overrides++
+			}
+			if d.Declined {
+				elected++
+			}
+			now = now.Add(tipSampleInterval)
+		}
+		assert.Zero(t, overrides,
+			"a static group cannot have produced the chain progress the fit describes, "+
+				"however close the sweeping expected head passes to it (offset +%d)", ahead)
+		t.Logf("offset +%-6d : 0 overrides, %d evaluations where the sweep put it on trajectory", ahead, elected)
+	}
+}
+
+func TestTipTrajectory_DwellMustBeEarned(t *testing.T) {
+	p := trajectoryParams()
+
+	// The confirmed false-override shape: two of four upstreams pause for 15s
+	// (a poller hiccup, a vendor blip) and then catch up. Nothing is wrong with
+	// the fleet, and the divergence is over long before the dwell completes.
+	t.Run("TransientDivergenceNeverWins", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		overrides := 0
+		paused := head
+		for k := 0; k < 3; k++ { // 15s of two-of-four divergence
+			head += 100
+			d := tr.Observe(now, ballotOf(
+				in("u1", head), in("u2", head),
+				in("u3", paused), in("u4", paused),
+			), paused, p)
+			if d.Overrode {
+				overrides++
+			}
+			now = now.Add(tipSampleInterval)
+		}
+		// The pair catches up: one cluster again.
+		head += 100
+		d := tr.Observe(now, ballotOf(in("u1", head), in("u2", head), in("u3", head), in("u4", head)), head, p)
+		assert.False(t, d.Overrode)
+		assert.Zero(t, overrides,
+			"a 15-second divergence must not hand the tip to half the fleet")
+	})
+
+	// The headline case still works — and only after the group has held its
+	// place for the dwell.
+	t.Run("StalledMajorityLosesOnlyAfterTheDwell", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+		start := now
+
+		frozen := head
+		var firstOverride time.Duration = -1
+		for k := 0; k < 24; k++ {
+			head += 100
+			d := tr.Observe(now, ballotOf(
+				in("u1", head), in("u2", head),
+				in("u3", frozen), in("u4", frozen), in("u5", frozen),
+			), frozen, p)
+			if d.Overrode && firstOverride < 0 {
+				firstOverride = now.Sub(start)
+			}
+			now = now.Add(tipSampleInterval)
+		}
+		require.GreaterOrEqual(t, firstOverride, time.Duration(0),
+			"the corroborated fresh pair must still win a genuine majority stall")
+		assert.GreaterOrEqual(t, firstOverride, tipDwellDuration,
+			"and never before it has held its place for the dwell")
+	})
+
+	// A group is a SET of upstreams, not a pair of head values: replacing a
+	// member restarts the corroboration from zero, because the new set has
+	// proven nothing.
+	t.Run("MembershipChangeRestartsTheDwell", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		frozen := head
+		stall := func(freshA, freshB string) TipTrajectoryDecision {
+			head += 100
+			d := tr.Observe(now, ballotOf(
+				in(freshA, head), in(freshB, head),
+				in("u3", frozen), in("u4", frozen), in("u5", frozen),
+			), frozen, p)
+			now = now.Add(tipSampleInterval)
+			return d
+		}
+		for k := 0; k < 24; k++ {
+			stall("u1", "u2")
+		}
+		require.True(t, stall("u1", "u2").Overrode, "precondition: {u1,u2} has earned its override")
+
+		d := stall("u1", "u6")
+		assert.False(t, d.Overrode, "a different set of upstreams starts a new dwell")
+		assert.True(t, d.Declined, "and the refusal is the fallback outcome, not silence")
+	})
+}
+
+// The gap rule is about the WINDOW, not about the newest sample: standing the
+// referee down for the single evaluation that notices a hole let the next
+// evaluation — a millisecond later — extrapolate straight across it.
+func TestTipTrajectory_GapMustLeaveTheWindow(t *testing.T) {
+	p := trajectoryParams()
+
+	t.Run("TheEvaluationAfterTheGapIsInertToo", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 74_500_000, 100, 140)
+
+		// A 10-minute traffic hole: the chain kept going, the process saw none
+		// of it. Then the stall shape — 2 fresh, 3 frozen far behind.
+		gap := 10 * time.Minute
+		now = now.Add(gap)
+		head += int64(gap.Seconds()) * 20
+		frozen := head - 30_000
+		tips := ballotOf(
+			in("a", head), in("b", head),
+			in("c", frozen), in("d", frozen), in("e", frozen),
+		)
+
+		d1 := tr.Observe(now, tips, frozen, p)
+		d2 := tr.Observe(now.Add(time.Millisecond), tips, frozen, p)
+		assert.False(t, d1.Overrode, "the evaluation that notices the gap is inert")
+		assert.False(t, d2.Overrode,
+			"and so is the next one: the fit still spans the hole it cannot see across")
+	})
+
+	t.Run("HaltInsideTheGapCannotLiftExpected", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 74_500_000, 100, 140)
+
+		// 10 minutes of neither traffic nor chain progress. The robust intercept
+		// would otherwise lift the fit's anchor by a whole gap of chain, putting
+		// "expected" thousands of blocks above the true halted head — exactly
+		// where a rogue pair would be waiting.
+		now = now.Add(10 * time.Minute)
+		_ = tr.Observe(now, ballotOf(in("h1", head), in("h2", head), in("h3", head)), head, p)
+
+		fit := tr.fit.Load()
+		require.NotNil(t, fit)
+		nowMs := int64(now.Sub(*tr.base.Load()) / time.Millisecond)
+		inflation := int64(fit.expectedAt(nowMs)) - head
+		require.Positive(t, inflation, "precondition: the raw fit does extrapolate across the hole")
+
+		d := tr.Observe(now.Add(time.Millisecond), ballotOf(
+			in("r1", head+inflation), in("r2", head+inflation),
+			in("h1", head), in("h2", head), in("h3", head),
+		), head, p)
+		assert.False(t, d.Overrode,
+			"a pair sitting exactly where the gap-inflated fit expects the head must not win")
+		assert.Zero(t, d.Expected, "the fit is refused outright, so nothing is even compared to it")
+	})
+}
+
+// A ballot that cannot form a group can never produce a decision, so it must not
+// pay for one: no ring, no fit, no periodic O(n log n) refit. Most chains in a
+// large deployment have exactly one upstream.
+func TestTipTrajectory_BallotBelowGroupSizeRecordsNothing(t *testing.T) {
+	var tr TipTrajectory
+	p := trajectoryParams()
+	now := time.Now()
+	for i := 0; i < 200; i++ {
+		head := 1_000_000 + int64(i)*100
+		tr.Observe(now, ballot(head), head, p)
+		now = now.Add(tipSampleInterval)
+	}
+	assert.Zero(t, tr.SampleCount(), "a single-upstream network must not materialize a head track")
+	assert.Nil(t, tr.fit.Load())
 }
 
 func TestTipClusterWidth(t *testing.T) {

--- a/common/config.go
+++ b/common/config.go
@@ -2566,6 +2566,16 @@ type EvmServedTipConfig struct {
 	// (membership auto-detected via ShouldHandleMethod — no per-upstream config).
 	// Empty means only the global (all-eligible) majority is computed.
 	GuaranteedMethods []string `yaml:"guaranteedMethods,omitempty" json:"guaranteedMethods,omitempty"`
+
+	// MaxRegressionBlocks is how far below the freshest LIVE upstream head the
+	// majority pick may fall before it is treated as a poisoned ballot rather
+	// than as reality. While a pick is below that bound the network keeps
+	// serving its last corroborated pick (in-process, for at most one minute,
+	// then it fails open and serves the pick as computed). 0 uses
+	// DefaultToleratedBlockHeadRollback (1024) — the same rollback tolerance the
+	// state poller and health tracker apply to a retreating head, so all three
+	// layers agree on what counts as a genuine deep correction.
+	MaxRegressionBlocks int64 `yaml:"maxRegressionBlocks,omitempty" json:"maxRegressionBlocks,omitempty"`
 }
 
 // ServedTipEnabledFor reports whether the majority served tip is enabled for

--- a/common/config.go
+++ b/common/config.go
@@ -2567,14 +2567,16 @@ type EvmServedTipConfig struct {
 	// Empty means only the global (all-eligible) majority is computed.
 	GuaranteedMethods []string `yaml:"guaranteedMethods,omitempty" json:"guaranteedMethods,omitempty"`
 
-	// MaxRegressionBlocks is how far below the freshest LIVE upstream head the
-	// majority pick may fall before it is treated as a poisoned ballot rather
-	// than as reality. While a pick is below that bound the network keeps
-	// serving its last corroborated pick (in-process, for at most one minute,
-	// then it fails open and serves the pick as computed). 0 uses
-	// DefaultToleratedBlockHeadRollback (1024) — the same rollback tolerance the
-	// state poller and health tracker apply to a retreating head, so all three
-	// layers agree on what counts as a genuine deep correction.
+	// MaxRegressionBlocks is how far below the corroborated LIVE upstream head
+	// (the second-highest live head) the majority pick may fall before it is
+	// treated as a poisoned ballot rather than as reality. While a pick is below
+	// that bound the network keeps serving its last corroborated pick
+	// (in-process, for at most one minute, then it fails open and serves the
+	// pick as computed). 0 uses DefaultToleratedBlockHeadRollback (1024) — the
+	// same rollback tolerance the state poller and health tracker apply to a
+	// retreating head, so all three layers agree on what counts as a genuine
+	// deep correction. -1 disables the regression guard entirely (the symmetric
+	// opposite of trajectoryWindow: 0); no other negative value is accepted.
 	MaxRegressionBlocks int64 `yaml:"maxRegressionBlocks,omitempty" json:"maxRegressionBlocks,omitempty"`
 
 	// TrajectoryWindow is how much recorded head history the trajectory referee

--- a/common/config.go
+++ b/common/config.go
@@ -2587,10 +2587,13 @@ type EvmServedTipConfig struct {
 	// upward-only, in-process, and a no-op until every confidence condition
 	// holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
 	// disables the referee entirely — nothing is recorded and the pick is the
-	// plain majority. Values much below a few minutes are self-defeating (the
-	// window must be long enough that a stall cannot look like a trajectory),
-	// and values beyond about an hour never warm up at all: the sample ring is
-	// capped, so the span the referee requires would never be reached.
+	// plain majority. Any other value must be between
+	// MinServedTipTrajectoryWindow and MaxServedTipTrajectoryWindow: below the
+	// minimum the window is self-defeating (it must be long enough that a stall
+	// cannot look like a trajectory), and above the maximum the sample ring can
+	// never span it, so the referee would stand down forever while looking
+	// configured. WRITE IT AS A DURATION STRING — trajectoryWindow: "10m". A
+	// bare number is parsed as MILLISECONDS.
 	TrajectoryWindow *Duration `yaml:"trajectoryWindow,omitempty" json:"trajectoryWindow,omitempty"`
 }
 

--- a/common/config.go
+++ b/common/config.go
@@ -2576,6 +2576,20 @@ type EvmServedTipConfig struct {
 	// state poller and health tracker apply to a retreating head, so all three
 	// layers agree on what counts as a genuine deep correction.
 	MaxRegressionBlocks int64 `yaml:"maxRegressionBlocks,omitempty" json:"maxRegressionBlocks,omitempty"`
+
+	// TrajectoryWindow is how much recorded head history the trajectory referee
+	// needs before it may participate in the pick. The referee tracks where this
+	// network's head has been over the window and, when a stalled group holds
+	// the majority, serves the corroborated group that is actually where the
+	// chain should be by now (see architecture/evm's TipTrajectory: advisory,
+	// upward-only, in-process, and a no-op until every confidence condition
+	// holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
+	// disables the referee entirely — nothing is recorded and the pick is the
+	// plain majority. Values much below a few minutes are self-defeating (the
+	// window must be long enough that a stall cannot look like a trajectory),
+	// and values beyond about an hour never warm up at all: the sample ring is
+	// capped, so the span the referee requires would never be reached.
+	TrajectoryWindow *Duration `yaml:"trajectoryWindow,omitempty" json:"trajectoryWindow,omitempty"`
 }
 
 // ServedTipEnabledFor reports whether the majority served tip is enabled for

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -2175,6 +2175,29 @@ const DefaultToleratedBlockHeadRollback = 1024
 // pod's lifetime.
 const DefaultServedTipTrajectoryWindow = 10 * time.Minute
 
+// ServedTipTrajectorySampleInterval and ServedTipTrajectoryMaxSamples are the
+// referee's recording cadence and its hard ring cap (architecture/evm's
+// tipSampleInterval / tipMaxBufferCapacity, which read them from here so the
+// config bounds below cannot drift from the mechanism they describe).
+const (
+	ServedTipTrajectorySampleInterval = 5 * time.Second
+	ServedTipTrajectoryMaxSamples     = 1024
+)
+
+// MinServedTipTrajectoryWindow / MaxServedTipTrajectoryWindow bound a configured
+// EvmServedTipConfig.TrajectoryWindow to the values that can actually work.
+//
+// Below a minute the window is self-defeating: it must be long enough that a
+// stall cannot look like a trajectory, and a fit over seconds of history is
+// noise. Above 80% of what the ring can span (cadence × capacity) the required
+// span is never reached, so the referee would stand down forever while looking
+// configured — the failure mode a range check exists to prevent, since nothing
+// in the metrics distinguishes "never warm" from "never needed".
+const (
+	MinServedTipTrajectoryWindow = time.Minute
+	MaxServedTipTrajectoryWindow = ServedTipTrajectorySampleInterval * ServedTipTrajectoryMaxSamples * 4 / 5
+)
+
 // DefaultEmptyResultMaxAttempts bounds retries when the requested data isn't on the
 // upstream yet (empty/missing-data point-lookups, pending tx-lookups, and
 // ErrUpstreamBlockUnavailable): one original attempt + one retry after ~one block.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -2166,6 +2166,15 @@ const DefaultBlockUnavailableDelayMultiplier = 1.0
 // and the health tracker so both layers converge on the same head.
 const DefaultToleratedBlockHeadRollback = 1024
 
+// DefaultServedTipTrajectoryWindow is how much head history the served-tip
+// trajectory referee needs before it may participate in a pick
+// (EvmServedTipConfig.TrajectoryWindow). Ten minutes is long enough that a
+// majority stall cannot masquerade as the trajectory (the referee's evidence is
+// the median of live heads, so a stall of half the window already flattens the
+// fit and stands the referee down), and short enough to be warm well within a
+// pod's lifetime.
+const DefaultServedTipTrajectoryWindow = 10 * time.Minute
+
 // DefaultEmptyResultMaxAttempts bounds retries when the requested data isn't on the
 // upstream yet (empty/missing-data point-lookups, pending tx-lookups, and
 // ErrUpstreamBlockUnavailable): one original attempt + one retry after ~one block.

--- a/common/validation.go
+++ b/common/validation.go
@@ -1517,6 +1517,9 @@ func (e *EvmNetworkConfig) Validate() error {
 		if e.ServedTip.ClusterDelta < 0 {
 			return fmt.Errorf("network.*.evm.servedTip.clusterDelta must be >= 0 (0 auto-derives from block time)")
 		}
+		if e.ServedTip.MaxRegressionBlocks < 0 {
+			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0 (0 uses the default rollback tolerance)")
+		}
 		for _, m := range e.ServedTip.GuaranteedMethods {
 			if err := ValidatePattern(m); err != nil {
 				return fmt.Errorf("network.*.evm.servedTip.guaranteedMethods has invalid pattern %q: %w", m, err)

--- a/common/validation.go
+++ b/common/validation.go
@@ -1517,8 +1517,8 @@ func (e *EvmNetworkConfig) Validate() error {
 		if e.ServedTip.ClusterDelta < 0 {
 			return fmt.Errorf("network.*.evm.servedTip.clusterDelta must be >= 0 (0 auto-derives from block time)")
 		}
-		if e.ServedTip.MaxRegressionBlocks < 0 {
-			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0 (0 uses the default rollback tolerance)")
+		if e.ServedTip.MaxRegressionBlocks < -1 {
+			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0, or -1 to disable the regression guard (0 uses the default rollback tolerance)")
 		}
 		if e.ServedTip.TrajectoryWindow != nil && *e.ServedTip.TrajectoryWindow < 0 {
 			return fmt.Errorf("network.*.evm.servedTip.trajectoryWindow must be >= 0 (0 disables the trajectory referee)")

--- a/common/validation.go
+++ b/common/validation.go
@@ -1520,6 +1520,9 @@ func (e *EvmNetworkConfig) Validate() error {
 		if e.ServedTip.MaxRegressionBlocks < 0 {
 			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0 (0 uses the default rollback tolerance)")
 		}
+		if e.ServedTip.TrajectoryWindow != nil && *e.ServedTip.TrajectoryWindow < 0 {
+			return fmt.Errorf("network.*.evm.servedTip.trajectoryWindow must be >= 0 (0 disables the trajectory referee)")
+		}
 		for _, m := range e.ServedTip.GuaranteedMethods {
 			if err := ValidatePattern(m); err != nil {
 				return fmt.Errorf("network.*.evm.servedTip.guaranteedMethods has invalid pattern %q: %w", m, err)

--- a/common/validation.go
+++ b/common/validation.go
@@ -1520,8 +1520,14 @@ func (e *EvmNetworkConfig) Validate() error {
 		if e.ServedTip.MaxRegressionBlocks < -1 {
 			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0, or -1 to disable the regression guard (0 uses the default rollback tolerance)")
 		}
-		if e.ServedTip.TrajectoryWindow != nil && *e.ServedTip.TrajectoryWindow < 0 {
-			return fmt.Errorf("network.*.evm.servedTip.trajectoryWindow must be >= 0 (0 disables the trajectory referee)")
+		if w := e.ServedTip.TrajectoryWindow; w != nil && w.Duration() != 0 {
+			if d := w.Duration(); d < MinServedTipTrajectoryWindow || d > MaxServedTipTrajectoryWindow {
+				return fmt.Errorf(
+					"network.*.evm.servedTip.trajectoryWindow must be 0 (disables the trajectory referee) "+
+						"or between %s and %s, got %s — NOTE a bare number in YAML is parsed as MILLISECONDS, "+
+						"so write trajectoryWindow: \"10m\", not trajectoryWindow: 10",
+					MinServedTipTrajectoryWindow, MaxServedTipTrajectoryWindow, d)
+			}
 		}
 		for _, m := range e.ServedTip.GuaranteedMethods {
 			if err := ValidatePattern(m); err != nil {

--- a/common/validation_servedtip_test.go
+++ b/common/validation_servedtip_test.go
@@ -42,6 +42,20 @@ func TestEvmNetworkConfig_Validate_ServedTip(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "clusterDelta")
 	})
+
+	t.Run("negative maxRegressionBlocks rejected", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{MaxRegressionBlocks: -1}
+		err := e.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maxRegressionBlocks")
+	})
+
+	t.Run("zero maxRegressionBlocks means the default tolerance", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}}
+		require.NoError(t, e.Validate())
+	})
 }
 
 // TestNetworkConfig_SetDefaults_InheritsServedTip ensures a global

--- a/common/validation_servedtip_test.go
+++ b/common/validation_servedtip_test.go
@@ -56,6 +56,20 @@ func TestEvmNetworkConfig_Validate_ServedTip(t *testing.T) {
 		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}}
 		require.NoError(t, e.Validate())
 	})
+
+	t.Run("negative trajectoryWindow rejected", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{TrajectoryWindow: Duration(-1).Ptr()}
+		err := e.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trajectoryWindow")
+	})
+
+	t.Run("zero trajectoryWindow disables the referee", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}, TrajectoryWindow: Duration(0).Ptr()}
+		require.NoError(t, e.Validate())
+	})
 }
 
 // TestNetworkConfig_SetDefaults_InheritsServedTip ensures a global

--- a/common/validation_servedtip_test.go
+++ b/common/validation_servedtip_test.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func baseValidEvmNetworkConfig() *EvmNetworkConfig {
@@ -63,18 +65,62 @@ func TestEvmNetworkConfig_Validate_ServedTip(t *testing.T) {
 		require.NoError(t, e.Validate())
 	})
 
-	t.Run("negative trajectoryWindow rejected", func(t *testing.T) {
-		e := baseValidEvmNetworkConfig()
-		e.ServedTip = &EvmServedTipConfig{TrajectoryWindow: Duration(-1).Ptr()}
-		err := e.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "trajectoryWindow")
-	})
-
 	t.Run("zero trajectoryWindow disables the referee", func(t *testing.T) {
 		e := baseValidEvmNetworkConfig()
 		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}, TrajectoryWindow: Duration(0).Ptr()}
 		require.NoError(t, e.Validate())
+	})
+
+	// A window outside the range the mechanism can honour is a configuration
+	// that LOOKS enabled and can never act: below a minute a fit is noise, and
+	// beyond what the sample ring can span the referee stands down forever while
+	// nothing in the metrics says so.
+	t.Run("trajectoryWindow range", func(t *testing.T) {
+		for _, c := range []struct {
+			name   string
+			window Duration
+			valid  bool
+		}{
+			{"the default", Duration(DefaultServedTipTrajectoryWindow), true},
+			{"exactly the minimum", Duration(MinServedTipTrajectoryWindow), true},
+			{"exactly the maximum", Duration(MaxServedTipTrajectoryWindow), true},
+			{"one second below the minimum", Duration(MinServedTipTrajectoryWindow - time.Second), false},
+			{"one second above the maximum", Duration(MaxServedTipTrajectoryWindow + time.Second), false},
+			{"negative", Duration(-1), false},
+			{"5 milliseconds (a bare YAML 5)", Duration(5 * time.Millisecond), false},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				e := baseValidEvmNetworkConfig()
+				e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}, TrajectoryWindow: c.window.Ptr()}
+				err := e.Validate()
+				if c.valid {
+					require.NoError(t, err)
+					return
+				}
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "trajectoryWindow")
+				assert.Contains(t, err.Error(), "MILLISECONDS",
+					"the error must name the trap it exists for: a bare YAML number is milliseconds")
+			})
+		}
+	})
+
+	// End to end through the YAML an operator actually writes.
+	t.Run("trajectoryWindow YAML round-trip", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		require.NoError(t, yaml.Unmarshal([]byte("enabledFor: [latest]\ntrajectoryWindow: \"10m\"\n"), &e.ServedTip))
+		require.Equal(t, 10*time.Minute, e.ServedTip.TrajectoryWindow.Duration())
+		require.NoError(t, e.Validate())
+
+		// A bare number is the trap the error message names. The config loader's
+		// yaml.v3 rejects it outright here; a Duration that reaches the config
+		// any other way (a JSON tool, yaml.v2, a programmatic literal) carries
+		// the millisecond reading instead, which is what the range check above
+		// catches — 5 means 5ms, never 5 minutes, on every path.
+		bare := baseValidEvmNetworkConfig()
+		err := yaml.Unmarshal([]byte("enabledFor: [latest]\ntrajectoryWindow: 5\n"), &bare.ServedTip)
+		require.Error(t, err, "a bare number must never be read as 5 minutes")
+		assert.Contains(t, err.Error(), "duration")
 	})
 }
 

--- a/common/validation_servedtip_test.go
+++ b/common/validation_servedtip_test.go
@@ -43,12 +43,18 @@ func TestEvmNetworkConfig_Validate_ServedTip(t *testing.T) {
 		assert.Contains(t, err.Error(), "clusterDelta")
 	})
 
-	t.Run("negative maxRegressionBlocks rejected", func(t *testing.T) {
+	t.Run("maxRegressionBlocks below -1 rejected", func(t *testing.T) {
 		e := baseValidEvmNetworkConfig()
-		e.ServedTip = &EvmServedTipConfig{MaxRegressionBlocks: -1}
+		e.ServedTip = &EvmServedTipConfig{MaxRegressionBlocks: -2}
 		err := e.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "maxRegressionBlocks")
+	})
+
+	t.Run("maxRegressionBlocks -1 disables the guard", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}, MaxRegressionBlocks: -1}
+		require.NoError(t, e.Validate())
 	})
 
 	t.Run("zero maxRegressionBlocks means the default tolerance", func(t *testing.T) {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -351,6 +351,16 @@ func (n *Network) Logger() *zerolog.Logger {
 // network-wide eligible set (the global served tip); a concrete method yields
 // the per-method eligible set (a capability lane). Falls back to the full
 // registered set on cold start / when the policy has produced no decision yet.
+//
+// BOUND-CAPPED UPSTREAMS DO NOT VOTE (when any live head is present). An
+// upstream whose effective head is its configured blockAvailability.upper bound
+// is declaring a SERVING RANGE ("I answer up to block X"), not observing where
+// the chain's head is — see evmTipObservation. Letting such a declaration into
+// the ballot is what broke celo (evm:42220) on 2026-08-11: two legacy upstreams
+// pinned at `upper.exactBlock: 21615999` outvoted the live heads (74.5M) the
+// moment a third live upstream was excluded for lag, "latest" interpolated to a
+// September-2023 block, the availability gate then admitted ONLY those two
+// upstreams (the live ones start at 21616000), and funded accounts read 0x0.
 func (n *Network) gatherEvmTipInputsForMethod(
 	ctx context.Context,
 	useFinalized bool,
@@ -358,6 +368,7 @@ func (n *Network) gatherEvmTipInputsForMethod(
 ) []evm.ServedTipInput {
 	upstreams := n.tipCandidateUpstreams(ctx, method)
 	out := make([]evm.ServedTipInput, 0, len(upstreams))
+	var capped []evm.ServedTipInput
 	for _, cu := range upstreams {
 		u, ok := cu.(common.EvmUpstream)
 		if !ok || u.EvmStatePoller() == nil {
@@ -366,21 +377,59 @@ func (n *Network) gatherEvmTipInputsForMethod(
 		if u.EvmSyncingState() == common.EvmSyncingStateSyncing {
 			continue
 		}
-		var blk int64
-		if useFinalized {
-			blk = u.EvmEffectiveFinalizedBlock()
-		} else {
-			blk = u.EvmEffectiveLatestBlock()
-		}
+		blk, boundCapped := evmTipObservation(u, useFinalized)
 		if blk <= 0 {
 			continue
 		}
-		out = append(out, evm.ServedTipInput{
+		in := evm.ServedTipInput{
 			UpstreamID:  u.Id(),
 			BlockNumber: blk,
-		})
+		}
+		if boundCapped {
+			capped = append(capped, in)
+			continue
+		}
+		out = append(out, in)
+	}
+	if len(out) == 0 {
+		// All-capped pool: a network of only historical/frozen upstreams
+		// legitimately serves its cap as "latest" — there is no live head to
+		// prefer, so the caps remain the only observations available.
+		return capped
 	}
 	return out
+}
+
+// evmTipObservation returns an upstream's effective head for the axis, plus
+// whether that value is CAPPED by the upstream's configured
+// blockAvailability.upper bound rather than being an observation of the chain
+// head.
+//
+// Upstream.EvmEffectiveLatestBlock computes min(head, upper) and discards which
+// side won; this recovers that distinction from the same two inputs, so a
+// serving-range declaration can be told apart from a head observation.
+func evmTipObservation(u common.EvmUpstream, useFinalized bool) (blk int64, boundCapped bool) {
+	if useFinalized {
+		blk = u.EvmEffectiveFinalizedBlock()
+	} else {
+		blk = u.EvmEffectiveLatestBlock()
+	}
+	if blk <= 0 {
+		return blk, false
+	}
+	_, upper := u.EvmBlockAvailabilityBounds()
+	if upper == math.MaxInt64 {
+		return blk, false
+	}
+	sp := u.EvmStatePoller()
+	if sp == nil {
+		return blk, false
+	}
+	head := sp.LatestBlock()
+	if useFinalized {
+		head = sp.FinalizedBlock()
+	}
+	return blk, head > 0 && upper < head
 }
 
 // tipCandidateUpstreams returns the eligible upstreams that feed the served-tip

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -123,6 +123,18 @@ type servedTipAnchor struct {
 	// on transitions, so a sustained regression reports twice (once when it
 	// starts holding, once if it gives up) instead of once per request.
 	guardState atomic.Int32
+
+	// trajectory is this lane+axis's long-term head track — the referee that
+	// lets a corroborated FRESH MINORITY outvote a stalled majority
+	// (refereeServedTip). It holds no pick either: its samples are the plain
+	// majority over live heads, its output is always one of the head values the
+	// live upstreams offer in the same evaluation, and it can only ever raise
+	// the pick. See evm.TipTrajectory.
+	trajectory evm.TipTrajectory
+
+	// trajectoryOverriding mirrors guardState for the referee: the override is
+	// logged on transitions only.
+	trajectoryOverriding atomic.Bool
 }
 
 const (
@@ -764,13 +776,19 @@ func (n *Network) tryShortCircuitFutureBlock(ctx context.Context, req *common.No
 }
 
 // servedTip computes the majority served tip for one axis over the
-// selection-policy-eligible upstreams — the freshest block a strict majority
-// of them already has (see evm.PickServedTip) — guards it against a regression
-// far below the live heads, applies the guaranteed-method floor, and exports
-// the gauges. The pick itself carries NO history: nothing is persisted and
-// nothing predicted, so no inherited or rogue value can pin, freeze or poison
-// the result (networks_served_tip_invariants_test.go pins those outcomes
-// against the 2026-06 production incident).
+// selection-policy-eligible upstreams — the freshest block a strict majority of
+// them already has (see evm.PickServedTip) — lets the trajectory referee prefer
+// a corroborated on-trajectory group when that majority has stalled, guards the
+// result against a regression far below the live heads, applies the
+// guaranteed-method floor, and exports the gauges.
+//
+// Both history-aware layers are in-process, bounded and one-directional (the
+// referee can only raise the pick; the guard can only hold it, and only
+// briefly), and NEITHER can produce a block that no live upstream reports in
+// the very same evaluation. Nothing is persisted and nothing is predicted, so
+// no inherited or rogue value can pin, freeze or poison the result
+// (networks_served_tip_invariants_test.go pins those outcomes against the
+// 2026-06 production incident).
 func (n *Network) servedTip(
 	ctx context.Context,
 	span trace.Span,
@@ -781,6 +799,13 @@ func (n *Network) servedTip(
 ) int64 {
 	tips, maxLiveHead := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
 	pick := evm.PickServedTip(tips)
+
+	// Trajectory referee: when the live heads split and the majority is the
+	// STALLED group, serve the corroborated group that matches where this
+	// network's head has been going for the last ten minutes. Advisory and
+	// upward-only — it can only replace the majority pick with a higher block
+	// that at least two live upstreams already have.
+	pick.Tip = n.refereeServedTip(axis, lane, anchor, tips, pick.Tip, maxLiveHead)
 
 	// Regression guard: "latest" cannot drop far below the freshest live head
 	// in one evaluation. Runs BEFORE the guaranteed-method floor, which is a
@@ -817,6 +842,101 @@ func (n *Network) servedTip(
 	}
 	n.observeServedTipMetrics(axis, lane, pick, advanceAge)
 	return pick.Tip
+}
+
+// refereeServedTip returns the tip to serve for `median` (the plain majority
+// pick), letting the network's long-term head trajectory choose between the
+// groups the LIVE heads of this same evaluation form.
+//
+// Every mechanism before this one is a snapshot of one instant, which is what a
+// majority stall defeats: if N upstreams freeze while staying inside the
+// lag-exclusion threshold — or a fleet-wide shared-counter freeze stalls the
+// lag metric itself — the majority IS the stale group, and the two upstreams
+// that genuinely hold the chain's head are outvoted. The trajectory is the one
+// piece of evidence that separates "the chain stopped" from "those upstreams
+// stopped": where this network's head has actually been going for the last ten
+// minutes (evm.TipTrajectory).
+//
+// It is deliberately the weakest intervention that answers that:
+//
+//   - it never runs without an anchor (arbitrary use-upstream selectors
+//     materialize no state), without a pick, or without a live head — the same
+//     conditions the regression guard stands down on;
+//   - it never runs when the config disables it (trajectoryWindow: 0), and it
+//     is a no-op until every confidence condition in evm.TipTrajectory holds,
+//     so a cold or stale process behaves byte-identically to the plain
+//     majority;
+//   - it can only RAISE the pick, and only to the minimum of a group of ≥2
+//     live upstreams — a value they can all serve, and one at most as high as
+//     the freshest live head. It can neither hold the tip back nor invent one.
+//
+// The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
+// same reason, so the served-tip lag gauge never reads negative.
+func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, tips []evm.ServedTipInput, median int64, maxLiveHead int64) int64 {
+	if anchor == nil || median <= 0 || maxLiveHead <= 0 {
+		// maxLiveHead > 0 is also what makes `tips` safe to sample and cluster:
+		// gatherEvmTipInputsForMethod only returns bound-capped observations
+		// when there is no live head at all, and a serving range must never
+		// enter a head trajectory.
+		return median
+	}
+	window := n.servedTipTrajectoryWindow()
+	if window <= 0 {
+		return median
+	}
+
+	decision := anchor.trajectory.Observe(servedTipClock(), tips, median, evm.TipTrajectoryParams{
+		Window:         window,
+		ToleranceFloor: n.servedTipMaxRegressionBlocks(),
+	})
+
+	switch {
+	case decision.Overrode:
+		telemetry.MetricNetworkServedTipTrajectoryTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "override").
+			Inc()
+	case decision.Declined:
+		telemetry.MetricNetworkServedTipTrajectoryTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "fallback").
+			Inc()
+	}
+	n.logServedTipTrajectoryTransition(anchor, axis, median, decision)
+
+	return decision.Pick
+}
+
+// logServedTipTrajectoryTransition logs only when the referee STARTS or STOPS
+// overriding, so a stall that persists across thousands of requests produces
+// one line at each end of it.
+func (n *Network) logServedTipTrajectoryTransition(anchor *servedTipAnchor, axis string, median int64, d evm.TipTrajectoryDecision) {
+	if anchor.trajectoryOverriding.Swap(d.Overrode) == d.Overrode {
+		return
+	}
+	if !d.Overrode {
+		n.logger.Warn().
+			Str("axis", axis).
+			Int64("pick", d.Pick).
+			Msg("served tip is back on the majority pick; the trajectory referee is no longer overriding")
+		return
+	}
+	n.logger.Error().
+		Str("axis", axis).
+		Int64("pick", d.Pick).
+		Int64("majorityPick", median).
+		Int64("expectedBlock", d.Expected).
+		Int64("tolerance", d.Tolerance).
+		Float64("blocksPerSecond", d.VelocityPerSec).
+		Msg("majority of the eligible upstreams is off the network's long-term head trajectory; serving the corroborated group that is on it")
+}
+
+// servedTipTrajectoryWindow is how much recorded head history the trajectory
+// referee needs before it may participate. Unset uses
+// DefaultServedTipTrajectoryWindow; an explicit 0 disables the referee.
+func (n *Network) servedTipTrajectoryWindow() time.Duration {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.ServedTip != nil && n.cfg.Evm.ServedTip.TrajectoryWindow != nil {
+		return n.cfg.Evm.ServedTip.TrajectoryWindow.Duration()
+	}
+	return common.DefaultServedTipTrajectoryWindow
 }
 
 // guardServedTipRegression returns the tip to serve for `pick`, substituting

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1370,6 +1370,26 @@ func (n *Network) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
 // upstream also supports that method. If only capped upstreams support it, they
 // set the floor — which is the entire point of the floor, since they are the
 // only upstreams that can serve the method at all.
+//
+// STATIC CONFIG DECIDES THAT, NOT TRANSIENT ELIGIBILITY. A cap-only ballot has
+// two very different causes, and only one of them is a floor:
+//
+//   - PERMANENT: no live upstream is configured to serve the method at all
+//     (the archive-only trace_* shape). The cap is genuinely the freshest block
+//     anyone can serve, so it floors the tip.
+//   - TRANSIENT: live upstreams DO serve the method, they are just absent from
+//     this instant's eligible set — lag-excluded, cordoned, mid-restart. Their
+//     absence is exactly the condition the regression guard is holding through,
+//     and flooring to the cap would hand the incident value back the moment the
+//     eligible set collapsed. That composition (the guard correctly holding
+//     74.5M while the floor dragged the served value to 21,615,999) was live at
+//     the previous head of this branch.
+//
+// So a cap-only ballot floors only when the REGISTERED set — the operator's
+// configuration, which eligibility churn cannot change — has no live upstream
+// serving that method. Otherwise the method sets no floor for this evaluation
+// and the guard's hold (and its bounded fail-open) governs, exactly as it does
+// when the whole ballot goes cap-only.
 func (n *Network) guaranteedMethodFloor(ctx context.Context, useFinalized bool) int64 {
 	if n.cfg == nil || n.cfg.Evm == nil || n.cfg.Evm.ServedTip == nil {
 		return 0
@@ -1390,10 +1410,17 @@ func (n *Network) guaranteedMethodFloor(ctx context.Context, useFinalized bool) 
 			}
 			supporting = append(supporting, cu)
 		}
-		tips, _ := evmTipBallot(supporting, useFinalized)
+		tips, ref := evmTipBallot(supporting, useFinalized)
 		if len(tips) == 0 {
 			// No supporting upstream for this method → no constraint (fall through
 			// rather than pinning the tip to 0).
+			continue
+		}
+		if ref.Max <= 0 && n.liveUpstreamServesMethod(ctx, m, useFinalized) {
+			// Cap-only ballot, but the configuration says live upstreams serve
+			// this method — they are merely absent right now. See the comment
+			// above: that floor is a transient lie, and serving it is the celo
+			// value.
 			continue
 		}
 		if t := evm.PickServedTip(tips).Tip; t > 0 && (floor == 0 || t < floor) {
@@ -1401,6 +1428,34 @@ func (n *Network) guaranteedMethodFloor(ctx context.Context, useFinalized bool) 
 		}
 	}
 	return floor
+}
+
+// liveUpstreamServesMethod reports whether any REGISTERED upstream that is not a
+// static serving-range cap is configured to serve `method` — the static-config
+// question guaranteedMethodFloor asks before letting a cap-only ballot set a
+// floor. It reads the registered set, not the eligible one, precisely because
+// eligibility is the thing that churns.
+//
+// An upstream with no head yet counts as live: "we cannot tell" must fall on the
+// side of skipping the floor, since serving a stale cap is the failure this
+// whole change exists to prevent. Only reached when a method's ballot came back
+// cap-only, i.e. approximately never on the hot path.
+func (n *Network) liveUpstreamServesMethod(ctx context.Context, method string, useFinalized bool) bool {
+	if n.upstreamsRegistry == nil {
+		return false
+	}
+	for _, u := range n.upstreamsRegistry.GetNetworkUpstreams(ctx, n.networkId) {
+		if handle, _ := u.ShouldHandleMethod(method); !handle {
+			continue
+		}
+		if eu, ok := common.Upstream(u).(common.EvmUpstream); ok {
+			if _, capped := evmTipObservation(eu, useFinalized); capped {
+				continue
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // observeServedTipMetrics exports the served-tip gauges. axis

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -526,6 +526,17 @@ type servedTipReference struct {
 	// a regression, so the guard never took its healthy branch, never recorded a
 	// corroborated value, and sat permanently disarmed — emitting no metric and
 	// no log at all.
+	//
+	// BOUNDARY, stated because it is a real one: this tolerates ONE Byzantine
+	// head, not two. Two upstreams reporting the same far-future block are
+	// indistinguishable from two upstreams that are simply ahead, so they can
+	// still raise the reference and leave the guard unarmed (silently — the
+	// guard only records a corroborated value on its healthy branch). Nothing
+	// available in a single evaluation separates those cases; what limits the
+	// damage is elsewhere: the majority pick itself needs a MAJORITY to move,
+	// rememberServedTipPick refuses to commit an uncorroborated leap into the
+	// memory, and the trajectory referee's dwell refuses to elect a group that
+	// has not tracked the chain for half a minute.
 	Corroborated int64
 
 	// Max is the highest live head: the ceiling a HELD value may not exceed, so
@@ -1151,15 +1162,15 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 		minAcceptable = reference - tolerance
 	}
 	if pick >= minAcceptable {
-		if ref.Max > 0 {
-			// Only a LIVE-corroborated pick may be remembered: promoting a capped
-			// pick here would let a serving range become the value the network is
-			// later held to.
-			if lastGood != pick {
-				anchor.lastGoodValue.Store(pick)
-			}
+		if n.rememberServedTipPick(anchor, pick, lastGood, lastGoodAt, ref, tolerance) {
 			at := servedTipClock()
-			anchor.lastGoodAt.Store(&at)
+			// F5: the timestamp is a TTL clock, not an audit log. Refreshing it at
+			// most once a second keeps a 60s window exact to within its own
+			// granularity while removing a pointer store (and its allocation) from
+			// every evaluation of every request.
+			if lastGoodAt == nil || at.Sub(*lastGoodAt) >= time.Second {
+				anchor.lastGoodAt.Store(&at)
+			}
 		}
 		n.noteServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, reference, 0)
 		return pick
@@ -1194,6 +1205,48 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 			Inc()
 	}
 	return served
+}
+
+// rememberServedTipPick decides whether `pick` may become the value the guard
+// holds the network to, and stores it if so. It reports whether the memory is
+// now current (so the caller may refresh its TTL clock).
+//
+// Three conditions, each closing a way the memory could be poisoned:
+//
+//   - A LIVE ballot. A capped pick must never become the remembered value, or a
+//     serving range would become the block the network is later held to.
+//   - CORROBORATED BY TWO. The pick must sit at or below the second-highest live
+//     head, i.e. at least two live upstreams already have it. (With a single
+//     live input that head IS the reference, so a one-upstream network behaves
+//     as before.)
+//   - NO UNCORROBORATED LEAP. A memory that is still fresh may not be RAISED by
+//     more than the regression tolerance in one step. Without this, a moment in
+//     which the eligible set is majority far-future — two rogues outvoting one
+//     honest upstream while the rest are lag-excluded — commits the fantasy
+//     into the memory, and when the honest fleet returns the guard holds that
+//     fantasy against them for the full TTL. main recovers on the next
+//     evaluation because it remembers nothing; that regression is what this
+//     condition removes.
+//
+// The leap rule constrains only what is REMEMBERED, never what is SERVED: the
+// healthy branch serves the pick either way, so it cannot hold, freeze or lower
+// a tip. A legitimate leap (a halt resuming, an L2 landing a large batch) simply
+// leaves the memory where it was; the memory then ages out of its TTL and the
+// next healthy evaluation adopts the new height. Nothing is pinned, and the
+// detection reference is unaffected — it takes the higher of the memory and the
+// live corroborated head, so a memory left behind by a burst is simply ignored.
+func (n *Network) rememberServedTipPick(anchor *servedTipAnchor, pick int64, lastGood int64, lastGoodAt *time.Time, ref servedTipReference, tolerance int64) bool {
+	if ref.Max <= 0 || pick > ref.Corroborated {
+		return false
+	}
+	if lastGood > 0 && lastGoodAt != nil && pick > lastGood+tolerance &&
+		servedTipClock().Sub(*lastGoodAt) < servedTipRegressionTTL {
+		return false
+	}
+	if lastGood != pick {
+		anchor.lastGoodValue.Store(pick)
+	}
+	return true
 }
 
 // noteServedTipGuardTransition records the guard's state and reports whether it

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -889,7 +889,7 @@ func (n *Network) servedTip(
 	anchor *servedTipAnchor,
 	lane string,
 ) int64 {
-	tips, liveReference := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
+	tips, ref := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
 	pick := evm.PickServedTip(tips)
 
 	// Trajectory referee: when the live heads split and the majority is the
@@ -898,13 +898,13 @@ func (n *Network) servedTip(
 	// upward-only — it can only replace the majority pick with a higher block
 	// that at least two live upstreams already have.
 	majority := pick.Tip
-	decision := n.refereeServedTip(anchor, pick.Sorted, pick.Tip, liveReference)
+	decision := n.refereeServedTip(anchor, pick.Sorted, pick.Tip, ref)
 	pick.Tip = decision.Pick
 
 	// Regression guard: "latest" cannot drop far below the corroborated live
 	// head in one evaluation. Runs BEFORE the guaranteed-method floor, which is
 	// a deliberate operator-configured clamp the guard must not fight.
-	pick.Tip = n.guardServedTipRegression(axis, lane, anchor, pick.Tip, liveReference)
+	pick.Tip = n.guardServedTipRegression(axis, lane, anchor, pick.Tip, ref)
 
 	// Capability guarantee (#855): the served tip must never exceed what any
 	// configured guaranteed-method's supporting upstreams can serve, so a
@@ -960,8 +960,11 @@ func (n *Network) servedTip(
 // It is deliberately the weakest intervention that answers that:
 //
 //   - it never runs without an anchor (arbitrary use-upstream selectors
-//     materialize no state), without a pick, or without a live head — the same
-//     conditions the regression guard stands down on;
+//     materialize no state), without a pick, or without a live head. That last
+//     condition is stricter than the guard's, which measures against its own
+//     last corroborated pick when the live heads are gone: the referee's
+//     evidence is a HEAD TRACK, and a ballot of serving ranges must never enter
+//     one;
 //   - it never runs when the config disables it (trajectoryWindow: 0), and it
 //     is a no-op until every confidence condition in evm.TipTrajectory holds,
 //     so a cold or stale process behaves byte-identically to the plain
@@ -975,8 +978,9 @@ func (n *Network) servedTip(
 //     over by a halting chain's expected head nor a routine 15-second
 //     divergence can trigger an intervention.
 //
-// The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
-// same reason, so the served-tip lag gauge never reads negative.
+// Serving a winning group's MINIMUM also keeps the pick ≤
+// evm.ServedTipPick.Freshest (the 2nd-highest head): a group has at least two
+// members, so at least two heads sit at or above what it serves.
 func (n *Network) refereeServedTip(anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, ref servedTipReference) evm.TipTrajectoryDecision {
 	stood := evm.TipTrajectoryDecision{Pick: median}
 	if anchor == nil || median <= 0 || ref.Max <= 0 {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1162,13 +1162,15 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 		minAcceptable = reference - tolerance
 	}
 	if pick >= minAcceptable {
-		if n.rememberServedTipPick(anchor, pick, lastGood, lastGoodAt, ref, tolerance) {
-			at := servedTipClock()
-			// F5: the timestamp is a TTL clock, not an audit log. Refreshing it at
+		now := servedTipClock()
+		if n.rememberServedTipPick(anchor, pick, lastGood, lastGoodAt, ref, tolerance, now) {
+			// The timestamp is a TTL clock, not an audit log: refreshing it at
 			// most once a second keeps a 60s window exact to within its own
-			// granularity while removing a pointer store (and its allocation) from
-			// every evaluation of every request.
-			if lastGoodAt == nil || at.Sub(*lastGoodAt) >= time.Second {
+			// granularity, and keeps the ONLY heap allocation on this path — the
+			// time.Time the atomic pointer must own — off all but one evaluation
+			// per second. (Measured: 0 allocs/op on the throttled path.)
+			if lastGoodAt == nil || now.Sub(*lastGoodAt) >= time.Second {
+				at := now
 				anchor.lastGoodAt.Store(&at)
 			}
 		}
@@ -1199,6 +1201,14 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 	if ref.Max > 0 && ref.Max < served {
 		served = ref.Max
 	}
+	if served <= pick {
+		// A HOLD MAY ONLY EVER RAISE. A memory at or below the current pick has
+		// nothing to offer, and serving it would drag the tip DOWN — the exact
+		// harm the guard exists to prevent, inflicted by the guard. Reachable
+		// whenever the memory is stale-low and it is the live corroborated head,
+		// not the memory, that tripped the tolerance.
+		return pick
+	}
 	if n.noteServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, reference, held) {
 		telemetry.MetricNetworkServedTipRegressionTotal.
 			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "held").
@@ -1215,32 +1225,54 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 //
 //   - A LIVE ballot. A capped pick must never become the remembered value, or a
 //     serving range would become the block the network is later held to.
+//
 //   - CORROBORATED BY TWO. The pick must sit at or below the second-highest live
 //     head, i.e. at least two live upstreams already have it. (With a single
 //     live input that head IS the reference, so a one-upstream network behaves
 //     as before.)
-//   - NO UNCORROBORATED LEAP. A memory that is still fresh may not be RAISED by
-//     more than the regression tolerance in one step. Without this, a moment in
-//     which the eligible set is majority far-future — two rogues outvoting one
-//     honest upstream while the rest are lag-excluded — commits the fantasy
-//     into the memory, and when the honest fleet returns the guard holds that
-//     fantasy against them for the full TTL. main recovers on the next
-//     evaluation because it remembers nothing; that regression is what this
-//     condition removes.
 //
-// The leap rule constrains only what is REMEMBERED, never what is SERVED: the
-// healthy branch serves the pick either way, so it cannot hold, freeze or lower
-// a tip. A legitimate leap (a halt resuming, an L2 landing a large batch) simply
-// leaves the memory where it was; the memory then ages out of its TTL and the
-// next healthy evaluation adopts the new height. Nothing is pinned, and the
-// detection reference is unaffected — it takes the higher of the memory and the
-// live corroborated head, so a memory left behind by a burst is simply ignored.
-func (n *Network) rememberServedTipPick(anchor *servedTipAnchor, pick int64, lastGood int64, lastGoodAt *time.Time, ref servedTipReference, tolerance int64) bool {
+//   - CONTINUITY. A value may enter the memory only if it is within the
+//     regression tolerance ABOVE the last value this process already trusted:
+//     the memory itself while that is fresh, and otherwise the tip this process
+//     most recently SERVED. Without it, a moment in which the eligible set is
+//     majority far-future — two rogues outvoting one honest upstream while the
+//     rest are lag-excluded — commits the fantasy, and when the honest fleet
+//     returns the guard holds that fantasy against them for a full TTL. main
+//     recovers on the next evaluation because it remembers nothing, and a
+//     memory that makes us worse than no memory is not worth having.
+//
+//     Gating only a FRESH memory was not enough: every fail-open disarms
+//     (deliberately — a value that outlived its window is not evidence), and an
+//     empty memory then armed at whatever pick appeared. The window between a
+//     fail-open and the next honest evaluation is exactly when a rogue majority
+//     is most likely, so an unarmed guard is precisely where the continuity
+//     check is needed. Falling back to the last served value closes it without
+//     any new state: that value is this process's own recent history.
+//
+//     A TRUE first evaluation — nothing remembered and nothing ever served —
+//     arms unconditionally. There is no history to be continuous with, and one
+//     evaluation of exposure is exactly what a process without a guard has at
+//     all times.
+//
+// None of this constrains what is SERVED. The healthy branch returns the pick
+// either way, so no arming rule can hold, freeze or lower a tip; only what
+// enters the memory is gated. A legitimate leap (a halt resuming, an L2 landing
+// a batch) simply leaves the memory where it was until it ages out of its TTL,
+// after which the next healthy evaluation adopts the new height — and the
+// detection reference already takes the HIGHER of the memory and the live
+// corroborated head, so a memory left behind is ignored rather than harmful.
+func (n *Network) rememberServedTipPick(anchor *servedTipAnchor, pick int64, lastGood int64, lastGoodAt *time.Time, ref servedTipReference, tolerance int64, now time.Time) bool {
 	if ref.Max <= 0 || pick > ref.Corroborated {
 		return false
 	}
-	if lastGood > 0 && lastGoodAt != nil && pick > lastGood+tolerance &&
-		servedTipClock().Sub(*lastGoodAt) < servedTipRegressionTTL {
+	// The last value this process trusted: the memory while it is still fresh,
+	// otherwise the tip it most recently served (0 = nothing yet, i.e. a true
+	// first evaluation).
+	trusted := anchor.seenValue.Load()
+	if lastGood > 0 && lastGoodAt != nil && now.Sub(*lastGoodAt) < servedTipRegressionTTL {
+		trusted = lastGood
+	}
+	if trusted > 0 && pick > trusted+tolerance {
 		return false
 	}
 	if lastGood != pick {

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -137,10 +137,22 @@ type servedTipAnchor struct {
 	// the pick. See evm.TipTrajectory.
 	trajectory evm.TipTrajectory
 
-	// trajectoryOverriding mirrors guardState for the referee: the override is
-	// logged on transitions only.
-	trajectoryOverriding atomic.Bool
+	// refereeState is one of the servedTipReferee* constants: like guardState,
+	// both the referee's counter and its log fire on state ENTRY only.
+	refereeState atomic.Int32
 }
+
+const (
+	// servedTipRefereeIdle: the referee is not intervening.
+	servedTipRefereeIdle int32 = iota
+	// servedTipRefereeOverriding: a corroborated group is being served in place
+	// of the majority pick.
+	servedTipRefereeOverriding
+	// servedTipRefereeDeclining: a fresher corroborated group sat above the
+	// majority pick and was refused — too far off the trajectory, or it has not
+	// held its place long enough to have earned it.
+	servedTipRefereeDeclining
+)
 
 const (
 	// servedTipGuardHealthy: the pick tracks the live heads.
@@ -885,7 +897,9 @@ func (n *Network) servedTip(
 	// network's head has been going for the last ten minutes. Advisory and
 	// upward-only — it can only replace the majority pick with a higher block
 	// that at least two live upstreams already have.
-	pick.Tip = n.refereeServedTip(axis, lane, anchor, pick.Sorted, pick.Tip, liveReference)
+	majority := pick.Tip
+	decision := n.refereeServedTip(anchor, pick.Sorted, pick.Tip, liveReference)
+	pick.Tip = decision.Pick
 
 	// Regression guard: "latest" cannot drop far below the corroborated live
 	// head in one evaluation. Runs BEFORE the guaranteed-method floor, which is
@@ -901,6 +915,12 @@ func (n *Network) servedTip(
 			pick.Tip = floor
 		}
 	}
+
+	// The referee's outcome is reported only now, against the value the network
+	// actually serves: an override the guaranteed-method floor pulled back to
+	// (or below) the majority pick changed nothing, and counting or logging it
+	// would page someone about an intervention that did not happen.
+	n.observeServedTipRefereeTransition(axis, lane, anchor, majority, pick.Tip, decision)
 
 	if common.IsTracingDetailed {
 		span.SetAttributes(
@@ -957,66 +977,77 @@ func (n *Network) servedTip(
 //
 // The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
 // same reason, so the served-tip lag gauge never reads negative.
-func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, ref servedTipReference) int64 {
+func (n *Network) refereeServedTip(anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, ref servedTipReference) evm.TipTrajectoryDecision {
+	stood := evm.TipTrajectoryDecision{Pick: median}
 	if anchor == nil || median <= 0 || ref.Max <= 0 {
 		// A live head is also what makes `sorted` safe to sample and cluster:
 		// gatherEvmTipInputsForMethod only returns bound-capped observations
 		// when there is no live head at all, and a serving range must never
 		// enter a head trajectory.
-		return median
+		return stood
 	}
 	window := n.servedTipTrajectoryWindow()
 	if window <= 0 {
-		return median
+		return stood
 	}
 
-	decision := anchor.trajectory.Observe(servedTipClock(), sorted, median, evm.TipTrajectoryParams{
+	return anchor.trajectory.Observe(servedTipClock(), sorted, median, evm.TipTrajectoryParams{
 		Window: window,
 		// maxRegressionBlocks: -1 turns the GUARD off; for the referee it only
 		// removes the floor under the tolerance, which the window's own residual
 		// spread then sets on its own.
 		ToleranceFloor: max(0, n.servedTipMaxRegressionBlocks()),
 	})
+}
 
+// observeServedTipRefereeTransition counts and logs the referee's outcome ONCE
+// PER STATE CHANGE, against `final` — the value the network actually serves
+// after the guaranteed-method floor.
+//
+// Transitions, not evaluations: EvmHighestLatestBlockNumber runs several times
+// per request, so a per-evaluation counter scales with RPS and reads as a storm
+// of interventions when there is exactly one. Counting entries is what makes
+// "any non-zero rate is alert-worthy" true.
+func (n *Network) observeServedTipRefereeTransition(axis string, lane string, anchor *servedTipAnchor, majority int64, final int64, d evm.TipTrajectoryDecision) {
+	if anchor == nil {
+		return
+	}
+	state := servedTipRefereeIdle
 	switch {
-	case decision.Overrode:
+	case d.Overrode && final > majority:
+		state = servedTipRefereeOverriding
+	case d.Declined:
+		state = servedTipRefereeDeclining
+	}
+
+	// Load first: "still idle" is the answer on essentially every evaluation
+	// this process ever makes.
+	if anchor.refereeState.Load() == state || anchor.refereeState.Swap(state) == state {
+		return
+	}
+	switch state {
+	case servedTipRefereeOverriding:
 		telemetry.MetricNetworkServedTipTrajectoryTotal.
 			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "override").
 			Inc()
-	case decision.Declined:
+		n.logger.Error().
+			Str("axis", axis).
+			Int64("pick", final).
+			Int64("majorityPick", majority).
+			Int64("expectedBlock", d.Expected).
+			Int64("tolerance", d.Tolerance).
+			Float64("blocksPerSecond", d.VelocityPerSec).
+			Msg("majority of the eligible upstreams is off the network's long-term head trajectory; serving the corroborated group that is on it")
+	case servedTipRefereeDeclining:
 		telemetry.MetricNetworkServedTipTrajectoryTotal.
 			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "fallback").
 			Inc()
-	}
-	n.logServedTipTrajectoryTransition(anchor, axis, median, decision)
-
-	return decision.Pick
-}
-
-// logServedTipTrajectoryTransition logs only when the referee STARTS or STOPS
-// overriding, so a stall that persists across thousands of requests produces
-// one line at each end of it.
-func (n *Network) logServedTipTrajectoryTransition(anchor *servedTipAnchor, axis string, median int64, d evm.TipTrajectoryDecision) {
-	// Load first (see logServedTipGuardTransition): "still not overriding" is
-	// the answer on essentially every evaluation this process ever makes.
-	if anchor.trajectoryOverriding.Load() == d.Overrode || anchor.trajectoryOverriding.Swap(d.Overrode) == d.Overrode {
-		return
-	}
-	if !d.Overrode {
+	default:
 		n.logger.Warn().
 			Str("axis", axis).
-			Int64("pick", d.Pick).
+			Int64("pick", final).
 			Msg("served tip is back on the majority pick; the trajectory referee is no longer overriding")
-		return
 	}
-	n.logger.Error().
-		Str("axis", axis).
-		Int64("pick", d.Pick).
-		Int64("majorityPick", median).
-		Int64("expectedBlock", d.Expected).
-		Int64("tolerance", d.Tolerance).
-		Float64("blocksPerSecond", d.VelocityPerSec).
-		Msg("majority of the eligible upstreams is off the network's long-term head trajectory; serving the corroborated group that is on it")
 }
 
 // servedTipTrajectoryWindow is how much recorded head history the trajectory
@@ -1126,7 +1157,7 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 			at := servedTipClock()
 			anchor.lastGoodAt.Store(&at)
 		}
-		n.logServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, reference, 0)
+		n.noteServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, reference, 0)
 		return pick
 	}
 
@@ -1135,10 +1166,11 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 	}
 	held := servedTipClock().Sub(*lastGoodAt)
 	if held >= servedTipRegressionTTL {
-		n.logServedTipGuardTransition(anchor, servedTipGuardFailedOpen, axis, pick, reference, held)
-		telemetry.MetricNetworkServedTipRegressionTotal.
-			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "failed_open").
-			Inc()
+		if n.noteServedTipGuardTransition(anchor, servedTipGuardFailedOpen, axis, pick, reference, held) {
+			telemetry.MetricNetworkServedTipRegressionTotal.
+				WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "failed_open").
+				Inc()
+		}
 		anchor.lastGoodValue.Store(0)
 		anchor.lastGoodAt.Store(nil)
 		return pick
@@ -1152,21 +1184,25 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 	if ref.Max > 0 && ref.Max < served {
 		served = ref.Max
 	}
-	n.logServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, reference, held)
-	telemetry.MetricNetworkServedTipRegressionTotal.
-		WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "held").
-		Inc()
+	if n.noteServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, reference, held) {
+		telemetry.MetricNetworkServedTipRegressionTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "held").
+			Inc()
+	}
 	return served
 }
 
-// logServedTipGuardTransition logs only when the guard CHANGES state, so a
-// regression that persists across thousands of requests produces one line when
-// the hold starts and one when it gives up.
-func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int32, axis string, pick int64, reference int64, held time.Duration) {
+// noteServedTipGuardTransition records the guard's state and reports whether it
+// CHANGED, so both the log line and the counter fire once when a hold starts and
+// once when it gives up — never once per evaluation. EvmHighestLatestBlockNumber
+// runs several times per request, so a per-evaluation counter would scale with
+// RPS and read as thousands of suppressed picks where there is one sustained
+// regression.
+func (n *Network) noteServedTipGuardTransition(anchor *servedTipAnchor, state int32, axis string, pick int64, reference int64, held time.Duration) bool {
 	// Load first: the steady state is "still healthy", read by every serving
 	// core on every evaluation, and it must not cost an exclusive line.
 	if anchor.guardState.Load() == state || anchor.guardState.Swap(state) == state {
-		return
+		return false
 	}
 	switch state {
 	case servedTipGuardHolding:
@@ -1190,6 +1226,7 @@ func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int
 			Int64("reference", reference).
 			Msg("served tip recovered; the regression guard is no longer holding")
 	}
+	return true
 }
 
 // servedTipMaxRegressionBlocks is how far below the corroborated live head a

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -428,24 +428,36 @@ func (n *Network) Logger() *zerolog.Logger {
 // the per-method eligible set (a capability lane). Falls back to the full
 // registered set on cold start / when the policy has produced no decision yet.
 //
-// BOUND-CAPPED UPSTREAMS DO NOT VOTE (when any live head is present). An
-// upstream whose effective head is its configured blockAvailability.upper bound
-// is declaring a SERVING RANGE ("I answer up to block X"), not observing where
-// the chain's head is — see evmTipObservation. Letting such a declaration into
-// the ballot is what broke celo (evm:42220) on 2026-08-11: two legacy upstreams
-// pinned at `upper.exactBlock: 21615999` outvoted the live heads (74.5M) the
-// moment a third live upstream was excluded for lag, "latest" interpolated to a
-// September-2023 block, the availability gate then admitted ONLY those two
-// upstreams (the live ones start at 21616000), and funded accounts read 0x0.
-//
-// The second return value is the regression guard's view of the LIVE heads on
-// this ballot (see servedTipReference).
+// The ballot itself (who votes, and the guard's live reference) is
+// evmTipBallot's rule.
 func (n *Network) gatherEvmTipInputsForMethod(
 	ctx context.Context,
 	useFinalized bool,
 	method string,
 ) ([]evm.ServedTipInput, servedTipReference) {
-	upstreams := n.tipCandidateUpstreams(ctx, method)
+	return evmTipBallot(n.tipCandidateUpstreams(ctx, method), useFinalized)
+}
+
+// evmTipBallot turns one candidate set into the served-tip ballot for an axis,
+// plus the regression guard's view of its live heads (servedTipReference).
+//
+// STATIC-CAP UPSTREAMS DO NOT VOTE while any live head is present. An upstream
+// configured with `blockAvailability.upper.exactBlock` below the chain's head is
+// declaring a SERVING RANGE ("I answer up to block X"), not observing where the
+// head is — see evmTipObservation. Letting such a declaration onto the ballot is
+// what broke celo (evm:42220) on 2026-08-11: two legacy upstreams pinned at
+// `upper.exactBlock: 21615999` outvoted the live heads (74.5M) the moment a
+// third live upstream was excluded for lag, "latest" interpolated to a
+// September-2023 block, the availability gate then admitted ONLY those two
+// upstreams (the live ones start at 21616000), and funded accounts read 0x0.
+//
+// MIXED POOL vs ALL-CAPPED POOL. The rule applies per candidate set, which is
+// what lets the same function build the network-wide ballot AND each
+// guaranteed-method's floor ballot: caps are dropped only when the SAME set
+// contains at least one live head. A set of only historical/frozen upstreams
+// legitimately serves its cap — that cap is the freshest block anyone in it can
+// serve — so it keeps voting.
+func evmTipBallot(upstreams []common.Upstream, useFinalized bool) ([]evm.ServedTipInput, servedTipReference) {
 	out := make([]evm.ServedTipInput, 0, len(upstreams))
 	var capped []evm.ServedTipInput
 	var liveTop, liveSecond int64
@@ -478,11 +490,10 @@ func (n *Network) gatherEvmTipInputsForMethod(
 		out = append(out, in)
 	}
 	if len(out) == 0 {
-		// All-capped pool: a network of only historical/frozen upstreams
-		// legitimately serves its cap as "latest" — there is no live head to
-		// prefer, so the caps remain the only observations available. (No live
-		// head means no live reference for the regression guard either; it falls
-		// back to its own last corroborated pick, see guardServedTipRegression.)
+		// All-capped set: there is no live head to prefer, so the caps remain
+		// the only observations available. (No live head means no live reference
+		// for the regression guard either; it falls back to its own last
+		// corroborated pick, see guardServedTipRegression.)
 		return capped, servedTipReference{}
 	}
 	if liveSecond <= 0 {
@@ -493,7 +504,7 @@ func (n *Network) gatherEvmTipInputsForMethod(
 
 // servedTipReference is what the LIVE (non-capped) heads of one ballot say,
 // in the two distinct roles the regression guard needs. Both are 0 when every
-// candidate is bound-capped.
+// candidate is capped.
 type servedTipReference struct {
 	// Corroborated is the SECOND-highest live head — the freshest view that two
 	// live upstreams both reach — or the only live head when there is exactly
@@ -517,13 +528,25 @@ type servedTipReference struct {
 }
 
 // evmTipObservation returns an upstream's effective head for the axis, plus
-// whether that value is CAPPED by the upstream's configured
-// blockAvailability.upper bound rather than being an observation of the chain
-// head.
+// whether that value is a STATIC SERVING-RANGE DECLARATION rather than an
+// observation of the chain head.
 //
-// Upstream.EvmEffectiveLatestBlock computes min(head, upper) and discards which
-// side won; this recovers that distinction from the same two inputs, so a
-// serving-range declaration can be told apart from a head observation.
+// The classification is a property of the CONFIG, not of a resolved bound:
+// `blockAvailability.upper.exactBlock` is a constant an operator wrote down
+// ("this upstream answers up to block X"), so once the chain passes X the
+// upstream's effective latest stops moving and stops being a head observation.
+// Every OTHER upper form is derived from the upstream's own head — most of all
+// `latestBlockMinus: N`, which tracks the chain at a fixed lag — and those are
+// live observations: an upstream that serves up to head-5 still knows exactly
+// where the head is. The earlier dynamic test ("the resolved upper bound is
+// below the head") could not tell the two apart and disenfranchised every
+// latestBlockMinus upstream, turning a tip four of four upstreams could serve
+// into one only one of them could.
+//
+// Reading the configured constant also drops the SECOND resolveAvailabilityBounds
+// call per upstream per evaluation that the dynamic test required — the largest
+// per-request cost this feature added — and with it a torn two-load snapshot
+// (bound and head resolved at different instants, off the same moving head).
 func evmTipObservation(u common.EvmUpstream, useFinalized bool) (blk int64, boundCapped bool) {
 	if useFinalized {
 		blk = u.EvmEffectiveFinalizedBlock()
@@ -533,19 +556,31 @@ func evmTipObservation(u common.EvmUpstream, useFinalized bool) (blk int64, boun
 	if blk <= 0 {
 		return blk, false
 	}
-	_, upper := u.EvmBlockAvailabilityBounds()
-	if upper == math.MaxInt64 {
+	exact := configuredUpperExactBlock(u)
+	if exact == nil {
 		return blk, false
 	}
 	sp := u.EvmStatePoller()
 	if sp == nil {
 		return blk, false
 	}
+	// Per axis: a cap the FINALIZED head has not reached yet still caps nothing
+	// on the finalized ballot, even while it caps the latest one.
 	head := sp.LatestBlock()
 	if useFinalized {
 		head = sp.FinalizedBlock()
 	}
-	return blk, head > 0 && upper < head
+	return blk, head > 0 && *exact < head
+}
+
+// configuredUpperExactBlock returns the upstream's configured
+// blockAvailability.upper.exactBlock, or nil when it declares no such constant.
+func configuredUpperExactBlock(u common.Upstream) *int64 {
+	cfg := u.Config()
+	if cfg == nil || cfg.Evm == nil || cfg.Evm.BlockAvailability == nil || cfg.Evm.BlockAvailability.Upper == nil {
+		return nil
+	}
+	return cfg.Evm.BlockAvailability.Upper.ExactBlock
 }
 
 // tipCandidateUpstreams returns the eligible upstreams that feed the served-tip
@@ -1280,6 +1315,20 @@ func (n *Network) EvmHighestFinalizedBlockNumber(ctx context.Context) int64 {
 // no guaranteed methods are configured or none constrain the tip. Each method's
 // supporting set is the selection-policy-eligible set for that method (which,
 // via autoIgnoreUnsupportedMethods, excludes upstreams that don't support it).
+//
+// Each method's ballot is built by evmTipBallot, i.e. by exactly the rule the
+// network-wide ballot uses — including the static-cap filter, applied to THAT
+// method's supporting set. Without it the floor was a second door onto the
+// incident value: with `guaranteedMethods` configured, the floor ballot took raw
+// effective heads and ran AFTER the guard, so the celo pair's 21,615,999 came
+// back as a "floor" and was served, on a branch whose whole premise is that a
+// serving range never defines the head.
+//
+// The per-set mixed-pool rule is what keeps that from breaking the floor's
+// purpose: capped upstreams drop out of a method's ballot only when some LIVE
+// upstream also supports that method. If only capped upstreams support it, they
+// set the floor — which is the entire point of the floor, since they are the
+// only upstreams that can serve the method at all.
 func (n *Network) guaranteedMethodFloor(ctx context.Context, useFinalized bool) int64 {
 	if n.cfg == nil || n.cfg.Evm == nil || n.cfg.Evm.ServedTip == nil {
 		return 0
@@ -1289,27 +1338,18 @@ func (n *Network) guaranteedMethodFloor(ctx context.Context, useFinalized bool) 
 		return 0
 	}
 	eligible := n.tipCandidateUpstreams(ctx, "*")
+	supporting := make([]common.Upstream, 0, len(eligible))
 	var floor int64
 	for _, m := range methods {
-		tips := make([]evm.ServedTipInput, 0, len(eligible))
+		supporting = supporting[:0]
 		for _, cu := range eligible {
-			u, ok := cu.(common.EvmUpstream)
-			if !ok || u.EvmStatePoller() == nil || u.EvmSyncingState() == common.EvmSyncingStateSyncing {
-				continue
-			}
 			// Supporting set = eligible upstreams that handle this method.
 			if handle, _ := cu.ShouldHandleMethod(m); !handle {
 				continue
 			}
-			blk := u.EvmEffectiveLatestBlock()
-			if useFinalized {
-				blk = u.EvmEffectiveFinalizedBlock()
-			}
-			if blk <= 0 {
-				continue
-			}
-			tips = append(tips, evm.ServedTipInput{UpstreamID: u.Id(), BlockNumber: blk})
+			supporting = append(supporting, cu)
 		}
+		tips, _ := evmTipBallot(supporting, useFinalized)
 		if len(tips) == 0 {
 			// No supporting upstream for this method → no constraint (fall through
 			// rather than pinning the tip to 0).

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -95,16 +95,57 @@ type servedTipPartition struct {
 }
 
 // servedTipAnchor tracks, per process, when the served-tip VALUE was last
-// seen to change — the advance-age watchdog's clock. Telemetry only: nothing
-// feeds back into the pick.
+// seen to change — the advance-age watchdog's clock — and holds the regression
+// guard's last corroborated pick (see guardServedTipRegression).
 //
 // The first observed value does NOT count as a change (there is nothing to
 // compare against): the anchor stays unset until the process witnesses the
 // value actually move.
+//
+// IN-PROCESS ONLY, by design: nothing here is persisted or shared between
+// pods. A persisted anchor plus a strict clamp is exactly what wedged the
+// served tip fleet-wide in 2026-06 (see the picker's doc comment and
+// networks_served_tip_invariants_test.go); every field below is rebuilt from
+// live observations after a restart, and the guard always fails open on its
+// own after a bounded window.
 type servedTipAnchor struct {
 	seenValue   atomic.Int64
 	changedAtMs atomic.Int64
+
+	// lastGoodValue / lastGoodAtMs is the most recent pick the guard saw
+	// corroborated by a live head (within tolerance), and when it recorded it.
+	// Only a corroborated pick is stored, so the guard can never hold a value
+	// that no live upstream ever backed.
+	lastGoodValue atomic.Int64
+	lastGoodAtMs  atomic.Int64
+
+	// guardState is one of the servedTipGuard* constants. The guard logs only
+	// on transitions, so a sustained regression reports twice (once when it
+	// starts holding, once if it gives up) instead of once per request.
+	guardState atomic.Int32
 }
+
+const (
+	// servedTipGuardHealthy: the pick tracks the live heads.
+	servedTipGuardHealthy int32 = iota
+	// servedTipGuardHolding: the pick regressed and the last corroborated pick
+	// is being served in its place.
+	servedTipGuardHolding
+	// servedTipGuardFailedOpen: the regression outlasted
+	// servedTipRegressionTTL, so the pick is served as computed.
+	servedTipGuardFailedOpen
+)
+
+// servedTipRegressionTTL bounds how long the guard may serve its last
+// corroborated pick instead of the current one. Past it the guard fails OPEN:
+// a minute of disagreement is long enough that reality, not a transient
+// poisoned ballot, is the better explanation — and a guard that can hold
+// forever is the absorbing frozen-tip state this design exists to make
+// impossible.
+const servedTipRegressionTTL = time.Minute
+
+// servedTipClock is the regression guard's clock, swapped in tests.
+var servedTipClock = time.Now
 
 // observe records v as the latest served value, stamping the anchor when the
 // value changed since the last observation.
@@ -131,6 +172,15 @@ const servedTipLaneAll = "all"
 // group): observeServedTipMetrics emits nothing for it, so such a subset value
 // never overwrites any gauge.
 const servedTipLaneNone = "\x00scoped"
+
+// servedTipLaneLabel maps an internal lane to its metric label: the
+// network-wide pick ("") is published as lane="all".
+func servedTipLaneLabel(lane string) string {
+	if lane == "" {
+		return servedTipLaneAll
+	}
+	return lane
+}
 
 // Bootstrap registers this network with the policy engine. The engine kicks
 // off the slot's ticker and runs an initial synchronous eval so request-path
@@ -361,14 +411,19 @@ func (n *Network) Logger() *zerolog.Logger {
 // moment a third live upstream was excluded for lag, "latest" interpolated to a
 // September-2023 block, the availability gate then admitted ONLY those two
 // upstreams (the live ones start at 21616000), and funded accounts read 0x0.
+//
+// The second return value is the highest LIVE (non-capped) head among the
+// candidates, or 0 when every candidate is capped — the regression guard's
+// reference (see servedTip).
 func (n *Network) gatherEvmTipInputsForMethod(
 	ctx context.Context,
 	useFinalized bool,
 	method string,
-) []evm.ServedTipInput {
+) ([]evm.ServedTipInput, int64) {
 	upstreams := n.tipCandidateUpstreams(ctx, method)
 	out := make([]evm.ServedTipInput, 0, len(upstreams))
 	var capped []evm.ServedTipInput
+	var maxLiveHead int64
 	for _, cu := range upstreams {
 		u, ok := cu.(common.EvmUpstream)
 		if !ok || u.EvmStatePoller() == nil {
@@ -389,15 +444,19 @@ func (n *Network) gatherEvmTipInputsForMethod(
 			capped = append(capped, in)
 			continue
 		}
+		if blk > maxLiveHead {
+			maxLiveHead = blk
+		}
 		out = append(out, in)
 	}
 	if len(out) == 0 {
 		// All-capped pool: a network of only historical/frozen upstreams
 		// legitimately serves its cap as "latest" — there is no live head to
-		// prefer, so the caps remain the only observations available.
-		return capped
+		// prefer, so the caps remain the only observations available. (No live
+		// head means no reference for the regression guard either → 0.)
+		return capped, 0
 	}
-	return out
+	return out, maxLiveHead
 }
 
 // evmTipObservation returns an upstream's effective head for the axis, plus
@@ -706,11 +765,12 @@ func (n *Network) tryShortCircuitFutureBlock(ctx context.Context, req *common.No
 
 // servedTip computes the majority served tip for one axis over the
 // selection-policy-eligible upstreams — the freshest block a strict majority
-// of them already has (see evm.PickServedTip) — applies the guaranteed-method
-// floor, and exports the gauges. STATELESS by design: nothing is persisted
-// and nothing predicted, so no inherited or rogue value can ever pin, freeze
-// or poison the result (networks_served_tip_invariants_test.go pins those
-// outcomes against the 2026-06 production incident).
+// of them already has (see evm.PickServedTip) — guards it against a regression
+// far below the live heads, applies the guaranteed-method floor, and exports
+// the gauges. The pick itself carries NO history: nothing is persisted and
+// nothing predicted, so no inherited or rogue value can pin, freeze or poison
+// the result (networks_served_tip_invariants_test.go pins those outcomes
+// against the 2026-06 production incident).
 func (n *Network) servedTip(
 	ctx context.Context,
 	span trace.Span,
@@ -719,8 +779,13 @@ func (n *Network) servedTip(
 	anchor *servedTipAnchor,
 	lane string,
 ) int64 {
-	tips := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
+	tips, maxLiveHead := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
 	pick := evm.PickServedTip(tips)
+
+	// Regression guard: "latest" cannot drop far below the freshest live head
+	// in one evaluation. Runs BEFORE the guaranteed-method floor, which is a
+	// deliberate operator-configured clamp the guard must not fight.
+	pick.Tip = n.guardServedTipRegression(axis, lane, anchor, pick.Tip, maxLiveHead)
 
 	// Capability guarantee (#855): the served tip must never exceed what any
 	// configured guaranteed-method's supporting upstreams can serve, so a
@@ -752,6 +817,132 @@ func (n *Network) servedTip(
 	}
 	n.observeServedTipMetrics(axis, lane, pick, advanceAge)
 	return pick.Tip
+}
+
+// guardServedTipRegression returns the tip to serve for `pick`, substituting
+// the last corroborated pick when `pick` sits further than the configured
+// tolerance below `maxLiveHead` (the freshest LIVE upstream head of this same
+// evaluation, 0 when there is none).
+//
+// This is a physics check, independent of which voters are honest: a chain's
+// head does not fall a thousand blocks between two evaluations while an
+// upstream still reports the old one, so a pick that far below the best live
+// head is a poisoned ballot — an availability bound voting as a head (the
+// 2026-08 celo incident), a bogus vendor head, a rolled-back shared counter.
+// It is deliberately independent of the bound-capped filter in
+// gatherEvmTipInputsForMethod: that removes ONE known source of low votes,
+// this bounds the damage of any other.
+//
+// It never blocks serving and never persists anything:
+//   - no live head to compare against, no pick, or no anchor for this lane
+//     (arbitrary use-upstream selectors deliberately materialize no state) →
+//     returns the pick untouched;
+//   - within tolerance → the pick becomes the new corroborated value;
+//   - below tolerance, for up to servedTipRegressionTTL since the last
+//     corroborated pick → serves that pick instead, never above the best live
+//     head;
+//   - past the TTL → fails open and serves the pick as computed.
+//
+// While it holds, the served-tip lag gauge (Freshest - Tip) can read negative:
+// the served value is above the corroborated freshest view. That IS the hold —
+// erpc_network_served_tip_regression_total says so explicitly.
+//
+// The reference is the raw max, not the corroborated 2nd-highest head the lag
+// gauge uses, so a single far-future/wrong-chain upstream can make honest picks
+// look like regressions. That direction is the cheap one to be wrong about: a
+// false trip costs a tip held ≤ servedTipRegressionTTL (after which it fails
+// open and stays open, since a held pick never refreshes its own timestamp) plus
+// an alert on an upstream that genuinely needs one, while a missed trip is the
+// celo outage — ancient state served as "latest".
+func (n *Network) guardServedTipRegression(axis string, lane string, anchor *servedTipAnchor, pick int64, maxLiveHead int64) int64 {
+	if anchor == nil || pick <= 0 || maxLiveHead <= 0 {
+		return pick
+	}
+
+	// Regressions are measured against the live head, floored at 0 so an
+	// absurd tolerance disables the guard rather than underflowing.
+	var minAcceptable int64
+	if tolerance := n.servedTipMaxRegressionBlocks(); tolerance < maxLiveHead {
+		minAcceptable = maxLiveHead - tolerance
+	}
+	if pick >= minAcceptable {
+		anchor.lastGoodValue.Store(pick)
+		anchor.lastGoodAtMs.Store(servedTipClock().UnixMilli())
+		n.logServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, maxLiveHead, 0)
+		return pick
+	}
+
+	lastGood, lastGoodAtMs := anchor.lastGoodValue.Load(), anchor.lastGoodAtMs.Load()
+	if lastGood <= 0 || lastGoodAtMs <= 0 {
+		// Nothing corroborated yet in this process (cold start, or every
+		// evaluation so far had no live head): there is no better answer to
+		// serve than the pick itself.
+		return pick
+	}
+
+	held := servedTipClock().Sub(time.UnixMilli(lastGoodAtMs))
+	if held >= servedTipRegressionTTL {
+		n.logServedTipGuardTransition(anchor, servedTipGuardFailedOpen, axis, pick, maxLiveHead, held)
+		telemetry.MetricNetworkServedTipRegressionTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "failed_open").
+			Inc()
+		return pick
+	}
+
+	// Serve the last corroborated pick — but never above the best live head,
+	// so the guard cannot advertise a block no upstream has (the invariant the
+	// old monotonic clamp broke).
+	served := lastGood
+	if maxLiveHead < served {
+		served = maxLiveHead
+	}
+	n.logServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, maxLiveHead, held)
+	telemetry.MetricNetworkServedTipRegressionTotal.
+		WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "held").
+		Inc()
+	return served
+}
+
+// logServedTipGuardTransition logs only when the guard CHANGES state, so a
+// regression that persists across thousands of requests produces one line when
+// the hold starts and one when it gives up.
+func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int32, axis string, pick int64, maxLiveHead int64, held time.Duration) {
+	if anchor.guardState.Swap(state) == state {
+		return
+	}
+	switch state {
+	case servedTipGuardHolding:
+		n.logger.Error().
+			Str("axis", axis).
+			Int64("pick", pick).
+			Int64("maxLiveHead", maxLiveHead).
+			Int64("lastGoodPick", anchor.lastGoodValue.Load()).
+			Msg("served tip regressed far below the freshest live upstream head; serving the last corroborated tip")
+	case servedTipGuardFailedOpen:
+		n.logger.Error().
+			Str("axis", axis).
+			Int64("pick", pick).
+			Int64("maxLiveHead", maxLiveHead).
+			Dur("heldFor", held).
+			Msg("served tip regression outlasted the guard window; failing open and serving the current pick")
+	default:
+		n.logger.Warn().
+			Str("axis", axis).
+			Int64("pick", pick).
+			Int64("maxLiveHead", maxLiveHead).
+			Msg("served tip recovered; the regression guard is no longer holding")
+	}
+}
+
+// servedTipMaxRegressionBlocks is how far below the freshest live head a pick
+// may fall before the regression guard treats it as poisoned. Defaults to the
+// rollback tolerance the state poller and health tracker already use, so every
+// layer agrees on what a genuine deep correction looks like.
+func (n *Network) servedTipMaxRegressionBlocks() int64 {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.ServedTip != nil && n.cfg.Evm.ServedTip.MaxRegressionBlocks > 0 {
+		return n.cfg.Evm.ServedTip.MaxRegressionBlocks
+	}
+	return common.DefaultToleratedBlockHeadRollback
 }
 
 // SvmHighestLatestSlot returns the majority-vote latest slot across SVM
@@ -915,10 +1106,7 @@ func (n *Network) observeServedTipMetrics(axis string, lane string, pick evm.Ser
 	if lane == servedTipLaneNone {
 		return
 	}
-	laneLabel := lane
-	if laneLabel == "" {
-		laneLabel = servedTipLaneAll
-	}
+	laneLabel := servedTipLaneLabel(lane)
 	if pick.Tip > 0 {
 		telemetry.MetricNetworkServedTipBlockNumber.
 			WithLabelValues(n.projectId, n.Label(), laneLabel, axis).

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -805,7 +805,7 @@ func (n *Network) servedTip(
 	// network's head has been going for the last ten minutes. Advisory and
 	// upward-only — it can only replace the majority pick with a higher block
 	// that at least two live upstreams already have.
-	pick.Tip = n.refereeServedTip(axis, lane, anchor, tips, pick.Tip, maxLiveHead)
+	pick.Tip = n.refereeServedTip(axis, lane, anchor, pick.Sorted, pick.Tip, maxLiveHead)
 
 	// Regression guard: "latest" cannot drop far below the freshest live head
 	// in one evaluation. Runs BEFORE the guaranteed-method floor, which is a
@@ -868,11 +868,16 @@ func (n *Network) servedTip(
 //     majority;
 //   - it can only RAISE the pick, and only to the minimum of a group of ≥2
 //     live upstreams — a value they can all serve, and one at most as high as
-//     the freshest live head. It can neither hold the tip back nor invent one.
+//     the freshest live head. It can neither hold the tip back nor invent one;
+//   - and that group must have EARNED it: half a minute of continuously
+//     matching the trajectory while advancing its own head (evm.TipTrajectory's
+//     dwell and velocity-agreement conditions), so neither a static fork swept
+//     over by a halting chain's expected head nor a routine 15-second
+//     divergence can trigger an intervention.
 //
 // The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
 // same reason, so the served-tip lag gauge never reads negative.
-func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, tips []evm.ServedTipInput, median int64, maxLiveHead int64) int64 {
+func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, maxLiveHead int64) int64 {
 	if anchor == nil || median <= 0 || maxLiveHead <= 0 {
 		// maxLiveHead > 0 is also what makes `tips` safe to sample and cluster:
 		// gatherEvmTipInputsForMethod only returns bound-capped observations
@@ -885,7 +890,7 @@ func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAn
 		return median
 	}
 
-	decision := anchor.trajectory.Observe(servedTipClock(), tips, median, evm.TipTrajectoryParams{
+	decision := anchor.trajectory.Observe(servedTipClock(), sorted, median, evm.TipTrajectoryParams{
 		Window:         window,
 		ToleranceFloor: n.servedTipMaxRegressionBlocks(),
 	})

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -112,12 +112,17 @@ type servedTipAnchor struct {
 	seenValue   atomic.Int64
 	changedAtMs atomic.Int64
 
-	// lastGoodValue / lastGoodAtMs is the most recent pick the guard saw
+	// lastGoodValue / lastGoodAt is the most recent pick the guard saw
 	// corroborated by a live head (within tolerance), and when it recorded it.
-	// Only a corroborated pick is stored, so the guard can never hold a value
-	// that no live upstream ever backed.
+	// Only a LIVE-corroborated pick is stored, so the guard can never hold a
+	// value that no live upstream ever backed.
+	//
+	// The timestamp is a monotonic time.Time, not a wall-clock UnixMilli: the
+	// guard's TTL is a duration measured across an interval, and an NTP step
+	// (or a container clock correction) must not be able to expire — or extend
+	// — a hold that is bounded precisely so it cannot become a wedge.
 	lastGoodValue atomic.Int64
-	lastGoodAtMs  atomic.Int64
+	lastGoodAt    atomic.Pointer[time.Time]
 
 	// guardState is one of the servedTipGuard* constants. The guard logs only
 	// on transitions, so a sustained regression reports twice (once when it
@@ -161,7 +166,16 @@ var servedTipClock = time.Now
 
 // observe records v as the latest served value, stamping the anchor when the
 // value changed since the last observation.
+//
+// LOAD FIRST: the served tip is read several times per request and is the same
+// value on almost every one of them, so the steady state must be a shared READ
+// of this cache line, not an exclusive read-modify-write from every serving
+// core. The Swap survives only on the (rare) path where the value really moved,
+// where it is what makes exactly one caller see the transition.
 func (a *servedTipAnchor) observe(v int64) {
+	if a.seenValue.Load() == v {
+		return
+	}
 	if old := a.seenValue.Swap(v); old != v && old != 0 {
 		a.changedAtMs.Store(time.Now().UnixMilli())
 	}
@@ -424,18 +438,17 @@ func (n *Network) Logger() *zerolog.Logger {
 // September-2023 block, the availability gate then admitted ONLY those two
 // upstreams (the live ones start at 21616000), and funded accounts read 0x0.
 //
-// The second return value is the highest LIVE (non-capped) head among the
-// candidates, or 0 when every candidate is capped — the regression guard's
-// reference (see servedTip).
+// The second return value is the regression guard's view of the LIVE heads on
+// this ballot (see servedTipReference).
 func (n *Network) gatherEvmTipInputsForMethod(
 	ctx context.Context,
 	useFinalized bool,
 	method string,
-) ([]evm.ServedTipInput, int64) {
+) ([]evm.ServedTipInput, servedTipReference) {
 	upstreams := n.tipCandidateUpstreams(ctx, method)
 	out := make([]evm.ServedTipInput, 0, len(upstreams))
 	var capped []evm.ServedTipInput
-	var maxLiveHead int64
+	var liveTop, liveSecond int64
 	for _, cu := range upstreams {
 		u, ok := cu.(common.EvmUpstream)
 		if !ok || u.EvmStatePoller() == nil {
@@ -456,8 +469,11 @@ func (n *Network) gatherEvmTipInputsForMethod(
 			capped = append(capped, in)
 			continue
 		}
-		if blk > maxLiveHead {
-			maxLiveHead = blk
+		switch {
+		case blk > liveTop:
+			liveTop, liveSecond = blk, liveTop
+		case blk > liveSecond:
+			liveSecond = blk
 		}
 		out = append(out, in)
 	}
@@ -465,10 +481,39 @@ func (n *Network) gatherEvmTipInputsForMethod(
 		// All-capped pool: a network of only historical/frozen upstreams
 		// legitimately serves its cap as "latest" — there is no live head to
 		// prefer, so the caps remain the only observations available. (No live
-		// head means no reference for the regression guard either → 0.)
-		return capped, 0
+		// head means no live reference for the regression guard either; it falls
+		// back to its own last corroborated pick, see guardServedTipRegression.)
+		return capped, servedTipReference{}
 	}
-	return out, maxLiveHead
+	if liveSecond <= 0 {
+		liveSecond = liveTop // a single live input corroborates only itself
+	}
+	return out, servedTipReference{Corroborated: liveSecond, Max: liveTop}
+}
+
+// servedTipReference is what the LIVE (non-capped) heads of one ballot say,
+// in the two distinct roles the regression guard needs. Both are 0 when every
+// candidate is bound-capped.
+type servedTipReference struct {
+	// Corroborated is the SECOND-highest live head — the freshest view that two
+	// live upstreams both reach — or the only live head when there is exactly
+	// one. It is what a regression is MEASURED against, and it is second-highest
+	// for the same reason ServedTipPick.Freshest is: measured against the raw
+	// max, one far-future/wrong-chain upstream made every honest pick look like
+	// a regression, so the guard never took its healthy branch, never recorded a
+	// corroborated value, and sat permanently disarmed — emitting no metric and
+	// no log at all.
+	Corroborated int64
+
+	// Max is the highest live head: the ceiling a HELD value may not exceed, so
+	// the guard can never advertise a block no live upstream has (the invariant
+	// the old monotonic clamp broke). It is deliberately the raw max and not the
+	// corroborated view — a ceiling that a single rogue can only RAISE cannot be
+	// used to make the guard serve anything the rogue chose, while a ceiling of
+	// the second-highest head would collapse the hold back onto the poisoned
+	// pick in the very shape the guard exists for (one live witness left, two
+	// stuck upstreams outvoting it).
+	Max int64
 }
 
 // evmTipObservation returns an upstream's effective head for the axis, plus
@@ -797,7 +842,7 @@ func (n *Network) servedTip(
 	anchor *servedTipAnchor,
 	lane string,
 ) int64 {
-	tips, maxLiveHead := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
+	tips, liveReference := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
 	pick := evm.PickServedTip(tips)
 
 	// Trajectory referee: when the live heads split and the majority is the
@@ -805,12 +850,12 @@ func (n *Network) servedTip(
 	// network's head has been going for the last ten minutes. Advisory and
 	// upward-only — it can only replace the majority pick with a higher block
 	// that at least two live upstreams already have.
-	pick.Tip = n.refereeServedTip(axis, lane, anchor, pick.Sorted, pick.Tip, maxLiveHead)
+	pick.Tip = n.refereeServedTip(axis, lane, anchor, pick.Sorted, pick.Tip, liveReference)
 
-	// Regression guard: "latest" cannot drop far below the freshest live head
-	// in one evaluation. Runs BEFORE the guaranteed-method floor, which is a
-	// deliberate operator-configured clamp the guard must not fight.
-	pick.Tip = n.guardServedTipRegression(axis, lane, anchor, pick.Tip, maxLiveHead)
+	// Regression guard: "latest" cannot drop far below the corroborated live
+	// head in one evaluation. Runs BEFORE the guaranteed-method floor, which is
+	// a deliberate operator-configured clamp the guard must not fight.
+	pick.Tip = n.guardServedTipRegression(axis, lane, anchor, pick.Tip, liveReference)
 
 	// Capability guarantee (#855): the served tip must never exceed what any
 	// configured guaranteed-method's supporting upstreams can serve, so a
@@ -877,9 +922,9 @@ func (n *Network) servedTip(
 //
 // The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
 // same reason, so the served-tip lag gauge never reads negative.
-func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, maxLiveHead int64) int64 {
-	if anchor == nil || median <= 0 || maxLiveHead <= 0 {
-		// maxLiveHead > 0 is also what makes `tips` safe to sample and cluster:
+func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, sorted []evm.ServedTipInput, median int64, ref servedTipReference) int64 {
+	if anchor == nil || median <= 0 || ref.Max <= 0 {
+		// A live head is also what makes `sorted` safe to sample and cluster:
 		// gatherEvmTipInputsForMethod only returns bound-capped observations
 		// when there is no live head at all, and a serving range must never
 		// enter a head trajectory.
@@ -891,8 +936,11 @@ func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAn
 	}
 
 	decision := anchor.trajectory.Observe(servedTipClock(), sorted, median, evm.TipTrajectoryParams{
-		Window:         window,
-		ToleranceFloor: n.servedTipMaxRegressionBlocks(),
+		Window: window,
+		// maxRegressionBlocks: -1 turns the GUARD off; for the referee it only
+		// removes the floor under the tolerance, which the window's own residual
+		// spread then sets on its own.
+		ToleranceFloor: max(0, n.servedTipMaxRegressionBlocks()),
 	})
 
 	switch {
@@ -914,7 +962,9 @@ func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAn
 // overriding, so a stall that persists across thousands of requests produces
 // one line at each end of it.
 func (n *Network) logServedTipTrajectoryTransition(anchor *servedTipAnchor, axis string, median int64, d evm.TipTrajectoryDecision) {
-	if anchor.trajectoryOverriding.Swap(d.Overrode) == d.Overrode {
+	// Load first (see logServedTipGuardTransition): "still not overriding" is
+	// the answer on essentially every evaluation this process ever makes.
+	if anchor.trajectoryOverriding.Load() == d.Overrode || anchor.trajectoryOverriding.Swap(d.Overrode) == d.Overrode {
 		return
 	}
 	if !d.Overrode {
@@ -944,84 +994,130 @@ func (n *Network) servedTipTrajectoryWindow() time.Duration {
 	return common.DefaultServedTipTrajectoryWindow
 }
 
-// guardServedTipRegression returns the tip to serve for `pick`, substituting
-// the last corroborated pick when `pick` sits further than the configured
-// tolerance below `maxLiveHead` (the freshest LIVE upstream head of this same
-// evaluation, 0 when there is none).
+// guardServedTipRegression returns the tip to serve for `pick`, substituting the
+// last corroborated pick when `pick` sits further than the configured tolerance
+// below the best CORROBORATED evidence of where the chain is.
 //
 // This is a physics check, independent of which voters are honest: a chain's
-// head does not fall a thousand blocks between two evaluations while an
-// upstream still reports the old one, so a pick that far below the best live
-// head is a poisoned ballot — an availability bound voting as a head (the
-// 2026-08 celo incident), a bogus vendor head, a rolled-back shared counter.
-// It is deliberately independent of the bound-capped filter in
-// gatherEvmTipInputsForMethod: that removes ONE known source of low votes,
-// this bounds the damage of any other.
+// head does not fall a thousand blocks between two evaluations while an upstream
+// still reports the old one, so a pick that far below corroborated evidence is a
+// poisoned ballot — an availability bound voting as a head (the 2026-08 celo
+// incident), a bogus vendor head, a rolled-back shared counter. It is
+// deliberately independent of the bound-capped filter in
+// gatherEvmTipInputsForMethod: that removes ONE known source of low votes, this
+// bounds the damage of any other.
+//
+// TWO SOURCES OF EVIDENCE, ONE CEILING. A regression is measured against the
+// higher of (a) `ref.Corroborated`, the second-highest LIVE head of this
+// evaluation, and (b) the last pick this process saw live-corroborated. Neither
+// alone is enough: (a) alone is defeated by the guard's own headline shape —
+// one live upstream left, two stuck ones outvoting it, where the second-highest
+// live head IS the poison — and (b) alone would be memory with no present-tense
+// check. A HELD value is then capped at `ref.Max`, the highest live head, so the
+// guard can never advertise a block no live upstream has.
 //
 // It never blocks serving and never persists anything:
-//   - no live head to compare against, no pick, or no anchor for this lane
-//     (arbitrary use-upstream selectors deliberately materialize no state) →
-//     returns the pick untouched;
-//   - within tolerance → the pick becomes the new corroborated value;
-//   - below tolerance, for up to servedTipRegressionTTL since the last
-//     corroborated pick → serves that pick instead, never above the best live
-//     head;
-//   - past the TTL → fails open and serves the pick as computed.
+//   - no pick, or no anchor for this lane (arbitrary use-upstream selectors
+//     deliberately materialize no state), or maxRegressionBlocks: -1 → returns
+//     the pick untouched;
+//   - within tolerance → a LIVE-corroborated pick becomes the new remembered
+//     value (a capped one never does);
+//   - below tolerance, for up to servedTipRegressionTTL since that value was
+//     recorded → serves it instead, never above the highest live head;
+//   - past the TTL → fails open, serves the pick as computed, and DISARMS: a
+//     value that has outlived the window is no longer evidence, so the guard
+//     re-arms from whatever the live heads corroborate next instead of measuring
+//     forever against a number the chain has left behind.
 //
-// While it holds, the served-tip lag gauge (Freshest - Tip) can read negative:
-// the served value is above the corroborated freshest view. That IS the hold —
-// erpc_network_served_tip_regression_total says so explicitly.
+// NO LIVE HEAD IS NOT A REASON TO STAND DOWN. When every live upstream leaves the
+// eligible set while bound-capped ones remain, the ballot legitimately falls back
+// to the caps — and a guard that requires a live reference would be exactly as
+// absent as it was during the celo incident, on the one ballot shape that caused
+// it. With no live head the guard measures against its own last corroborated pick
+// and holds it UNCLAMPED (there is no live head to clamp to) for the same bounded
+// TTL, then fails open to the capped pick. Networks that are genuinely all-capped
+// never armed the guard in the first place — nothing live ever corroborated a
+// pick — so they keep passing straight through.
 //
-// The reference is the raw max, not the corroborated 2nd-highest head the lag
-// gauge uses, so a single far-future/wrong-chain upstream can make honest picks
-// look like regressions. That direction is the cheap one to be wrong about: a
-// false trip costs a tip held ≤ servedTipRegressionTTL (after which it fails
-// open and stays open, since a held pick never refreshes its own timestamp) plus
-// an alert on an upstream that genuinely needs one, while a missed trip is the
-// celo outage — ancient state served as "latest".
-func (n *Network) guardServedTipRegression(axis string, lane string, anchor *servedTipAnchor, pick int64, maxLiveHead int64) int64 {
-	if anchor == nil || pick <= 0 || maxLiveHead <= 0 {
+// COVERAGE BOUNDARY: the remembered value's freshness comes from REQUEST TRAFFIC —
+// the guard only runs when someone asks for the tip. A network that goes idle for
+// longer than servedTipRegressionTTL therefore fails open on its first poisoned
+// evaluation after the quiet period, exactly as a cold process does. That is the
+// deliberate direction: this guard bounds the damage of a poisoned ballot on a
+// busy network; it is not a memory that survives silence, because a memory that
+// survives silence is the frozen-tip absorbing state this design forbids.
+//
+// While it holds, the served-tip lag gauge (Freshest - Tip) would read negative —
+// the served value is above the corroborated freshest view — so it is clamped at
+// 0; erpc_network_served_tip_regression_total is what says a hold is in progress.
+func (n *Network) guardServedTipRegression(axis string, lane string, anchor *servedTipAnchor, pick int64, ref servedTipReference) int64 {
+	if anchor == nil || pick <= 0 {
+		return pick
+	}
+	tolerance := n.servedTipMaxRegressionBlocks()
+	if tolerance < 0 {
+		// maxRegressionBlocks: -1 — the operator turned the guard off, the
+		// symmetric opposite of trajectoryWindow: 0.
 		return pick
 	}
 
-	// Regressions are measured against the live head, floored at 0 so an
-	// absurd tolerance disables the guard rather than underflowing.
+	lastGood, lastGoodAt := anchor.lastGoodValue.Load(), anchor.lastGoodAt.Load()
+	armed := lastGood > 0 && lastGoodAt != nil
+	reference := ref.Corroborated
+	if armed && lastGood > reference {
+		reference = lastGood
+	}
+	if reference <= 0 {
+		// Nothing live and nothing remembered (cold start, or a genuinely
+		// all-capped network): there is no evidence to measure against, and a cap
+		// must never become the reference.
+		return pick
+	}
+
+	// Regressions are measured against the reference, floored at 0 so an absurd
+	// tolerance disables the guard rather than underflowing.
 	var minAcceptable int64
-	if tolerance := n.servedTipMaxRegressionBlocks(); tolerance < maxLiveHead {
-		minAcceptable = maxLiveHead - tolerance
+	if tolerance < reference {
+		minAcceptable = reference - tolerance
 	}
 	if pick >= minAcceptable {
-		anchor.lastGoodValue.Store(pick)
-		anchor.lastGoodAtMs.Store(servedTipClock().UnixMilli())
-		n.logServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, maxLiveHead, 0)
+		if ref.Max > 0 {
+			// Only a LIVE-corroborated pick may be remembered: promoting a capped
+			// pick here would let a serving range become the value the network is
+			// later held to.
+			if lastGood != pick {
+				anchor.lastGoodValue.Store(pick)
+			}
+			at := servedTipClock()
+			anchor.lastGoodAt.Store(&at)
+		}
+		n.logServedTipGuardTransition(anchor, servedTipGuardHealthy, axis, pick, reference, 0)
 		return pick
 	}
 
-	lastGood, lastGoodAtMs := anchor.lastGoodValue.Load(), anchor.lastGoodAtMs.Load()
-	if lastGood <= 0 || lastGoodAtMs <= 0 {
-		// Nothing corroborated yet in this process (cold start, or every
-		// evaluation so far had no live head): there is no better answer to
-		// serve than the pick itself.
+	if !armed {
 		return pick
 	}
-
-	held := servedTipClock().Sub(time.UnixMilli(lastGoodAtMs))
+	held := servedTipClock().Sub(*lastGoodAt)
 	if held >= servedTipRegressionTTL {
-		n.logServedTipGuardTransition(anchor, servedTipGuardFailedOpen, axis, pick, maxLiveHead, held)
+		n.logServedTipGuardTransition(anchor, servedTipGuardFailedOpen, axis, pick, reference, held)
 		telemetry.MetricNetworkServedTipRegressionTotal.
 			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "failed_open").
 			Inc()
+		anchor.lastGoodValue.Store(0)
+		anchor.lastGoodAt.Store(nil)
 		return pick
 	}
 
-	// Serve the last corroborated pick — but never above the best live head,
-	// so the guard cannot advertise a block no upstream has (the invariant the
-	// old monotonic clamp broke).
+	// Serve the remembered pick — but never above the highest live head, so the
+	// guard cannot advertise a block no live upstream has (the invariant the old
+	// monotonic clamp broke). With no live head there is nothing to clamp to and
+	// the remembered value stands as recorded.
 	served := lastGood
-	if maxLiveHead < served {
-		served = maxLiveHead
+	if ref.Max > 0 && ref.Max < served {
+		served = ref.Max
 	}
-	n.logServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, maxLiveHead, held)
+	n.logServedTipGuardTransition(anchor, servedTipGuardHolding, axis, pick, reference, held)
 	telemetry.MetricNetworkServedTipRegressionTotal.
 		WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "held").
 		Inc()
@@ -1031,8 +1127,10 @@ func (n *Network) guardServedTipRegression(axis string, lane string, anchor *ser
 // logServedTipGuardTransition logs only when the guard CHANGES state, so a
 // regression that persists across thousands of requests produces one line when
 // the hold starts and one when it gives up.
-func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int32, axis string, pick int64, maxLiveHead int64, held time.Duration) {
-	if anchor.guardState.Swap(state) == state {
+func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int32, axis string, pick int64, reference int64, held time.Duration) {
+	// Load first: the steady state is "still healthy", read by every serving
+	// core on every evaluation, and it must not cost an exclusive line.
+	if anchor.guardState.Load() == state || anchor.guardState.Swap(state) == state {
 		return
 	}
 	switch state {
@@ -1040,31 +1138,33 @@ func (n *Network) logServedTipGuardTransition(anchor *servedTipAnchor, state int
 		n.logger.Error().
 			Str("axis", axis).
 			Int64("pick", pick).
-			Int64("maxLiveHead", maxLiveHead).
+			Int64("reference", reference).
 			Int64("lastGoodPick", anchor.lastGoodValue.Load()).
-			Msg("served tip regressed far below the freshest live upstream head; serving the last corroborated tip")
+			Msg("served tip regressed far below the corroborated live head; serving the last corroborated tip")
 	case servedTipGuardFailedOpen:
 		n.logger.Error().
 			Str("axis", axis).
 			Int64("pick", pick).
-			Int64("maxLiveHead", maxLiveHead).
+			Int64("reference", reference).
 			Dur("heldFor", held).
 			Msg("served tip regression outlasted the guard window; failing open and serving the current pick")
 	default:
 		n.logger.Warn().
 			Str("axis", axis).
 			Int64("pick", pick).
-			Int64("maxLiveHead", maxLiveHead).
+			Int64("reference", reference).
 			Msg("served tip recovered; the regression guard is no longer holding")
 	}
 }
 
-// servedTipMaxRegressionBlocks is how far below the freshest live head a pick
-// may fall before the regression guard treats it as poisoned. Defaults to the
-// rollback tolerance the state poller and health tracker already use, so every
-// layer agrees on what a genuine deep correction looks like.
+// servedTipMaxRegressionBlocks is how far below the corroborated live head a
+// pick may fall before the regression guard treats it as poisoned. Defaults to
+// the rollback tolerance the state poller and health tracker already use, so
+// every layer agrees on what a genuine deep correction looks like. A configured
+// -1 is returned as-is: it disables the guard, the symmetric opposite of
+// trajectoryWindow: 0.
 func (n *Network) servedTipMaxRegressionBlocks() int64 {
-	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.ServedTip != nil && n.cfg.Evm.ServedTip.MaxRegressionBlocks > 0 {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.ServedTip != nil && n.cfg.Evm.ServedTip.MaxRegressionBlocks != 0 {
 		return n.cfg.Evm.ServedTip.MaxRegressionBlocks
 	}
 	return common.DefaultToleratedBlockHeadRollback
@@ -1236,11 +1336,20 @@ func (n *Network) observeServedTipMetrics(axis string, lane string, pick evm.Ser
 		telemetry.MetricNetworkServedTipBlockNumber.
 			WithLabelValues(n.projectId, n.Label(), laneLabel, axis).
 			Set(float64(pick.Tip))
-		// Deliberate lag: how far the majority tip sits behind the single
-		// freshest upstream view in the same set.
+		// Deliberate lag: how far the majority tip sits behind the corroborated
+		// freshest upstream view in the same set. Clamped at 0 because the tip
+		// can legitimately sit ABOVE that view — while the regression guard
+		// holds its last corroborated pick, and on the evaluation a referee
+		// override raises the tip to a fresh group — and a lag gauge that reads
+		// negative is a broken dashboard, not a signal. Both of those states
+		// have their own counters (…_regression_total / …_trajectory_total).
+		lag := pick.Freshest - pick.Tip
+		if lag < 0 {
+			lag = 0
+		}
 		telemetry.MetricNetworkServedTipLagBlocks.
 			WithLabelValues(n.projectId, n.Label(), laneLabel, axis).
-			Set(float64(pick.Freshest - pick.Tip))
+			Set(float64(lag))
 	}
 	// Universal stuck-tip signal: seconds since this process last saw the
 	// served value change. Skipped until a first change is observed.

--- a/erpc/networks_served_tip_invariants_test.go
+++ b/erpc/networks_served_tip_invariants_test.go
@@ -233,3 +233,55 @@ func TestServedTipInvariant_Fixture_ServedTipModeActive(t *testing.T) {
 	require.Equal(t, int64(100), network2.EvmHighestLatestBlockNumber(ctx),
 		"served-tip mode must be live (max mode would return 200)")
 }
+
+// THE 2026-08-11 incident (celo / evm:42220, 12:36–12:41 UTC): two "legacy"
+// upstreams configured with `blockAvailability.upper.exactBlock: 21615999`
+// polled the live head (74.5M) but reported the BOUND as their effective
+// latest. While all five upstreams were eligible the three live heads carried
+// the majority. Then the selection policy excluded one live upstream for lag,
+// the ballot became [74550978, 74550974, 21615999, 21615999], and the pick —
+// the 3rd of 4 — fell to 21,615,999. "latest" was interpolated to that
+// September-2023 block, the availability gate then admitted ONLY the two legacy
+// upstreams (the live ones declare a lower bound of 21,616,000), and they
+// correctly served state from 2023: eth_getBalance returned 0x0 for funded
+// accounts and eth_call reverted.
+//
+// INVARIANT: an upstream that is only DECLARING a serving range must never
+// define the network's head while any upstream is actually observing one — with
+// the full fleet eligible and with any subset of it eligible.
+func TestServedTipInvariant_AvailabilityBoundNeverDefinesTheHead(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const legacyCap = int64(21_615_999)
+	const liveHead = int64(74_550_978)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "prism-celo", chainID: 123, latestBlock: liveHead},
+		{id: "celo-mainnet-nirvana", chainID: 123, latestBlock: 74_550_974},
+		{id: "quicknode-celo", chainID: 123, latestBlock: 74_550_946},
+		// The legacy pair: pollers at the live tip, serving range frozen in 2023.
+		{id: "celo-mainnet-nirvana-legacy", chainID: 123, latestBlock: liveHead, upperExactBlock: legacyCap},
+		{id: "quicknode-celo-legacy", chainID: 123, latestBlock: liveHead, upperExactBlock: legacyCap},
+	})
+
+	served := network.EvmHighestLatestBlockNumber(ctx)
+	require.Greater(t, served, legacyCap,
+		"with the full fleet eligible the served tip must be a live head, not the legacy serving bound")
+
+	// 12:36 UTC: prism-celo's head froze ~30s and the selection policy excluded
+	// it for lag. This is the exact production ballot that broke.
+	network.PinUpstreamOrderForTest("celo-mainnet-nirvana", "quicknode-celo", "celo-mainnet-nirvana-legacy", "quicknode-celo-legacy")
+
+	served = network.EvmHighestLatestBlockNumber(ctx)
+	require.Greater(t, served, legacyCap,
+		"losing one live upstream must not hand the tip to the availability bounds: "+
+			"served %d, the legacy cap is %d — this is the celo outage (eth_getBalance = 0x0 on funded accounts)",
+		served, legacyCap)
+	require.LessOrEqual(t, served, liveHead,
+		"the served tip must still be a block the live upstreams actually have")
+}

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -916,6 +916,143 @@ func TestServedTip_RegressionGuard_SkippedWithoutLiveHead(t *testing.T) {
 		"an uncorroborated cap must never be remembered as a good pick")
 }
 
+// THE remaining door onto the celo incident value, and the reason the guard no
+// longer stands down without a live head: when EVERY live upstream leaves the
+// eligible set while the bound-capped ones stay, the ballot legitimately falls
+// back to the caps — and a guard that requires a live reference is absent on the
+// exact ballot shape that caused the outage. With no live head it measures
+// against its own last corroborated pick instead, holds it UNCLAMPED for the
+// TTL, and only then fails open to the cap.
+func TestServedTip_RegressionGuard_HoldsWhenEveryLiveUpstreamLeaves(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	advance := pinServedTipClock(t)
+
+	const legacyCap = int64(21_615_999)
+	network, _ := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+		{id: "prism-celo", chainID: 123, latestBlock: 74_550_978},
+		{id: "celo-mainnet-nirvana", chainID: 123, latestBlock: 74_550_974},
+		{id: "quicknode-celo", chainID: 123, latestBlock: 74_550_946},
+		{id: "celo-mainnet-nirvana-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+		{id: "quicknode-celo-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+	}, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+
+	healthy := network.EvmHighestLatestBlockNumber(ctx)
+	require.Greater(t, healthy, legacyCap, "precondition: the live heads carry the ballot")
+	beforeHeld := servedTipRegressionCount(network, "latest", "held")
+	beforeOpen := servedTipRegressionCount(network, "latest", "failed_open")
+
+	// All three live upstreams drop out at once (a vendor incident, a policy
+	// exclusion sweep): only the two 2023-capped ones remain eligible.
+	network.PinUpstreamOrderForTest("celo-mainnet-nirvana-legacy", "quicknode-celo-legacy")
+
+	assert.Equal(t, healthy, network.EvmHighestLatestBlockNumber(ctx),
+		"with no live head left the guard must hold its last corroborated pick, "+
+			"not hand `latest` to a September-2023 serving range")
+	assert.Equal(t, beforeHeld+1, servedTipRegressionCount(network, "latest", "held"))
+
+	advance(servedTipRegressionTTL + time.Second)
+	assert.Equal(t, legacyCap, network.EvmHighestLatestBlockNumber(ctx),
+		"and past the TTL it must still fail open: a guard that can hold forever is the wedge")
+	assert.Equal(t, beforeOpen+1, servedTipRegressionCount(network, "latest", "failed_open"))
+}
+
+// The guard's reference is the SECOND-highest live head, so a single far-future
+// upstream cannot make every honest pick look like a regression. Measured
+// against the raw max it did exactly that — and because a corroborated value is
+// only recorded on the healthy branch, the guard then sat permanently disarmed
+// while emitting no metric and no log at all.
+func TestServedTip_RegressionGuard_SingleRogueUpstreamDoesNotDisarmIt(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "rogue", chainID: 123, latestBlock: 100_000_000},
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"the majority pick ignores the rogue, as it always did")
+	require.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load(),
+		"and the guard must be ARMED by that honest pick, not silently disabled by the rogue")
+
+	// Armed means it still protects: lose the honest majority to a stuck pair.
+	network.PinUpstreamOrderForTest("rogue", "live-1", "stuck-1", "stuck-2")
+	assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"the armed guard holds the corroborated pick when the ballot collapses")
+}
+
+// The off switch, symmetric with trajectoryWindow: 0.
+func TestServedTip_RegressionGuard_DisabledByNegativeOne(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	}, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}, MaxRegressionBlocks: -1})
+
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	network.PinUpstreamOrderForTest("live-1", "stuck-1", "stuck-2")
+	assert.Equal(t, int64(5), network.EvmHighestLatestBlockNumber(ctx),
+		"maxRegressionBlocks: -1 means the operator gets the raw pick, poisoned or not")
+	assert.Equal(t, before, servedTipRegressionCount(network, "latest", "held"))
+	assert.Zero(t, network.servedLatestAnchor.lastGoodValue.Load(),
+		"a disabled guard records nothing either")
+}
+
+// The lag gauge is a lag gauge: while the guard serves ABOVE the corroborated
+// freshest view it must read 0, not a negative number no dashboard can plot.
+func TestServedTip_LagGaugeNeverReadsNegative(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+
+	network.PinUpstreamOrderForTest("live-1", "stuck-1", "stuck-2")
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"precondition: the guard is holding above the ballot's freshest corroborated view")
+
+	lag := promUtil.ToFloat64(telemetry.MetricNetworkServedTipLagBlocks.
+		WithLabelValues(network.projectId, network.Label(), servedTipLaneAll, "latest"))
+	assert.GreaterOrEqual(t, lag, float64(0), "the deliberate-lag gauge must never read negative")
+}
+
 // ─── Long-term trajectory referee ────────────────────────────────────────────
 //
 // Every mechanism above is a snapshot of one instant, and a majority stall

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -787,6 +787,57 @@ func TestServedTip_GuaranteedMethodFloorCannotReadmitTheCap(t *testing.T) {
 		"the guaranteed-method floor must not re-admit the serving range the ballot filter removed")
 }
 
+// THE COMPOSITION of the two doors: the guard correctly refuses a cap-only
+// ballot (no live head → it holds its last corroborated pick), and the
+// guaranteed-method floor — which runs AFTER the guard — then recomputes that
+// same collapsed instant and drags the served value back to the cap. Each fix
+// was correct alone; together they still served 21,615,999.
+//
+// The live upstreams here go SYNCING rather than being un-pinned: that is the
+// production shape (lag-excluded, cordoned, mid-restart upstreams stay
+// REGISTERED), and registration is what tells the floor that a cap-only ballot
+// is transient rather than the operator's configuration.
+func TestServedTip_GuaranteedMethodFloor_DoesNotUndoTheGuardsHold(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	advance := pinServedTipClock(t)
+
+	const legacyCap = int64(21_615_999)
+	network, ups := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+		{id: "prism-celo", chainID: 123, latestBlock: 74_550_978},
+		{id: "celo-mainnet-nirvana", chainID: 123, latestBlock: 74_550_974},
+		{id: "quicknode-celo", chainID: 123, latestBlock: 74_550_946},
+		{id: "celo-mainnet-nirvana-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+		{id: "quicknode-celo-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+	}, &common.EvmServedTipConfig{
+		EnabledFor:        []string{"latest"},
+		GuaranteedMethods: []string{"eth_getLogs"},
+	})
+
+	healthy := network.EvmHighestLatestBlockNumber(ctx)
+	require.Greater(t, healthy, legacyCap, "precondition: the live heads carry the ballot")
+
+	// Every live upstream drops out of the ballot at once; only the two
+	// 2023-capped ones remain servable, and they support eth_getLogs.
+	for _, u := range ups[:3] {
+		u.EvmStatePoller().SetSyncingState(common.EvmSyncingStateSyncing)
+	}
+
+	assert.Equal(t, healthy, network.EvmHighestLatestBlockNumber(ctx),
+		"the floor must not undo the guard's hold: live upstreams serve eth_getLogs, "+
+			"they are merely absent, so the cap-only floor is a transient lie")
+	assert.Zero(t, network.guaranteedMethodFloor(ctx, false),
+		"and the method must contribute no floor at all while that is true")
+
+	advance(servedTipRegressionTTL + time.Second)
+	assert.Equal(t, legacyCap, network.EvmHighestLatestBlockNumber(ctx),
+		"past the guard's TTL the cap is served — bounded fail-open, not a wedge")
+}
+
 // The floor's PURPOSE is unchanged by that filter: when only capped upstreams
 // support a guaranteed method, they are the only upstreams that can serve it at
 // all, so their cap is exactly the floor the tip must respect.
@@ -798,7 +849,7 @@ func TestServedTip_GuaranteedMethodFloor_CapsStillSetTheFloorWhenAloneOnAMethod(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	network, _ := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+	network, ups := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
 		{id: "live-1", chainID: 123, latestBlock: 10_000, ignoreMethods: []string{"trace_block"}},
 		{id: "live-2", chainID: 123, latestBlock: 10_000, ignoreMethods: []string{"trace_block"}},
 		{id: "archive-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
@@ -810,6 +861,15 @@ func TestServedTip_GuaranteedMethodFloor_CapsStillSetTheFloorWhenAloneOnAMethod(
 
 	assert.Equal(t, int64(5_000), network.EvmHighestLatestBlockNumber(ctx),
 		"only the capped pair serves trace_block, so their range IS the guarantee")
+
+	// And it stays the guarantee when the live upstreams leave the ballot: no
+	// live upstream is CONFIGURED to serve trace_block, so this cap-only ballot
+	// is the permanent case, not a transient one.
+	for _, u := range ups[:2] {
+		u.EvmStatePoller().SetSyncingState(common.EvmSyncingStateSyncing)
+	}
+	assert.Equal(t, int64(5_000), network.EvmHighestLatestBlockNumber(ctx),
+		"a permanently cap-only method must keep flooring the tip")
 }
 
 // A ballot the filter shrinks to a SINGLE live upstream is served as that

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/thirdparty"
 	"github.com/erpc/erpc/upstream"
 	"github.com/erpc/erpc/util"
 	"github.com/h2non/gock"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -747,4 +750,166 @@ func TestServedTip_AllInputsFiltered_FailsOpenToZero(t *testing.T) {
 
 	assert.Equal(t, int64(0), network.EvmHighestLatestBlockNumber(ctx),
 		"no eligible observations → unknown tip (0), never a remembered one")
+}
+
+// ─── Regression guard: the tip cannot fall far below the best live head ──────
+
+// servedTipRegressionCount reads the guard's counter for a network/axis/outcome.
+func servedTipRegressionCount(n *Network, axis, outcome string) float64 {
+	return promUtil.ToFloat64(telemetry.MetricNetworkServedTipRegressionTotal.
+		WithLabelValues(n.projectId, n.Label(), servedTipLaneAll, axis, outcome))
+}
+
+// pinServedTipClock freezes the guard's clock for the duration of a test and
+// returns a function that advances it (mirrors integrity's exhaustionClock).
+func pinServedTipClock(t *testing.T) func(time.Duration) {
+	t.Helper()
+	var mu sync.Mutex
+	now := time.Now()
+	prev := servedTipClock
+	servedTipClock = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+	t.Cleanup(func() { servedTipClock = prev })
+	return func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = now.Add(d)
+	}
+}
+
+// A pick that drops more than the tolerance below the freshest live head is a
+// poisoned ballot, not a chain that moved: the last corroborated pick is served
+// instead. Here the two upstreams stuck at block 5 become the majority the
+// moment the healthy pair leaves the eligible set — the same shape as celo's
+// bound-capped pair, reached without any bounds at all (which is why the guard
+// exists independently of the bounds filter).
+func TestServedTip_RegressionGuard_HoldsLastCorroboratedPick(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"majority of [10000,10000,10000,5,5] = 10000, corroborated by the live heads")
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	// The healthy pair drops out (policy exclusion / cordon): the ballot
+	// becomes [10000, 5, 5] and the majority pick collapses to 5.
+	network.PinUpstreamOrderForTest("live-1", "stuck-1", "stuck-2")
+
+	assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"a pick 9995 blocks below the live head is a poisoned ballot; "+
+			"the last corroborated pick must be served instead")
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "held"),
+		"the guard must count what it suppressed")
+}
+
+// The guard is a bounded pause, never a wedge: once the regression outlasts
+// servedTipRegressionTTL, reality is the better explanation and the pick is
+// served as computed. This is the property whose absence (a clamp that could
+// hold forever) froze the fleet in 2026-06.
+func TestServedTip_RegressionGuard_FailsOpenAfterTTL(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	advance := pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	network.PinUpstreamOrderForTest("live-1", "stuck-1", "stuck-2")
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"inside the window the guard holds")
+
+	before := servedTipRegressionCount(network, "latest", "failed_open")
+	advance(servedTipRegressionTTL + time.Second)
+
+	assert.Equal(t, int64(5), network.EvmHighestLatestBlockNumber(ctx),
+		"past the guard window the pick must be served as computed (fail open)")
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "failed_open"),
+		"failing open is still worth counting")
+}
+
+// A genuine reorg/lag inside the tolerance is reality, not poison: it passes
+// through untouched and becomes the new corroborated value (so the guard can
+// never ratchet the tip upward across small legitimate steps back).
+func TestServedTip_RegressionGuard_SmallReorgPassesThrough(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "behind-1", chainID: 123, latestBlock: 9_500},
+		{id: "behind-2", chainID: 123, latestBlock: 9_500},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	// [10000, 9500, 9500] → 9500: 500 blocks back, inside the 1024 tolerance.
+	network.PinUpstreamOrderForTest("live-1", "behind-1", "behind-2")
+
+	assert.Equal(t, int64(9_500), network.EvmHighestLatestBlockNumber(ctx),
+		"a regression inside the tolerance is reality and must pass through")
+	assert.Equal(t, before, servedTipRegressionCount(network, "latest", "held"),
+		"a tolerated regression is not a guard trip")
+	assert.Equal(t, int64(9_500), network.servedLatestAnchor.lastGoodValue.Load(),
+		"the tolerated pick becomes the new corroborated value")
+}
+
+// With no live head on the ballot there is nothing to measure a regression
+// against, so the guard steps aside entirely — and records nothing, because a
+// cap must never become the value it later holds the network to.
+func TestServedTip_RegressionGuard_SkippedWithoutLiveHead(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	// Every upstream's poller sits at 10_000 while serving only up to 5_000:
+	// were the raw heads a live reference, 5_000 would trip the guard.
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "capped-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-3", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+	})
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	assert.Equal(t, int64(5_000), network.EvmHighestLatestBlockNumber(ctx),
+		"no live head → no reference → the guard must not interfere")
+	assert.Equal(t, before, servedTipRegressionCount(network, "latest", "held"),
+		"the guard cannot trip without a live head to compare against")
+	assert.Zero(t, network.servedLatestAnchor.lastGoodValue.Load(),
+		"an uncorroborated cap must never be remembered as a good pick")
 }

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -3,11 +3,13 @@ package erpc
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
@@ -912,4 +914,388 @@ func TestServedTip_RegressionGuard_SkippedWithoutLiveHead(t *testing.T) {
 		"the guard cannot trip without a live head to compare against")
 	assert.Zero(t, network.servedLatestAnchor.lastGoodValue.Load(),
 		"an uncorroborated cap must never be remembered as a good pick")
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// Every mechanism above is a snapshot of one instant, and a majority stall
+// defeats all of them at once: when N upstreams freeze while staying eligible,
+// the majority IS the stale group and the 2 upstreams holding the real head are
+// outvoted. These tests pin the referee that breaks that tie from the network's
+// own 10-minute head trajectory — and, just as importantly, pin how narrowly it
+// is allowed to act.
+
+const (
+	// servedTipSampleInterval mirrors the tracker's unexported sample throttle
+	// (architecture/evm: tipSampleInterval) — the cadence a warm-up must tick
+	// at for the buffer to fill.
+	servedTipSampleInterval = 5 * time.Second
+
+	// servedTipMaxSampleGap mirrors architecture/evm's tipMaxSampleGap.
+	servedTipMaxSampleGap = time.Minute
+
+	// The warm-up track: 100 blocks per 5s sample = 20 blocks/s, a fast-L2
+	// cadence that makes one stalled sample worth 100 blocks and keeps the
+	// scenarios legible. 130 samples ≈ 10m45s, just past the default window.
+	trajectoryStartHead       = int64(1_000_000)
+	trajectoryBlocksPerSample = int64(100)
+	trajectoryWarmSamples     = 130
+)
+
+// servedTipTrajectoryCount reads the referee's counter for a network/axis/outcome.
+func servedTipTrajectoryCount(n *Network, axis, outcome string) float64 {
+	return promUtil.ToFloat64(telemetry.MetricNetworkServedTipTrajectoryTotal.
+		WithLabelValues(n.projectId, n.Label(), servedTipLaneAll, axis, outcome))
+}
+
+// setupTrajectoryNetwork builds a `count`-upstream network with the pinned
+// served-tip clock, and returns the clock's advance function.
+func setupTrajectoryNetwork(t *testing.T, ctx context.Context, count int, stCfg *common.EvmServedTipConfig) (*Network, []*upstream.Upstream, func(time.Duration)) {
+	t.Helper()
+	advance := pinServedTipClock(t)
+	fixtures := make([]servedTipFixture, count)
+	for i := range fixtures {
+		fixtures[i] = servedTipFixture{id: "u" + strconv.Itoa(i+1), chainID: 123, latestBlock: trajectoryStartHead}
+	}
+	network, ups := setupServedTipNetworkWith(t, ctx, fixtures, stCfg)
+	return network, ups, advance
+}
+
+// suggestServedTipHead moves an upstream's poller head up to `head` in steps no
+// larger than the poller's major-jump threshold. A single larger suggestion is
+// deliberately deferred to an asynchronous chain-identity check
+// (verifyThenSuggestLatestBlock), which these deterministic scenarios must not
+// race against.
+func suggestServedTipHead(u *upstream.Upstream, head int64) {
+	for {
+		current := u.EvmStatePoller().LatestBlock()
+		if current >= head {
+			return
+		}
+		next := head
+		if head-current > common.DefaultToleratedBlockHeadRollback {
+			next = current + common.DefaultToleratedBlockHeadRollback
+		}
+		u.EvmStatePoller().SuggestLatestBlock(next)
+		if u.EvmStatePoller().LatestBlock() < next {
+			return // the poller refused it; let the assertion report the state
+		}
+	}
+}
+
+// warmServedTipTrajectory drives `samples` real evaluations one sample interval
+// apart with every upstream advancing together, so the network's tracker sees a
+// clean linear head track through the ordinary request path. Returns the head
+// every upstream ends on (the clock sits on the last sample).
+func warmServedTipTrajectory(t *testing.T, ctx context.Context, network *Network, ups []*upstream.Upstream, advance func(time.Duration), samples int) int64 {
+	t.Helper()
+	head := trajectoryStartHead
+	for i := 0; i < samples; i++ {
+		for _, u := range ups {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		require.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx),
+			"warm-up sample %d: an agreeing fleet must serve its agreed head", i)
+		if i < samples-1 {
+			advance(servedTipSampleInterval)
+			head += trajectoryBlocksPerSample
+		}
+	}
+	return head
+}
+
+// stallMajority freezes every upstream except the first `fresh` of them, which
+// keep the warm-up track for `samples` more evaluations. Returns the head the
+// fresh group ends on and the last served value.
+func stallMajority(t *testing.T, ctx context.Context, network *Network, ups []*upstream.Upstream, advance func(time.Duration), head int64, fresh int, samples int) (int64, int64) {
+	t.Helper()
+	served := int64(0)
+	for i := 0; i < samples; i++ {
+		advance(servedTipSampleInterval)
+		head += trajectoryBlocksPerSample
+		for _, u := range ups[:fresh] {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		served = network.EvmHighestLatestBlockNumber(ctx)
+	}
+	return head, served
+}
+
+// THE headline case, and the requirement the referee exists for: in an N-vs-2
+// split where the 2 sit at the higher block, use the 2. Three upstreams freeze
+// inside the lag-exclusion threshold (a shared-counter freeze, a stuck vendor
+// region) while two keep the chain's head; the strict majority is now the stale
+// group, so the plain majority pick — and every instantaneous rule — serves a
+// block the chain left minutes ago.
+func TestServedTip_TrajectoryReferee_StalledMajorityLosesToFreshMinority(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeHeld := servedTipRegressionCount(network, "latest", "held")
+
+	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	// What the plain majority pick WOULD be over the very same ballot: the
+	// frozen head, held by 3 of the 5 upstreams.
+	majority := evm.PickServedTip([]evm.ServedTipInput{
+		{UpstreamID: "u1", BlockNumber: fresh},
+		{UpstreamID: "u2", BlockNumber: fresh},
+		{UpstreamID: "u3", BlockNumber: frozen},
+		{UpstreamID: "u4", BlockNumber: frozen},
+		{UpstreamID: "u5", BlockNumber: frozen},
+	}).Tip
+	require.Equal(t, frozen, majority,
+		"precondition: the stalled group holds the majority, so the plain pick is the stale head")
+
+	assert.Equal(t, fresh, served,
+		"the corroborated pair that is where the chain should be by now must define the tip; "+
+			"the plain majority would have served %d, %d blocks behind", majority, fresh-majority)
+	assert.Greater(t, servedTipTrajectoryCount(network, "latest", "override"), beforeOverride,
+		"an override is an intervention and must be counted")
+	assert.Equal(t, beforeHeld, servedTipRegressionCount(network, "latest", "held"),
+		"raising the tip to the live pair is not a regression; the guard must stay out of it")
+}
+
+// The inverse split, and the reason a group is elected by its DISTANCE to the
+// trajectory rather than by its freshness: two upstreams running far past where
+// the chain can possibly be (wrong chain, garbage endpoint) must lose to the
+// healthy group, however corroborated they are with each other.
+func TestServedTip_TrajectoryReferee_RunawayMinorityLoses(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// maxRegressionBlocks is widened so the branch's regression guard (which
+	// measures against the RAW max live head, and would hold the tip the moment
+	// any upstream runs 1024 blocks ahead) stays out of the way: what is under
+	// test here is the referee's own election.
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{
+		EnabledFor:          []string{"latest"},
+		MaxRegressionBlocks: 100_000,
+	})
+	head := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeFallback := servedTipTrajectoryCount(network, "latest", "fallback")
+
+	// Two upstreams run 20k blocks (≈16 minutes of this chain) ahead; the other
+	// three stay exactly on the track.
+	advance(servedTipSampleInterval)
+	head += trajectoryBlocksPerSample
+	for _, u := range ups {
+		suggestServedTipHead(u, head)
+	}
+	for _, u := range ups[:2] {
+		suggestServedTipHead(u, head+20_000)
+	}
+
+	assert.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx),
+		"the runaway pair is nowhere near the trajectory; the healthy majority keeps the tip")
+	assert.Equal(t, beforeOverride, servedTipTrajectoryCount(network, "latest", "override"),
+		"no override happened")
+	assert.Equal(t, beforeFallback, servedTipTrajectoryCount(network, "latest", "fallback"),
+		"the healthy group is elected outright, so this is not even a near miss")
+}
+
+// Warm-up inertness: until the tracker has a window's worth of history the
+// referee is a no-op and the network behaves exactly as it does without it.
+// This is also the boot behaviour of every pod after every deploy.
+func TestServedTip_TrajectoryReferee_ColdProcessIsInert(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	// Half a window: enough samples for a fit, nowhere near enough span.
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples/2)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	assert.Equal(t, frozen, served,
+		"a cold tracker must leave the plain majority pick untouched")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+}
+
+// Staleness: the fit describes the present only if the track is continuous. A
+// gap larger than the tracker's tolerance is exactly where a halt or a burst
+// hides, so extrapolating across one is guessing — and the referee stands down.
+// The paired sub-tests differ ONLY in the size of that gap.
+func TestServedTip_TrajectoryReferee_StaleTrackFailsOpen(t *testing.T) {
+	// After `gap` of silence the fresh pair sits exactly on the trajectory
+	// (20 blocks/s), i.e. the referee's evidence is otherwise perfect.
+	run := func(t *testing.T, gap time.Duration) (served, frozen, fresh int64, overrides float64) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+		frozen = warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+		before := servedTipTrajectoryCount(network, "latest", "override")
+
+		advance(gap)
+		fresh = frozen + trajectoryBlocksPerSample*int64(gap/servedTipSampleInterval)
+		for _, u := range ups[:2] {
+			suggestServedTipHead(u, fresh)
+		}
+		served = network.EvmHighestLatestBlockNumber(ctx)
+		return served, frozen, fresh, servedTipTrajectoryCount(network, "latest", "override") - before
+	}
+
+	t.Run("ContinuousTrackOverrides", func(t *testing.T) {
+		served, _, fresh, overrides := run(t, servedTipMaxSampleGap-5*time.Second)
+		assert.Equal(t, fresh, served, "an unbroken track lets the referee act")
+		assert.Equal(t, float64(1), overrides)
+	})
+
+	t.Run("GappedTrackFailsOpen", func(t *testing.T) {
+		served, frozen, _, overrides := run(t, servedTipMaxSampleGap+time.Second)
+		assert.Equal(t, frozen, served,
+			"one sample past the gap tolerance the same evidence must be refused")
+		assert.Zero(t, overrides)
+	})
+}
+
+// A chain that pauses and bursts (an L2 landing batches) has a large residual
+// spread of its own, which widens the referee's tolerance automatically — and a
+// legitimate fleet-wide jump keeps every head in ONE cluster, where the referee
+// has nothing to choose between. Neither may produce a false override.
+func TestServedTip_TrajectoryReferee_PauseThenBurstDoesNotFalsePositive(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+
+	// Same average velocity as the linear warm-up, delivered in batches: nine
+	// samples of nothing, then 1000 blocks at once.
+	head := trajectoryStartHead
+	for i := 0; i < trajectoryWarmSamples; i++ {
+		if i%10 == 9 {
+			head += trajectoryBlocksPerSample * 10
+		}
+		for _, u := range ups {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		require.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx))
+		advance(servedTipSampleInterval)
+	}
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeFallback := servedTipTrajectoryCount(network, "latest", "fallback")
+
+	// The whole fleet lands the next batch, with ordinary propagation skew.
+	head += 5_000
+	for i, u := range ups {
+		suggestServedTipHead(u, head-int64(i%2)*50)
+	}
+	served := network.EvmHighestLatestBlockNumber(ctx)
+
+	assert.Equal(t, head, served,
+		"a legitimate fleet-wide burst is one cluster; the majority pick stands")
+	assert.Equal(t, beforeOverride, servedTipTrajectoryCount(network, "latest", "override"))
+	assert.Equal(t, beforeFallback, servedTipTrajectoryCount(network, "latest", "fallback"),
+		"a fleet in one cluster does not even register a disagreement")
+}
+
+// Corroboration, not agreement with the model: a single upstream sitting
+// exactly where the trajectory says the head is proves nothing — it is the one
+// endpoint that could be wrong in the same direction as everyone else being
+// stuck. A group of one is never electable.
+func TestServedTip_TrajectoryReferee_SingletonIsNotCorroboration(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 1, 24)
+
+	assert.Equal(t, frozen, served,
+		"one on-trajectory witness cannot move the tip, however well it fits")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+}
+
+// Composition with the regression guard: the referee runs first and the guard
+// judges whatever comes out of it. Once a stall has handed the tip to the fresh
+// pair, losing that pair from the eligible set drops the majority pick far below
+// the best live head — and the guard holds the last corroborated value exactly
+// as it does for any other poisoned ballot.
+func TestServedTip_TrajectoryReferee_ComposesWithRegressionGuard(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+	require.Equal(t, fresh, served, "precondition: the referee is holding the tip on the fresh pair")
+	require.Greater(t, fresh-frozen, int64(common.DefaultToleratedBlockHeadRollback),
+		"precondition: the stall is deeper than the regression tolerance")
+
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	// One fresh upstream leaves the eligible set: the remaining ballot is
+	// [fresh, frozen, frozen] — a lone fresh head is no group, so the referee
+	// stands down and the majority pick collapses onto the stalled pair.
+	network.PinUpstreamOrderForTest("u1", "u3", "u4")
+
+	assert.Equal(t, fresh, network.EvmHighestLatestBlockNumber(ctx),
+		"the guard must hold the last corroborated pick, as it does for any poisoned ballot")
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "held"))
+}
+
+// The off switch is a real off switch: trajectoryWindow: 0 records nothing and
+// decides nothing, so the network serves the plain majority pick — the stale
+// head — through the exact scenario the referee exists to fix.
+func TestServedTip_TrajectoryReferee_DisabledByZeroWindow(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{
+		EnabledFor:       []string{"latest"},
+		TrajectoryWindow: common.Duration(0).Ptr(),
+	})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	assert.Equal(t, frozen, served,
+		"with the referee off the stalled majority defines the tip again")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+	assert.Zero(t, network.servedLatestAnchor.trajectory.SampleCount(),
+		"a disabled referee must not even record a head track")
 }

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -1197,6 +1197,203 @@ func TestServedTip_RegressionGuard_SingleRogueUpstreamDoesNotDisarmIt(t *testing
 // once they return. main, which remembers nothing, recovers on the next
 // evaluation; the memory must not make us worse than that.
 func TestServedTip_RegressionGuard_DoesNotCommitAFantasyPick(t *testing.T) {
+	// fantasyFleet returns a network whose eligible set can be reshaped at will:
+	// the syncing state is how an upstream leaves and RE-ENTERS the ballot (the
+	// order-pinning helper only ever removes, and removes from the registry).
+	fantasyFleet := func(t *testing.T, ctx context.Context) (*Network, func(id string, in bool), func(time.Duration)) {
+		util.SetupMocksForEvmStatePoller()
+		advance := pinServedTipClock(t)
+		network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
+			{id: "rogue-1", chainID: 123, latestBlock: 100_000_000},
+			{id: "rogue-2", chainID: 123, latestBlock: 100_000_000},
+			{id: "h1", chainID: 123, latestBlock: 10_000},
+			{id: "h2", chainID: 123, latestBlock: 10_000},
+			{id: "h3", chainID: 123, latestBlock: 10_000},
+			{id: "stuck-1", chainID: 123, latestBlock: 5},
+			{id: "stuck-2", chainID: 123, latestBlock: 5},
+		})
+		byID := map[string]*upstream.Upstream{}
+		for _, u := range ups {
+			byID[u.Id()] = u
+		}
+		eligible := func(id string, in bool) {
+			st := common.EvmSyncingStateSyncing
+			if in {
+				st = common.EvmSyncingStateNotSyncing
+			}
+			byID[id].EvmStatePoller().SetSyncingState(st)
+		}
+		for _, id := range []string{"rogue-1", "rogue-2", "h1", "h2", "h3", "stuck-1", "stuck-2"} {
+			eligible(id, false)
+		}
+		return network, eligible, advance
+	}
+
+	// The armed case: a fresh memory refuses an uncorroborated leap.
+	t.Run("WhileArmed", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		network, eligible, advance := fantasyFleet(t, ctx)
+
+		for _, id := range []string{"h1", "h2", "h3"} {
+			eligible(id, true)
+		}
+		require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+		require.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load())
+
+		// Both rogues return, two honest upstreams drop out: the ballot is
+		// [100M, 100M, 10000] and the majority pick IS the fantasy.
+		eligible("rogue-1", true)
+		eligible("rogue-2", true)
+		eligible("h2", false)
+		eligible("h3", false)
+		advance(time.Second)
+		require.Equal(t, int64(100_000_000), network.EvmHighestLatestBlockNumber(ctx),
+			"precondition: the majority of this eligible set really is far-future")
+		assert.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load(),
+			"an uncorroborated leap must never become the value the guard holds the network to")
+
+		eligible("h2", true)
+		eligible("h3", true)
+		eligible("rogue-2", false)
+		advance(time.Second)
+		assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+			"recovery must be immediate, not after the guard's TTL expires")
+	})
+
+	// THE UNARMED CASE, and the one that mattered: every fail-open DISARMS, and
+	// an empty memory used to arm at whatever pick appeared next. The window
+	// right after a fail-open is exactly when a rogue majority is most likely,
+	// so that is precisely where the continuity check is needed.
+	t.Run("AfterFailOpenDisarm", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		network, eligible, advance := fantasyFleet(t, ctx)
+		anchor := &network.servedLatestAnchor
+
+		// 1. Armed at the honest head.
+		for _, id := range []string{"h1", "h2", "h3"} {
+			eligible(id, true)
+		}
+		require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+		require.Equal(t, int64(10_000), anchor.lastGoodValue.Load())
+
+		// 2. A poisoned ballot is held.
+		eligible("h2", false)
+		eligible("h3", false)
+		eligible("stuck-1", true)
+		eligible("stuck-2", true)
+		require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+			"precondition: the guard is holding the poisoned ballot")
+
+		// 3. The hold outlasts its window: fail open, and disarm.
+		advance(servedTipRegressionTTL + time.Second)
+		require.Equal(t, int64(5), network.EvmHighestLatestBlockNumber(ctx))
+		require.Zero(t, anchor.lastGoodValue.Load(), "precondition: failing open disarms the memory")
+
+		// 4. One majority-rogue evaluation. It must SERVE the rogue value — no
+		//    arming rule may ever constrain what is served — and must commit
+		//    nothing, because 100M has no continuity with anything this process
+		//    has served.
+		eligible("stuck-1", false)
+		eligible("stuck-2", false)
+		eligible("rogue-1", true)
+		eligible("rogue-2", true)
+		advance(time.Second)
+		assert.Equal(t, int64(100_000_000), network.EvmHighestLatestBlockNumber(ctx),
+			"serving is never constrained by an arming rule: the pick is the pick")
+		assert.Zero(t, anchor.lastGoodValue.Load(),
+			"but an unarmed guard must not commit a value discontinuous with what it just served")
+
+		// 5. The honest fleet returns: immediate recovery, and the memory arms
+		//    at the honest head.
+		eligible("h2", true)
+		eligible("h3", true)
+		eligible("rogue-1", false)
+		eligible("rogue-2", false)
+		advance(time.Second)
+		assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+			"recovery on the very next evaluation, exactly as a guardless process behaves")
+		assert.Equal(t, int64(10_000), anchor.lastGoodValue.Load(),
+			"and the memory re-arms at the honest head")
+	})
+
+	// A true first evaluation has no history to be continuous with, so it arms
+	// unconditionally: one evaluation of exposure, which is what a process with
+	// no guard at all has permanently. The value must still not survive contact
+	// with the honest fleet.
+	t.Run("AtColdBoot", func(t *testing.T) {
+		util.ResetGock()
+		defer util.ResetGock()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		network, eligible, advance := fantasyFleet(t, ctx)
+		anchor := &network.servedLatestAnchor
+
+		// The very first evaluation this process ever makes is majority-rogue.
+		eligible("rogue-1", true)
+		eligible("rogue-2", true)
+		eligible("h1", true)
+		require.Zero(t, anchor.seenValue.Load(), "precondition: nothing has ever been served")
+		require.Equal(t, int64(100_000_000), network.EvmHighestLatestBlockNumber(ctx))
+		require.Equal(t, int64(100_000_000), anchor.lastGoodValue.Load(),
+			"with no history at all there is nothing to be continuous with")
+
+		// The honest fleet arrives.
+		eligible("h2", true)
+		eligible("h3", true)
+		eligible("rogue-1", false)
+		eligible("rogue-2", false)
+		advance(time.Second)
+		assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+			"a boot-time fantasy must not survive the first honest evaluation")
+	})
+}
+
+// A hold may only ever RAISE the served value toward the corroborated past. A
+// memory that is stale-LOW (the live corroborated head is what tripped the
+// tolerance, not the memory) must never drag the tip below the pick the ballot
+// produced — that is the harm the guard exists to prevent, inflicted by the
+// guard itself. Driven through guardServedTipRegression directly, because the
+// shape needs a memory the fleet has long since left behind.
+func TestServedTip_RegressionGuard_AHoldNeverLowersTheTip(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "u1", chainID: 123, latestBlock: 10_000},
+		{id: "u2", chainID: 123, latestBlock: 10_000},
+	})
+
+	var anchor servedTipAnchor
+	anchor.lastGoodValue.Store(100)
+	at := servedTipClock()
+	anchor.lastGoodAt.Store(&at)
+
+	// The ballot's own corroborated head is 10_000, so a pick of 5_000 trips the
+	// guard — but the memory (100) is far below the pick.
+	served := network.guardServedTipRegression("latest", "", &anchor, 5_000,
+		servedTipReference{Corroborated: 10_000, Max: 10_000})
+
+	assert.GreaterOrEqual(t, served, int64(5_000),
+		"a hold must never serve a block LOWER than the pick it was suppressing")
+	assert.Equal(t, int64(5_000), served, "with nothing better to offer, the guard is transparent")
+}
+
+// The guard runs several times per request, so its steady state must not
+// allocate. The only heap allocation on the healthy path is the time.Time the
+// atomic pointer owns, and the once-a-second throttle keeps it off every other
+// evaluation.
+func TestServedTip_RegressionGuard_HealthyPathDoesNotAllocate(t *testing.T) {
 	util.ResetGock()
 	defer util.ResetGock()
 	util.SetupMocksForEvmStatePoller()
@@ -1205,48 +1402,27 @@ func TestServedTip_RegressionGuard_DoesNotCommitAFantasyPick(t *testing.T) {
 	defer cancel()
 	advance := pinServedTipClock(t)
 
-	network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
-		{id: "rogue-1", chainID: 123, latestBlock: 100_000_000},
-		{id: "rogue-2", chainID: 123, latestBlock: 100_000_000},
-		{id: "h1", chainID: 123, latestBlock: 10_000},
-		{id: "h2", chainID: 123, latestBlock: 10_000},
-		{id: "h3", chainID: 123, latestBlock: 10_000},
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "u1", chainID: 123, latestBlock: 10_000},
+		{id: "u2", chainID: 123, latestBlock: 10_000},
 	})
-	// The syncing state is how an upstream leaves and RE-ENTERS the ballot; the
-	// order-pinning helper only ever removes.
-	eligible := func(i int, in bool) {
-		st := common.EvmSyncingStateSyncing
-		if in {
-			st = common.EvmSyncingStateNotSyncing
-		}
-		ups[i].EvmStatePoller().SetSyncingState(st)
-	}
 
-	// Honest steady state arms the guard at the honest head.
-	eligible(0, false)
-	eligible(1, false)
-	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
-	require.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load())
+	var anchor servedTipAnchor
+	ref := servedTipReference{Corroborated: 10_000, Max: 10_000}
+	require.Equal(t, int64(10_000), network.guardServedTipRegression("latest", "", &anchor, 10_000, ref),
+		"arm the guard first; that evaluation is the one allowed to allocate")
 
-	// The window: both rogues return, two honest upstreams drop out. The ballot
-	// is [100M, 100M, 10000] and the majority pick IS the fantasy.
-	eligible(0, true)
-	eligible(1, true)
-	eligible(3, false)
-	eligible(4, false)
-	advance(time.Second)
-	require.Equal(t, int64(100_000_000), network.EvmHighestLatestBlockNumber(ctx),
-		"precondition: the majority of this eligible set really is far-future")
-	assert.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load(),
-		"but an uncorroborated leap must never become the value the guard holds the network to")
+	allocs := testing.AllocsPerRun(200, func() {
+		network.guardServedTipRegression("latest", "", &anchor, 10_000, ref)
+	})
+	assert.Zero(t, allocs, "the throttled healthy path must not allocate at all")
 
-	// The honest fleet returns (one rogue still eligible, as in a real recovery).
-	eligible(3, true)
-	eligible(4, true)
-	eligible(1, false)
-	advance(time.Second)
-	assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
-		"recovery must be immediate, not after the guard's TTL expires")
+	// And the throttle is a throttle, not a disable: past a second the clock is
+	// refreshed again.
+	advance(2 * time.Second)
+	before := anchor.lastGoodAt.Load()
+	network.guardServedTipRegression("latest", "", &anchor, 10_000, ref)
+	assert.NotEqual(t, before, anchor.lastGoodAt.Load(), "the TTL clock still advances")
 }
 
 // The off switch, symmetric with trajectoryWindow: 0.

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -27,12 +27,17 @@ import (
 // servedTipFixture is a compact description of one upstream's poller state
 // at test time. Used to drive the lighter setupServedTipNetwork helper.
 type servedTipFixture struct {
-	id            string
-	chainID       int64
-	latestBlock   int64
-	syncing       bool
-	ignoreMethods []string
-	tags          []string
+	id          string
+	chainID     int64
+	latestBlock int64
+	// upperExactBlock, when > 0, configures blockAvailability.upper.exactBlock —
+	// the upstream still polls latestBlock as its head, but only SERVES up to
+	// this block, so its effective latest is the bound rather than a head
+	// observation (the celo "legacy" upstream shape).
+	upperExactBlock int64
+	syncing         bool
+	ignoreMethods   []string
+	tags            []string
 }
 
 // setupServedTipNetwork bootstraps a Network with the supplied upstream
@@ -66,15 +71,20 @@ func setupServedTipNetworkWith(t *testing.T, ctx context.Context, fixtures []ser
 			cid = chainID
 		}
 		endpoint := "http://" + f.id + ".localhost"
+		evmCfg := &common.EvmUpstreamConfig{ChainId: cid}
+		if f.upperExactBlock > 0 {
+			upper := f.upperExactBlock
+			evmCfg.BlockAvailability = &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{ExactBlock: &upper},
+			}
+		}
 		upstreamConfigs = append(upstreamConfigs, &common.UpstreamConfig{
 			Type:          common.UpstreamTypeEvm,
 			Id:            f.id,
 			Endpoint:      endpoint,
 			IgnoreMethods: f.ignoreMethods,
 			Tags:          f.tags,
-			Evm: &common.EvmUpstreamConfig{
-				ChainId: cid,
-			},
+			Evm:           evmCfg,
 		})
 
 		gock.New(endpoint).
@@ -655,4 +665,86 @@ func TestServedTip_HaltedChainResume_CatchesUpImmediately(t *testing.T) {
 	}
 	assert.Equal(t, int64(600), network.EvmHighestLatestBlockNumber(ctx),
 		"the post-halt burst must be served on the first pick that sees it")
+}
+
+// ─── Availability bounds are not head observations (2026-08 celo) ────────────
+
+// A blockAvailability.upper bound is a SERVING-RANGE declaration, not a view of
+// the chain head, so it must not appear on the ballot while any live head does.
+// Two upstreams pinned at `upper.exactBlock` (their pollers sitting at the live
+// tip) used to outvote the live heads as soon as the eligible set shrank —
+// exactly how celo served September-2023 state on 2026-08-11.
+func TestServedTip_BoundCappedUpstreamsDoNotVote(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 9_998},
+		{id: "capped-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+	})
+
+	// Ballot without the caps: [10000, 9998] → the lower live head.
+	// With them it would be [10000, 9998, 5000, 5000] → 3rd highest = 5000.
+	assert.Equal(t, int64(9_998), network.EvmHighestLatestBlockNumber(ctx),
+		"a bound-capped upstream declares what it SERVES, not where the head is; "+
+			"it must not vote a cap onto the ballot while live heads exist")
+}
+
+// The all-capped pool is the legitimate case for a cap to be served: a network
+// of only historical/frozen upstreams has no live head to prefer, and its cap
+// IS the freshest block anyone can serve. Unchanged by the filter.
+func TestServedTip_AllCappedPool_ServesTheCap(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "capped-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-3", chainID: 123, latestBlock: 10_000, upperExactBlock: 4_000},
+	})
+
+	assert.Equal(t, int64(5_000), network.EvmHighestLatestBlockNumber(ctx),
+		"with no live head on the ballot the caps are the only observations there are; "+
+			"the majority of [5000,5000,4000] must still be served")
+}
+
+// Every candidate filtered (all syncing here) → the tip is UNKNOWN, and unknown
+// must stay unknown: eth_blockNumber falls through untouched and "latest" is
+// left uninterpolated (architecture/evm: resolveBlockTagToHex and the
+// eth_blockNumber pin both fail open on <= 0 — "never synthesize a block number
+// from nothing"). The regression guard must not resurrect a remembered tip
+// here either: with nothing to corroborate it, a held value would be exactly
+// the frozen tip served from memory that this design forbids.
+func TestServedTip_AllInputsFiltered_FailsOpenToZero(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "u1", chainID: 123, latestBlock: 10_000},
+		{id: "u2", chainID: 123, latestBlock: 10_000},
+		{id: "u3", chainID: 123, latestBlock: 10_000},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"healthy pick first, so the guard has a corroborated value to (not) serve")
+
+	for _, u := range ups {
+		u.EvmStatePoller().SetSyncingState(common.EvmSyncingStateSyncing)
+	}
+
+	assert.Equal(t, int64(0), network.EvmHighestLatestBlockNumber(ctx),
+		"no eligible observations → unknown tip (0), never a remembered one")
 }

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -948,6 +948,13 @@ func servedTipTrajectoryCount(n *Network, axis, outcome string) float64 {
 		WithLabelValues(n.projectId, n.Label(), servedTipLaneAll, axis, outcome))
 }
 
+// servedTipRefereeOverriding reports whether the network-wide latest lane is
+// CURRENTLY being overridden by the referee — the state the transition log and
+// counter are driven from.
+func servedTipRefereeOverriding(n *Network) bool {
+	return n.servedLatestAnchor.trajectoryOverriding.Load()
+}
+
 // setupTrajectoryNetwork builds a `count`-upstream network with the pinned
 // served-tip clock, and returns the clock's advance function.
 func setupTrajectoryNetwork(t *testing.T, ctx context.Context, count int, stCfg *common.EvmServedTipConfig) (*Network, []*upstream.Upstream, func(time.Duration)) {
@@ -1064,6 +1071,102 @@ func TestServedTip_TrajectoryReferee_StalledMajorityLosesToFreshMinority(t *test
 		"raising the tip to the live pair is not a regression; the guard must stay out of it")
 }
 
+// A routine transient: two of four upstreams fall behind for 15 seconds (a
+// poller hiccup, a vendor blip) and catch up. Nothing is wrong with the fleet,
+// and the value every upstream can serve is the lagged head — an intervention
+// here would advertise a block only half the fleet has, for minutes. This shape
+// is why corroboration has to be earned over time rather than in one instant.
+func TestServedTip_TrajectoryReferee_TransientHalfFleetLagIsNotAnOverride(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 4, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	head := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+	lagged := head
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+
+	// Three ticks in which only u1/u2 advance: u3/u4 end 300 blocks (15s of this
+	// 20 blocks/s chain) behind — past the 200-block cluster width, so the fleet
+	// reads as two groups of two.
+	fresh, served := stallMajority(t, ctx, network, ups, advance, head, 2, 3)
+
+	assert.Equal(t, lagged, served,
+		"a 15-second divergence must keep serving the value all four upstreams have (fresh pair was at %d)", fresh)
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"),
+		"and must not be counted as an intervention")
+}
+
+// A PERMANENTLY split fleet (the flashblocks shape: two upstreams always ~300
+// blocks ahead, both halves advancing at the same velocity) is a normal
+// topology, not a stall. The trajectory is fitted to the MEDIAN of the live
+// heads, so no permanently-offset group is ever closer to it than the median's
+// own — the referee has nothing to correct and stays silent forever.
+func TestServedTip_TrajectoryReferee_PermanentlySplitFleetIsSilent(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 4, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	before := servedTipTrajectoryCount(network, "latest", "override")
+
+	head := trajectoryStartHead
+	for i := 0; i < trajectoryWarmSamples+40; i++ {
+		for j, u := range ups {
+			target := head
+			if j < 2 {
+				target = head + 300 // the always-ahead pair
+			}
+			suggestServedTipHead(u, target)
+		}
+		network.EvmHighestLatestBlockNumber(ctx)
+		advance(servedTipSampleInterval)
+		head += trajectoryBlocksPerSample
+	}
+
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"),
+		"a permanently split fleet must never trigger an override")
+}
+
+// The referee's intervention EXPIRES on its own. Once the group it elected stops
+// advancing, that group can no longer have produced the chain progress the fit
+// describes, and the override ends without any operator action — the property
+// that makes an upward-only referee unable to pin a tip the way the 2026-06
+// clamp did.
+func TestServedTip_TrajectoryReferee_OverrideSelfExpires(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+	require.Equal(t, fresh, served, "precondition: the referee is holding the tip on the corroborated pair")
+
+	require.True(t, servedTipRefereeOverriding(network), "precondition: the referee reports itself as overriding")
+
+	// Now the whole chain stops: nobody advances, including the elected pair.
+	for i := 0; i < 240; i++ {
+		advance(servedTipSampleInterval)
+		network.EvmHighestLatestBlockNumber(ctx)
+		if !servedTipRefereeOverriding(network) {
+			t.Logf("override expired after %v of a fully halted chain", time.Duration(i+1)*servedTipSampleInterval)
+			return
+		}
+	}
+	t.Fatalf("the override never expired over %v of a halted chain", 240*servedTipSampleInterval)
+}
+
 // The inverse split, and the reason a group is elected by its DISTANCE to the
 // trajectory rather than by its freshness: two upstreams running far past where
 // the chain can possibly be (wrong chain, garbage endpoint) must lose to the
@@ -1136,8 +1239,10 @@ func TestServedTip_TrajectoryReferee_ColdProcessIsInert(t *testing.T) {
 // hides, so extrapolating across one is guessing — and the referee stands down.
 // The paired sub-tests differ ONLY in the size of that gap.
 func TestServedTip_TrajectoryReferee_StaleTrackFailsOpen(t *testing.T) {
-	// After `gap` of silence the fresh pair sits exactly on the trajectory
-	// (20 blocks/s), i.e. the referee's evidence is otherwise perfect.
+	// After `gap` of silence the fresh pair returns exactly on the trajectory
+	// (20 blocks/s) and then HOLDS it for longer than the dwell — i.e. the
+	// referee's evidence is otherwise perfect, and the only difference between
+	// the sub-tests is whether the hole in the track is inside the tolerance.
 	run := func(t *testing.T, gap time.Duration) (served, frozen, fresh int64, overrides float64) {
 		util.ResetGock()
 		defer util.ResetGock()
@@ -1156,13 +1261,24 @@ func TestServedTip_TrajectoryReferee_StaleTrackFailsOpen(t *testing.T) {
 			suggestServedTipHead(u, fresh)
 		}
 		served = network.EvmHighestLatestBlockNumber(ctx)
+
+		// Eight more samples (40s) of the pair tracking the chain: enough dwell
+		// for a group that is genuinely where the head should be.
+		for i := 0; i < 8; i++ {
+			advance(servedTipSampleInterval)
+			fresh += trajectoryBlocksPerSample
+			for _, u := range ups[:2] {
+				suggestServedTipHead(u, fresh)
+			}
+			served = network.EvmHighestLatestBlockNumber(ctx)
+		}
 		return served, frozen, fresh, servedTipTrajectoryCount(network, "latest", "override") - before
 	}
 
 	t.Run("ContinuousTrackOverrides", func(t *testing.T) {
 		served, _, fresh, overrides := run(t, servedTipMaxSampleGap-5*time.Second)
 		assert.Equal(t, fresh, served, "an unbroken track lets the referee act")
-		assert.Equal(t, float64(1), overrides)
+		assert.Positive(t, overrides)
 	})
 
 	t.Run("GappedTrackFailsOpen", func(t *testing.T) {

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -1190,6 +1190,65 @@ func TestServedTip_RegressionGuard_SingleRogueUpstreamDoesNotDisarmIt(t *testing
 		"the armed guard holds the corroborated pick when the ballot collapses")
 }
 
+// The guard's memory must not be able to commit a FANTASY. If the eligible set
+// is momentarily majority far-future — two wrong-chain upstreams outvoting one
+// honest head while the rest are lag-excluded — the pick IS that fantasy, and a
+// guard that remembers it holds it against the honest fleet for the whole TTL
+// once they return. main, which remembers nothing, recovers on the next
+// evaluation; the memory must not make us worse than that.
+func TestServedTip_RegressionGuard_DoesNotCommitAFantasyPick(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	advance := pinServedTipClock(t)
+
+	network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "rogue-1", chainID: 123, latestBlock: 100_000_000},
+		{id: "rogue-2", chainID: 123, latestBlock: 100_000_000},
+		{id: "h1", chainID: 123, latestBlock: 10_000},
+		{id: "h2", chainID: 123, latestBlock: 10_000},
+		{id: "h3", chainID: 123, latestBlock: 10_000},
+	})
+	// The syncing state is how an upstream leaves and RE-ENTERS the ballot; the
+	// order-pinning helper only ever removes.
+	eligible := func(i int, in bool) {
+		st := common.EvmSyncingStateSyncing
+		if in {
+			st = common.EvmSyncingStateNotSyncing
+		}
+		ups[i].EvmStatePoller().SetSyncingState(st)
+	}
+
+	// Honest steady state arms the guard at the honest head.
+	eligible(0, false)
+	eligible(1, false)
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	require.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load())
+
+	// The window: both rogues return, two honest upstreams drop out. The ballot
+	// is [100M, 100M, 10000] and the majority pick IS the fantasy.
+	eligible(0, true)
+	eligible(1, true)
+	eligible(3, false)
+	eligible(4, false)
+	advance(time.Second)
+	require.Equal(t, int64(100_000_000), network.EvmHighestLatestBlockNumber(ctx),
+		"precondition: the majority of this eligible set really is far-future")
+	assert.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load(),
+		"but an uncorroborated leap must never become the value the guard holds the network to")
+
+	// The honest fleet returns (one rogue still eligible, as in a real recovery).
+	eligible(3, true)
+	eligible(4, true)
+	eligible(1, false)
+	advance(time.Second)
+	assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"recovery must be immediate, not after the guard's TTL expires")
+}
+
 // The off switch, symmetric with trajectoryWindow: 0.
 func TestServedTip_RegressionGuard_DisabledByNegativeOne(t *testing.T) {
 	util.ResetGock()

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -40,9 +40,14 @@ type servedTipFixture struct {
 	// this block, so its effective latest is the bound rather than a head
 	// observation (the celo "legacy" upstream shape).
 	upperExactBlock int64
-	syncing         bool
-	ignoreMethods   []string
-	tags            []string
+	// upperLatestMinus, when set, configures blockAvailability.upper.latestBlockMinus
+	// — a bound DERIVED from the upstream's own head, so it tracks the chain at
+	// a fixed lag and remains a head observation (the "serve up to head-N"
+	// shape).
+	upperLatestMinus *int64
+	syncing          bool
+	ignoreMethods    []string
+	tags             []string
 }
 
 // setupServedTipNetwork bootstraps a Network with the supplied upstream
@@ -81,6 +86,11 @@ func setupServedTipNetworkWith(t *testing.T, ctx context.Context, fixtures []ser
 			upper := f.upperExactBlock
 			evmCfg.BlockAvailability = &common.EvmBlockAvailabilityConfig{
 				Upper: &common.EvmAvailabilityBoundConfig{ExactBlock: &upper},
+			}
+		}
+		if f.upperLatestMinus != nil {
+			evmCfg.BlockAvailability = &common.EvmBlockAvailabilityConfig{
+				Upper: &common.EvmAvailabilityBoundConfig{LatestBlockMinus: f.upperLatestMinus},
 			}
 		}
 		upstreamConfigs = append(upstreamConfigs, &common.UpstreamConfig{
@@ -699,6 +709,131 @@ func TestServedTip_BoundCappedUpstreamsDoNotVote(t *testing.T) {
 	assert.Equal(t, int64(9_998), network.EvmHighestLatestBlockNumber(ctx),
 		"a bound-capped upstream declares what it SERVES, not where the head is; "+
 			"it must not vote a cap onto the ballot while live heads exist")
+}
+
+// A DERIVED upper bound is still a head observation. `upper.latestBlockMinus: N`
+// tracks the chain at a fixed lag — such an upstream knows exactly where the head
+// is, it just declines to serve the last N blocks — so it must keep voting. The
+// earlier dynamic classification ("the resolved upper bound is below the head")
+// could not tell it apart from a frozen serving range and dropped all three of
+// them here, handing the tip to the single unbounded upstream: a tip four of four
+// upstreams could serve became one only one of them could.
+func TestServedTip_LatestBlockMinusUpstreamsStillVote(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	minus := int64(5)
+	network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "u1", chainID: 123, latestBlock: 10_000},
+		{id: "u2", chainID: 123, latestBlock: 10_000, upperLatestMinus: &minus},
+		{id: "u3", chainID: 123, latestBlock: 10_000, upperLatestMinus: &minus},
+		{id: "u4", chainID: 123, latestBlock: 10_000, upperLatestMinus: &minus},
+	})
+
+	served := network.EvmHighestLatestBlockNumber(ctx)
+	assert.Equal(t, int64(9_995), served,
+		"the ballot is [10000, 9995, 9995, 9995]: a lagging-but-live bound is a head observation")
+
+	// And the point of the majority pick holds: the advertised tip is servable
+	// by a majority of the upstreams that produced it.
+	canServe := 0
+	for _, u := range ups {
+		ok, err := u.EvmAssertBlockAvailability(ctx, "eth_call", common.AvailbilityConfidenceBlockHead, false, served)
+		require.NoError(t, err)
+		if ok {
+			canServe++
+		}
+	}
+	assert.Greater(t, canServe, len(ups)/2,
+		"served tip %d must be servable by a majority; only %d of %d upstreams can serve it",
+		served, canServe, len(ups))
+}
+
+// The guaranteed-method floor was the second door onto the incident value: its
+// ballot took raw effective heads and ran AFTER the guard, so a static cap that
+// the network ballot had just refused came back as a "floor" and was served.
+// The floor now builds its per-method ballot with the same rule.
+func TestServedTip_GuaranteedMethodFloorCannotReadmitTheCap(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const legacyCap = int64(21_615_999)
+	network, _ := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+		{id: "prism-celo", chainID: 123, latestBlock: 74_550_978},
+		{id: "celo-mainnet-nirvana", chainID: 123, latestBlock: 74_550_974},
+		{id: "quicknode-celo", chainID: 123, latestBlock: 74_550_946},
+		{id: "celo-mainnet-nirvana-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+		{id: "quicknode-celo-legacy", chainID: 123, latestBlock: 74_550_978, upperExactBlock: legacyCap},
+	}, &common.EvmServedTipConfig{
+		EnabledFor:        []string{"latest"},
+		GuaranteedMethods: []string{"eth_getLogs"},
+	})
+
+	require.Greater(t, network.EvmHighestLatestBlockNumber(ctx), legacyCap,
+		"precondition: with the full fleet eligible the tip is a live head")
+
+	// The incident ballot: one live upstream lag-excluded.
+	network.PinUpstreamOrderForTest("celo-mainnet-nirvana", "quicknode-celo", "celo-mainnet-nirvana-legacy", "quicknode-celo-legacy")
+
+	assert.Greater(t, network.EvmHighestLatestBlockNumber(ctx), legacyCap,
+		"the guaranteed-method floor must not re-admit the serving range the ballot filter removed")
+}
+
+// The floor's PURPOSE is unchanged by that filter: when only capped upstreams
+// support a guaranteed method, they are the only upstreams that can serve it at
+// all, so their cap is exactly the floor the tip must respect.
+func TestServedTip_GuaranteedMethodFloor_CapsStillSetTheFloorWhenAloneOnAMethod(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, _ := setupServedTipNetworkWith(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000, ignoreMethods: []string{"trace_block"}},
+		{id: "live-2", chainID: 123, latestBlock: 10_000, ignoreMethods: []string{"trace_block"}},
+		{id: "archive-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "archive-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+	}, &common.EvmServedTipConfig{
+		EnabledFor:        []string{"latest"},
+		GuaranteedMethods: []string{"trace_block"},
+	})
+
+	assert.Equal(t, int64(5_000), network.EvmHighestLatestBlockNumber(ctx),
+		"only the capped pair serves trace_block, so their range IS the guarantee")
+}
+
+// A ballot the filter shrinks to a SINGLE live upstream is served as that
+// upstream's head — deliberately. One live witness is thin evidence, but the
+// alternative is advertising a serving range that stopped tracking the chain
+// years ago, and the regression guard bounds how far the tip may move from what
+// this process last saw corroborated.
+func TestServedTip_CapFilterMayShrinkTheBallotToOneLiveUpstream(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "capped-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+	})
+
+	assert.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx),
+		"one live head beats two serving ranges; the ballot is [10000], not [10000,5000,5000]")
 }
 
 // The all-capped pool is the legitimate case for a cap to be served: a network

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -1220,11 +1220,11 @@ func servedTipTrajectoryCount(n *Network, axis, outcome string) float64 {
 		WithLabelValues(n.projectId, n.Label(), servedTipLaneAll, axis, outcome))
 }
 
-// servedTipRefereeOverriding reports whether the network-wide latest lane is
+// servedTipIsOverriding reports whether the network-wide latest lane is
 // CURRENTLY being overridden by the referee — the state the transition log and
 // counter are driven from.
-func servedTipRefereeOverriding(n *Network) bool {
-	return n.servedLatestAnchor.trajectoryOverriding.Load()
+func servedTipIsOverriding(n *Network) bool {
+	return n.servedLatestAnchor.refereeState.Load() == servedTipRefereeOverriding
 }
 
 // setupTrajectoryNetwork builds a `count`-upstream network with the pinned
@@ -1425,13 +1425,13 @@ func TestServedTip_TrajectoryReferee_OverrideSelfExpires(t *testing.T) {
 	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
 	require.Equal(t, fresh, served, "precondition: the referee is holding the tip on the corroborated pair")
 
-	require.True(t, servedTipRefereeOverriding(network), "precondition: the referee reports itself as overriding")
+	require.True(t, servedTipIsOverriding(network), "precondition: the referee reports itself as overriding")
 
 	// Now the whole chain stops: nobody advances, including the elected pair.
 	for i := 0; i < 240; i++ {
 		advance(servedTipSampleInterval)
 		network.EvmHighestLatestBlockNumber(ctx)
-		if !servedTipRefereeOverriding(network) {
+		if !servedTipIsOverriding(network) {
 			t.Logf("override expired after %v of a fully halted chain", time.Duration(i+1)*servedTipSampleInterval)
 			return
 		}
@@ -1659,6 +1659,216 @@ func TestServedTip_TrajectoryReferee_ComposesWithRegressionGuard(t *testing.T) {
 	assert.Equal(t, fresh, network.EvmHighestLatestBlockNumber(ctx),
 		"the guard must hold the last corroborated pick, as it does for any poisoned ballot")
 	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "held"))
+}
+
+// ─── The finalized axis is not a second-class citizen ────────────────────────
+//
+// Every mechanism runs per axis, and the finalized tip drives cache finality and
+// the availability gate just as the latest tip drives interpolation. These pin
+// all three of them end to end on `finalized`.
+
+// setServedTipFinalized pushes an upstream's finalized head and waits for the
+// poller's asynchronous suggestion path to apply it.
+func setServedTipFinalized(t *testing.T, u *upstream.Upstream, head int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		if u.EvmStatePoller().FinalizedBlock() >= head {
+			return true
+		}
+		u.EvmStatePoller().SuggestFinalizedBlock(head)
+		return u.EvmStatePoller().FinalizedBlock() >= head
+	}, 5*time.Second, time.Millisecond, "finalized head %d never applied on %s", head, u.Id())
+}
+
+// A serving-range cap must not define the FINALIZED tip either — same filter,
+// same per-axis head comparison.
+func TestServedTip_Finalized_BoundCappedUpstreamsDoNotVote(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "capped-1", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+		{id: "capped-2", chainID: 123, latestBlock: 10_000, upperExactBlock: 5_000},
+	})
+	for i, u := range ups {
+		fin := int64(9_900)
+		if i == 1 {
+			fin = 9_898
+		}
+		setServedTipFinalized(t, u, fin)
+	}
+
+	assert.Equal(t, int64(9_898), network.EvmHighestFinalizedBlockNumber(ctx),
+		"the capped pair's effective finalized is their 5000 bound, which is a serving range, not a finalized head")
+}
+
+// The regression guard and the trajectory referee, both on the finalized axis,
+// in one run: warm a finalized head track, stall the majority (the referee must
+// serve the corroborated fresh pair), then lose one of that pair from the
+// eligible set (the guard must hold what it last saw corroborated).
+func TestServedTip_Finalized_RefereeAndGuardEndToEnd(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"finalized"}})
+
+	head := trajectoryStartHead
+	for i := 0; i < trajectoryWarmSamples; i++ {
+		for _, u := range ups {
+			setServedTipFinalized(t, u, head)
+		}
+		require.Equal(t, head, network.EvmHighestFinalizedBlockNumber(ctx),
+			"warm-up sample %d: an agreeing fleet serves its agreed finalized head", i)
+		advance(servedTipSampleInterval)
+		head += trajectoryBlocksPerSample
+	}
+	frozen := head - trajectoryBlocksPerSample
+
+	// The stall: three finalized heads freeze, two keep tracking the chain.
+	var served int64
+	for i := 0; i < 24; i++ {
+		for _, u := range ups[:2] {
+			setServedTipFinalized(t, u, head)
+		}
+		served = network.EvmHighestFinalizedBlockNumber(ctx)
+		advance(servedTipSampleInterval)
+		head += trajectoryBlocksPerSample
+	}
+	fresh := head - trajectoryBlocksPerSample
+	require.Equal(t, fresh, served,
+		"the corroborated fresh pair must define the finalized tip; the plain majority would serve %d", frozen)
+	assert.Positive(t, servedTipTrajectoryCount(network, "finalized", "override"),
+		"the finalized axis gets its own counter series")
+
+	// One of the fresh pair leaves: the ballot collapses onto the stalled trio
+	// and the guard holds the last corroborated finalized tip.
+	before := servedTipRegressionCount(network, "finalized", "held")
+	network.PinUpstreamOrderForTest("u1", "u3", "u4")
+	assert.Equal(t, fresh, network.EvmHighestFinalizedBlockNumber(ctx),
+		"the guard protects the finalized axis exactly as it protects latest")
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "finalized", "held"))
+}
+
+// The guard's clamp branch: the upstream that backed the remembered pick leaves
+// the eligible set and the best remaining LIVE head is BELOW it, so the held
+// value must be capped to what a live upstream actually has.
+func TestServedTip_RegressionGuard_HeldValueIsClampedToTheLiveHead(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "live-4", chainID: 123, latestBlock: 10_000},
+		{id: "low", chainID: 123, latestBlock: 9_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	require.Equal(t, int64(10_000), network.servedLatestAnchor.lastGoodValue.Load())
+
+	// Every upstream that had 10_000 drops out. The ballot is [9000, 5, 5] → 5,
+	// which the guard suppresses — but it may not serve its remembered 10_000
+	// either, because no live upstream has it any more.
+	network.PinUpstreamOrderForTest("low", "stuck-1", "stuck-2")
+
+	assert.Equal(t, int64(9_000), network.EvmHighestLatestBlockNumber(ctx),
+		"the held value must be clamped to the best live head, and must still suppress the poisoned pick")
+}
+
+// Metrics count STATE TRANSITIONS, not evaluations. The served tip is computed
+// several times per request (block-tag interpolation, the availability gate, the
+// empty-result guard), so a per-evaluation counter scales with RPS and reports
+// one sustained regression as thousands of them.
+func TestServedTip_MetricsCountTransitionsNotEvaluations(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	advance := pinServedTipClock(t)
+
+	network, _ := setupServedTipNetwork(t, ctx, []servedTipFixture{
+		{id: "live-1", chainID: 123, latestBlock: 10_000},
+		{id: "live-2", chainID: 123, latestBlock: 10_000},
+		{id: "live-3", chainID: 123, latestBlock: 10_000},
+		{id: "stuck-1", chainID: 123, latestBlock: 5},
+		{id: "stuck-2", chainID: 123, latestBlock: 5},
+	})
+	require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+
+	before := servedTipRegressionCount(network, "latest", "held")
+	network.PinUpstreamOrderForTest("live-1", "stuck-1", "stuck-2")
+
+	// One sustained regression, twenty evaluations of it — the shape of a few
+	// requests, not of twenty incidents.
+	for i := 0; i < 20; i++ {
+		require.Equal(t, int64(10_000), network.EvmHighestLatestBlockNumber(ctx))
+	}
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "held"),
+		"entering the hold is one event, however many times the tip is computed while it lasts")
+
+	// Failing open is likewise one event, not one per evaluation.
+	beforeOpen := servedTipRegressionCount(network, "latest", "failed_open")
+	advance(servedTipRegressionTTL + time.Second)
+	for i := 0; i < 20; i++ {
+		network.EvmHighestLatestBlockNumber(ctx)
+	}
+	assert.Equal(t, beforeOpen+1, servedTipRegressionCount(network, "latest", "failed_open"))
+}
+
+// An override the guaranteed-method floor immediately nullifies did not happen:
+// the referee raised the pick, the floor put it back, the served value is the
+// majority pick — counting or logging that would page someone about nothing.
+func TestServedTip_OverrideNullifiedByTheFloorIsNotCounted(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// u5 is the only trace_block-capable upstream and it is one of the stalled
+	// trio, so its supporting set floors the tip back at the frozen head.
+	advance := pinServedTipClock(t)
+	fixtures := make([]servedTipFixture, 5)
+	for i := range fixtures {
+		fixtures[i] = servedTipFixture{id: "u" + strconv.Itoa(i+1), chainID: 123, latestBlock: trajectoryStartHead}
+		if i < 4 {
+			fixtures[i].ignoreMethods = []string{"trace_block"}
+		}
+	}
+	network, ups := setupServedTipNetworkWith(t, ctx, fixtures, &common.EvmServedTipConfig{
+		EnabledFor:        []string{"latest"},
+		GuaranteedMethods: []string{"trace_block"},
+	})
+
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+	before := servedTipTrajectoryCount(network, "latest", "override")
+
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	assert.Equal(t, frozen, served,
+		"the floor holds the tip at what the trace_block upstream can serve")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"),
+		"an override the floor nullified must not be counted as an intervention")
 }
 
 // The off switch is a real off switch: trajectoryWindow: 0 records nothing and

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -154,6 +154,19 @@ var (
 		Help:      "Seconds since the served-tip value last changed (observed in-process, exported at pick time); sustained high values on a live chain = stuck tip.",
 	}, []string{"project", "network", "lane", "axis"})
 
+	// MetricNetworkServedTipRegressionTotal counts the picks that fell further
+	// than the configured tolerance below the freshest LIVE upstream head — a
+	// ballot poisoned by values that are not head observations (the 2026-08 celo
+	// incident: two upstreams voting their blockAvailability.upper bound). Any
+	// non-zero rate is alert-worthy. outcome="held" = the network kept serving
+	// its last corroborated pick; outcome="failed_open" = the regression
+	// outlasted the guard's window and the pick was served as computed.
+	MetricNetworkServedTipRegressionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_served_tip_regression_total",
+		Help:      "Served-tip picks rejected as a regression far below the freshest live upstream head, by outcome (held = last corroborated pick served instead; failed_open = the pick was served anyway after the guard's window).",
+	}, []string{"project", "network", "lane", "axis", "outcome"})
+
 	MetricUpstreamCordoned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "erpc",
 		Name:      "upstream_cordoned",

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -154,36 +154,47 @@ var (
 		Help:      "Seconds since the served-tip value last changed (observed in-process, exported at pick time); sustained high values on a live chain = stuck tip.",
 	}, []string{"project", "network", "lane", "axis"})
 
-	// MetricNetworkServedTipRegressionTotal counts the picks that fell further
-	// than the configured tolerance below the freshest LIVE upstream head — a
-	// ballot poisoned by values that are not head observations (the 2026-08 celo
-	// incident: two upstreams voting their blockAvailability.upper bound). Any
-	// non-zero rate is alert-worthy. outcome="held" = the network kept serving
-	// its last corroborated pick; outcome="failed_open" = the regression
-	// outlasted the guard's window and the pick was served as computed.
+	// MetricNetworkServedTipRegressionTotal counts the TRANSITIONS into a guard
+	// state: a pick fell further than the configured tolerance below the
+	// corroborated live head, i.e. a ballot poisoned by values that are not head
+	// observations (the 2026-08 celo incident: two upstreams voting their
+	// blockAvailability.upper bound). outcome="held" = the network started
+	// serving its last corroborated pick instead; outcome="failed_open" = a hold
+	// outlasted the guard's window and the pick is served as computed.
+	//
+	// TRANSITIONS, NOT EVALUATIONS: the served tip is computed several times per
+	// request, so a per-evaluation counter would scale with RPS and report one
+	// sustained regression as thousands. One sustained hold is +1 held, then +1
+	// failed_open if it never recovers — which is what makes any non-zero rate
+	// alert-worthy.
 	MetricNetworkServedTipRegressionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_served_tip_regression_total",
-		Help:      "Served-tip picks rejected as a regression far below the freshest live upstream head, by outcome (held = last corroborated pick served instead; failed_open = the pick was served anyway after the guard's window).",
+		Help:      "Transitions into a served-tip regression-guard state (counts state ENTRIES, not evaluations; any nonzero rate is alert-worthy), by outcome: held = the last corroborated pick is being served instead of a pick far below the corroborated live head; failed_open = that hold outlasted the guard's window and the pick is served as computed.",
 	}, []string{"project", "network", "lane", "axis", "outcome"})
 
-	// MetricNetworkServedTipTrajectoryTotal counts the evaluations where the
-	// long-term trajectory referee had a FRESHER corroborated group of live
-	// heads on the table than the majority pick. outcome="override" = that
-	// group matched the network's own head trajectory and was served instead of
-	// a stalled majority — rare, and the reason to page someone: some upstreams
-	// froze while remaining eligible. outcome="fallback" = it did not match
-	// closely enough, so the majority pick stood.
+	// MetricNetworkServedTipTrajectoryTotal counts the TRANSITIONS into a
+	// trajectory-referee state: a FRESHER corroborated group of live heads sat
+	// above the majority pick. outcome="override" = that group matched the
+	// network's own head trajectory, earned its dwell, and is being served
+	// instead of a stalled majority — rare, and the reason to page someone: some
+	// upstreams froze while remaining eligible. outcome="fallback" = it was
+	// refused (too far from the trajectory, or it has not held its place long
+	// enough), so the majority pick stands.
 	//
-	// Both are silent in steady state by construction: a fleet whose live heads
-	// form one cluster elects that cluster, and a fleet permanently split around
-	// its own median elects the median's group (the trajectory is fitted to the
-	// median, so no permanently-offset group is ever closer to it). Any sustained
-	// rate here means the fleet's groups are genuinely diverging.
+	// TRANSITIONS, NOT EVALUATIONS (see MetricNetworkServedTipRegressionTotal),
+	// and an override the guaranteed-method floor pulls back to the majority pick
+	// is not counted at all — it changed nothing.
+	//
+	// Both outcomes are silent in steady state by construction: a fleet whose
+	// live heads form one cluster elects that cluster, and a fleet permanently
+	// split around its own median elects the median's group (the trajectory is
+	// fitted to the median, so no permanently-offset group is ever closer to it).
+	// Any nonzero rate here means the fleet's groups are genuinely diverging.
 	MetricNetworkServedTipTrajectoryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_served_tip_trajectory_total",
-		Help:      "Served-tip evaluations where a corroborated group of live heads sat above the majority pick, by outcome (override = that group matched the network's head trajectory and was served; fallback = it did not, and the majority pick stood).",
+		Help:      "Transitions into a served-tip trajectory-referee state (counts state ENTRIES, not evaluations; any nonzero rate is alert-worthy), by outcome: override = a corroborated group of live heads matched the network's head trajectory and is served in place of a stalled majority; fallback = such a group sat above the majority pick and was refused.",
 	}, []string{"project", "network", "lane", "axis", "outcome"})
 
 	MetricUpstreamCordoned = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -167,6 +167,25 @@ var (
 		Help:      "Served-tip picks rejected as a regression far below the freshest live upstream head, by outcome (held = last corroborated pick served instead; failed_open = the pick was served anyway after the guard's window).",
 	}, []string{"project", "network", "lane", "axis", "outcome"})
 
+	// MetricNetworkServedTipTrajectoryTotal counts the evaluations where the
+	// long-term trajectory referee had a FRESHER corroborated group of live
+	// heads on the table than the majority pick. outcome="override" = that
+	// group matched the network's own head trajectory and was served instead of
+	// a stalled majority — rare, and the reason to page someone: some upstreams
+	// froze while remaining eligible. outcome="fallback" = it did not match
+	// closely enough, so the majority pick stood.
+	//
+	// Both are silent in steady state by construction: a fleet whose live heads
+	// form one cluster elects that cluster, and a fleet permanently split around
+	// its own median elects the median's group (the trajectory is fitted to the
+	// median, so no permanently-offset group is ever closer to it). Any sustained
+	// rate here means the fleet's groups are genuinely diverging.
+	MetricNetworkServedTipTrajectoryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_served_tip_trajectory_total",
+		Help:      "Served-tip evaluations where a corroborated group of live heads sat above the majority pick, by outcome (override = that group matched the network's head trajectory and was served; fallback = it did not, and the majority pick stood).",
+	}, []string{"project", "network", "lane", "axis", "outcome"})
+
 	MetricUpstreamCordoned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "erpc",
 		Name:      "upstream_cordoned",

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1602,6 +1602,17 @@ export interface EvmServedTipConfig {
    * Empty means only the global (all-eligible) majority is computed.
    */
   guaranteedMethods?: string[];
+  /**
+   * MaxRegressionBlocks is how far below the freshest LIVE upstream head the
+   * majority pick may fall before it is treated as a poisoned ballot rather
+   * than as reality. While a pick is below that bound the network keeps
+   * serving its last corroborated pick (in-process, for at most one minute,
+   * then it fails open and serves the pick as computed). 0 uses
+   * DefaultToleratedBlockHeadRollback (1024) — the same rollback tolerance the
+   * state poller and health tracker apply to a retreating head, so all three
+   * layers agree on what counts as a genuine deep correction.
+   */
+  maxRegressionBlocks?: number /* int64 */;
 }
 /**
  * EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1603,14 +1603,16 @@ export interface EvmServedTipConfig {
    */
   guaranteedMethods?: string[];
   /**
-   * MaxRegressionBlocks is how far below the freshest LIVE upstream head the
-   * majority pick may fall before it is treated as a poisoned ballot rather
-   * than as reality. While a pick is below that bound the network keeps
-   * serving its last corroborated pick (in-process, for at most one minute,
-   * then it fails open and serves the pick as computed). 0 uses
-   * DefaultToleratedBlockHeadRollback (1024) — the same rollback tolerance the
-   * state poller and health tracker apply to a retreating head, so all three
-   * layers agree on what counts as a genuine deep correction.
+   * MaxRegressionBlocks is how far below the corroborated LIVE upstream head
+   * (the second-highest live head) the majority pick may fall before it is
+   * treated as a poisoned ballot rather than as reality. While a pick is below
+   * that bound the network keeps serving its last corroborated pick
+   * (in-process, for at most one minute, then it fails open and serves the
+   * pick as computed). 0 uses DefaultToleratedBlockHeadRollback (1024) — the
+   * same rollback tolerance the state poller and health tracker apply to a
+   * retreating head, so all three layers agree on what counts as a genuine
+   * deep correction. -1 disables the regression guard entirely (the symmetric
+   * opposite of trajectoryWindow: 0); no other negative value is accepted.
    */
   maxRegressionBlocks?: number /* int64 */;
   /**
@@ -1622,10 +1624,13 @@ export interface EvmServedTipConfig {
    * upward-only, in-process, and a no-op until every confidence condition
    * holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
    * disables the referee entirely — nothing is recorded and the pick is the
-   * plain majority. Values much below a few minutes are self-defeating (the
-   * window must be long enough that a stall cannot look like a trajectory),
-   * and values beyond about an hour never warm up at all: the sample ring is
-   * capped, so the span the referee requires would never be reached.
+   * plain majority. Any other value must be between
+   * MinServedTipTrajectoryWindow and MaxServedTipTrajectoryWindow: below the
+   * minimum the window is self-defeating (it must be long enough that a stall
+   * cannot look like a trajectory), and above the maximum the sample ring can
+   * never span it, so the referee would stand down forever while looking
+   * configured. WRITE IT AS A DURATION STRING — trajectoryWindow: "10m". A
+   * bare number is parsed as MILLISECONDS.
    */
   trajectoryWindow?: Duration;
 }

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1613,6 +1613,21 @@ export interface EvmServedTipConfig {
    * layers agree on what counts as a genuine deep correction.
    */
   maxRegressionBlocks?: number /* int64 */;
+  /**
+   * TrajectoryWindow is how much recorded head history the trajectory referee
+   * needs before it may participate in the pick. The referee tracks where this
+   * network's head has been over the window and, when a stalled group holds
+   * the majority, serves the corroborated group that is actually where the
+   * chain should be by now (see architecture/evm's TipTrajectory: advisory,
+   * upward-only, in-process, and a no-op until every confidence condition
+   * holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
+   * disables the referee entirely — nothing is recorded and the pick is the
+   * plain majority. Values much below a few minutes are self-defeating (the
+   * window must be long enough that a stall cannot look like a trajectory),
+   * and values beyond about an hour never warm up at all: the sample ring is
+   * capped, so the span the referee requires would never be reached.
+   */
+  trajectoryWindow?: Duration;
 }
 /**
  * EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.


### PR DESCRIPTION
# Served tip: bounds don't vote, regressions are guarded, corroborated fresh minorities can win

Eleven commits, one coherent change to how the served tip is computed and defended: three that build it, then eight that apply the findings of three adversarial reviews and of an independent verification pass over the result. Every finding is mapped to its resolving commit in the comments below.

## Incident this fixes

2026-08-11 12:36–12:41 UTC, network `celo` (evm:42220): the served-tip pick collapsed from 74,550,946 to exactly **21,615,999** — the `blockAvailability.upper.exactBlock` of two pre-Gingerbread "legacy" upstreams. One healthy upstream (`prism-celo`) froze for ~30s and was lag-excluded; the ballot became `[live 74,550,978, live 74,550,974, cap 21,615,999, cap 21,615,999]`; `PickServedTip` takes `heads[len/2]` (3rd of 4) = the cap. The `latest` tag was interpolated to that height, the availability gate then rejected the healthy upstreams (their lower bound is 21,616,000) and admitted only the legacy pair — which correctly served September-2023 state: successful `eth_getBalance` = `0x0` for funded accounts (accepted via `emptyResultAccept`), `eth_call` reverts, empty logs/receipts. Recovery was self-healing when the frozen upstream returned.

## 1 — Availability-bounded upstreams no longer vote a cap as a head observation

A `blockAvailability.upper.exactBlock` bound is a serving-range declaration, not a chain-head observation. `EvmEffectiveLatestBlock()` returns `min(pollerHead, upperBound)`, so a bound-capped upstream voted its config constant into the tip ballot. `evmTipBallot` now drops such inputs **when at least one live-head input exists** in the same candidate set.

**The classification is static, from the CONFIG** (review finding M3). An upstream is a non-voting cap only when its configured `upper.exactBlock` sits below the axis-appropriate head (`LatestBlock` for latest, `FinalizedBlock` for finalized). Every other upper form is *derived* from the upstream's own head — `latestBlockMinus: N` above all — so it tracks the chain at a fixed lag and remains a live observation: an upstream that serves up to `head-5` still knows exactly where the head is. The first version tested the *resolved* bound against the head, which is true for every `latestBlockMinus` upstream, so it disenfranchised them all: on a 4-node fleet with three `latestBlockMinus: 5` nodes, a tip all four could serve became one only the single unbounded node could. Reading the configured constant also removes the second `resolveAvailabilityBounds` call per upstream per evaluation (the largest per-request cost this feature added) and the torn two-load snapshot it implied.

Decided edge cases:
- Mixed pool (≥1 live head): capped upstreams are not voters. They keep serving their range; routing is unchanged.
- All-capped pool: unchanged behavior — a network of only historical/frozen upstreams legitimately serves its cap as `latest`.
- The filter may shrink a ballot to ONE live upstream. That is deliberate and tested: one live witness is thin evidence, but the alternative is advertising a serving range that stopped tracking the chain years ago, and the regression guard bounds how far the tip may move from what this process last saw corroborated.
- **The guaranteed-method floor uses the same rule** (review finding M4). It previously built its ballot from raw effective heads and ran *after* the guard, so with `servedTip.guaranteedMethods` configured the celo pair's 21,615,999 came back as a "floor" and was served end to end. Both ballots now come from one function, with the same per-set mixed-pool rule: capped upstreams drop out of a method's ballot only when some live upstream also supports that method. When only capped upstreams support it, they still set the floor — that is the floor's purpose.

## 2 — Regression guard against corroborated live evidence

Physics backstop, independent of which voters are honest: `latest` cannot fall far below where the chain demonstrably is in one tick. If `pick < reference − maxRegressionBlocks` (new `servedTip.maxRegressionBlocks`, default 1024 = `DefaultToleratedBlockHeadRollback`, `-1` disables), the guard serves the last corroborated pick for a 60s TTL, then **fails open and disarms**. State lives on the existing `servedTipAnchor`, in-process only, no persistence, no shared state.

The reference is split into the two roles it was conflating (review findings m5, M2):

- **Detection** measures against the higher of the *second-highest* live head and the last live-corroborated pick. Against the raw max, one far-future/wrong-chain upstream made every honest pick look like a regression — and because a corroborated value is only recorded on the healthy branch, the guard then never recorded one and sat **permanently disarmed, emitting no metric and no log at all**. The last-corroborated term is needed too: the second-highest live head is itself the poison in the guard's headline shape (one live witness left, two stuck upstreams outvoting it).
- **Ceiling** on a held value is the highest live head, so the guard still cannot advertise a block no live upstream has. A ceiling a rogue can only *raise* is harmless; a ceiling of the second-highest head would collapse the hold back onto the poisoned pick.

**No live head is no longer a reason to stand down** (M2). If every live upstream leaves the eligible set while capped ones remain, the ballot correctly falls back to the caps — and both history-aware layers used to stand down there, on the ballot shape closest to the incident itself. With no live head the guard now measures against its own last corroborated pick, holds it *unclamped* for the TTL, then fails open to the capped pick. Genuinely all-capped networks never armed the guard, so they still pass straight through.

Coverage boundary, documented in the code: the remembered value's freshness comes from **request traffic**, so a network idle longer than the TTL fails open on its first poisoned evaluation after the quiet period, exactly as a cold process does. A memory that survives silence is the frozen-tip absorbing state this design forbids.

## 3 — Trajectory referee: corroborated fresh minorities beat stalled majorities

Every other mechanism is a snapshot; none knows where the chain was ten minutes ago. If a majority of eligible upstreams stalls (inside the lag-exclusion threshold, or during a fleet-wide shared-counter freeze that stalls the lag metric itself), the median follows the stale majority and two genuinely-fresh nodes are outvoted.

`TipTrajectory` samples the median of live heads (never the pick — no feedback loop) at most every 5s into a per-network/axis/lane in-memory ring, fits a robust velocity (median of half-window-lagged slopes; one poisoned sample touches ≤2 of ~90 slopes), and projects expected-now `E`. Tolerance = `max(6 × median-absolute-residual, maxRegressionBlocks)` (≈4σ) — bursty chains widen their own gate.

It participates only when **all** confidence clauses hold: window span ≥ `servedTip.trajectoryWindow` (default 10m; `0` disables; otherwise validated to `[1m, 68m16s]`), ≥30 samples, freshest sample ≤60s old, **no gap larger than 60s anywhere inside the window**, positive finite velocity. Then: cluster live heads (width `max(16, 10s × v)`), candidate groups need **≥2 members**, elect the group closest to `E` within tolerance, serve the group **minimum** (every member can serve it).

**Corroboration is earned over time, not in an instant** (review finding M1 — two confirmed exploits of the first version):

- a **chain halt** makes `E` sweep upward through every fixed offset, so a *static* pair (fork, wrong-chain pair, frozen counter) at +2000 was elected on 74 of 240 halt evaluations;
- a **routine 15s divergence** of 2-of-4 upstreams produced an override that lasted ~4m50s, advertising a block only half the fleet had.

A group may now win only after being the elected group, continuously within tolerance, for **≥30s** (6 samples), *and* having advanced its own head over that stretch by at least **0.5 × v × dwellSeconds**. The dwell is keyed on the group's member SET, so replacing a member restarts it. The velocity condition makes the halt sweep structurally impossible rather than unlikely: a static group's advance is 0 and the threshold is strictly positive whenever the referee is confident at all. **Minimum group size stays 2 at any fleet size** — scaling it with the fleet hands a stalled majority a veto in exactly the topology the referee exists for; what makes two witnesses trustworthy is the dwell and the velocity agreement, not the count.

The referee remains **upward-only**: it can raise the pick toward a corroborated fresh group, never lower it. Any uncertainty → exact plain-median behavior, byte-identical.

## Why the incident value cannot recur

`PickServedTip` is unchanged, so the *ordering* that produced 21,615,999 is still what it always was. Four independent gates now stand between it and a client:

1. a static cap is not on the ballot while any live head is (commit 1);
2. the guaranteed-method floor cannot re-admit one — **without this the claim was false end to end whenever `guaranteedMethods` was configured**;
3. losing every live upstream no longer disables the guard — **without this the claim was false whenever the eligible set collapsed onto the capped pair**, which is precisely how the incident began;
4. and (2) and (3) no longer defeat each other. Each was correct alone and they **composed straight back onto the incident value**: the guard correctly refused the cap-only ballot and held 74,550,974, and then the floor — which runs after the guard — recomputed that same collapsed instant and dragged the served value to 21,615,999. A cap-only method ballot may now set a floor only when the **registered** configuration has no live upstream serving that method; when live upstreams serve it and are merely absent, the floor is a transient lie and the guard's hold (with its bounded fail-open) governs. Pinned by `TestServedTip_GuaranteedMethodFloor_DoesNotUndoTheGuardsHold`, which drives the eligibility loss the way production does — the live upstreams stay registered.

The first version of this PR claimed (1) alone was sufficient; the second closed (2) and (3) separately. All four are needed, and all four are tested.

## Observability

`erpc_network_served_tip_regression_total{outcome=held|failed_open}` and `erpc_network_served_tip_trajectory_total{outcome=override|fallback}` count **state transitions, not evaluations** (review finding m12). The served tip is computed several times per request, so the previous per-evaluation counters scaled with RPS and reported one sustained regression as thousands — which made the help text's "any nonzero rate is alert-worthy" unusable. One sustained hold is now `+1 held`, then `+1 failed_open` if it never recovers. An override the guaranteed-method floor nullifies is not counted or logged at all: it changed nothing. `erpc_network_served_tip_lag_blocks` is clamped at 0 (it read negative whenever the guard held above the corroborated freshest view).

## Known boundary: the guard tolerates one Byzantine head, not two

The regression guard's detection reference is the second-highest live head, which neutralises a single far-future/wrong-chain upstream. **Two** upstreams reporting the same far-future block are indistinguishable, in one evaluation, from two upstreams that are simply ahead — so they can still leave the guard unarmed, and silently, since a corroborated value is only recorded on the healthy branch. Nothing available in a snapshot separates those cases. What bounds the damage is stated in the code where the reference is computed: the majority pick still needs a majority to move, the guard's memory refuses to commit an uncorroborated leap, and the referee's dwell refuses to elect a group that has not tracked the chain for half a minute.

## Two findings deliberately left as-is

- **A 2-upstream network in deep divergence holds for up to 60s.** With two upstreams far apart, the guard holds its last corroborated pick until the TTL rather than following the lower head immediately. That is the better answer: the alternative is `main`'s behaviour of serving, say, a devnet's post-reset block 1 as `latest` the moment one node is re-genesised. The hold is bounded, counted and fails open.
- **The served tip can drift between the several calls of one request.** `EvmHighestLatestBlockNumber` is called independently by block-tag interpolation, the availability gate and the empty-result guard, and nothing pins one value for the request's lifetime. This predates the branch and is unchanged by it; noted here so it is not read as introduced.

## Verification

- `go build ./...`, `gofmt` clean on every touched file (the pre-existing offenders on `main` are untouched).
- `go test ./architecture/... ./erpc/... ./upstream/... ./common/... -count=1 -timeout 40m` green (`erpc` alone runs ~14 minutes, so the default 10-minute timeout panics — pass `-timeout 30m` or more).
- Served-tip subset re-run with `-race`.
- Mutation-checked where a constant could silently un-pin a test: with `tipDwellDuration = 0` two of the three dwell tests fail; with the guard memory's leap rule disabled the fantasy-recovery test fails.
- Reviewer repro material ported into real regression tests: halt-sweep + static pair, gap amnesia (both the "one evaluation later" and "halt inside the gap" shapes), transient 2-of-4 divergence, permanently split fleet, `latestBlockMinus` fleet servability, the guaranteed-method floor re-admission, the all-live-excluded hold, single-rogue disarm, the guard's clamp branch, transition-counted metrics, and the finalized axis end to end for all three mechanisms.
- `typescript/config/src/generated.ts` updated for the changed config docs (relevant fields only; the repo regenerates types at release time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
