### PR TITLE
feat(evm): trajectory referee for the served-tip pick — corroborated fresh minorities beat stalled majorities

### DIFF
--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -1,6 +1,12 @@
 package evm
 
-import "sort"
+import (
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
 
 // ServedTipInput is a single observation: an upstream's last-known tip block.
 // Callers are responsible for excluding syncing or cordoned upstreams BEFORE
@@ -88,4 +94,468 @@ func PickServedTip(tips []ServedTipInput) ServedTipPick {
 		Freshest: freshest,
 		Inputs:   len(heads),
 	}
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// PickServedTip is a snapshot of one instant, and so is every filter feeding
+// it: they all answer "what do the eligible upstreams say RIGHT NOW". That is
+// exactly the assumption a majority stall breaks. If N upstreams freeze inside
+// the lag-exclusion threshold (or a fleet-wide shared-counter freeze stalls the
+// lag metric itself), the majority IS the stale group, and the 2 upstreams that
+// genuinely have the chain's head are outvoted — no instantaneous rule can tell
+// that apart from a chain that simply stopped.
+//
+// One thing does distinguish them: what the network's head has been doing for
+// the last ten minutes. TipTrajectory records that track and lets the referee
+// answer "which of these groups is where the chain should be by now".
+//
+// STRUCTURAL LIMITS — this is deliberately NOT the stateful tip pipeline that
+// commit 7dee07c0 removed (a velocity gate plus a persisted monotonic clamp,
+// which reached an absorbing state where every live tip was rejected forever
+// and the served tip froze fleet-wide):
+//
+//   - ADVISORY, NEVER GENERATIVE. The referee only ever chooses among head
+//     values live upstreams are offering in this very evaluation. It cannot
+//     invent, remember, or extrapolate a servable block; the trajectory is used
+//     ONLY to rank the groups those upstreams form.
+//   - UPWARD-ONLY. It may raise the pick to a corroborated fresher group; it can
+//     never lower or hold one. A referee that cannot hold a value back cannot
+//     freeze a tip — the 7dee07c0 failure mode is unreachable, not merely
+//     unlikely. (Erring low is already the majority picker's job, and the
+//     regression guard's.)
+//   - SELF-LIMITING EVIDENCE. Samples are the plain MEDIAN of the live heads —
+//     never the served value, never the referee's own output. During a majority
+//     stall the tracker therefore keeps recording the stalled median, the fitted
+//     velocity decays, and the referee stops participating on its own after
+//     roughly half a window. Its intervention has a built-in expiry that no
+//     configuration can extend.
+//   - FAIL OPEN ON ANY UNCERTAINTY, and no shared state: everything below is
+//     per-process, in-memory, rebuilt from live observations after a restart.
+//     Per-pod independence is the point — a shared head counter is how the
+//     2026-08 celo trigger propagated fleet-wide in the first place.
+
+const (
+	// tipSampleInterval throttles recording to one sample per evaluation-with-
+	// this-much-elapsed. Fast enough that the default 10-minute window holds
+	// 120 samples, slow enough that the O(n log n) refit runs at most 0.2 Hz
+	// per network+axis while reads stay O(1).
+	tipSampleInterval = 5 * time.Second
+
+	// tipMinSamples is the smallest buffer the fit is computed over: below it
+	// a handful of points could define a "trajectory" on noise alone.
+	tipMinSamples = 30
+
+	// tipMaxSampleGap is how stale the freshest sample may be (as of the START
+	// of an evaluation) for the fit to still describe the present. A gap larger
+	// than this is where a halt or a burst hides, and extrapolating across it
+	// is guessing — the referee steps aside instead.
+	tipMaxSampleGap = time.Minute
+
+	// tipMinGroupSize is the corroboration rule: one witness is not evidence,
+	// however perfectly it matches the trajectory. A group must contain at
+	// least two upstreams to be electable.
+	tipMinGroupSize = 2
+
+	// tipToleranceSigmas (k) scales the window's OWN residual spread into the
+	// distance-from-expected a group may sit at and still count as
+	// on-trajectory. The spread is a median absolute residual, which for
+	// normal-ish noise is ≈0.67σ, so k=6 is ≈4σ: a chain that pauses and
+	// bursts widens its own gate automatically, while a metronomic chain keeps
+	// the floor (EvmServedTipConfig.MaxRegressionBlocks).
+	tipToleranceSigmas = 6.0
+
+	// tipClusterSeconds derives the cluster width from the fitted velocity:
+	// heads within this much CHAIN PROGRESS of each other are the same view of
+	// the head. 10s comfortably covers poller-interval skew and propagation
+	// between healthy providers, and is far below any stall worth correcting.
+	tipClusterSeconds = 10.0
+
+	// tipMinClusterWidth keeps sub-second-block chains (and a small fitted
+	// velocity generally) from splitting a healthy fleet into singletons.
+	tipMinClusterWidth = 16
+
+	// tipMaxClusterWidth is an overflow stop, not a tuning knob: an absurd
+	// fitted velocity must not produce an int64 conversion of a huge float. A
+	// too-wide cluster merges everything into one group, which can only make
+	// the referee defer.
+	tipMaxClusterWidth = int64(1) << 40
+
+	// tipMinBufferCapacity / tipMaxBufferCapacity bound the ring derived from
+	// the configured window (tipBufferCapacity).
+	tipMinBufferCapacity = 64
+	tipMaxBufferCapacity = 1024
+)
+
+// TipTrajectoryParams are the per-network knobs the referee reads on every
+// evaluation. They come straight from EvmServedTipConfig, so a config change
+// takes effect without rebuilding the tracker.
+type TipTrajectoryParams struct {
+	// Window is the minimum span of recorded history required before the
+	// referee may participate at all. <= 0 disables the tracker entirely:
+	// nothing is recorded and nothing is computed.
+	Window time.Duration
+
+	// ToleranceFloor is the minimum distance-from-expected a group may sit at
+	// and still be on-trajectory, in blocks (EvmServedTipConfig's
+	// MaxRegressionBlocks, defaulted by the caller). The observed residual
+	// spread can only widen the gate, never narrow it below this.
+	ToleranceFloor int64
+}
+
+// TipTrajectoryDecision is the referee's advice for one evaluation. Pick is
+// always a value the caller may serve as-is: the majority pick it passed in,
+// or a corroborated group's minimum.
+type TipTrajectoryDecision struct {
+	// Pick is the block to serve: the majority pick unless Overrode.
+	Pick int64
+
+	// Overrode reports that Pick differs from the majority pick — the only
+	// outcome that is an intervention, and the one worth an alert.
+	Overrode bool
+
+	// Declined reports the near miss: the group the trajectory elected sat
+	// ABOVE the majority pick — an override was on the table — and the referee
+	// refused it because the group was not close enough to where the head
+	// should be. It is the only other outcome worth counting, and like Overrode
+	// it is silent in steady state: a fleet in one cluster elects that cluster,
+	// and a fleet permanently split around its own median elects the median's
+	// group (the trajectory is fitted to the median, so no permanently-offset
+	// group is ever closer to it), so neither flag is set.
+	Declined bool
+
+	// Expected / Tolerance / VelocityPerSec describe the fit that produced the
+	// decision. Populated only once the confidence gate passes; for logs.
+	Expected       int64
+	Tolerance      int64
+	VelocityPerSec float64
+}
+
+// tipSample is one recorded observation of where the network's head was.
+type tipSample struct {
+	atMs int64
+	head int64
+}
+
+// tipFit is the robust linear fit over the buffer, recomputed on insertion and
+// read lock-free on every evaluation.
+type tipFit struct {
+	refMs   int64   // timestamp of the newest sample in the fit
+	refHead float64 // FITTED head at refMs (not the raw sample: one poisoned sample must not define the anchor)
+	vPerSec float64 // robust velocity, blocks/second
+	spread  float64 // median absolute residual around the fit, blocks
+	spanMs  int64   // newest − oldest sample timestamp
+	count   int
+}
+
+// expectedAt extrapolates the fit to an instant on the tracker's timeline.
+func (f *tipFit) expectedAt(nowMs int64) float64 {
+	return f.refHead + f.vPerSec*float64(nowMs-f.refMs)/1000
+}
+
+// confident is the gate: unless EVERY condition holds the referee is a no-op
+// and the caller's majority pick stands byte-identically. prevSampleAgeMs is
+// the age of the freshest sample as of the START of this evaluation — the
+// evaluation's own sample must not paper over a gap in the history.
+func (f *tipFit) confident(nowMs int64, prevSampleAgeMs int64, p TipTrajectoryParams) bool {
+	if f == nil || f.count < tipMinSamples {
+		return false
+	}
+	if f.spanMs < p.Window.Milliseconds() {
+		// Also the warm-up condition: an empty buffer after boot has no span.
+		return false
+	}
+	if prevSampleAgeMs > tipMaxSampleGap.Milliseconds() {
+		return false
+	}
+	if !(f.vPerSec > 0) || math.IsInf(f.vPerSec, 0) {
+		// A non-advancing (or NaN) fit describes a halted chain, where the
+		// majority pick is already the right answer.
+		return false
+	}
+	return !math.IsInf(f.refHead, 0) && !math.IsNaN(f.refHead) && nowMs >= f.refMs
+}
+
+// TipTrajectory is one network+axis's long-term head track: a ring of head
+// samples plus the robust fit over them. The zero value is ready to use and
+// allocates on first use; a tracker whose Window is <= 0 never allocates at
+// all.
+type TipTrajectory struct {
+	mu      sync.Mutex
+	samples []tipSample
+	next    int // ring write cursor
+	count   int
+
+	// ordered / slopes / resid are refit scratch, retained so the periodic fit
+	// allocates nothing after warm-up.
+	ordered []tipSample
+	slopes  []float64
+	resid   []float64
+
+	// base is the instant the first sample was recorded; every timestamp below
+	// is milliseconds since it, measured with time.Time's MONOTONIC reading.
+	// A velocity fit is exactly the thing an NTP step would corrupt (a wall
+	// clock that jumps injects a slope no chain ever had), so the timeline the
+	// fit lives on never touches wall time.
+	base         atomic.Pointer[time.Time]
+	lastSampleMs atomic.Int64
+	fit          atomic.Pointer[tipFit]
+}
+
+// SampleCount returns how many samples the tracker holds. Diagnostics and
+// tests only — the decision path never needs it.
+func (t *TipTrajectory) SampleCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// Observe records this evaluation's live-head median (throttled) and returns
+// the trajectory's advice for it.
+//
+// `tips` must be the LIVE head observations of this same evaluation (the
+// caller drops availability-bound-capped upstreams first — a serving range is
+// not a head), and `median` the plain majority pick over them. Both the sample
+// and the candidate groups come from those heads, so the referee's own output
+// never feeds back into its evidence.
+func (t *TipTrajectory) Observe(now time.Time, tips []ServedTipInput, median int64, p TipTrajectoryParams) TipTrajectoryDecision {
+	d := TipTrajectoryDecision{Pick: median}
+	if p.Window <= 0 || median <= 0 {
+		return d
+	}
+
+	nowMs, prevSampleAgeMs := t.record(now, median, p)
+
+	fit := t.fit.Load()
+	if !fit.confident(nowMs, prevSampleAgeMs, p) {
+		return d
+	}
+
+	heads := make([]int64, 0, len(tips))
+	for _, in := range tips {
+		if in.BlockNumber > 0 {
+			heads = append(heads, in.BlockNumber)
+		}
+	}
+	if len(heads) < tipMinGroupSize {
+		return d
+	}
+	sort.Slice(heads, func(i, j int) bool { return heads[i] > heads[j] })
+
+	expected := fit.expectedAt(nowMs)
+	tolerance := float64(p.ToleranceFloor)
+	if widened := tipToleranceSigmas * fit.spread; widened > tolerance {
+		tolerance = widened
+	}
+	d.Expected = int64(math.Round(expected))
+	d.Tolerance = int64(math.Round(tolerance))
+	d.VelocityPerSec = fit.vPerSec
+
+	// Single-linkage clustering over the descending heads: a gap wider than one
+	// cluster width starts a new group. Candidate groups are those with at
+	// least tipMinGroupSize members; the winner is the one whose MAX (its best
+	// claim about the head — using the min would penalise a wide group for its
+	// slowest member) sits closest to where the trajectory says the head is.
+	width := tipClusterWidth(fit.vPerSec)
+	bestDistance := math.Inf(1)
+	var bestMin int64
+	for i := 0; i < len(heads); {
+		j := i + 1
+		for j < len(heads) && heads[j-1]-heads[j] <= width {
+			j++
+		}
+		if j-i >= tipMinGroupSize {
+			groupMax, groupMin := heads[i], heads[j-1]
+			if distance := math.Abs(float64(groupMax) - expected); distance < bestDistance {
+				bestDistance, bestMin = distance, groupMin
+			}
+		}
+		i = j
+	}
+
+	if bestDistance > tolerance {
+		// No candidate group at all (+Inf), or the elected one is nowhere near
+		// the trajectory — nothing here is better evidence than the majority.
+		d.Declined = bestMin > median
+		return d
+	}
+	if bestMin <= median {
+		// UPWARD-ONLY (see the section comment): the referee exists to let a
+		// corroborated fresh minority outvote a stalled majority. Lowering or
+		// holding the tip is the majority picker's and the regression guard's
+		// job, and is the only direction from which a frozen tip is reachable.
+		return d
+	}
+
+	// Serve the group's MINIMUM: every member of a winning group already has
+	// that block, so the advertised tip stays servable by all of them — the
+	// same invariant the majority order statistic provides.
+	d.Pick = bestMin
+	d.Overrode = true
+	return d
+}
+
+// record appends a sample if at least tipSampleInterval has passed since the
+// last one. It returns `now` on the tracker's monotonic timeline, and the age
+// there of the previous freshest sample — the age BEFORE this evaluation's own
+// sample, so a gap in the history cannot be papered over by the sample that
+// notices it (a value past tipMaxSampleGap when there is no previous sample).
+//
+// The lock is taken only when a sample is actually due, so the per-request cost
+// is two atomic loads.
+func (t *TipTrajectory) record(now time.Time, head int64, p TipTrajectoryParams) (nowMs int64, prevAgeMs int64) {
+	staleSentinel := tipMaxSampleGap.Milliseconds() + 1
+
+	if base := t.base.Load(); base != nil {
+		nowMs = int64(now.Sub(*base) / time.Millisecond)
+		if last := t.lastSampleMs.Load(); nowMs-last < tipSampleInterval.Milliseconds() {
+			return nowMs, nowMs - last
+		}
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	base := t.base.Load()
+	if base == nil {
+		at := now
+		base = &at
+		t.base.Store(base)
+	}
+	nowMs = int64(now.Sub(*base) / time.Millisecond)
+
+	prevAgeMs = staleSentinel
+	if t.count > 0 {
+		last := t.lastSampleMs.Load()
+		if nowMs-last < tipSampleInterval.Milliseconds() {
+			return nowMs, nowMs - last
+		}
+		prevAgeMs = nowMs - last
+	}
+
+	if t.samples == nil {
+		t.samples = make([]tipSample, tipBufferCapacity(p.Window))
+	}
+	t.samples[t.next] = tipSample{atMs: nowMs, head: head}
+	t.next = (t.next + 1) % len(t.samples)
+	if t.count < len(t.samples) {
+		t.count++
+	}
+	t.lastSampleMs.Store(nowMs)
+	t.refit()
+
+	return nowMs, prevAgeMs
+}
+
+// refit recomputes the robust fit over the whole buffer. Called under t.mu, at
+// most once per tipSampleInterval.
+//
+// Velocity is the MEDIAN OF HALF-WINDOW-LAGGED SLOPES: slope_i between sample i
+// and sample i+n/2, median over the ~n/2 of them. Two properties matter here
+// and full Theil-Sen buys neither: every slope spans about half the window, so
+// per-sample noise is divided by a long baseline; and any single poisoned
+// sample enters at most two of the ~90 slopes, so the median never moves.
+// Theil-Sen's n²/2 pairs (≈16k at n=180) would cost a 128 KB sort per fit for
+// the same answer. The intercept is the median residual (the standard robust
+// intercept), and the spread is the median absolute residual around the
+// resulting line — the window's own noise, which is what widens the tolerance
+// for a chain that pauses and bursts.
+func (t *TipTrajectory) refit() {
+	n := t.count
+	if n < tipMinSamples {
+		t.fit.Store(nil)
+		return
+	}
+
+	// Materialise the ring chronologically.
+	ord := t.ordered[:0]
+	if t.count < len(t.samples) {
+		ord = append(ord, t.samples[:t.count]...)
+	} else {
+		ord = append(ord, t.samples[t.next:]...)
+		ord = append(ord, t.samples[:t.next]...)
+	}
+	t.ordered = ord
+
+	newest := ord[n-1]
+	lag := n / 2
+	slopes := t.slopes[:0]
+	for i := 0; i+lag < n; i++ {
+		dt := float64(ord[i+lag].atMs-ord[i].atMs) / 1000
+		if dt <= 0 {
+			continue
+		}
+		slopes = append(slopes, float64(ord[i+lag].head-ord[i].head)/dt)
+	}
+	t.slopes = slopes
+	if len(slopes) == 0 {
+		t.fit.Store(nil)
+		return
+	}
+	vPerSec := medianInPlace(slopes)
+
+	// Residuals in coordinates relative to the newest sample: seconds and
+	// blocks, never epoch milliseconds or 8-digit block numbers, so float64
+	// keeps full precision on chains of any height.
+	resid := t.resid[:0]
+	for _, s := range ord {
+		ts := float64(s.atMs-newest.atMs) / 1000
+		resid = append(resid, float64(s.head-newest.head)-vPerSec*ts)
+	}
+	t.resid = resid
+	intercept := medianInPlace(resid)
+	for i, r := range resid {
+		resid[i] = math.Abs(r - intercept)
+	}
+
+	t.fit.Store(&tipFit{
+		refMs:   newest.atMs,
+		refHead: float64(newest.head) + intercept,
+		vPerSec: vPerSec,
+		spread:  medianInPlace(resid),
+		spanMs:  newest.atMs - ord[0].atMs,
+		count:   n,
+	})
+}
+
+// tipBufferCapacity sizes the ring from the configured window: enough samples
+// to span it with headroom for jitter, so a window an operator raises still
+// becomes reachable instead of silently never satisfying the span gate. The
+// hard cap means windows beyond ~85 minutes can never be spanned, and would
+// stand the referee down permanently — see EvmServedTipConfig.TrajectoryWindow.
+func tipBufferCapacity(window time.Duration) int {
+	n := int(window/tipSampleInterval)*5/4 + 8
+	if n < tipMinBufferCapacity {
+		return tipMinBufferCapacity
+	}
+	if n > tipMaxBufferCapacity {
+		return tipMaxBufferCapacity
+	}
+	return n
+}
+
+// tipClusterWidth is how far apart two heads may be and still be one view of
+// the chain: tipClusterSeconds of chain progress, floored at
+// tipMinClusterWidth.
+func tipClusterWidth(vPerSec float64) int64 {
+	w := vPerSec * tipClusterSeconds
+	if !(w > tipMinClusterWidth) { // also catches NaN
+		return tipMinClusterWidth
+	}
+	if w > float64(tipMaxClusterWidth) {
+		return tipMaxClusterWidth
+	}
+	return int64(w)
+}
+
+// medianInPlace sorts xs and returns its median.
+func medianInPlace(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sort.Float64s(xs)
+	if n := len(xs); n%2 == 1 {
+		return xs[n/2]
+	}
+	return (xs[len(xs)/2-1] + xs[len(xs)/2]) / 2
 }

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -1,9 +1,13 @@
 package evm
 
 import (
+	"math"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The served-tip contract: PickServedTip returns the freshest block a strict
@@ -165,4 +169,295 @@ func TestPickServedTip_Scenario_HaltedChainHoldsHonestly(t *testing.T) {
 	frozen := tipsFromInts(500, 500, 499)
 	assert.Equal(t, int64(500), PickServedTip(frozen).Tip)
 	assert.Equal(t, PickServedTip(frozen), PickServedTip(frozen), "pure function: same inputs, same pick")
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// These pin the tracker's own mechanics: the fit it derives from a head track,
+// the confidence gate that keeps it inert, and the group election. The
+// end-to-end behaviour (which block a network actually serves) is pinned in
+// package erpc's networks_served_tip_test.go.
+
+// trajectoryParams is the referee's config as a network with default settings
+// supplies it: a 10-minute window and the 1024-block regression tolerance.
+func trajectoryParams() TipTrajectoryParams {
+	return TipTrajectoryParams{Window: 10 * time.Minute, ToleranceFloor: 1024}
+}
+
+// warmTrajectory feeds `samples` observations one tipSampleInterval apart,
+// advancing the head by `perSample` blocks each time, and returns the clock and
+// head it stopped at. Every sample goes through Observe, i.e. the same entry
+// point the request path uses.
+func warmTrajectory(tr *TipTrajectory, start time.Time, head int64, perSample int64, samples int) (time.Time, int64) {
+	now := start
+	for i := 0; i < samples; i++ {
+		tr.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		now = now.Add(tipSampleInterval)
+		head += perSample
+	}
+	return now, head
+}
+
+func TestTipTrajectory_FitRecoversVelocityAndExpectedHead(t *testing.T) {
+	var tr TipTrajectory
+	// 20 blocks/s (100 blocks per 5s sample), 130 samples ≈ 10m50s of history.
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+	fit := tr.fit.Load()
+	require.NotNil(t, fit)
+	assert.InDelta(t, 20.0, fit.vPerSec, 0.001, "robust velocity must recover the 20 blocks/s track")
+	assert.InDelta(t, 0.0, fit.spread, 0.001, "a perfectly linear track has no residual spread")
+
+	// The head the fit expects one sample-interval on is the next sample's.
+	assert.InDelta(t, float64(head), fit.expectedAt(int64(now.Sub(*tr.base.Load())/time.Millisecond)), 1.0)
+}
+
+func TestTipTrajectory_PoisonedSampleDoesNotMoveTheFit(t *testing.T) {
+	var tr TipTrajectory
+	now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 60)
+	clean := tr.fit.Load()
+	require.NotNil(t, clean)
+
+	// One wrong-chain / garbage observation lands in the middle of the track.
+	tr.Observe(now, tipsFromInts(head), 999_999_999, trajectoryParams())
+	now, _ = warmTrajectory(&tr, now.Add(tipSampleInterval), head+100, 100, 70)
+
+	poisoned := tr.fit.Load()
+	require.NotNil(t, poisoned)
+	assert.InDelta(t, clean.vPerSec, poisoned.vPerSec, 0.001,
+		"a single poisoned sample must not move the median-of-lagged-slopes velocity")
+	assert.Less(t, poisoned.spread, float64(1024),
+		"nor may it inflate the residual spread past the tolerance floor")
+}
+
+func TestTipTrajectory_ConfidenceGate(t *testing.T) {
+	params := trajectoryParams()
+
+	t.Run("ColdBufferIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		now := time.Now()
+		for i := 0; i < tipMinSamples-1; i++ {
+			d := tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100, 999_000), 999_000, params)
+			require.False(t, d.Overrode, "sample %d: a cold tracker must never override", i)
+			now = now.Add(tipSampleInterval)
+		}
+		assert.Nil(t, tr.fit.Load(), "no fit below tipMinSamples")
+	})
+
+	t.Run("ShortWindowIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		// 60 samples = 5 minutes of span: enough points, not enough window.
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 60)
+		fit := tr.fit.Load()
+		require.NotNil(t, fit)
+		require.Less(t, fit.spanMs, params.Window.Milliseconds())
+
+		// A stalled majority + a fresh pair: the shape that WOULD be overridden.
+		d := tr.Observe(now, tipsFromInts(head, head, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		assert.False(t, d.Overrode, "span below the configured window must keep the referee inert")
+	})
+
+	t.Run("StaleTrackIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+		require.True(t, tr.fit.Load().spanMs >= params.Window.Milliseconds())
+
+		// Nothing evaluated for longer than the maximum gap: the fit no longer
+		// describes the present, whatever it says.
+		now = now.Add(tipMaxSampleGap + time.Second)
+		d := tr.Observe(now, tipsFromInts(head+1200, head+1200, head, head, head), head, params)
+		assert.False(t, d.Overrode, "a gap past tipMaxSampleGap must stand the referee down")
+	})
+
+	t.Run("HaltedChainIsInert", func(t *testing.T) {
+		var tr TipTrajectory
+		// A completely flat track: velocity 0, so there is no trajectory to be
+		// off. The majority pick is already the right answer for a halted chain.
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 0, 130)
+		require.NotNil(t, tr.fit.Load())
+		d := tr.Observe(now, tipsFromInts(head+5_000, head+5_000, head, head, head), head, params)
+		assert.False(t, d.Overrode, "v <= 0 must stand the referee down")
+	})
+
+	t.Run("DisabledRecordsNothing", func(t *testing.T) {
+		var tr TipTrajectory
+		off := TipTrajectoryParams{Window: 0, ToleranceFloor: 1024}
+		now := time.Now()
+		for i := 0; i < 200; i++ {
+			tr.Observe(now, tipsFromInts(1_000_000+int64(i)*100), 1_000_000+int64(i)*100, off)
+			now = now.Add(tipSampleInterval)
+		}
+		assert.Zero(t, tr.SampleCount(), "trajectoryWindow: 0 must record nothing at all")
+		assert.Nil(t, tr.fit.Load())
+	})
+}
+
+func TestTipTrajectory_GroupElection(t *testing.T) {
+	params := trajectoryParams()
+
+	t.Run("StalledMajorityLosesToCorroboratedFreshPair", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// The stall: three heads freeze, two keep the track. The tracker keeps
+		// sampling the (frozen) majority median throughout — its evidence is
+		// never its own output.
+		frozen := head
+		for i := 0; i < 24; i++ {
+			now = now.Add(tipSampleInterval)
+			head += 100
+			tr.Observe(now, tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+		}
+
+		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, head, frozen, frozen, frozen), frozen, params)
+		assert.True(t, d.Overrode, "the on-trajectory pair must outvote the stalled majority")
+		assert.Equal(t, head, d.Pick, "the pick is the fresh group's MINIMUM — both members have it")
+		assert.False(t, d.Declined, "an override is not a near miss")
+	})
+
+	t.Run("SingletonIsNeverCorroboration", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		frozen := head
+		for i := 0; i < 24; i++ {
+			now = now.Add(tipSampleInterval)
+			head += 100
+			tr.Observe(now, tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+		}
+
+		d := tr.Observe(now.Add(time.Second), tipsFromInts(head, frozen, frozen, frozen, frozen), frozen, params)
+		assert.False(t, d.Overrode,
+			"one upstream matching the trajectory perfectly is still one witness")
+		assert.Equal(t, frozen, d.Pick)
+	})
+
+	t.Run("NearMissIsDeclinedNotOverridden", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Everything is off the trajectory: the freshest pair is the closest
+		// group to where the head should be, but still further than the
+		// tolerance. The referee elects it and then refuses it — a near miss,
+		// which is the one non-override outcome worth counting.
+		d := tr.Observe(now, tipsFromInts(head+3_000, head+3_000, head-20_000, head-20_000, head-20_000), head-20_000, params)
+		assert.False(t, d.Overrode)
+		assert.True(t, d.Declined, "a refused raise is the fallback outcome")
+		assert.Equal(t, head-20_000, d.Pick)
+	})
+
+	t.Run("RunawayPairIsOutsideTolerance", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Two upstreams jump far past where the chain can possibly be.
+		d := tr.Observe(now, tipsFromInts(head+500_000, head+500_000, head, head, head), head, params)
+		assert.False(t, d.Overrode, "a group that far off the trajectory must not win")
+		assert.Equal(t, head, d.Pick)
+	})
+
+	t.Run("UpwardOnly", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Three upstreams run ahead, two sit exactly on the trajectory: the
+		// on-trajectory group wins the election, but electing it would LOWER
+		// the majority pick, so the referee stands down instead.
+		d := tr.Observe(now, tipsFromInts(head+50_000, head+50_000, head+50_000, head, head), head+50_000, params)
+		assert.False(t, d.Overrode, "the referee may never lower or hold the pick")
+		assert.Equal(t, head+50_000, d.Pick)
+	})
+
+	t.Run("HealthyFleetIsOneGroupAndNeverIntervenes", func(t *testing.T) {
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)
+
+		// Normal propagation skew, well inside one cluster width.
+		heads := tipsFromInts(head, head-1, head-3, head-7, head-11)
+		median := PickServedTip(heads).Tip
+		d := tr.Observe(now, heads, median, params)
+		assert.False(t, d.Overrode)
+		assert.False(t, d.Declined, "a fleet in one cluster is not even a near miss")
+		assert.Equal(t, median, d.Pick)
+	})
+}
+
+func TestTipTrajectory_BurstyChainWidensItsOwnTolerance(t *testing.T) {
+	var steady, bursty TipTrajectory
+
+	_, _ = warmTrajectory(&steady, time.Now(), 1_000_000, 100, 130)
+
+	// Same average velocity, delivered in bursts: 9 samples of nothing, then a
+	// 1000-block batch (the L2-sequencer shape).
+	now, head := time.Now(), int64(1_000_000)
+	for i := 0; i < 130; i++ {
+		if i%10 == 9 {
+			head += 1000
+		}
+		bursty.Observe(now, tipsFromInts(head), head, trajectoryParams())
+		now = now.Add(tipSampleInterval)
+	}
+
+	steadyFit, burstyFit := steady.fit.Load(), bursty.fit.Load()
+	require.NotNil(t, steadyFit)
+	require.NotNil(t, burstyFit)
+	assert.InDelta(t, steadyFit.vPerSec, burstyFit.vPerSec, 2.0,
+		"both tracks average the same velocity")
+	assert.Greater(t, burstyFit.spread*tipToleranceSigmas, float64(1024),
+		"a chain that pauses and bursts must widen its own tolerance past the floor")
+	assert.Less(t, steadyFit.spread*tipToleranceSigmas, float64(1024),
+		"a metronomic chain keeps the configured floor")
+}
+
+func TestTipTrajectory_SampleThrottleAndBufferBound(t *testing.T) {
+	var tr TipTrajectory
+	params := trajectoryParams()
+	now := time.Now()
+
+	// A hot request path: 500 evaluations inside one sample interval.
+	for i := 0; i < 500; i++ {
+		tr.Observe(now.Add(time.Duration(i)*time.Millisecond), tipsFromInts(1_000_000), 1_000_000, params)
+	}
+	assert.Equal(t, 1, tr.SampleCount(), "the throttle admits one sample per interval, whatever the QPS")
+
+	// And the ring never grows past the capacity derived from the window.
+	_, _ = warmTrajectory(&tr, now.Add(tipSampleInterval), 1_000_100, 100, 4_000)
+	assert.Equal(t, tipBufferCapacity(params.Window), tr.SampleCount())
+	assert.LessOrEqual(t, tr.fit.Load().spanMs, int64(tipBufferCapacity(params.Window))*tipSampleInterval.Milliseconds())
+}
+
+// The request path calls Observe from every serving goroutine at once, so the
+// throttle's double-checked lock, the refit and the lock-free fit read all have
+// to hold up under -race.
+func TestTipTrajectory_ConcurrentObserve(t *testing.T) {
+	var tr TipTrajectory
+	params := trajectoryParams()
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				head := int64(1_000_000 + i*100)
+				tr.Observe(start.Add(time.Duration(i)*tipSampleInterval), tipsFromInts(head, head-1), head, params)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Positive(t, tr.SampleCount())
+	assert.LessOrEqual(t, tr.SampleCount(), tipBufferCapacity(params.Window),
+		"the ring must stay bounded however many goroutines record into it")
+}
+
+func TestTipClusterWidth(t *testing.T) {
+	// Sub-second-block chains and slow chains alike keep the floor; a fast
+	// chain gets 10 seconds of its own progress.
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(0.083), "12s blocks → floor")
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(1), "1s blocks → floor")
+	assert.Equal(t, int64(40), tipClusterWidth(4), "250ms blocks → 10s of progress")
+	assert.Equal(t, int64(tipMinClusterWidth), tipClusterWidth(math.NaN()), "NaN must fall to the floor")
+	assert.Equal(t, tipMaxClusterWidth, tipClusterWidth(math.MaxFloat64), "no int64 overflow")
 }

--- a/common/config.go
+++ b/common/config.go
@@ -2576,6 +2576,20 @@ type EvmServedTipConfig struct {
 	// state poller and health tracker apply to a retreating head, so all three
 	// layers agree on what counts as a genuine deep correction.
 	MaxRegressionBlocks int64 `yaml:"maxRegressionBlocks,omitempty" json:"maxRegressionBlocks,omitempty"`
+
+	// TrajectoryWindow is how much recorded head history the trajectory referee
+	// needs before it may participate in the pick. The referee tracks where this
+	// network's head has been over the window and, when a stalled group holds
+	// the majority, serves the corroborated group that is actually where the
+	// chain should be by now (see architecture/evm's TipTrajectory: advisory,
+	// upward-only, in-process, and a no-op until every confidence condition
+	// holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
+	// disables the referee entirely — nothing is recorded and the pick is the
+	// plain majority. Values much below a few minutes are self-defeating (the
+	// window must be long enough that a stall cannot look like a trajectory),
+	// and values beyond about an hour never warm up at all: the sample ring is
+	// capped, so the span the referee requires would never be reached.
+	TrajectoryWindow *Duration `yaml:"trajectoryWindow,omitempty" json:"trajectoryWindow,omitempty"`
 }
 
 // ServedTipEnabledFor reports whether the majority served tip is enabled for

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -2166,6 +2166,15 @@ const DefaultBlockUnavailableDelayMultiplier = 1.0
 // and the health tracker so both layers converge on the same head.
 const DefaultToleratedBlockHeadRollback = 1024
 
+// DefaultServedTipTrajectoryWindow is how much head history the served-tip
+// trajectory referee needs before it may participate in a pick
+// (EvmServedTipConfig.TrajectoryWindow). Ten minutes is long enough that a
+// majority stall cannot masquerade as the trajectory (the referee's evidence is
+// the median of live heads, so a stall of half the window already flattens the
+// fit and stands the referee down), and short enough to be warm well within a
+// pod's lifetime.
+const DefaultServedTipTrajectoryWindow = 10 * time.Minute
+
 // DefaultEmptyResultMaxAttempts bounds retries when the requested data isn't on the
 // upstream yet (empty/missing-data point-lookups, pending tx-lookups, and
 // ErrUpstreamBlockUnavailable): one original attempt + one retry after ~one block.

--- a/common/validation.go
+++ b/common/validation.go
@@ -1520,6 +1520,9 @@ func (e *EvmNetworkConfig) Validate() error {
 		if e.ServedTip.MaxRegressionBlocks < 0 {
 			return fmt.Errorf("network.*.evm.servedTip.maxRegressionBlocks must be >= 0 (0 uses the default rollback tolerance)")
 		}
+		if e.ServedTip.TrajectoryWindow != nil && *e.ServedTip.TrajectoryWindow < 0 {
+			return fmt.Errorf("network.*.evm.servedTip.trajectoryWindow must be >= 0 (0 disables the trajectory referee)")
+		}
 		for _, m := range e.ServedTip.GuaranteedMethods {
 			if err := ValidatePattern(m); err != nil {
 				return fmt.Errorf("network.*.evm.servedTip.guaranteedMethods has invalid pattern %q: %w", m, err)

--- a/common/validation_servedtip_test.go
+++ b/common/validation_servedtip_test.go
@@ -56,6 +56,20 @@ func TestEvmNetworkConfig_Validate_ServedTip(t *testing.T) {
 		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}}
 		require.NoError(t, e.Validate())
 	})
+
+	t.Run("negative trajectoryWindow rejected", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{TrajectoryWindow: Duration(-1).Ptr()}
+		err := e.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trajectoryWindow")
+	})
+
+	t.Run("zero trajectoryWindow disables the referee", func(t *testing.T) {
+		e := baseValidEvmNetworkConfig()
+		e.ServedTip = &EvmServedTipConfig{EnabledFor: []string{"latest"}, TrajectoryWindow: Duration(0).Ptr()}
+		require.NoError(t, e.Validate())
+	})
 }
 
 // TestNetworkConfig_SetDefaults_InheritsServedTip ensures a global

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -123,6 +123,18 @@ type servedTipAnchor struct {
 	// on transitions, so a sustained regression reports twice (once when it
 	// starts holding, once if it gives up) instead of once per request.
 	guardState atomic.Int32
+
+	// trajectory is this lane+axis's long-term head track — the referee that
+	// lets a corroborated FRESH MINORITY outvote a stalled majority
+	// (refereeServedTip). It holds no pick either: its samples are the plain
+	// majority over live heads, its output is always one of the head values the
+	// live upstreams offer in the same evaluation, and it can only ever raise
+	// the pick. See evm.TipTrajectory.
+	trajectory evm.TipTrajectory
+
+	// trajectoryOverriding mirrors guardState for the referee: the override is
+	// logged on transitions only.
+	trajectoryOverriding atomic.Bool
 }
 
 const (
@@ -764,13 +776,19 @@ func (n *Network) tryShortCircuitFutureBlock(ctx context.Context, req *common.No
 }
 
 // servedTip computes the majority served tip for one axis over the
-// selection-policy-eligible upstreams — the freshest block a strict majority
-// of them already has (see evm.PickServedTip) — guards it against a regression
-// far below the live heads, applies the guaranteed-method floor, and exports
-// the gauges. The pick itself carries NO history: nothing is persisted and
-// nothing predicted, so no inherited or rogue value can pin, freeze or poison
-// the result (networks_served_tip_invariants_test.go pins those outcomes
-// against the 2026-06 production incident).
+// selection-policy-eligible upstreams — the freshest block a strict majority of
+// them already has (see evm.PickServedTip) — lets the trajectory referee prefer
+// a corroborated on-trajectory group when that majority has stalled, guards the
+// result against a regression far below the live heads, applies the
+// guaranteed-method floor, and exports the gauges.
+//
+// Both history-aware layers are in-process, bounded and one-directional (the
+// referee can only raise the pick; the guard can only hold it, and only
+// briefly), and NEITHER can produce a block that no live upstream reports in
+// the very same evaluation. Nothing is persisted and nothing is predicted, so
+// no inherited or rogue value can pin, freeze or poison the result
+// (networks_served_tip_invariants_test.go pins those outcomes against the
+// 2026-06 production incident).
 func (n *Network) servedTip(
 	ctx context.Context,
 	span trace.Span,
@@ -781,6 +799,13 @@ func (n *Network) servedTip(
 ) int64 {
 	tips, maxLiveHead := n.gatherEvmTipInputsForMethod(ctx, useFinalized, "*")
 	pick := evm.PickServedTip(tips)
+
+	// Trajectory referee: when the live heads split and the majority is the
+	// STALLED group, serve the corroborated group that matches where this
+	// network's head has been going for the last ten minutes. Advisory and
+	// upward-only — it can only replace the majority pick with a higher block
+	// that at least two live upstreams already have.
+	pick.Tip = n.refereeServedTip(axis, lane, anchor, tips, pick.Tip, maxLiveHead)
 
 	// Regression guard: "latest" cannot drop far below the freshest live head
 	// in one evaluation. Runs BEFORE the guaranteed-method floor, which is a
@@ -817,6 +842,101 @@ func (n *Network) servedTip(
 	}
 	n.observeServedTipMetrics(axis, lane, pick, advanceAge)
 	return pick.Tip
+}
+
+// refereeServedTip returns the tip to serve for `median` (the plain majority
+// pick), letting the network's long-term head trajectory choose between the
+// groups the LIVE heads of this same evaluation form.
+//
+// Every mechanism before this one is a snapshot of one instant, which is what a
+// majority stall defeats: if N upstreams freeze while staying inside the
+// lag-exclusion threshold — or a fleet-wide shared-counter freeze stalls the
+// lag metric itself — the majority IS the stale group, and the two upstreams
+// that genuinely hold the chain's head are outvoted. The trajectory is the one
+// piece of evidence that separates "the chain stopped" from "those upstreams
+// stopped": where this network's head has actually been going for the last ten
+// minutes (evm.TipTrajectory).
+//
+// It is deliberately the weakest intervention that answers that:
+//
+//   - it never runs without an anchor (arbitrary use-upstream selectors
+//     materialize no state), without a pick, or without a live head — the same
+//     conditions the regression guard stands down on;
+//   - it never runs when the config disables it (trajectoryWindow: 0), and it
+//     is a no-op until every confidence condition in evm.TipTrajectory holds,
+//     so a cold or stale process behaves byte-identically to the plain
+//     majority;
+//   - it can only RAISE the pick, and only to the minimum of a group of ≥2
+//     live upstreams — a value they can all serve, and one at most as high as
+//     the freshest live head. It can neither hold the tip back nor invent one.
+//
+// The pick stays ≤ evm.ServedTipPick.Freshest (the 2nd-highest head) for the
+// same reason, so the served-tip lag gauge never reads negative.
+func (n *Network) refereeServedTip(axis string, lane string, anchor *servedTipAnchor, tips []evm.ServedTipInput, median int64, maxLiveHead int64) int64 {
+	if anchor == nil || median <= 0 || maxLiveHead <= 0 {
+		// maxLiveHead > 0 is also what makes `tips` safe to sample and cluster:
+		// gatherEvmTipInputsForMethod only returns bound-capped observations
+		// when there is no live head at all, and a serving range must never
+		// enter a head trajectory.
+		return median
+	}
+	window := n.servedTipTrajectoryWindow()
+	if window <= 0 {
+		return median
+	}
+
+	decision := anchor.trajectory.Observe(servedTipClock(), tips, median, evm.TipTrajectoryParams{
+		Window:         window,
+		ToleranceFloor: n.servedTipMaxRegressionBlocks(),
+	})
+
+	switch {
+	case decision.Overrode:
+		telemetry.MetricNetworkServedTipTrajectoryTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "override").
+			Inc()
+	case decision.Declined:
+		telemetry.MetricNetworkServedTipTrajectoryTotal.
+			WithLabelValues(n.projectId, n.Label(), servedTipLaneLabel(lane), axis, "fallback").
+			Inc()
+	}
+	n.logServedTipTrajectoryTransition(anchor, axis, median, decision)
+
+	return decision.Pick
+}
+
+// logServedTipTrajectoryTransition logs only when the referee STARTS or STOPS
+// overriding, so a stall that persists across thousands of requests produces
+// one line at each end of it.
+func (n *Network) logServedTipTrajectoryTransition(anchor *servedTipAnchor, axis string, median int64, d evm.TipTrajectoryDecision) {
+	if anchor.trajectoryOverriding.Swap(d.Overrode) == d.Overrode {
+		return
+	}
+	if !d.Overrode {
+		n.logger.Warn().
+			Str("axis", axis).
+			Int64("pick", d.Pick).
+			Msg("served tip is back on the majority pick; the trajectory referee is no longer overriding")
+		return
+	}
+	n.logger.Error().
+		Str("axis", axis).
+		Int64("pick", d.Pick).
+		Int64("majorityPick", median).
+		Int64("expectedBlock", d.Expected).
+		Int64("tolerance", d.Tolerance).
+		Float64("blocksPerSecond", d.VelocityPerSec).
+		Msg("majority of the eligible upstreams is off the network's long-term head trajectory; serving the corroborated group that is on it")
+}
+
+// servedTipTrajectoryWindow is how much recorded head history the trajectory
+// referee needs before it may participate. Unset uses
+// DefaultServedTipTrajectoryWindow; an explicit 0 disables the referee.
+func (n *Network) servedTipTrajectoryWindow() time.Duration {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.ServedTip != nil && n.cfg.Evm.ServedTip.TrajectoryWindow != nil {
+		return n.cfg.Evm.ServedTip.TrajectoryWindow.Duration()
+	}
+	return common.DefaultServedTipTrajectoryWindow
 }
 
 // guardServedTipRegression returns the tip to serve for `pick`, substituting

--- a/erpc/networks_served_tip_test.go
+++ b/erpc/networks_served_tip_test.go
@@ -3,11 +3,13 @@ package erpc
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
@@ -912,4 +914,388 @@ func TestServedTip_RegressionGuard_SkippedWithoutLiveHead(t *testing.T) {
 		"the guard cannot trip without a live head to compare against")
 	assert.Zero(t, network.servedLatestAnchor.lastGoodValue.Load(),
 		"an uncorroborated cap must never be remembered as a good pick")
+}
+
+// ─── Long-term trajectory referee ────────────────────────────────────────────
+//
+// Every mechanism above is a snapshot of one instant, and a majority stall
+// defeats all of them at once: when N upstreams freeze while staying eligible,
+// the majority IS the stale group and the 2 upstreams holding the real head are
+// outvoted. These tests pin the referee that breaks that tie from the network's
+// own 10-minute head trajectory — and, just as importantly, pin how narrowly it
+// is allowed to act.
+
+const (
+	// servedTipSampleInterval mirrors the tracker's unexported sample throttle
+	// (architecture/evm: tipSampleInterval) — the cadence a warm-up must tick
+	// at for the buffer to fill.
+	servedTipSampleInterval = 5 * time.Second
+
+	// servedTipMaxSampleGap mirrors architecture/evm's tipMaxSampleGap.
+	servedTipMaxSampleGap = time.Minute
+
+	// The warm-up track: 100 blocks per 5s sample = 20 blocks/s, a fast-L2
+	// cadence that makes one stalled sample worth 100 blocks and keeps the
+	// scenarios legible. 130 samples ≈ 10m45s, just past the default window.
+	trajectoryStartHead       = int64(1_000_000)
+	trajectoryBlocksPerSample = int64(100)
+	trajectoryWarmSamples     = 130
+)
+
+// servedTipTrajectoryCount reads the referee's counter for a network/axis/outcome.
+func servedTipTrajectoryCount(n *Network, axis, outcome string) float64 {
+	return promUtil.ToFloat64(telemetry.MetricNetworkServedTipTrajectoryTotal.
+		WithLabelValues(n.projectId, n.Label(), servedTipLaneAll, axis, outcome))
+}
+
+// setupTrajectoryNetwork builds a `count`-upstream network with the pinned
+// served-tip clock, and returns the clock's advance function.
+func setupTrajectoryNetwork(t *testing.T, ctx context.Context, count int, stCfg *common.EvmServedTipConfig) (*Network, []*upstream.Upstream, func(time.Duration)) {
+	t.Helper()
+	advance := pinServedTipClock(t)
+	fixtures := make([]servedTipFixture, count)
+	for i := range fixtures {
+		fixtures[i] = servedTipFixture{id: "u" + strconv.Itoa(i+1), chainID: 123, latestBlock: trajectoryStartHead}
+	}
+	network, ups := setupServedTipNetworkWith(t, ctx, fixtures, stCfg)
+	return network, ups, advance
+}
+
+// suggestServedTipHead moves an upstream's poller head up to `head` in steps no
+// larger than the poller's major-jump threshold. A single larger suggestion is
+// deliberately deferred to an asynchronous chain-identity check
+// (verifyThenSuggestLatestBlock), which these deterministic scenarios must not
+// race against.
+func suggestServedTipHead(u *upstream.Upstream, head int64) {
+	for {
+		current := u.EvmStatePoller().LatestBlock()
+		if current >= head {
+			return
+		}
+		next := head
+		if head-current > common.DefaultToleratedBlockHeadRollback {
+			next = current + common.DefaultToleratedBlockHeadRollback
+		}
+		u.EvmStatePoller().SuggestLatestBlock(next)
+		if u.EvmStatePoller().LatestBlock() < next {
+			return // the poller refused it; let the assertion report the state
+		}
+	}
+}
+
+// warmServedTipTrajectory drives `samples` real evaluations one sample interval
+// apart with every upstream advancing together, so the network's tracker sees a
+// clean linear head track through the ordinary request path. Returns the head
+// every upstream ends on (the clock sits on the last sample).
+func warmServedTipTrajectory(t *testing.T, ctx context.Context, network *Network, ups []*upstream.Upstream, advance func(time.Duration), samples int) int64 {
+	t.Helper()
+	head := trajectoryStartHead
+	for i := 0; i < samples; i++ {
+		for _, u := range ups {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		require.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx),
+			"warm-up sample %d: an agreeing fleet must serve its agreed head", i)
+		if i < samples-1 {
+			advance(servedTipSampleInterval)
+			head += trajectoryBlocksPerSample
+		}
+	}
+	return head
+}
+
+// stallMajority freezes every upstream except the first `fresh` of them, which
+// keep the warm-up track for `samples` more evaluations. Returns the head the
+// fresh group ends on and the last served value.
+func stallMajority(t *testing.T, ctx context.Context, network *Network, ups []*upstream.Upstream, advance func(time.Duration), head int64, fresh int, samples int) (int64, int64) {
+	t.Helper()
+	served := int64(0)
+	for i := 0; i < samples; i++ {
+		advance(servedTipSampleInterval)
+		head += trajectoryBlocksPerSample
+		for _, u := range ups[:fresh] {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		served = network.EvmHighestLatestBlockNumber(ctx)
+	}
+	return head, served
+}
+
+// THE headline case, and the requirement the referee exists for: in an N-vs-2
+// split where the 2 sit at the higher block, use the 2. Three upstreams freeze
+// inside the lag-exclusion threshold (a shared-counter freeze, a stuck vendor
+// region) while two keep the chain's head; the strict majority is now the stale
+// group, so the plain majority pick — and every instantaneous rule — serves a
+// block the chain left minutes ago.
+func TestServedTip_TrajectoryReferee_StalledMajorityLosesToFreshMinority(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeHeld := servedTipRegressionCount(network, "latest", "held")
+
+	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	// What the plain majority pick WOULD be over the very same ballot: the
+	// frozen head, held by 3 of the 5 upstreams.
+	majority := evm.PickServedTip([]evm.ServedTipInput{
+		{UpstreamID: "u1", BlockNumber: fresh},
+		{UpstreamID: "u2", BlockNumber: fresh},
+		{UpstreamID: "u3", BlockNumber: frozen},
+		{UpstreamID: "u4", BlockNumber: frozen},
+		{UpstreamID: "u5", BlockNumber: frozen},
+	}).Tip
+	require.Equal(t, frozen, majority,
+		"precondition: the stalled group holds the majority, so the plain pick is the stale head")
+
+	assert.Equal(t, fresh, served,
+		"the corroborated pair that is where the chain should be by now must define the tip; "+
+			"the plain majority would have served %d, %d blocks behind", majority, fresh-majority)
+	assert.Greater(t, servedTipTrajectoryCount(network, "latest", "override"), beforeOverride,
+		"an override is an intervention and must be counted")
+	assert.Equal(t, beforeHeld, servedTipRegressionCount(network, "latest", "held"),
+		"raising the tip to the live pair is not a regression; the guard must stay out of it")
+}
+
+// The inverse split, and the reason a group is elected by its DISTANCE to the
+// trajectory rather than by its freshness: two upstreams running far past where
+// the chain can possibly be (wrong chain, garbage endpoint) must lose to the
+// healthy group, however corroborated they are with each other.
+func TestServedTip_TrajectoryReferee_RunawayMinorityLoses(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// maxRegressionBlocks is widened so the branch's regression guard (which
+	// measures against the RAW max live head, and would hold the tip the moment
+	// any upstream runs 1024 blocks ahead) stays out of the way: what is under
+	// test here is the referee's own election.
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{
+		EnabledFor:          []string{"latest"},
+		MaxRegressionBlocks: 100_000,
+	})
+	head := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeFallback := servedTipTrajectoryCount(network, "latest", "fallback")
+
+	// Two upstreams run 20k blocks (≈16 minutes of this chain) ahead; the other
+	// three stay exactly on the track.
+	advance(servedTipSampleInterval)
+	head += trajectoryBlocksPerSample
+	for _, u := range ups {
+		suggestServedTipHead(u, head)
+	}
+	for _, u := range ups[:2] {
+		suggestServedTipHead(u, head+20_000)
+	}
+
+	assert.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx),
+		"the runaway pair is nowhere near the trajectory; the healthy majority keeps the tip")
+	assert.Equal(t, beforeOverride, servedTipTrajectoryCount(network, "latest", "override"),
+		"no override happened")
+	assert.Equal(t, beforeFallback, servedTipTrajectoryCount(network, "latest", "fallback"),
+		"the healthy group is elected outright, so this is not even a near miss")
+}
+
+// Warm-up inertness: until the tracker has a window's worth of history the
+// referee is a no-op and the network behaves exactly as it does without it.
+// This is also the boot behaviour of every pod after every deploy.
+func TestServedTip_TrajectoryReferee_ColdProcessIsInert(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	// Half a window: enough samples for a fit, nowhere near enough span.
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples/2)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	assert.Equal(t, frozen, served,
+		"a cold tracker must leave the plain majority pick untouched")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+}
+
+// Staleness: the fit describes the present only if the track is continuous. A
+// gap larger than the tracker's tolerance is exactly where a halt or a burst
+// hides, so extrapolating across one is guessing — and the referee stands down.
+// The paired sub-tests differ ONLY in the size of that gap.
+func TestServedTip_TrajectoryReferee_StaleTrackFailsOpen(t *testing.T) {
+	// After `gap` of silence the fresh pair sits exactly on the trajectory
+	// (20 blocks/s), i.e. the referee's evidence is otherwise perfect.
+	run := func(t *testing.T, gap time.Duration) (served, frozen, fresh int64, overrides float64) {
+		util.ResetGock()
+		defer util.ResetGock()
+		util.SetupMocksForEvmStatePoller()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+		frozen = warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+		before := servedTipTrajectoryCount(network, "latest", "override")
+
+		advance(gap)
+		fresh = frozen + trajectoryBlocksPerSample*int64(gap/servedTipSampleInterval)
+		for _, u := range ups[:2] {
+			suggestServedTipHead(u, fresh)
+		}
+		served = network.EvmHighestLatestBlockNumber(ctx)
+		return served, frozen, fresh, servedTipTrajectoryCount(network, "latest", "override") - before
+	}
+
+	t.Run("ContinuousTrackOverrides", func(t *testing.T) {
+		served, _, fresh, overrides := run(t, servedTipMaxSampleGap-5*time.Second)
+		assert.Equal(t, fresh, served, "an unbroken track lets the referee act")
+		assert.Equal(t, float64(1), overrides)
+	})
+
+	t.Run("GappedTrackFailsOpen", func(t *testing.T) {
+		served, frozen, _, overrides := run(t, servedTipMaxSampleGap+time.Second)
+		assert.Equal(t, frozen, served,
+			"one sample past the gap tolerance the same evidence must be refused")
+		assert.Zero(t, overrides)
+	})
+}
+
+// A chain that pauses and bursts (an L2 landing batches) has a large residual
+// spread of its own, which widens the referee's tolerance automatically — and a
+// legitimate fleet-wide jump keeps every head in ONE cluster, where the referee
+// has nothing to choose between. Neither may produce a false override.
+func TestServedTip_TrajectoryReferee_PauseThenBurstDoesNotFalsePositive(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+
+	// Same average velocity as the linear warm-up, delivered in batches: nine
+	// samples of nothing, then 1000 blocks at once.
+	head := trajectoryStartHead
+	for i := 0; i < trajectoryWarmSamples; i++ {
+		if i%10 == 9 {
+			head += trajectoryBlocksPerSample * 10
+		}
+		for _, u := range ups {
+			u.EvmStatePoller().SuggestLatestBlock(head)
+		}
+		require.Equal(t, head, network.EvmHighestLatestBlockNumber(ctx))
+		advance(servedTipSampleInterval)
+	}
+
+	beforeOverride := servedTipTrajectoryCount(network, "latest", "override")
+	beforeFallback := servedTipTrajectoryCount(network, "latest", "fallback")
+
+	// The whole fleet lands the next batch, with ordinary propagation skew.
+	head += 5_000
+	for i, u := range ups {
+		suggestServedTipHead(u, head-int64(i%2)*50)
+	}
+	served := network.EvmHighestLatestBlockNumber(ctx)
+
+	assert.Equal(t, head, served,
+		"a legitimate fleet-wide burst is one cluster; the majority pick stands")
+	assert.Equal(t, beforeOverride, servedTipTrajectoryCount(network, "latest", "override"))
+	assert.Equal(t, beforeFallback, servedTipTrajectoryCount(network, "latest", "fallback"),
+		"a fleet in one cluster does not even register a disagreement")
+}
+
+// Corroboration, not agreement with the model: a single upstream sitting
+// exactly where the trajectory says the head is proves nothing — it is the one
+// endpoint that could be wrong in the same direction as everyone else being
+// stuck. A group of one is never electable.
+func TestServedTip_TrajectoryReferee_SingletonIsNotCorroboration(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 1, 24)
+
+	assert.Equal(t, frozen, served,
+		"one on-trajectory witness cannot move the tip, however well it fits")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+}
+
+// Composition with the regression guard: the referee runs first and the guard
+// judges whatever comes out of it. Once a stall has handed the tip to the fresh
+// pair, losing that pair from the eligible set drops the majority pick far below
+// the best live head — and the guard holds the last corroborated value exactly
+// as it does for any other poisoned ballot.
+func TestServedTip_TrajectoryReferee_ComposesWithRegressionGuard(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{EnabledFor: []string{"latest"}})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+	fresh, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+	require.Equal(t, fresh, served, "precondition: the referee is holding the tip on the fresh pair")
+	require.Greater(t, fresh-frozen, int64(common.DefaultToleratedBlockHeadRollback),
+		"precondition: the stall is deeper than the regression tolerance")
+
+	before := servedTipRegressionCount(network, "latest", "held")
+
+	// One fresh upstream leaves the eligible set: the remaining ballot is
+	// [fresh, frozen, frozen] — a lone fresh head is no group, so the referee
+	// stands down and the majority pick collapses onto the stalled pair.
+	network.PinUpstreamOrderForTest("u1", "u3", "u4")
+
+	assert.Equal(t, fresh, network.EvmHighestLatestBlockNumber(ctx),
+		"the guard must hold the last corroborated pick, as it does for any poisoned ballot")
+	assert.Equal(t, before+1, servedTipRegressionCount(network, "latest", "held"))
+}
+
+// The off switch is a real off switch: trajectoryWindow: 0 records nothing and
+// decides nothing, so the network serves the plain majority pick — the stale
+// head — through the exact scenario the referee exists to fix.
+func TestServedTip_TrajectoryReferee_DisabledByZeroWindow(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	util.SetupMocksForEvmStatePoller()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	network, ups, advance := setupTrajectoryNetwork(t, ctx, 5, &common.EvmServedTipConfig{
+		EnabledFor:       []string{"latest"},
+		TrajectoryWindow: common.Duration(0).Ptr(),
+	})
+	frozen := warmServedTipTrajectory(t, ctx, network, ups, advance, trajectoryWarmSamples)
+
+	before := servedTipTrajectoryCount(network, "latest", "override")
+	_, served := stallMajority(t, ctx, network, ups, advance, frozen, 2, 24)
+
+	assert.Equal(t, frozen, served,
+		"with the referee off the stalled majority defines the tip again")
+	assert.Equal(t, before, servedTipTrajectoryCount(network, "latest", "override"))
+	assert.Zero(t, network.servedLatestAnchor.trajectory.SampleCount(),
+		"a disabled referee must not even record a head track")
 }

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -167,6 +167,25 @@ var (
 		Help:      "Served-tip picks rejected as a regression far below the freshest live upstream head, by outcome (held = last corroborated pick served instead; failed_open = the pick was served anyway after the guard's window).",
 	}, []string{"project", "network", "lane", "axis", "outcome"})
 
+	// MetricNetworkServedTipTrajectoryTotal counts the evaluations where the
+	// long-term trajectory referee had a FRESHER corroborated group of live
+	// heads on the table than the majority pick. outcome="override" = that
+	// group matched the network's own head trajectory and was served instead of
+	// a stalled majority — rare, and the reason to page someone: some upstreams
+	// froze while remaining eligible. outcome="fallback" = it did not match
+	// closely enough, so the majority pick stood.
+	//
+	// Both are silent in steady state by construction: a fleet whose live heads
+	// form one cluster elects that cluster, and a fleet permanently split around
+	// its own median elects the median's group (the trajectory is fitted to the
+	// median, so no permanently-offset group is ever closer to it). Any sustained
+	// rate here means the fleet's groups are genuinely diverging.
+	MetricNetworkServedTipTrajectoryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_served_tip_trajectory_total",
+		Help:      "Served-tip evaluations where a corroborated group of live heads sat above the majority pick, by outcome (override = that group matched the network's head trajectory and was served; fallback = it did not, and the majority pick stood).",
+	}, []string{"project", "network", "lane", "axis", "outcome"})
+
 	MetricUpstreamCordoned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "erpc",
 		Name:      "upstream_cordoned",

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1613,6 +1613,21 @@ export interface EvmServedTipConfig {
    * layers agree on what counts as a genuine deep correction.
    */
   maxRegressionBlocks?: number /* int64 */;
+  /**
+   * TrajectoryWindow is how much recorded head history the trajectory referee
+   * needs before it may participate in the pick. The referee tracks where this
+   * network's head has been over the window and, when a stalled group holds
+   * the majority, serves the corroborated group that is actually where the
+   * chain should be by now (see architecture/evm's TipTrajectory: advisory,
+   * upward-only, in-process, and a no-op until every confidence condition
+   * holds). Unset uses DefaultServedTipTrajectoryWindow (10m); an explicit 0
+   * disables the referee entirely — nothing is recorded and the pick is the
+   * plain majority. Values much below a few minutes are self-defeating (the
+   * window must be long enough that a stall cannot look like a trajectory),
+   * and values beyond about an hour never warm up at all: the sample ring is
+   * capped, so the span the referee requires would never be reached.
+   */
+  trajectoryWindow?: Duration;
 }
 /**
  * EvmIntegrityConfig is deprecated. Use DirectiveDefaultsConfig for validation settings.


### PR DESCRIPTION
> **Stacked on #1063** (`fix/served-tip-live-heads`). This PR targets that
> branch, so its diff is only the trajectory referee. Merge #1063 first; this
> retargets to `main` on its own afterwards.

## The gap #1063 does not close

#1063 fixes two ways a served-tip ballot gets poisoned by values that are not
head observations. Both fixes — and the majority order statistic itself — are
**snapshots of one instant**. That is exactly what a majority *stall* defeats:

* N upstreams freeze while staying inside the lag-exclusion threshold, or a
  fleet-wide shared-counter freeze stalls the lag metric itself;
* the strict majority is now the **stale** group;
* the 2 upstreams that genuinely hold the chain's head are outvoted;
* every instantaneous rule agrees with the stale majority, because "most
  upstreams say block H" and "the chain stopped at H" are the same observation.

The operator requirement, verbatim: *in an N vs 2 split where the 2 sit at a
higher block, still use the 2 — but governed by a long-term in-memory
latest-block track recorded over at least 10-15 minutes; pick the group closest
to that long-term trajectory; be robust and strict enough that the tracking
never creates more issues than it solves.*

The last clause is the hard part, and it has a name: commit `7dee07c0` removed
the previous stateful tip pipeline (velocity gate + persisted monotonic clamp)
because it reached an **absorbing state** — every live tip rejected, the served
tip frozen fleet-wide across 25+ chain/region pairs. Anything stateful here has
to be structurally incapable of that, not merely tuned away from it.

## Mechanism

`evm.TipTrajectory` — per network, per axis, per pod, in memory only.

**Record** (throttled to one sample per 5s, on the tip evaluation itself): a
monotonic-clock timestamp and the plain **median of the live heads**. Never the
served value, never the referee's own output, never a bound-capped observation.

**Refit** (on insertion, never per request):

| quantity | estimator |
|---|---|
| velocity | median of **half-window-lagged slopes** — sample `i` against sample `i+n/2`, median of the ~n/2 of them |
| intercept | median residual (the standard robust intercept) |
| spread | median absolute residual around that line |

Two properties matter and full Theil-Sen buys neither: every slope spans half
the window, so per-sample noise is divided by a long baseline; and one poisoned
sample enters at most two of the ~90 slopes, so the median never moves.
Theil-Sen's n²/2 pairs (≈16k at n=180) would cost a 128 KB sort per fit for the
same answer. `TestTipTrajectory_PoisonedSampleDoesNotMoveTheFit` pins it.

**Decide** (O(1) read per request): cluster the live heads by single linkage at
`max(16 blocks, 10s × velocity)`, elect the group of **≥2** whose max sits
closest to the extrapolated expected head, and require that distance to be
within `max(6 × spread, maxRegressionBlocks)`. The pick is the group's
**minimum** — a block every member can serve.

Derived constants, all justified in comments next to them:

| constant | value | why |
|---|---|---|
| sample throttle | 5s | 120 samples in the default window; the O(n log n) refit runs at most 0.2 Hz per network+axis |
| cluster width | `max(16, 10s × v)` | 10s of chain progress covers poller skew and propagation between healthy providers; the floor keeps sub-second-block chains from splitting a healthy fleet into singletons |
| tolerance | `max(6 × spread, maxRegressionBlocks)` | a median absolute residual is ≈0.67σ, so k=6 is ≈4σ — a chain that pauses and bursts widens its own gate, a metronomic chain keeps the configured floor |
| min group size | 2 | one witness is not corroboration, however perfectly it matches |
| min samples / max gap | 30 / 60s | below either, "trajectory" is noise or guesswork |

## Confidence gate — the feature is inert unless every clause holds

`span ≥ trajectoryWindow` (new optional config field: unset → 10m, explicit
`0` → disabled) **and** `≥30 samples` **and** the freshest sample is `≤60s` old
*as of the start of the evaluation* (an evaluation may not paper over the gap it
just noticed) **and** a finite `velocity > 0`.

Otherwise the served tip is **byte-identical** to this branch today — including
on every pod for the first ten minutes after every deploy.

## Why it cannot recreate the `7dee07c0` frozen tip

* **Advisory, never generative.** It only ranks the groups the live upstreams
  offer in this very evaluation. It cannot invent, remember or extrapolate a
  servable block; the trajectory is used to *choose*, never to *produce*.
* **Upward-only.** It may raise the pick to a corroborated fresher group; it
  can never lower or hold one. *A referee that cannot hold a value back cannot
  freeze a tip.* Erring low is already the majority picker's job, and the
  regression guard's — so this is also the weakest rule that satisfies the
  requirement. (Deviation from the spec I was given, which allowed a downward
  override too; it bought nothing the majority pick doesn't already do, and it
  was the only direction from which a frozen tip was reachable.)
* **Self-limiting evidence.** Because samples are the plain median, a majority
  stall keeps feeding the tracker the stalled median: the fitted velocity
  decays and after roughly half a window the referee stands *itself* down. The
  intervention has a built-in expiry no configuration can extend.
* **Self-calibrating.** The fit tracks the median's own history, so a fleet
  permanently split around its median (flashblocks-style groups) elects the
  median's group — no permanently-offset group is ever closer to the
  trajectory. Only a group that leaves its own long-term track loses.
* **No shared state.** Per-pod, in-memory, rebuilt from live observations after
  a restart. Deliberate: a shared head counter is how the 2026-08 celo trigger
  propagated fleet-wide in the first place.
* The existing `networks_served_tip_invariants_test.go` — the black-box
  prod-incident suite that must never be adapted to new internals — passes
  unchanged.

## Order and observability

Inside `servedTip`: bound-capped input filter (#1063 fix 1) → **trajectory or
majority pick** → regression guard (#1063 fix 2) → guaranteed-method floor. The
guard judges whatever the referee produced, unchanged; because the referee's
pick is the minimum of a group of ≥2, it never exceeds
`ServedTipPick.Freshest`, so the lag gauge cannot read negative.

`erpc_network_served_tip_trajectory_total{outcome=override|fallback}` counts
the only two evaluations worth counting — the referee served an on-trajectory
group instead of a stalled majority, or it elected a fresher group and refused
it as not close enough. Both are silent in steady state by construction (a
fleet in one cluster elects that cluster; a fleet split around its median
elects the median's group). Overrides also log once when they start and once
when they stop, never per request.

## Default-on vs default-off — your call

I made it **default-on with a strict gate** rather than opt-in, on this
reasoning: the gate makes it a no-op in every state except the one it exists
for, it can only ever move the tip *up* to a block two live upstreams already
serve, an opt-in flag would mean the networks that need it are exactly the ones
nobody enabled it on, and `trajectoryWindow: 0` is a complete, tested off
switch. If you would rather it be opt-in, say so and I will invert it — the
change is one line in `servedTipTrajectoryWindow()` plus the config doc, and
none of the tests move.

## Test evidence

```
$ go test ./architecture/... ./common/... -count=1
ok  	github.com/erpc/erpc/architecture/evm	3.596s
ok  	github.com/erpc/erpc/architecture/evm/integrity	0.547s
ok  	github.com/erpc/erpc/architecture/svm	2.990s
ok  	github.com/erpc/erpc/common	3.587s
ok  	github.com/erpc/erpc/common/legacy	2.085s

$ go test ./upstream/... -count=1
ok  	github.com/erpc/erpc/upstream	7.647s

$ go test ./erpc/... -count=1 -timeout 25m
ok  	github.com/erpc/erpc/erpc	824.339s

$ go test ./erpc/ -run TestServedTip -count=1 -race -v   # 35/35 pass, incl. the
                                                        # untouched prod-incident
                                                        # invariants
--- PASS: TestServedTip_TrajectoryReferee_StalledMajorityLosesToFreshMinority (1.14s)
--- PASS: TestServedTip_TrajectoryReferee_RunawayMinorityLoses (1.14s)
--- PASS: TestServedTip_TrajectoryReferee_ColdProcessIsInert (1.13s)
--- PASS: TestServedTip_TrajectoryReferee_StaleTrackFailsOpen (2.27s)
--- PASS: TestServedTip_TrajectoryReferee_PauseThenBurstDoesNotFalsePositive (1.12s)
--- PASS: TestServedTip_TrajectoryReferee_SingletonIsNotCorroboration (1.13s)
--- PASS: TestServedTip_TrajectoryReferee_ComposesWithRegressionGuard (1.14s)
--- PASS: TestServedTip_TrajectoryReferee_DisabledByZeroWindow (1.13s)
ok  	github.com/erpc/erpc/erpc	45.107s

$ go test ./architecture/evm/ -run 'TestTipTrajectory|TestTipClusterWidth' -count=1 -race -v
--- PASS: TestTipTrajectory_FitRecoversVelocityAndExpectedHead (0.00s)
--- PASS: TestTipTrajectory_PoisonedSampleDoesNotMoveTheFit (0.00s)
--- PASS: TestTipTrajectory_ConfidenceGate (0.00s)
    --- PASS: .../ColdBufferIsInert   .../ShortWindowIsInert   .../StaleTrackIsInert
    --- PASS: .../HaltedChainIsInert  .../DisabledRecordsNothing
--- PASS: TestTipTrajectory_GroupElection (0.01s)
    --- PASS: .../StalledMajorityLosesToCorroboratedFreshPair
    --- PASS: .../SingletonIsNeverCorroboration  .../NearMissIsDeclinedNotOverridden
    --- PASS: .../RunawayPairIsOutsideTolerance .../UpwardOnly
    --- PASS: .../HealthyFleetIsOneGroupAndNeverIntervenes
--- PASS: TestTipTrajectory_BurstyChainWidensItsOwnTolerance (0.00s)
--- PASS: TestTipTrajectory_SampleThrottleAndBufferBound (0.07s)
--- PASS: TestTipTrajectory_ConcurrentObserve (0.00s)
--- PASS: TestTipClusterWidth (0.00s)
ok  	github.com/erpc/erpc/architecture/evm	2.030s
```

New coverage:

* `architecture/evm/served_tip_test.go` — the fit recovers a known velocity;
  one poisoned sample does not move it; every clause of the confidence gate
  (cold buffer, short span, stale track, halted chain, disabled); the election
  (stalled majority loses, singleton is not corroboration, near-miss is
  declined not overridden, runaway is outside tolerance, upward-only, healthy
  fleet never intervenes); a bursty chain widens its own tolerance while a
  metronomic one keeps the floor; the throttle and the ring bound.
* `erpc/networks_served_tip_test.go` — the same behaviour end-to-end through
  real `EvmHighestLatestBlockNumber` evaluations on the pinned served-tip
  clock: the headline 3-stalled-vs-2-fresh case (with the plain majority pick
  computed alongside to prove an override happened), the runaway minority, a
  cold process, the stale-track pair (identical evidence, one sample past the
  gap), pause-then-burst, the singleton, composition with the regression guard,
  and the `trajectoryWindow: 0` off switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
