### PR TITLE
fix(clients): close abandoned BDS clients instead of leaking their goroutines

### DIFF
--- a/clients/grpc_bds_client.go
+++ b/clients/grpc_bds_client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"net/url"
+	"sync"
 	"sync/atomic"
 
 	_ "github.com/blockchain-data-standards/manifesto/common"
@@ -42,6 +43,15 @@ type GrpcBdsClient interface {
 	QueryClient() evm.QueryServiceClient
 }
 
+// Shutdown is deliberately NOT on GrpcBdsClient, for the same reason
+// SetExpectedChainId isn't: query_pipe_through.go type-asserts against that
+// interface as a capability probe, so widening it silently drops clients out
+// of the BDS path instead of failing to compile. Callers assert for
+// ShutdownableClient; this pins the real implementation at compile time.
+type ShutdownableClient interface{ Shutdown() }
+
+var _ ShutdownableClient = (*GenericGrpcBdsClient)(nil)
+
 type GenericGrpcBdsClient struct {
 	Url     *url.URL
 	headers map[string]string
@@ -67,6 +77,13 @@ type GenericGrpcBdsClient struct {
 	// the ChainId RPC (see grpc_bds_resilience.go). Atomic: the cache
 	// connector arms it via SetExpectedChainId after probing.
 	expectedChainId atomic.Uint64
+
+	// closed is shut by Shutdown and releases the appCtx watcher goroutine
+	// below. Without it that watcher blocks on appCtx.Done() for the life of
+	// the process, so an explicitly-closed client would still leak one
+	// goroutine even though its pool was gone.
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 // SetExpectedChainId arms chain-identity enforcement after construction —
@@ -107,6 +124,7 @@ func NewGrpcBdsClient(
 		upstreamId:      upsId,
 		isLogLevelTrace: logger.GetLevel() == zerolog.TraceLevel,
 		headers:         make(map[string]string),
+		closed:          make(chan struct{}),
 	}
 	if upstream != nil {
 		if cfg := upstream.Config(); cfg != nil && cfg.Evm != nil && cfg.Evm.ChainId > 0 {
@@ -168,10 +186,15 @@ func NewGrpcBdsClient(
 	}
 	client.pool = pool
 
-	// Setup graceful shutdown
+	// Releases on either the app going down or an explicit Shutdown; watching
+	// appCtx alone would pin this goroutine for the life of the process on
+	// every client the caller abandons.
 	go func() {
-		<-appCtx.Done()
-		client.shutdown()
+		select {
+		case <-appCtx.Done():
+		case <-client.closed:
+		}
+		client.Shutdown()
 	}()
 
 	logger.Debug().
@@ -1015,10 +1038,27 @@ func (c *GenericGrpcBdsClient) normalizeGrpcError(err error) error {
 	return common.NewErrEndpointTransportFailure(c.Url, err)
 }
 
-func (c *GenericGrpcBdsClient) shutdown() {
-	if c.pool != nil {
-		c.pool.Shutdown()
+// Shutdown closes the underlying connection pool. Callers that construct a
+// client and then abandon it — a failed bootstrap probe, a duplicate server,
+// a lost create race — MUST call this: the pool runs a maintainLoop goroutine
+// and each pooled grpc.ClientConn holds several of its own (callback
+// serializers, HTTP/2 transport loops) that only exit on Close.
+//
+// Exported deliberately. It was unexported with zero callers, so nothing ever
+// closed a BDS client, and every abandoned one leaked its goroutines for the
+// process lifetime.
+//
+// Safe to call more than once and on a nil receiver.
+func (c *GenericGrpcBdsClient) Shutdown() {
+	if c == nil {
+		return
 	}
+	c.closeOnce.Do(func() {
+		close(c.closed)
+		if c.pool != nil {
+			c.pool.Shutdown()
+		}
+	})
 }
 
 func (c *GenericGrpcBdsClient) SetHeaders(h map[string]string) {

--- a/clients/grpc_bds_client_shutdown_test.go
+++ b/clients/grpc_bds_client_shutdown_test.go
@@ -1,0 +1,187 @@
+package clients
+
+import (
+	"context"
+	"net/url"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/connectivity"
+)
+
+const (
+	// bdsAbandonedClients is how many clients the leak test creates and then
+	// abandons. The production leak was a retried bootstrap task, so the
+	// contract under test is that the goroutine residue does NOT scale with
+	// this number. 8 is picked so that even a one-goroutine-per-client
+	// regression overshoots the residue budget below by more than 2x.
+	bdsAbandonedClients = 8
+
+	// bdsAbandonedPoolSize keeps each client small (2 conns) so the test stays
+	// quick while still exercising a multi-conn pool — Shutdown has to close
+	// every slot, not just the first.
+	bdsAbandonedPoolSize = 2
+
+	// bdsResidueBudget is the total goroutine residue tolerated after all
+	// bdsAbandonedClients clients have been shut down.
+	//
+	// Measured on this tree (poolSize 2): ~8 goroutines per client while live
+	// — the pool's maintainLoop, the appCtx watcher, and per-conn grpc-go
+	// callback serializers / HTTP2 loops — and 0 residue once Shutdown runs.
+	// So the two outcomes at 8 clients are +64 (broken) versus +0 (fixed) and
+	// the budget only has to separate them. It is deliberately near the floor:
+	//   - Shutdown reverted to a no-op          => +64, 21x over budget
+	//   - pool closed but the appCtx watcher
+	//     left blocked on appCtx.Done()         =>  +8, 2.6x over budget
+	// The 3 goroutines of slack absorb whole-suite noise (a sibling test's
+	// background loop still winding down, a runtime worker that NumGoroutine
+	// stops excluding) without ever admitting a per-client leak, which is the
+	// only thing this test exists to catch.
+	bdsResidueBudget = 3
+)
+
+// newAbandonedBdsClient builds a client the way an aborted bootstrap does:
+// against an address nothing listens on. grpc.NewClient dials lazily, so
+// construction succeeds with no server while still spawning the pool
+// maintainer, the appCtx watcher, and each conn's grpc-go goroutines.
+//
+// The context is deliberately context.Background() and not a cancellable one:
+// cancelling the app context is the OTHER path that releases these goroutines,
+// so using it here would let a Shutdown that does nothing still pass.
+func newAbandonedBdsClient(t *testing.T) *GenericGrpcBdsClient {
+	t.Helper()
+	parsedURL, err := url.Parse("http://127.0.0.1:59999")
+	require.NoError(t, err)
+	logger := zerolog.Nop()
+	client, err := NewGrpcBdsClient(context.Background(), &logger, "test-project", nil, parsedURL, bdsAbandonedPoolSize)
+	require.NoError(t, err)
+
+	// data/grpc.go can only release an abandoned client through a runtime
+	// assertion, cli.(clients.ShutdownableClient): Shutdown is deliberately off
+	// GrpcBdsClient so query_pipe_through.go's capability probe keeps matching
+	// test doubles. That makes the constructor's DYNAMIC type load-bearing, and
+	// no compiler check covers it — wrapping the return value would still
+	// satisfy the `var _ ShutdownableClient = (*GenericGrpcBdsClient)(nil)` pin
+	// while making the cleanup path's assertion miss, silently restoring the
+	// leak. So probe the constructor's product exactly the way that path does.
+	_, shutdownable := client.(ShutdownableClient)
+	require.True(t, shutdownable,
+		"NewGrpcBdsClient returned %T, which does not satisfy ShutdownableClient; "+
+			"data/grpc.go's cleanup path would silently skip closing it", client)
+
+	concrete, ok := client.(*GenericGrpcBdsClient)
+	require.True(t, ok, "expected *GenericGrpcBdsClient, got %T", client)
+	return concrete
+}
+
+// settledGoroutineCount waits for runtime.NumGoroutine() to stop moving and
+// returns it. gRPC teardown is asynchronous — ClientConn.Close returns before
+// the HTTP2 transport loops and callback serializers have run their last
+// deferred exit — so a single read races the very exits it is trying to
+// observe. Polls to a deadline rather than sleeping a fixed span so a slow
+// machine costs correctness nothing and a fast one costs no time.
+func settledGoroutineCount() int {
+	const (
+		interval      = 25 * time.Millisecond
+		stableSamples = 4
+		timeout       = 5 * time.Second
+	)
+	until := time.Now().Add(timeout)
+	last, stable := -1, 0
+	for time.Now().Before(until) {
+		runtime.GC()
+		time.Sleep(interval)
+		n := runtime.NumGoroutine()
+		if n != last {
+			last, stable = n, 0
+			continue
+		}
+		if stable++; stable == stableSamples {
+			return n
+		}
+	}
+	return runtime.NumGoroutine()
+}
+
+// TestGrpcBdsClient_ShutdownReleasesGoroutines is the regression test for the
+// unbounded goroutine leak: a BDS client that is created and then abandoned
+// must give its goroutines back when Shutdown is called. A retried bootstrap
+// created one client per attempt and dropped it on the floor, so a residue
+// that scales with the client count is the production failure mode (a dev pod
+// reached 45.8k goroutines, 76% of them orphaned BDS clients).
+//
+// Shutdown is reached the way the abandoning caller reaches it: off the
+// GrpcBdsClient interface (see newAbandonedBdsClient). It was unexported with
+// zero callers, so no caller could close a client even if it wanted to.
+func TestGrpcBdsClient_ShutdownReleasesGoroutines(t *testing.T) {
+	// Warm-up client, created and closed before the baseline is taken: the
+	// first BDS client in a process also brings up grpc-go's and otel's
+	// process-wide singletons, whose goroutines never exit. Paying that once
+	// here keeps the one-time cost out of the delta, so what the budget
+	// measures below is purely per-client.
+	newAbandonedBdsClient(t).Shutdown()
+
+	before := settledGoroutineCount()
+
+	live := make([]*GenericGrpcBdsClient, 0, bdsAbandonedClients)
+	for range bdsAbandonedClients {
+		live = append(live, newAbandonedBdsClient(t))
+	}
+	peak := settledGoroutineCount()
+
+	// Guard against a vacuous pass. If construction ever stops spawning
+	// goroutines, the residue below goes to zero for the wrong reason and this
+	// test silently stops defending anything.
+	require.GreaterOrEqual(t, peak-before, bdsAbandonedClients,
+		"%d live clients should hold at least one goroutine each (count went %d -> %d); "+
+			"if construction no longer spawns any, this test can no longer detect the leak",
+		bdsAbandonedClients, before, peak)
+
+	for _, c := range live {
+		c.Shutdown()
+	}
+	residue := settledGoroutineCount() - before
+	t.Logf("goroutines: baseline %d, %d live clients %d (+%d, %.1f/client), after Shutdown +%d (budget %d)",
+		before, bdsAbandonedClients, peak, peak-before,
+		float64(peak-before)/float64(bdsAbandonedClients), residue, bdsResidueBudget)
+
+	require.LessOrEqual(t, residue, bdsResidueBudget,
+		"Shutdown must release every abandoned client's goroutines: %d clients grew the "+
+			"count %d -> %d (+%d) and left +%d behind after Shutdown, over the budget of %d. "+
+			"Residue that scales with the client count means Shutdown is not closing the "+
+			"pool, or is leaving the appCtx watcher blocked on appCtx.Done().",
+		bdsAbandonedClients, before, peak, peak-before, residue, bdsResidueBudget)
+}
+
+// TestGrpcBdsClient_ShutdownIsIdempotentAndNilSafe pins the two properties the
+// abandoned-client call sites rely on. Those sites are error and early-return
+// paths that cannot always prove the client is non-nil or that no one else has
+// closed it, and Shutdown closes a channel — so without sync.Once the second
+// call panics on a double close, and without the nil guard the first call
+// panics on a nil receiver. Both would turn a leak fix into a crash.
+//
+// Also asserts the state transition Shutdown is responsible for: every conn in
+// the pool ends up closed, not just the first slot.
+func TestGrpcBdsClient_ShutdownIsIdempotentAndNilSafe(t *testing.T) {
+	var absent *GenericGrpcBdsClient
+	absent.Shutdown()
+
+	client := newAbandonedBdsClient(t)
+	conns := client.pool.conns
+	require.Len(t, conns, bdsAbandonedPoolSize)
+	for i, c := range conns {
+		require.NotEqual(t, connectivity.Shutdown, c.conn.GetState(),
+			"conn %d should still be live before Shutdown", i)
+	}
+
+	client.Shutdown()
+	client.Shutdown()
+
+	for i, c := range conns {
+		require.Equal(t, connectivity.Shutdown, c.conn.GetState(),
+			"Shutdown must close pooled conn %d", i)
+	}
+}

--- a/data/grpc.go
+++ b/data/grpc.go
@@ -136,6 +136,26 @@ func NewGrpcConnector(
 					gc.logger.Warn().Err(cerr).Str("server", serverURL).Msg("failed to create gRPC client")
 					return cerr
 				}
+				// This task is retried with backoff by the initializer, and every
+				// attempt builds a fresh client with its own connection pool. A
+				// client abandoned on any path below therefore leaks its
+				// maintainLoop goroutine plus the callback-serializer and HTTP/2
+				// goroutines of each pooled conn — roughly eight per attempt,
+				// forever. A server whose chainId probe keeps failing leaks on
+				// every retry, which is unbounded.
+				//
+				// Retained is set only where the client is handed to
+				// clientByNetwork; every other exit closes it, including the
+				// duplicate-server case that returns nil.
+				retained := false
+				defer func() {
+					if retained {
+						return
+					}
+					if sd, ok := cli.(clients.ShutdownableClient); ok {
+						sd.Shutdown()
+					}
+				}()
 				// Apply headers
 				if len(gc.headers) > 0 {
 					cli.SetHeaders(gc.headers)
@@ -199,6 +219,7 @@ func NewGrpcConnector(
 					return nil
 				}
 				gc.clientByNetwork[networkId] = cli
+				retained = true
 				gc.logger.Info().Str("server", serverURL).Str("networkId", networkId).Msg("gRPC client initialized for network")
 				return nil
 			},


### PR DESCRIPTION
Found while chasing a goroutine leak on a dev pod that had climbed to **45,800 goroutines** over ~40 hours, monotonically, never dropping except on deploy.

## What the dump said

`pprof` isn't compiled into the shipped image (`//go:build pprof`) and the distroless image has no shell, so I pulled the stacks with `SIGQUIT` from an ephemeral debug container. 32,253 goroutines captured:

| count | stack |
|---|---|
| 19,198 | `grpcsync.NewCallbackSerializer` |
| 2,695 | `clients.NewGrpcBdsClient.func1` |
| 2,692 | `clients.newBdsPool.gowrap1` |

**76% of all goroutines were orphaned BDS gRPC clients.** 2,695 clients against 19 prism connectors — about 142 per connector, each leaving a `maintainLoop` plus ~7 gRPC `CallbackSerializer` goroutines blocked on channel receive until the conn is closed.

## Root cause

`data/grpc.go` creates the client inside a `BootstrapTask` that **the initializer retries with backoff**:

```go
cli, cerr := clients.NewGrpcBdsClient(...)   // new pool + ~8 goroutines
...
resp, rerr := cli.SendRequest(probeCtx, nrq) // chainId probe
if rerr != nil {
    return rerr                              // client ORPHANED
}
```

Six exits after construction abandoned the client, **including the duplicate-server path, which returns `nil`**. Every retry leaked another ~8 goroutines. A server whose probe keeps failing leaks forever — unbounded, not a fixed cost.

It also could not have been fixed at the call site: `shutdown()` was **unexported with zero callers repo-wide**. The leak was a missing capability, not a missing call.

## The fix

Export `Shutdown()`, and add a `retained` flag so the bootstrap task closes the client on every exit that doesn't hand it to `clientByNetwork`.

**`Shutdown` is deliberately NOT on the `GrpcBdsClient` interface.** I tried that first and it was wrong. `query_pipe_through.go:29` does `concrete.Client.(clients.GrpcBdsClient)` as a **runtime capability probe**, so widening that interface doesn't fail to compile — it silently drops clients out of the BDS pipe-through path. It cost a SIGSEGV in `TestQueryBlocks_DoesNotFallbackAfterPartialPipeThroughFailure`: the test double stopped matching, fell through to `Forward`, and hit a nil `inFlightRequests`. Same reason `SetExpectedChainId` is kept off that interface, which the existing comment says outright.

So: callers assert for a narrow `ShutdownableClient`, and `var _ ShutdownableClient = (*GenericGrpcBdsClient)(nil)` pins the real implementation at compile time.

**The subtle half:** `Shutdown` also releases the appCtx watcher through a `closed` channel. That goroutine selected on `appCtx.Done()` alone, so closing the pool without touching it would still leak **one goroutine per abandoned client** — a 1/8 fix that looks complete. `sync.Once` + nil guard, because the call sites are error paths that can't always prove either.

## Verification

8 clients built against a dead address, goroutines measured after settling. The test was proven to **fail** under five separately applied regressions, not merely asserted to pass here:

| variant | residue after `Shutdown` | vs budget (3) |
|---|---|---|
| **this PR** | **+0** | pass |
| `Shutdown` reverted to a no-op | +64 | fail, 21x |
| pool closed, watcher left blocked | +8 (1.0/client) | fail, 2.6x |
| `sync.Once` removed | — | fail, `close of closed channel` |
| nil guard removed | — | fail, nil deref |
| constructor return wrapped | — | fail, capability assertion |

That last one is worth calling out. The compile-time pin covers the *concrete type*, but the cleanup path asserts on whatever `NewGrpcBdsClient` actually **returns** — wrap that return value in anything and the pin still compiles, the assertion misses, and the leak comes back with zero compile errors. The test probes the constructor's product the same way the cleanup path does.

Sizing is deliberate: 8 clients against a budget of 3, because at 5 a watcher-only regression is +5 and would pass. The test also asserts the live count grew before shutting down, so a future change that stops spawning goroutines fails loudly instead of passing while defending nothing.

`./clients/` and `./data/` green under `-race -count=3`; the `erpc` regression above passes.

## Not in this PR

Two bootstrap-only findings, both real, neither load-bearing here — happy to split them out:

1. `common/upstream.go:73` — `UniqueUpstreamKey` hashes `JsonRpc.Headers` by **ranging a map**. Go randomizes map order, so any upstream with 2+ headers hashes differently every call and the registry's memo key is never stable. `GetOrCreateClient` has one non-test caller (in `NewUpstream`), so it wastes the cache rather than leaking.
2. `clients/registry.go:56` — `var once sync.Once` is declared **inside** `CreateClient`, so it's a fresh `Once` per call and can never dedupe. The real store happens at line 149, leaving a check-then-act race: two concurrent callers both miss the `Load`, both build a client, one `Store` wins and the loser's client is orphaned. Bounded by concurrency, and now trivially fixable with `LoadOrStore` + `Shutdown` on the loser.

## Note for the team

Twice in this PR the same trap: **a shared contract widened without a compile error.** `WithLabelValues` is variadic, so adding a label silently breaks every call site the author didn't grep for (that was #1067, two days ago). `GrpcBdsClient` is probed with a type assertion, so adding a method silently drops implementations out of a code path — I did that one to myself here and CI caught it.

Prefer `.With(prometheus.Labels{...})` on shared metrics, and treat any interface that is type-asserted somewhere as append-only.

## AI assistance

<!-- Format from erpc/erpc#1073, which adds this section to the PR template. -->

- **Model:** `anthropic/claude-opus-5`
- **Harness / skills:** Oh My Pi; skills `ce-code-review`, `ponytail`
- **Human-reviewed:** No — not line by line. The fix was agent-authored and human-directed. Weigh that against what *is* independently checked: CI is green, the regression test was proven to fail under five separately-applied neuterings of the fix, and the one design error I made (widening a type-asserted interface) was caught by CI rather than by me. The goroutine numbers quoted are measured, not estimated.
