### PR TITLE
fix(evm): the served-tip referee must check that the majority actually stalled

### DIFF
--- a/architecture/evm/served_tip.go
+++ b/architecture/evm/served_tip.go
@@ -206,6 +206,30 @@ const (
 	// genuine majority stall is corrected inside one block-explorer refresh.
 	tipDwellDuration = 30 * time.Second
 
+	// tipMajorityStallSeconds is how far behind the trajectory the MAJORITY pick
+	// must have fallen — expressed as chain progress in SECONDS, converted to
+	// blocks through the fitted velocity — before the referee may outvote it.
+	//
+	// It exists because nothing else in the decision path tests the referee's
+	// own premise. The tolerance gate asks whether the ELECTED GROUP is on the
+	// trajectory; the upward-only rule asks whether that group is above the
+	// majority. Neither asks the question the override is named for: has the
+	// majority actually stalled? Without this gate the answer is assumed, and
+	// the assumption is wrong on any healthy fleet with a persistent upper
+	// group — see the note on TipTrajectoryDecision.Declined.
+	//
+	// The gate is a duration, not a block count, because block counts are not
+	// comparable across chains: ToleranceFloor's 1024-block default is ~3 hours
+	// of a 12s chain but only ~10 minutes of a 1.7 blocks/s one, so as an
+	// absolute floor it binds on slow chains and never binds on fast ones.
+	// Seconds of missing chain progress mean the same thing everywhere.
+	//
+	// 30s matches tipDwellDuration: the elected group must hold its place for
+	// that long anyway, so requiring the majority to be at least that far
+	// behind adds no latency to correcting a genuine stall — a frozen majority
+	// crosses this gate and earns the dwell over the same interval.
+	tipMajorityStallSeconds = 30.0
+
 	// tipDwellMinVelocityFraction is the share of the fitted velocity the
 	// elected group must have delivered FROM ITS OWN HEAD over the dwell. It is
 	// a lower bound only — closeness to expected already bounds the group from
@@ -278,12 +302,24 @@ type TipTrajectoryDecision struct {
 
 	// Declined reports the near miss: the group the trajectory elected sat
 	// ABOVE the majority pick — an override was on the table — and the referee
-	// refused it because the group was not close enough to where the head
-	// should be. It is the only other outcome worth counting, and like Overrode
-	// it is silent in steady state: a fleet in one cluster elects that cluster,
-	// and a fleet permanently split around its own median elects the median's
-	// group (the trajectory is fitted to the median, so no permanently-offset
-	// group is ever closer to it), so neither flag is set.
+	// refused it, because the group was not close enough to where the head
+	// should be, because it had not held its place long enough, or because the
+	// majority it would have outvoted had not actually stalled.
+	//
+	// A fleet in one cluster elects that cluster and sets neither flag. A fleet
+	// permanently split around its own median sets Declined, NOT Overrode.
+	//
+	// It was once claimed here that such a fleet could not even elect its upper
+	// group, reasoning that the fit is made from the median so no
+	// permanently-offset group can sit nearer to it. That is wrong. Once the
+	// split exceeds one cluster width the lower upstreams are singletons, which
+	// tipMinGroupSize rejects, so the upper group is often the ONLY candidate
+	// and wins by default however far from the median it sits — it is elected
+	// against the tolerance, never against the median's distance. What keeps
+	// election from becoming an override on a healthy fleet is the
+	// majority-stall gate (tipMajorityStallSeconds), not the geometry of the
+	// fit. Observed on a four-upstream fleet at a persistent ladder, which
+	// before that gate took a ~24-block override every ~28 minutes.
 	Declined bool
 
 	// Expected / Tolerance / VelocityPerSec describe the fit that produced the
@@ -493,6 +529,32 @@ func (t *TipTrajectory) Observe(now time.Time, sorted []ServedTipInput, median i
 		// corroborated fresh minority outvote a stalled majority. Lowering or
 		// holding the tip is the majority picker's and the regression guard's
 		// job, and is the only direction from which a frozen tip is reachable.
+		return d
+	}
+	if expected-float64(median) <= fit.vPerSec*tipMajorityStallSeconds {
+		// THE MAJORITY HAS NOT STALLED, so there is nothing here to correct.
+		// Everything above establishes that some group is on the trajectory and
+		// sits above the majority; none of it establishes that the majority is
+		// OFF the trajectory, which is the only thing that justifies trading the
+		// order statistic's servability guarantee for a fresher tip.
+		//
+		// That gap was load-bearing. Once a fleet splits wider than one cluster
+		// width, the upper group is frequently the ONLY electable group — the
+		// lower upstreams are singletons, and tipMinGroupSize rejects them — so
+		// the tolerance gate is the sole remaining check, and at ToleranceFloor's
+		// 1024-block default it admits essentially any split a real fleet
+		// produces. Election then implies override, and the referee fires on
+		// ordinary poller skew.
+		//
+		// Production, on a ~1.66 blocks/s chain with four upstreams: majority
+		// pick 30,699,698, elected group 30,699,722, expected 30,699,716,
+		// tolerance 1024. The majority was 18 blocks — eleven seconds — off the
+		// trajectory, and the referee raised the tip by 24 blocks every ~28
+		// minutes. Nothing had stalled.
+		//
+		// Declined, not silent: an override was genuinely on the table, and the
+		// near miss belongs in the same counter as the other refusals.
+		d.Declined = true
 		return d
 	}
 	if !corroborated {

--- a/architecture/evm/served_tip_test.go
+++ b/architecture/evm/served_tip_test.go
@@ -379,6 +379,50 @@ func TestTipTrajectory_GroupElection(t *testing.T) {
 		assert.Equal(t, head+50_000, d.Pick)
 	})
 
+	t.Run("PersistentSplitOnAHealthyFleetIsDeclinedNotOverridden", func(t *testing.T) {
+		// The production shape this gate exists for. A ~1.6 blocks/s chain with
+		// four upstreams, every one of them advancing, split wider than one
+		// cluster width: the top pair is the only electable group (the other two
+		// are singletons, which tipMinGroupSize rejects), so it wins the election
+		// unopposed and sits well inside the 1024-block tolerance.
+		//
+		// Nothing has stalled — the majority tracks the chain — so the referee
+		// must decline. Before the majority-stall gate it let the pair earn a 30s
+		// dwell and then raised the tip by the width of the split, indefinitely.
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 30_000_000, 8, 130)
+
+		for i := 0; i < 240; i++ { // 20 minutes — far past tipDwellDuration
+			now = now.Add(tipSampleInterval)
+			head += 8
+			pick := PickServedTip(tipsFromInts(head, head, head-24, head-64))
+			d := tr.Observe(now, pick.Sorted, pick.Tip, params)
+			require.False(t, d.Overrode,
+				"sample %d: a fleet whose majority is on the trajectory must never be overridden (pick %d, majority %d, expected %d)",
+				i, d.Pick, pick.Tip, d.Expected)
+			require.Equal(t, pick.Tip, d.Pick, "sample %d: the majority pick must survive intact", i)
+		}
+	})
+
+	t.Run("SlowChainStallIsStillCorrected", func(t *testing.T) {
+		// The same slow chain, but the majority genuinely stops. The gate is
+		// chain-relative, so a stall crosses it after tipMajorityStallSeconds
+		// however few blocks that is — 48 here, against the 2400 a 20 blocks/s
+		// chain would produce in the same time.
+		var tr TipTrajectory
+		now, head := warmTrajectory(&tr, time.Now(), 30_000_000, 8, 130)
+
+		frozen := head
+		var d TipTrajectoryDecision
+		for i := 0; i < 24; i++ { // 2 minutes of a frozen majority
+			now = now.Add(tipSampleInterval)
+			head += 8
+			d = tr.Observe(now, ballot(head, head, frozen, frozen, frozen), frozen, params)
+		}
+		assert.True(t, d.Overrode, "a genuine stall must still be corrected on a slow chain")
+		assert.Equal(t, head, d.Pick, "the pick is the fresh group's minimum")
+	})
+
 	t.Run("HealthyFleetIsOneGroupAndNeverIntervenes", func(t *testing.T) {
 		var tr TipTrajectory
 		now, head := warmTrajectory(&tr, time.Now(), 1_000_000, 100, 130)


### PR DESCRIPTION
The trajectory referee added in #1063/#1064 exists to raise the served tip off a **stalled** majority. Nothing in the decision path tests that premise.

- The tolerance gate asks whether the **elected group** is on the trajectory.
- The upward-only rule asks whether that group sits **above the majority**.
- Nothing asks whether **the majority is off the trajectory** — the only thing that justifies giving up the majority order statistic's servability guarantee.

## Why the gap is load-bearing, not theoretical

Once a fleet splits wider than one cluster width, the lower upstreams become singletons and `tipMinGroupSize` rejects them. The upper group is then frequently the **only** candidate, so it wins the election unopposed and is judged solely against `ToleranceFloor` — whose 1024-block default admits essentially any split a real fleet produces. Election implies override, and the referee fires on ordinary poller skew.

## What it did in production

A ~1.66 blocks/s chain, four upstreams, **all of them advancing**. From the referee's own log line:

| | value |
|---|---|
| majority pick | 30,699,698 |
| elected group | 30,699,722 |
| expected | 30,699,716 |
| tolerance | **1024** |
| blocksPerSecond | 1.658 |

The majority was **18 blocks — eleven seconds — off the trajectory**, inside a tolerance of 1024. The referee raised the tip by 24 blocks every ~28 minutes and flapped its alert. Because the pick is the elected group's minimum, the served tip sat above what half the fleet could serve, trading the servability guarantee for ~14 seconds of freshness with no stall to justify it.

## The fix

The majority pick must be behind the trajectory by more than `tipMajorityStallSeconds` of chain progress before it may be outvoted. Three lines and a constant:

```go
if expected-float64(median) <= fit.vPerSec*tipMajorityStallSeconds {
    d.Declined = true
    return d
}
```

**Why a duration, not a block count.** Block counts are not comparable across chains: `ToleranceFloor`'s 1024 blocks is about three hours of a 12s chain and ten minutes of a 1.7 blocks/s one, so as an absolute floor it binds on slow chains and never binds on fast ones. Seconds of missing chain progress mean the same thing everywhere.

**Why 30s.** It matches `tipDwellDuration`, which the elected group must satisfy anyway, so correcting a genuine stall is no slower — a frozen majority crosses this gate and earns its dwell over the same interval.

A refused raise stays `Declined`, so the near miss still lands in the `fallback` series and stays visible without paging.

## Doc correction

`TipTrajectoryDecision.Declined` claimed a fleet split around its own median can never elect its upper group, "the trajectory is fitted to the median, so no permanently-offset group is ever closer to it". Election is against the **tolerance**, never against the median's distance, so a persistent split elects routinely. What prevents the override is this gate, not the geometry of the fit.

## Verification

Two tests in `TestTipTrajectory_GroupElection`:

- **`PersistentSplitOnAHealthyFleetIsDeclinedNotOverridden`** — the production shape, 20 simulated minutes (far past the dwell) on a 1.6 blocks/s chain with a fleet at `head, head, head-24, head-64`. Asserts the majority pick survives every evaluation.
- **`SlowChainStallIsStillCorrected`** — same slow chain, majority genuinely frozen. Asserts the override still fires, so the gate isn't merely disabling the feature.

Confirmed the first test fails without the fix, reproducing production's exact signature:

```
--- FAIL: TestTipTrajectory_GroupElection/PersistentSplitOnAHealthyFleetIsDeclinedNotOverridden
    sample 0: a fleet whose majority is on the trajectory must never be overridden
              (pick 30001048, majority 30001024, expected 30001048)
```

A +24 block override, matching the +24 measured in production. Note `expected == pick`: the group is elected unopposed.

```
go build ./...                                    # clean
go vet ./architecture/evm/...                     # clean
go test ./architecture/evm/... -count 1           # ok
go test ./erpc/ -run 'ServedTip|Trajectory'       # ok (75.8s)
```

Existing referee tests pass unchanged, including `StalledMajorityLosesToCorroboratedFreshPair` — a 20 blocks/s chain frozen for 120s produces a 2400-block gap against this gate's 600, so genuine stalls are unaffected.

## Open question for maintainers

`ToleranceFloor` is `EvmServedTipConfig.MaxRegressionBlocks`, defaulting to `DefaultToleratedBlockHeadRollback` (1024). That constant is about how far a head may *retreat*; reusing it as "how far from the fitted head a group may sit and still be on-trajectory" is what makes the tolerance gate vacuous on fast chains. This PR leaves it alone and adds the orthogonal majority-stall test instead, but making the tolerance chain-relative too seems worth considering separately. Happy to follow up if you agree.

## AI assistance

- **Model:** anthropic/claude-opus-5
- **Harness / skills:** Claude Code
- **Human-reviewed:** Diagnosis and diff reviewed in-session before push; not an independent line-by-line audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)