### PR TITLE
fix(http): return 404 for ErrNetworkNoUpstreamsAvailable, not 503

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -1382,6 +1382,14 @@ func (e *ErrNetworkInitializing) ErrorStatusCode() int { return http.StatusServi
 // or provider serves — removed from config, deprecated, never supported — sits
 // in that state permanently, so callers keep retrying and operators read the
 // message as a temporary blip. This one names the actual condition.
+//
+// It maps to 404, not 503. The state is terminal rather than transient: once a
+// network has sat past NoUpstreamsAvailableAfter with zero upstreams registered,
+// no amount of caller retrying changes the outcome — the project does not serve
+// that network. A 5xx invites a retry that cannot succeed and reports what is
+// really a coverage gap as a server fault. Operators should alert on the
+// erpc_network_no_upstreams_available_total counter, which is emitted regardless
+// of the wire status.
 type ErrNetworkNoUpstreamsAvailable struct{ BaseError }
 
 const ErrCodeNetworkNoUpstreamsAvailable ErrorCode = "ErrNetworkNoUpstreamsAvailable"
@@ -1403,7 +1411,7 @@ var NewErrNetworkNoUpstreamsAvailable = func(project string, network string) err
 }
 
 func (e *ErrNetworkNoUpstreamsAvailable) ErrorStatusCode() int {
-	return http.StatusServiceUnavailable
+	return http.StatusNotFound
 }
 
 // ErrNetworkNotSupported indicates that providers do not support the requested network

--- a/docs/pages/reference/errors.mdx
+++ b/docs/pages/reference/errors.mdx
@@ -176,7 +176,7 @@ Legend:
 | 21 | `ErrNoUpstreamsDefined` | yes | yes | 200 | −32603 | **Dead code** — zero production call sites |
 | 22 | `ErrNoUpstreamsFound` | yes | yes | 200 | −32603 | — |
 | 23 | `ErrNetworkInitializing` | yes | yes | 200 | −32603 | retry shortly; becomes `ErrNetworkNoUpstreamsAvailable` past the threshold |
-| 23b | `ErrNetworkNoUpstreamsAvailable` | yes | yes | 503 | −32603 | network stuck initializing with zero upstreams for `upstream.NoUpstreamsAvailableAfter` (5m) |
+| 23b | `ErrNetworkNoUpstreamsAvailable` | yes | yes | 404 | −32603 | network stuck initializing with zero upstreams for `upstream.NoUpstreamsAvailableAfter` (5m) |
 | 24 | `ErrNetworkNotSupported` | yes | yes | 404 | −32603 | no provider covers network |
 | 25 | `ErrUpstreamNetworkNotDetected` | yes | yes | — | — | **Dead code** — zero production call sites |
 | 26 | `ErrUpstreamInitialization` | yes | yes | — | — | — |
@@ -257,7 +257,7 @@ All defined at [`common/errors.go:L2151-L2174`](https://github.com/erpc/erpc/blo
 |---|---|
 | 400 | `ErrInvalidUrlPath`, `ErrJsonRpcRequestUnmarshal`, `ErrInvalidRequest` |
 | 401 | `ErrAuthUnauthorized`, `ErrEndpointUnauthorized` |
-| 404 | `ErrProjectNotFound`, `ErrNetworkNotFound`, `ErrNetworkNotSupported` |
+| 404 | `ErrProjectNotFound`, `ErrNetworkNotFound`, `ErrNetworkNotSupported`, `ErrNetworkNoUpstreamsAvailable` |
 | 429 | `ErrAuthRateLimitRuleExceeded`, `ErrProjectRateLimitRuleExceeded`, `ErrNetworkRateLimitRuleExceeded`, `ErrEndpointCapacityExceeded` |
 | 200 | everything else |
 
@@ -533,7 +533,7 @@ Entry: [`common/json_rpc.go:L1501`](https://github.com/erpc/erpc/blob/main/commo
 
 **8. Solana `requestAirdrop` fails and is not retried.** `requestAirdrop` is in the SVM write-method guard because it **mints per call** — a failover after an effective first attempt mints twice. `sendTransaction`/`sendRawTransaction` are in the same set for a different reason: same-signature broadcasts are idempotent on-chain, so the risk is duplicate broadcasts burning vendor quota, not a double-spend.
 
-**9. A chain answers `is initializing; please retry shortly` forever.** That message is only correct while a bootstrap is in progress. Once a network has been in initialization for `upstream.NoUpstreamsAvailableAfter` (5 minutes) with **zero** upstreams registered, eRPC swaps it for `ErrNetworkNoUpstreamsAvailable` — `no RPC providers are available for network '<id>' in project '<id>'` on HTTP 503, and increments `erpc_network_no_upstreams_available_total{project,network}`. It means no configured upstream or provider covers that chain (removed from config, deprecated, or never supported), so retrying will not help; fix the config or provider coverage. The initializer keeps re-attempting in the background, so a network that later gains an upstream recovers on its own.
+**9. A chain answers `is initializing; please retry shortly` forever.** That message is only correct while a bootstrap is in progress. Once a network has been in initialization for `upstream.NoUpstreamsAvailableAfter` (5 minutes) with **zero** upstreams registered, eRPC swaps it for `ErrNetworkNoUpstreamsAvailable` — `no RPC providers are available for network '<id>' in project '<id>'` on HTTP 404, and increments `erpc_network_no_upstreams_available_total{project,network}`. It means no configured upstream or provider covers that chain (removed from config, deprecated, or never supported), so retrying will not help; fix the config or provider coverage. The status is 404 rather than 5xx because the condition is a coverage gap, not a server fault — but it is still an operator-actionable state, so alert on `erpc_network_no_upstreams_available_total` rather than on wire 5xx. The initializer keeps re-attempting in the background, so a network that later gains an upstream recovers on its own.
 
 ### Best practices
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -1615,11 +1615,12 @@ func determineResponseStatusCode(res interface{}) int {
 		common.ErrCodeNetworkRateLimitRuleExceeded,
 		common.ErrCodeEndpointCapacityExceeded):
 		return http.StatusTooManyRequests
-	// 503 Service Unavailable - no upstream could be initialized for this
-	// network at all. Deliberately last: a more specific verdict already on the
-	// cause chain (404 unsupported, 429 quota) describes the failure better.
+	// 404 Not Found - no upstream could be initialized for this network at all.
+	// Terminal, not transient, so it is a coverage gap rather than a server fault
+	// (see ErrNetworkNoUpstreamsAvailable). Deliberately last: a more specific
+	// verdict already on the cause chain (429 quota) describes the failure better.
 	case common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable):
-		return http.StatusServiceUnavailable
+		return http.StatusNotFound
 	}
 
 	// All other errors (JSON-RPC application errors) return 200
@@ -1851,11 +1852,12 @@ func handleErrorResponse(
 		common.ErrCodeNetworkRateLimitRuleExceeded,
 		common.ErrCodeEndpointCapacityExceeded):
 		statusCode = http.StatusTooManyRequests
-	// 503 Service Unavailable - no upstream could be initialized for this
-	// network at all. Deliberately last: a more specific verdict already on the
-	// cause chain (404 unsupported, 429 quota) describes the failure better.
+	// 404 Not Found - no upstream could be initialized for this network at all.
+	// Terminal, not transient, so it is a coverage gap rather than a server fault
+	// (see ErrNetworkNoUpstreamsAvailable). Deliberately last: a more specific
+	// verdict already on the cause chain (429 quota) describes the failure better.
 	case common.HasErrorCode(err, common.ErrCodeNetworkNoUpstreamsAvailable):
-		statusCode = http.StatusServiceUnavailable
+		statusCode = http.StatusNotFound
 	}
 	// Emit X-ERPC-* headers BEFORE WriteHeader — once WriteHeader fires
 	// the header map is sealed. processErrorBody attaches `nq` to the

--- a/erpc/http_server_status_test.go
+++ b/erpc/http_server_status_test.go
@@ -242,16 +242,17 @@ func TestBuildErrorResponseBody_PrunedBodyKeepsDominantCauseWhileStatusKeepsBund
 }
 
 // A network no provider serves must not reach the client as a plain JSON-RPC
-// application error on HTTP 200: 503 is what makes client-side backoff and
-// multi-provider failover engage, and the body has to name the actual
-// condition rather than promising that a retry will help.
-func TestDetermineResponseStatusCode_NoUpstreamsAvailableIs503(t *testing.T) {
+// application error on HTTP 200. It is a coverage gap rather than a server
+// fault, and it is terminal — 404 names it honestly, stops a retry loop that
+// cannot succeed, and still engages client-side failover in multi-provider
+// setups. The body must name the condition, not promise that a retry helps.
+func TestDetermineResponseStatusCode_NoUpstreamsAvailableIs404(t *testing.T) {
 	err := common.NewErrNetworkNoUpstreamsAvailable("prjA", "evm:534351")
 
-	require.Equal(t, http.StatusServiceUnavailable, determineResponseStatusCode(err))
+	require.Equal(t, http.StatusNotFound, determineResponseStatusCode(err))
 
 	body := buildErrorResponseBody(nil, err, err, nil)
-	require.Equal(t, http.StatusServiceUnavailable, determineResponseStatusCode(body))
+	require.Equal(t, http.StatusNotFound, determineResponseStatusCode(body))
 
 	encoded, jerr := common.SonicCfg.Marshal(body)
 	require.NoError(t, jerr)


### PR DESCRIPTION
## What

`ErrNetworkNoUpstreamsAvailable` now maps to **404** on the wire instead of 503.

## Why

The error fires only after a network has sat past `NoUpstreamsAvailableAfter` (5m) with **zero** upstreams registered. That state is terminal, not transient — no amount of caller retrying changes the outcome, because the project simply does not serve that network.

503 got two things wrong:

1. **It invites a retry that cannot succeed.** The whole reason this error exists (#1065) was that `initializing; please retry shortly` is a lie once the threshold passes. A 5xx re-introduces the same "try again" implication at the HTTP layer.
2. **It reports a coverage gap as a server fault.** A chain with no configured upstream or provider is a config problem, but it surfaces through generic 5xx alerting and reads like an outage.

`ErrNetworkNotSupported` — the other "we don't serve this network" verdict — already returns 404. This aligns the two, so callers get one consistent answer for "this network is not available here" regardless of whether the gap is in the network list or in upstream coverage.

## Alerting note

This deliberately removes a 5xx signal, so the replacement is called out explicitly in the docs: `erpc_network_no_upstreams_available_total{project,network}` is incremented regardless of wire status and is the correct thing to alert on for this condition. Anyone relying on wire 5xx to notice zero-upstream networks should move to that counter.

## Implementation

Three sites decide this status, and `ErrorStatusCode()` alone is a **no-op on the wire** — the same trap already documented for `ErrUpstreamRateLimitRuleExceeded`. All three move together:

- `common/errors.go` — `ErrorStatusCode()`
- `erpc/http_server.go` — `determineResponseStatusCode`
- `erpc/http_server.go` — the response-writing status switch

The case stays **last** in both switches, so a more specific verdict already on the cause chain (429 quota) still wins. Precedence is unchanged.

## Tradeoff considered

The original 503 rationale was that a 5xx engages client-side backoff and multi-provider failover. A 404 still engages failover in multi-provider clients (any non-2xx does) while correctly stopping a retry loop that cannot succeed.

## Tests

`TestDetermineResponseStatusCode_NoUpstreamsAvailableIs503` → `...Is404`, assertions updated. The body assertions are unchanged: it still names the condition and still must not say `retry shortly`.

`go build ./common/... ./erpc/...`, `go test ./erpc/ ./common/` pass.