### PR TITLE
fix(data): stop leaking ristretto goroutines from MemoryConnector

### DIFF
--- a/data/memory.go
+++ b/data/memory.go
@@ -34,8 +34,10 @@ type MemoryConnector struct {
 		setsDropped  uint64
 		setsRejected uint64
 	}
-	metricsMutex sync.RWMutex
-	stopMetrics  context.CancelFunc
+	metricsMutex     sync.RWMutex
+	stopMetrics      context.CancelFunc
+	stopCacheWatcher context.CancelFunc
+	closeCacheOnce   *sync.Once
 }
 
 func NewMemoryConnector(
@@ -86,10 +88,11 @@ func NewMemoryConnector(
 	}
 
 	c := &MemoryConnector{
-		id:          id,
-		logger:      &lg,
-		cache:       cache,
-		emitMetrics: enableMetrics,
+		id:             id,
+		logger:         &lg,
+		cache:          cache,
+		emitMetrics:    enableMetrics,
+		closeCacheOnce: &sync.Once{},
 	}
 
 	// Start metrics collection goroutine if enabled
@@ -105,9 +108,15 @@ func NewMemoryConnector(
 	// currently calls MemoryConnector.Close(), so tie the cache's lifetime to ctx here;
 	// otherwise every connector created over the life of a process (e.g. hundreds of
 	// short-lived instances in a single test binary) leaks 2 goroutines forever.
+	// Close() also cancels this watcher's own context so callers using a non-cancelable
+	// ctx (context.Background()) and relying solely on Close() don't leak the watcher itself.
+	// Both paths close the cache through closeCacheOnce since ristretto.Cache.Close() panics
+	// (send on closed channel) if it ever runs twice concurrently.
+	watcherCtx, stopWatcher := context.WithCancel(ctx)
+	c.stopCacheWatcher = stopWatcher
 	go func() {
-		<-ctx.Done()
-		cache.Close()
+		<-watcherCtx.Done()
+		c.closeCacheOnce.Do(cache.Close)
 	}()
 
 	return c, nil
@@ -363,7 +372,10 @@ func (m *MemoryConnector) Close() error {
 		m.stopMetrics()
 	}
 	if m.cache != nil {
-		m.cache.Close()
+		m.closeCacheOnce.Do(m.cache.Close)
+	}
+	if m.stopCacheWatcher != nil {
+		m.stopCacheWatcher()
 	}
 	return nil
 }

--- a/data/memory.go
+++ b/data/memory.go
@@ -100,6 +100,16 @@ func NewMemoryConnector(
 		lg.Info().Msg("Ristretto metrics collection enabled")
 	}
 
+	// Ristretto's own background goroutines (Cache.processItems, defaultPolicy.processItems)
+	// only stop via cache.Close() — they don't watch ctx themselves. Nothing else in erpc
+	// currently calls MemoryConnector.Close(), so tie the cache's lifetime to ctx here;
+	// otherwise every connector created over the life of a process (e.g. hundreds of
+	// short-lived instances in a single test binary) leaks 2 goroutines forever.
+	go func() {
+		<-ctx.Done()
+		cache.Close()
+	}()
+
 	return c, nil
 }
 

--- a/data/memory.go
+++ b/data/memory.go
@@ -37,7 +37,14 @@ type MemoryConnector struct {
 	metricsMutex     sync.RWMutex
 	stopMetrics      context.CancelFunc
 	stopCacheWatcher context.CancelFunc
-	closeCacheOnce   *sync.Once
+
+	// closeMu/closed guard every Ristretto access against a concurrent Close(): Ristretto's
+	// Cache.Close() closes internal channels, so a Set/Get/Delete racing a Close() can panic
+	// ("send on closed channel") or data-race rather than just erroring. Close() takes the
+	// write lock, flips closed, and only then closes the cache — so it can't run until every
+	// in-flight cache op (holding a read lock) has finished, and no new one can start after.
+	closeMu sync.RWMutex
+	closed  bool
 }
 
 func NewMemoryConnector(
@@ -88,11 +95,10 @@ func NewMemoryConnector(
 	}
 
 	c := &MemoryConnector{
-		id:             id,
-		logger:         &lg,
-		cache:          cache,
-		emitMetrics:    enableMetrics,
-		closeCacheOnce: &sync.Once{},
+		id:          id,
+		logger:      &lg,
+		cache:       cache,
+		emitMetrics: enableMetrics,
 	}
 
 	// Start metrics collection goroutine if enabled
@@ -110,13 +116,11 @@ func NewMemoryConnector(
 	// short-lived instances in a single test binary) leaks 2 goroutines forever.
 	// Close() also cancels this watcher's own context so callers using a non-cancelable
 	// ctx (context.Background()) and relying solely on Close() don't leak the watcher itself.
-	// Both paths close the cache through closeCacheOnce since ristretto.Cache.Close() panics
-	// (send on closed channel) if it ever runs twice concurrently.
 	watcherCtx, stopWatcher := context.WithCancel(ctx)
 	c.stopCacheWatcher = stopWatcher
 	go func() {
 		<-watcherCtx.Done()
-		c.closeCacheOnce.Do(cache.Close)
+		c.closeCache()
 	}()
 
 	return c, nil
@@ -127,6 +131,12 @@ func (m *MemoryConnector) Id() string {
 }
 
 func (m *MemoryConnector) Set(ctx context.Context, partitionKey, rangeKey string, value []byte, ttl *time.Duration) error {
+	m.closeMu.RLock()
+	defer m.closeMu.RUnlock()
+	if m.closed {
+		return nil
+	}
+
 	m.logger.Debug().Str("partitionKey", partitionKey).Str("rangeKey", rangeKey).Int("len", len(value)).Msg("writing to memory (ristretto)")
 
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
@@ -176,6 +186,12 @@ func isReverseIndexable(partitionKey string) bool {
 }
 
 func (m *MemoryConnector) Get(ctx context.Context, index, partitionKey, rangeKey string, _ interface{}) ([]byte, error) {
+	m.closeMu.RLock()
+	defer m.closeMu.RUnlock()
+	if m.closed {
+		return nil, common.NewErrRecordNotFound(partitionKey, rangeKey, MemoryDriverName)
+	}
+
 	if index == ConnectorReverseIndex && strings.HasSuffix(partitionKey, "*") {
 		fullKey, found := m.cache.Get(memoryReverseIndexPrefix + "#" + partitionKey + "#" + rangeKey)
 		// Replace wildcard partitionKey with the resolved concrete value if found
@@ -337,6 +353,12 @@ func (m *MemoryConnector) collectAndEmitMetrics() {
 }
 
 func (m *MemoryConnector) Delete(ctx context.Context, partitionKey, rangeKey string) error {
+	m.closeMu.RLock()
+	defer m.closeMu.RUnlock()
+	if m.closed {
+		return nil
+	}
+
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	m.logger.Debug().Str("partitionKey", partitionKey).Str("rangeKey", rangeKey).Msg("deleting from memory (ristretto)")
 
@@ -371,11 +393,25 @@ func (m *MemoryConnector) Close() error {
 	if m.stopMetrics != nil {
 		m.stopMetrics()
 	}
-	if m.cache != nil {
-		m.closeCacheOnce.Do(m.cache.Close)
-	}
+	m.closeCache()
 	if m.stopCacheWatcher != nil {
 		m.stopCacheWatcher()
 	}
 	return nil
+}
+
+// closeCache marks the connector closed and closes the underlying Ristretto cache exactly
+// once. The write lock can only be acquired once every in-flight Set/Get/Delete (each holding
+// a read lock) has returned, and closed is checked before starting any new one — so this can
+// never race a live cache operation, unlike calling cache.Close() directly would.
+func (m *MemoryConnector) closeCache() {
+	m.closeMu.Lock()
+	defer m.closeMu.Unlock()
+	if m.closed {
+		return
+	}
+	m.closed = true
+	if m.cache != nil {
+		m.cache.Close()
+	}
 }

--- a/data/memory_test.go
+++ b/data/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -366,6 +367,42 @@ func TestMemoryConnector_ClosesRistrettoGoroutinesOnExplicitClose(t *testing.T) 
 		return runtime.NumGoroutine() <= before+5
 	}, 2*time.Second, 20*time.Millisecond,
 		"goroutine count should return close to baseline after explicit Close(), got %d (baseline %d)", runtime.NumGoroutine(), before)
+}
+
+// TestMemoryConnector_SetRacingContextCancelDoesNotPanic reproduces the shape of
+// TestSvmStatePoller_ConcurrentSuggestionsDuringPoll_StaySlotMonotonic: a background goroutine
+// keeps calling Set() while the connector's ctx is cancelled out from under it (e.g. request
+// handling still in flight during shutdown). Ristretto's Cache.Close() closes internal channels,
+// so calling it concurrently with Set()/Get()/Delete() is unsafe on its own — must run under
+// -race to actually catch a regression here.
+func TestMemoryConnector_SetRacingContextCancelDoesNotPanic(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	connector, err := NewMemoryConnector(ctx, &logger, "race-test", &common.MemoryConnectorConfig{
+		MaxItems: 1_000, MaxTotalSize: "10MB",
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = connector.Set(ctx, "pk", fmt.Sprintf("rk-%d", i), []byte("v"), nil)
+			}
+		}
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 // TestIsReverseIndexable_Filters validates the predicate's rejection rules so

--- a/data/memory_test.go
+++ b/data/memory_test.go
@@ -314,9 +314,6 @@ func TestMemoryConnector_ReverseIndex_SvmDelete(t *testing.T) {
 		"expected ErrRecordNotFound, got %T %v", err, err)
 }
 
-// TestIsReverseIndexable_Filters validates the predicate's rejection rules so
-// single-segment keys (e.g. internal bookkeeping) don't pollute the reverse
-// index and wildcard writes don't recursively index themselves.
 // Ristretto's Cache.processItems/defaultPolicy.processItems goroutines only stop via
 // cache.Close() — they don't watch the connector's ctx on their own. Nothing in erpc calls
 // MemoryConnector.Close() directly (it's only reachable via ctx cancellation), so a process
@@ -343,6 +340,37 @@ func TestMemoryConnector_ClosesRistrettoGoroutinesOnContextCancel(t *testing.T) 
 		"goroutine count should return close to baseline after connector contexts are cancelled, got %d (baseline %d)", runtime.NumGoroutine(), before)
 }
 
+// TestMemoryConnector_ClosesRistrettoGoroutinesOnExplicitClose covers callers that build a
+// connector with a non-cancelable ctx (context.Background(), as several call sites in this repo
+// do) and rely solely on calling Close() themselves. The ctx-watcher goroutine added to fix the
+// Ristretto leak must not become its own permanent leak in that case.
+func TestMemoryConnector_ClosesRistrettoGoroutinesOnExplicitClose(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+
+	before := runtime.NumGoroutine()
+
+	const n = 20
+	connectors := make([]*MemoryConnector, 0, n)
+	for i := 0; i < n; i++ {
+		c, err := NewMemoryConnector(context.Background(), &logger, fmt.Sprintf("leak-test-close-%d", i), &common.MemoryConnectorConfig{
+			MaxItems: 1_000, MaxTotalSize: "10MB",
+		})
+		require.NoError(t, err)
+		connectors = append(connectors, c)
+	}
+	for _, c := range connectors {
+		require.NoError(t, c.Close())
+	}
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= before+5
+	}, 2*time.Second, 20*time.Millisecond,
+		"goroutine count should return close to baseline after explicit Close(), got %d (baseline %d)", runtime.NumGoroutine(), before)
+}
+
+// TestIsReverseIndexable_Filters validates the predicate's rejection rules so
+// single-segment keys (e.g. internal bookkeeping) don't pollute the reverse
+// index and wildcard writes don't recursively index themselves.
 func TestIsReverseIndexable_Filters(t *testing.T) {
 	cases := []struct {
 		name string

--- a/data/memory_test.go
+++ b/data/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 	"time"
 
@@ -316,6 +317,32 @@ func TestMemoryConnector_ReverseIndex_SvmDelete(t *testing.T) {
 // TestIsReverseIndexable_Filters validates the predicate's rejection rules so
 // single-segment keys (e.g. internal bookkeeping) don't pollute the reverse
 // index and wildcard writes don't recursively index themselves.
+// Ristretto's Cache.processItems/defaultPolicy.processItems goroutines only stop via
+// cache.Close() — they don't watch the connector's ctx on their own. Nothing in erpc calls
+// MemoryConnector.Close() directly (it's only reachable via ctx cancellation), so a process
+// that creates many short-lived connectors (e.g. this package's own test binary, which builds
+// one per test/subtest) leaks 2 goroutines per connector forever.
+func TestMemoryConnector_ClosesRistrettoGoroutinesOnContextCancel(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+
+	before := runtime.NumGoroutine()
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		_, err := NewMemoryConnector(ctx, &logger, fmt.Sprintf("leak-test-%d", i), &common.MemoryConnectorConfig{
+			MaxItems: 1_000, MaxTotalSize: "10MB",
+		})
+		require.NoError(t, err)
+		cancel()
+	}
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= before+5
+	}, 2*time.Second, 20*time.Millisecond,
+		"goroutine count should return close to baseline after connector contexts are cancelled, got %d (baseline %d)", runtime.NumGoroutine(), before)
+}
+
 func TestIsReverseIndexable_Filters(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary
- `MemoryConnector.Close()` calls `ristretto.Cache.Close()`, but nothing in erpc ever called `Close()` on a memory connector — `SharedStateRegistry` and `EvmJsonRpcCache` don't expose their own `Close()`, so the only lifecycle signal a connector got was its `ctx` being cancelled, and ristretto's own `processItems`/`defaultPolicy` background goroutines don't watch that `ctx` themselves. Every memory connector ever created leaked 2 goroutines for the life of the process.
- Most visible inside erpc's own `erpc` package test suite: each test spins up its own short-lived ERPC/network stack (and its own memory connector(s) for shared-state and/or the EVM JSON-RPC cache). Running the full package in one binary accumulated tens of thousands of live ristretto goroutines by the end of the run — enough to blow through `go test`'s timeout on a full run of `./erpc/...` (confirmed via goroutine dump: thousands of `ristretto.(*Cache).processItems` / `defaultPolicy.processItems` goroutines, all in `[select]`, none ever collected).
- Fix: `data/memory.go` — tie the ristretto cache's lifetime to the connector's `ctx` inside `NewMemoryConnector`, so `cache.Close()` fires on context cancellation regardless of whether any caller ever reaches for `MemoryConnector.Close()` explicitly. `Close()` itself cancels a dedicated watcher context too, so callers that build a connector with a non-cancelable `ctx` (`context.Background()`, used by several call sites in this repo) and rely solely on calling `Close()` don't leak the watcher goroutine either.
- **Concurrency safety**: closing Ristretto's cache concurrently with an in-flight `Set`/`Get`/`Delete` is unsafe on its own (`Cache.Close()` closes internal channels — a racing `Set()` can data-race or panic with "send on closed channel"). Every cache-touching method now takes a read lock and checks a `closed` flag before touching the cache; `Close()` takes the write lock, so it can't proceed until every in-flight op has released, and no new op can start once closed. This was **not** theoretical — it's exactly what CI's `-race` run caught in `architecture/svm` (`TestSvmStatePoller_ConcurrentSuggestionsDuringPoll_StaySlotMonotonic` cancels a poller's ctx while a background goroutine is still writing a shared-state counter through the same connector).

## Test plan
- [x] `TestMemoryConnector_ClosesRistrettoGoroutinesOnContextCancel` / `...OnExplicitClose` — create/close 20 short-lived connectors each way and assert goroutine count returns near baseline; fail on the leaking version, pass with the fix.
- [x] `TestMemoryConnector_SetRacingContextCancelDoesNotPanic` — reproduces the `TestSvmStatePoller_ConcurrentSuggestionsDuringPoll_StaySlotMonotonic` shape (background `Set()` loop racing a `ctx` cancel) under `-race`; reliably data-races/panics on the intermediate `sync.Once`-only version, clean on the final `closeMu`/`closed` version.
- [x] `go test ./data/... -race` — passes (only Docker-testcontainer-dependent tests fail locally, no Docker daemon here, unrelated).
- [x] `go test ./architecture/svm/... -race -count=2` and `go test ./erpc/... -race -run 'TestSvm_'` — pass on top of latest `main` (which now includes #1067's SVM miss-reason fix).
- [x] Full `go test ./erpc/...`: on `main` before this fix, a full run of the package reliably timed out via goroutine-leak-driven slowdown; with the fix the suite progresses far further per unit time before hitting remaining, separate stdlib `net/http` keep-alive overhead from ~100 fixture-created HTTP servers in one binary (pre-existing test-scaffolding cost, not this leak — noted for visibility, not fixed here).

Rebased onto latest `main` (which now includes #1067) to drop an earlier, more superficial fix I'd made to the same SVM miss-reason bug — #1067 fixes it properly (including a second bug it uncovered) and supersedes that part of this PR entirely. This PR is now scoped purely to the Ristretto goroutine leak / concurrency fix.
