### PR TITLE
feat(network): report networks with no upstreams instead of "initializing"

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -1373,6 +1373,39 @@ var NewErrNetworkInitializing = func(project string, network string) error {
 
 func (e *ErrNetworkInitializing) ErrorStatusCode() int { return http.StatusServiceUnavailable }
 
+// ErrNetworkNoUpstreamsAvailable is the terminal counterpart of
+// ErrNetworkInitializing: the network has been initializing for longer than
+// NoUpstreamsAvailableAfter and still has zero upstreams registered.
+//
+// It exists because "initializing; please retry shortly" is true of the first
+// seconds and a lie after the first hour. A chain that no configured upstream
+// or provider serves — removed from config, deprecated, never supported — sits
+// in that state permanently, so callers keep retrying and operators read the
+// message as a temporary blip. This one names the actual condition.
+type ErrNetworkNoUpstreamsAvailable struct{ BaseError }
+
+const ErrCodeNetworkNoUpstreamsAvailable ErrorCode = "ErrNetworkNoUpstreamsAvailable"
+
+var NewErrNetworkNoUpstreamsAvailable = func(project string, network string) error {
+	return &ErrNetworkNoUpstreamsAvailable{
+		BaseError{
+			Code: ErrCodeNetworkNoUpstreamsAvailable,
+			Message: fmt.Sprintf(
+				"no RPC providers are available for network '%s' in project '%s'",
+				network, project,
+			),
+			Details: map[string]interface{}{
+				"project": project,
+				"network": network,
+			},
+		},
+	}
+}
+
+func (e *ErrNetworkNoUpstreamsAvailable) ErrorStatusCode() int {
+	return http.StatusServiceUnavailable
+}
+
 // ErrNetworkNotSupported indicates that providers do not support the requested network
 // and no static upstreams exist. It should be treated as fatal for initialization tasks.
 type ErrNetworkNotSupported struct{ BaseError }

--- a/docs/pages/reference/errors.mdx
+++ b/docs/pages/reference/errors.mdx
@@ -82,6 +82,7 @@ StandardError interface
     ├── Project / Network
     │   ├── ErrProjectNotFound, ErrProjectAlreadyExists
     │   ├── ErrNetworkNotFound, ErrNetworkNotSupported, ErrNetworkInitializing
+    │   ├── ErrNetworkNoUpstreamsAvailable
     │   ├── ErrUnknownNetworkID, ErrUnknownNetworkArchitecture
     │   ├── ErrInvalidEvmChainId, ErrFinalizedBlockUnavailable, ErrNetworkRequestTimeout
     │
@@ -174,7 +175,8 @@ Legend:
 | 20 | `ErrNoUpstreamsLeftToSelect` | yes | yes | 200 | −32603 | per-upstream states in details |
 | 21 | `ErrNoUpstreamsDefined` | yes | yes | 200 | −32603 | **Dead code** — zero production call sites |
 | 22 | `ErrNoUpstreamsFound` | yes | yes | 200 | −32603 | — |
-| 23 | `ErrNetworkInitializing` | yes | yes | 200 | −32603 | retry shortly |
+| 23 | `ErrNetworkInitializing` | yes | yes | 200 | −32603 | retry shortly; becomes `ErrNetworkNoUpstreamsAvailable` past the threshold |
+| 23b | `ErrNetworkNoUpstreamsAvailable` | yes | yes | 503 | −32603 | network stuck initializing with zero upstreams for `upstream.NoUpstreamsAvailableAfter` (5m) |
 | 24 | `ErrNetworkNotSupported` | yes | yes | 404 | −32603 | no provider covers network |
 | 25 | `ErrUpstreamNetworkNotDetected` | yes | yes | — | — | **Dead code** — zero production call sites |
 | 26 | `ErrUpstreamInitialization` | yes | yes | — | — | — |
@@ -530,6 +532,8 @@ Entry: [`common/json_rpc.go:L1501`](https://github.com/erpc/erpc/blob/main/commo
 **7. Every Solana upstream returns `−32009` and eRPC does not fail over.** `LongTermStorageSlotSkipped` is emitted only after the node consulted long-term storage, so the verdict is cluster-wide. eRPC marks it terminal **and** permanent: no cross-upstream sweep, and no time-delayed re-sweep. Stop retrying in the client too. Contrast `−32019 LongTermStorageUnreachable`, which is a statement about *this node's* backend being down and stays retryable.
 
 **8. Solana `requestAirdrop` fails and is not retried.** `requestAirdrop` is in the SVM write-method guard because it **mints per call** — a failover after an effective first attempt mints twice. `sendTransaction`/`sendRawTransaction` are in the same set for a different reason: same-signature broadcasts are idempotent on-chain, so the risk is duplicate broadcasts burning vendor quota, not a double-spend.
+
+**9. A chain answers `is initializing; please retry shortly` forever.** That message is only correct while a bootstrap is in progress. Once a network has been in initialization for `upstream.NoUpstreamsAvailableAfter` (5 minutes) with **zero** upstreams registered, eRPC swaps it for `ErrNetworkNoUpstreamsAvailable` — `no RPC providers are available for network '<id>' in project '<id>'` on HTTP 503, and increments `erpc_network_no_upstreams_available_total{project,network}`. It means no configured upstream or provider covers that chain (removed from config, deprecated, or never supported), so retrying will not help; fix the config or provider coverage. The initializer keeps re-attempting in the background, so a network that later gains an upstream recovers on its own.
 
 ### Best practices
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1615,6 +1615,11 @@ func determineResponseStatusCode(res interface{}) int {
 		common.ErrCodeNetworkRateLimitRuleExceeded,
 		common.ErrCodeEndpointCapacityExceeded):
 		return http.StatusTooManyRequests
+	// 503 Service Unavailable - no upstream could be initialized for this
+	// network at all. Deliberately last: a more specific verdict already on the
+	// cause chain (404 unsupported, 429 quota) describes the failure better.
+	case common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable):
+		return http.StatusServiceUnavailable
 	}
 
 	// All other errors (JSON-RPC application errors) return 200
@@ -1846,6 +1851,11 @@ func handleErrorResponse(
 		common.ErrCodeNetworkRateLimitRuleExceeded,
 		common.ErrCodeEndpointCapacityExceeded):
 		statusCode = http.StatusTooManyRequests
+	// 503 Service Unavailable - no upstream could be initialized for this
+	// network at all. Deliberately last: a more specific verdict already on the
+	// cause chain (404 unsupported, 429 quota) describes the failure better.
+	case common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable):
+		statusCode = http.StatusServiceUnavailable
 	}
 	// Emit X-ERPC-* headers BEFORE WriteHeader — once WriteHeader fires
 	// the header map is sealed. processErrorBody attaches `nq` to the

--- a/erpc/http_server_status_test.go
+++ b/erpc/http_server_status_test.go
@@ -240,3 +240,21 @@ func TestBuildErrorResponseBody_PrunedBodyKeepsDominantCauseWhileStatusKeepsBund
 			"iteration %d: serialized wire message changed", i)
 	}
 }
+
+// A network no provider serves must not reach the client as a plain JSON-RPC
+// application error on HTTP 200: 503 is what makes client-side backoff and
+// multi-provider failover engage, and the body has to name the actual
+// condition rather than promising that a retry will help.
+func TestDetermineResponseStatusCode_NoUpstreamsAvailableIs503(t *testing.T) {
+	err := common.NewErrNetworkNoUpstreamsAvailable("prjA", "evm:534351")
+
+	require.Equal(t, http.StatusServiceUnavailable, determineResponseStatusCode(err))
+
+	body := buildErrorResponseBody(nil, err, err, nil)
+	require.Equal(t, http.StatusServiceUnavailable, determineResponseStatusCode(body))
+
+	encoded, jerr := common.SonicCfg.Marshal(body)
+	require.NoError(t, jerr)
+	require.Contains(t, string(encoded), "no RPC providers are available for network 'evm:534351'")
+	require.NotContains(t, string(encoded), "retry shortly")
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -568,6 +568,17 @@ var (
 		Help:      "Total number of requests that were killed by the timeout policy (fixed or quantile-based).",
 	}, []string{"project", "network", "category", "finality", "scope"})
 
+	// MetricNetworkNoUpstreamsAvailableTotal counts requests rejected because a
+	// network stayed in initialization past NoUpstreamsAvailableAfter with zero
+	// upstreams registered. Non-zero means a chain nothing serves is still being
+	// asked for — a config or provider-coverage problem, not a traffic one — so
+	// alert on it directly rather than inferring it from error-rate ratios.
+	MetricNetworkNoUpstreamsAvailableTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "network_no_upstreams_available_total",
+		Help:      "Total number of requests rejected because no upstream could be initialized for the network.",
+	}, []string{"project", "network"})
+
 	// MetricUpstreamSelectionTotal counts each upstream pick by the
 	// reason for selection: primary / retry / hedge / consensus_slot /
 	// sweep. Lets operators see whether one upstream is dominating one

--- a/upstream/registry.go
+++ b/upstream/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/thirdparty"
 	"github.com/erpc/erpc/util"
 	"github.com/rs/zerolog"
@@ -44,6 +45,12 @@ type UpstreamsRegistry struct {
 	networkUpstreamsAtomic sync.Map
 
 	providerOnce sync.Map // networkId -> *sync.Once
+
+	// networkFirstPreparedAt is when each network first entered
+	// PrepareUpstreamsForNetwork, which is the only clock that can tell "still
+	// coming up" from "never came up". Written once per network and read only
+	// on the zero-upstream error paths.
+	networkFirstPreparedAt sync.Map // networkId -> time.Time
 
 	// pendingUpstreams holds Upstream instances created by bootstrap task
 	// attempts that have not completed successfully yet, keyed by upstream id.
@@ -159,10 +166,22 @@ func (u *UpstreamsRegistry) SharedStateRegistry() data.SharedStateRegistry {
 	return u.sharedStateRegistry
 }
 
+// NoUpstreamsAvailableAfter is how long a network may keep initializing with
+// zero upstreams registered before eRPC stops calling it "initializing" and
+// reports that no RPC provider serves this network at all.
+//
+// It is a claim about permanence, so it is set well past any real bootstrap:
+// provider discovery, chain-id detection and the initializer's own retry
+// backoff all finish inside a few tens of seconds. Anything still empty five
+// minutes in is not slow, it is unserved.
+var NoUpstreamsAvailableAfter = 5 * time.Minute
+
 func (u *UpstreamsRegistry) PrepareUpstreamsForNetwork(ctx context.Context, networkId string) error {
 	networkMu := u.getNetworkMutex(networkId)
 	networkMu.Lock()
 	defer networkMu.Unlock()
+
+	u.networkFirstPreparedAt.LoadOrStore(networkId, time.Now())
 
 	// 1) Static upstreams are expected to be registered via Bootstrap() already.
 
@@ -234,7 +253,7 @@ func (u *UpstreamsRegistry) PrepareUpstreamsForNetwork(ctx context.Context, netw
 				// Consider per-network and unknown upstream/provider activity
 				summary := u.summarizeNetworkTasks(networkId)
 				if summary.hasOngoing {
-					return common.NewErrNetworkInitializing(u.prjId, networkId)
+					return u.errStillInitializing(networkId)
 				}
 				if summary.providersAllTerminal {
 					// Grace period to allow in-flight upstream registrations to complete
@@ -254,7 +273,7 @@ func (u *UpstreamsRegistry) PrepareUpstreamsForNetwork(ctx context.Context, netw
 					return common.NewErrNetworkNotSupported(u.prjId, networkId)
 				}
 				// Default: initializing
-				return common.NewErrNetworkInitializing(u.prjId, networkId)
+				return u.errStillInitializing(networkId)
 			}
 			return timeoutCtx.Err()
 		case <-ticker.C:
@@ -297,6 +316,34 @@ func (u *UpstreamsRegistry) PrepareUpstreamsForNetwork(ctx context.Context, netw
 			return nil
 		}
 	}
+}
+
+// errStillInitializing names the state of a network that has no upstream yet.
+//
+// Callers reach it only from the zero-upstream branches, so the single thing
+// left to decide is whether waiting is still a reasonable thing to ask of the
+// client. Below NoUpstreamsAvailableAfter it is: bootstrap genuinely takes time
+// and the initializer keeps retrying. Past it, the same answer would be a
+// standing lie — nothing is coming for this network — so the client is told
+// that instead.
+//
+// The clock is the first PrepareUpstreamsForNetwork call, not process start:
+// a network first requested a minute ago is a minute old however long eRPC has
+// been running.
+func (u *UpstreamsRegistry) errStillInitializing(networkId string) error {
+	if NoUpstreamsAvailableAfter > 0 {
+		if v, ok := u.networkFirstPreparedAt.Load(networkId); ok {
+			if elapsed := time.Since(v.(time.Time)); elapsed >= NoUpstreamsAvailableAfter {
+				telemetry.MetricNetworkNoUpstreamsAvailableTotal.WithLabelValues(u.prjId, networkId).Inc()
+				u.logger.Warn().
+					Str("networkId", networkId).
+					Dur("initializingFor", elapsed).
+					Msg("no upstream could be initialized for network; reporting it as unavailable")
+				return common.NewErrNetworkNoUpstreamsAvailable(u.prjId, networkId)
+			}
+		}
+	}
+	return common.NewErrNetworkInitializing(u.prjId, networkId)
 }
 
 func (u *UpstreamsRegistry) GetNetworkShadowUpstreams(networkId string) []*Upstream {

--- a/upstream/registry_no_upstreams_available_test.go
+++ b/upstream/registry_no_upstreams_available_test.go
@@ -1,0 +1,116 @@
+package upstream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A network with no upstream yet is reported one of two ways, and the only
+// thing separating them is how long it has been that way.
+//
+// "initializing; please retry shortly" is accurate for the first seconds of a
+// bootstrap and a lie forever after: a chain that no configured upstream or
+// provider serves stays in exactly that state, so callers keep retrying and
+// operators read a permanent condition as a passing blip. That was the actual
+// production report behind this behaviour — a removed chain answering
+// "initializing" for days.
+
+// withNoUpstreamsAvailableAfter overrides the threshold for one test.
+func withNoUpstreamsAvailableAfter(t *testing.T, d time.Duration) {
+	t.Helper()
+	previous := NoUpstreamsAvailableAfter
+	NoUpstreamsAvailableAfter = d
+	t.Cleanup(func() { NoUpstreamsAvailableAfter = previous })
+}
+
+func TestErrStillInitializing_YoungNetworkIsInitializing(t *testing.T) {
+	withNoUpstreamsAvailableAfter(t, 5*time.Minute)
+	reg, _ := newBootstrapTestRegistry(t)
+	reg.networkFirstPreparedAt.Store("evm:123", time.Now())
+
+	err := reg.errStillInitializing("evm:123")
+
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeNetworkInitializing), "got: %v", err)
+}
+
+func TestErrStillInitializing_UnknownNetworkIsInitializing(t *testing.T) {
+	withNoUpstreamsAvailableAfter(t, 5*time.Minute)
+	reg, _ := newBootstrapTestRegistry(t)
+
+	// No recorded start means nothing is known about how long this has been
+	// going on, and an unbacked claim of permanence is the one thing this must
+	// never make.
+	err := reg.errStillInitializing("evm:123")
+
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeNetworkInitializing), "got: %v", err)
+}
+
+func TestErrStillInitializing_PastThresholdReportsNoProviders(t *testing.T) {
+	withNoUpstreamsAvailableAfter(t, 5*time.Minute)
+	reg, _ := newBootstrapTestRegistry(t)
+	reg.networkFirstPreparedAt.Store("evm:534351", time.Now().Add(-6*time.Minute))
+
+	err := reg.errStillInitializing("evm:534351")
+
+	require.True(t, common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable), "got: %v", err)
+	assert.Contains(t, err.Error(), "no RPC providers are available for network 'evm:534351' in project 'test'")
+	assert.NotContains(t, err.Error(), "retry shortly")
+
+	// What the client reads on the wire — the message must survive translation
+	// rather than collapsing into a generic internal error.
+	assert.Contains(t, common.TranslateToJsonRpcException(err).Error(), "no RPC providers are available")
+}
+
+func TestErrStillInitializing_ZeroThresholdKeepsInitializing(t *testing.T) {
+	withNoUpstreamsAvailableAfter(t, 0)
+	reg, _ := newBootstrapTestRegistry(t)
+	reg.networkFirstPreparedAt.Store("evm:534351", time.Now().Add(-24*time.Hour))
+
+	err := reg.errStillInitializing("evm:534351")
+
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeNetworkInitializing), "got: %v", err)
+}
+
+// TestPrepareUpstreamsForNetwork_ReportsNoProvidersOnceStale drives the real
+// bootstrap path: an upstream whose endpoint never answers, so the network
+// never gets one registered. The first attempt is still "initializing"; once
+// the network has been stuck past the threshold, the same call reports that no
+// provider is available for it.
+func TestPrepareUpstreamsForNetwork_ReportsNoProvidersOnceStale(t *testing.T) {
+	util.ResetGock()
+	defer util.ResetGock()
+	// No mocks at all: chain-id detection fails, so nothing ever registers.
+
+	withNoUpstreamsAvailableAfter(t, 5*time.Minute)
+	reg, _ := newBootstrapTestRegistry(t)
+	reg.Bootstrap(t.Context())
+
+	prepare := func() error {
+		// Short deadline: the wait loop otherwise sits for its full 30s budget
+		// hoping an upstream shows up.
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+		defer cancel()
+		return reg.PrepareUpstreamsForNetwork(ctx, "evm:123")
+	}
+
+	err := prepare()
+	require.Error(t, err)
+	require.Empty(t, reg.GetNetworkUpstreams(t.Context(), "evm:123"), "no upstream should have registered")
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeNetworkInitializing),
+		"a network that just started bootstrapping is still initializing, got: %v", err)
+
+	// Same network, same failure, five minutes older.
+	reg.networkFirstPreparedAt.Store("evm:123", time.Now().Add(-6*time.Minute))
+
+	err = prepare()
+	require.Error(t, err)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable),
+		"a network stuck with zero upstreams past the threshold is unavailable, got: %v", err)
+	assert.Contains(t, err.Error(), "evm:123")
+}


### PR DESCRIPTION
## Problem

A network that no configured upstream or provider serves never leaves initialization. Every request for it returned:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"network 'evm:534351' for project 'X' is initializing; please retry shortly"}}
```

That message is accurate for the first seconds of a bootstrap and wrong forever after. Callers read it as transient and keep retrying a chain that is not coming back; operators read a permanent condition as a passing blip.

## Change

Once a network has been initializing for `upstream.NoUpstreamsAvailableAfter` (5 minutes) with **zero** upstreams registered, the two zero-upstream branches in `PrepareUpstreamsForNetwork` return a new error instead:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"no RPC providers are available for network 'evm:534351' in project 'X'"}}
```

Nothing changes below the threshold — a real bootstrap still reports itself as initializing.

The clock is the first `PrepareUpstreamsForNetwork` call for that network, not process start, so a network first requested a minute ago is a minute old however long eRPC has been running. The initializer keeps re-attempting in the background, so a network that later gains an upstream recovers on its own.

## Wire behaviour

- **HTTP 503** rather than 200, so client backoff and multi-provider failover engage. The case is listed last in both status switches, so a more specific verdict already on the cause chain (404 unsupported, 429 quota) still wins.
- JSON-RPC code stays `-32603`.

## Observability

- `erpc_network_no_upstreams_available_total{project,network}` — a chain nothing serves becomes alertable directly instead of inferred from error-rate ratios.
- A warn log carrying the elapsed initializing time.

## Scope

Deliberately limited to the initialization path, which is where the reported symptom lives. A network that initialized successfully and later lost every upstream still returns `ErrNoUpstreamsFound`; that is a separate condition with its own honest message.

The threshold is a Go var (`upstream.NoUpstreamsAvailableAfter`), not a YAML field. Promoting it to project config is a one-liner if operators want to tune it.

## Files

| File | What |
| --- | --- |
| `common/errors.go` | `ErrNetworkNoUpstreamsAvailable` |
| `upstream/registry.go` | first-prepared clock + `errStillInitializing()` picking between the two errors |
| `erpc/http_server.go` | 503 mapping in both status switches |
| `telemetry/metrics.go` | the counter |
| `docs/pages/reference/errors.mdx` | error tree, table row, worked example |

## Tests

- `upstream/registry_no_upstreams_available_test.go` — young network, unknown network, past threshold, disabled threshold, plus the real `PrepareUpstreamsForNetwork` path with an upstream that never registers.
- `erpc/http_server_status_test.go` — the 503 and the client-visible body.

`go build ./...`, `go vet`, and the `common` / `upstream` / `health` / `telemetry` / `erpc` HTTP-server suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
