### PR TITLE
chore: ask PRs which model and tooling wrote them

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- What changes and why. Keep it short — the diff already shows the how. -->
+
+## Verification
+
+<!--
+What you ran and what it showed. Commands and observed output beat "tested locally".
+If a test would have caught the bug, say whether one now does.
+-->
+
+## AI assistance
+
+<!--
+Delete this section if you wrote the change by hand.
+
+This is review signal, not a disclaimer. The docs in this repo are written
+agent-first (see CONTRIBUTING.md), so agent-authored code is expected here —
+but a reviewer reads a 900-line agent-generated diff differently than a
+hand-written one, and knowing which model and which tooling produced it says
+where to look first. Long, confidently-worded, plausible-but-wrong is the
+characteristic failure mode, and it is cheapest to catch when disclosed.
+-->
+
+- **Model:** <!-- e.g. anthropic/claude-opus-5 · openai/gpt-5.4 · google/gemini-3-pro -->
+- **Harness / skills:** <!-- e.g. Claude Code · Codex · Cursor; plus any skills, e.g. ce-code-review, ponytail -->
+- **Human-reviewed:** <!-- Did a human read every changed line before pushing? yes / no -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,22 @@ Please be aware that by contributing to this project, you acknowledge that your 
 5. Push to the branch (`git push origin feature/YourFeature`).
 6. Open a Pull Request.
 
+## AI-assisted contributions
+
+Agent-written PRs are welcome — the docs here are authored agent-first, so it
+would be strange to bar agents from the code. We do ask that you say so.
+
+`.github/PULL_REQUEST_TEMPLATE.md` has an **AI assistance** section: the model,
+the harness and any skills, and whether a human read every changed line before
+you pushed. Delete the section if you wrote the change by hand.
+
+This is triage information, not a scarlet letter. Agent diffs fail differently
+from human ones — they are longer, they read as confident regardless of whether
+they are right, and the plausible-but-wrong parts look exactly like the correct
+parts. A reviewer who knows what produced a change knows where to spend the
+skepticism, and the answer to "did anyone actually read this?" is worth more
+than any other line in the PR body.
+
 ## Documentation
 
 The docs (`docs/pages/`, published at <https://docs.erpc.cloud>) are written


### PR DESCRIPTION
Adds a PR template with an **AI assistance** section — model, harness/skills, and whether a human read every changed line — plus a short CONTRIBUTING.md section explaining why we ask.

## Why

The docs in this repo are written [agent-first, human-second](https://github.com/erpc/erpc/blob/main/CONTRIBUTING.md#documentation). Agent-written code is the expected case here, not the exception. What's missing isn't permission, it's **review signal**.

Agent diffs fail differently from human ones. They're longer, they read as confident whether or not they're correct, and the plausible-but-wrong parts are indistinguishable in tone from the parts that are right. A reviewer who knows a change came from a model — and which one, under what tooling — knows where to spend skepticism. And "did anyone actually read this?" is worth more than any other line in a PR body.

## Design

Three headings, two of them deliberately thin. Long templates get stripped out by contributors, so this one asks for the minimum:

- **What** — a comment, no heading; the diff shows the how
- **Verification** — what you ran and what it showed
- **AI assistance** — model, harness/skills, human-reviewed; **delete the whole section if you wrote it by hand**

Nothing here is enforced by CI. It's a prompt, not a gate.

## Maintainer call

Flagging this honestly: unlike a bug fix, a PR template lands on **every** contributor's PR, including drive-by external ones. That's a process decision that belongs to you, not to me. Three things I'd be happy to change or drop:

1. Whether the two non-AI headings earn their place, or the template should carry *only* the AI section.
2. Whether "Human-reviewed" is too pointed. I think it's the highest-value field and the one most likely to be quietly skipped.
3. Whether this belongs in CONTRIBUTING.md alone, with no template at all — lighter touch, much lower compliance.

Happy to close this if the answer is "not worth the friction."

## Verification

Rendered locally; template is picked up from `.github/PULL_REQUEST_TEMPLATE.md`. No code paths touched, no CI behavior changed. **This PR's own body was written from the template it adds** — the section below is the dogfood.

## AI assistance

- **Model:** `anthropic/claude-opus-5`
- **Harness / skills:** Oh My Pi; skills `ce-code-review`, `ponytail`
- **Human-reviewed:** No — agent-authored and human-directed, reviewed at summary level rather than line by line. For a docs-and-template change that's a reasonable risk; I would not claim it on the two code PRs open alongside this one, and I've said the same there.