### PR TITLE
fix(evm): make the chain-identity verification threshold chain-relative

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -31,6 +31,20 @@ const FullySyncedThreshold = 4
 // apply the same rollback tolerance to block heads.
 const DefaultToleratedBlockHeadRollback = common.DefaultToleratedBlockHeadRollback
 
+const (
+	// chainIdVerifyChainProgress is how much CHAIN PROGRESS a head move must
+	// represent before it is treated as major and re-verified against a live
+	// eth_chainId (see majorHeadMoveThreshold). One minute is comfortably more
+	// chain than a healthy poller can miss between samples — the default state
+	// poller interval is 5s — while staying far below the height difference any
+	// two unrelated chains exhibit.
+	chainIdVerifyChainProgress = 60 * time.Second
+
+	// chainIdVerifyMinBlocks keeps the derived threshold off zero on a chain
+	// whose measured block time is longer than the window itself.
+	chainIdVerifyMinBlocks = 2
+)
+
 var _ common.EvmStatePoller = &EvmStatePoller{}
 
 type EvmStatePoller struct {
@@ -541,7 +555,7 @@ func (e *EvmStatePoller) SuggestLatestBlock(blockNumber int64) {
 	// eth_chainId call, so it runs OFF the hot path and this function stays
 	// non-blocking. Small advances (the common keep-fresh case) still apply
 	// inline with zero added latency, exactly as before.
-	if currentValue > 0 && blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback {
+	if currentValue > 0 && blockNumber-currentValue > e.majorHeadMoveThreshold() {
 		e.verifyThenSuggestLatestBlock(blockNumber)
 		return
 	}
@@ -577,7 +591,7 @@ func (e *EvmStatePoller) verifyThenSuggestLatestBlock(blockNumber int64) {
 		if blockNumber <= currentValue {
 			return
 		}
-		if blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback &&
+		if blockNumber-currentValue > e.majorHeadMoveThreshold() &&
 			!e.verifyChainIdOnMajorHeadMove(ctx, "latest", currentValue, blockNumber) {
 			e.logger.Warn().
 				Int64("blockNumber", blockNumber).
@@ -634,8 +648,42 @@ func (e *EvmStatePoller) OnLatestBlock(cb func(int64)) {
 // cross-wired upstream that never returns a correct low sample (it errors out
 // or keeps serving the wrong chain) would otherwise leave the bogus head pinned
 // in the shared counter and skew lag-based routing until manually corrected.
+// majorHeadMoveThreshold is how far a head may move, in blocks, before the move
+// counts as major and is re-verified against eth_chainId.
+//
+// The question it answers — "does this move represent more chain than we could
+// plausibly have missed?" — is about TIME, so the threshold is
+// chainIdVerifyChainProgress of chain progress converted through the network's
+// measured block time. A fixed block count cannot ask it across a multi-chain
+// fleet: DefaultToleratedBlockHeadRollback's 1024 blocks is ~3.4 hours of a 12s
+// chain and ~4 minutes of a 4 blocks/s one, so the same constant gates almost
+// nothing on the slow chains and a fair amount on the fast ones. Two chains
+// cross-wired at similar heights therefore slip through on exactly the chains
+// where the check is loosest.
+//
+// Clamped to DefaultToleratedBlockHeadRollback at the top so this can only ever
+// ADD verification relative to the previous behaviour, never remove it —
+// including on a sub-60ms-block chain, where a raw window would derive a LOOSER
+// threshold than the old constant. While the block time is still unknown (cold
+// start) it falls back to that constant, so nothing changes until there is a
+// measurement to act on.
+func (e *EvmStatePoller) majorHeadMoveThreshold() int64 {
+	blockTime := e.tracker.GetNetworkBlockTime(e.upstream.NetworkId())
+	if blockTime <= 0 {
+		return common.DefaultToleratedBlockHeadRollback
+	}
+	blocks := int64(chainIdVerifyChainProgress / blockTime)
+	if blocks < chainIdVerifyMinBlocks {
+		return chainIdVerifyMinBlocks
+	}
+	if blocks > common.DefaultToleratedBlockHeadRollback {
+		return common.DefaultToleratedBlockHeadRollback
+	}
+	return blocks
+}
+
 func (e *EvmStatePoller) verifyChainIdOnMajorHeadMove(ctx context.Context, tag string, current, polled int64) bool {
-	if current <= 0 || absInt64(polled-current) <= common.DefaultToleratedBlockHeadRollback {
+	if current <= 0 || absInt64(polled-current) <= e.majorHeadMoveThreshold() {
 		return true
 	}
 	cfgChainId := int64(0)
@@ -809,7 +857,7 @@ func (e *EvmStatePoller) SuggestFinalizedBlock(blockNumber int64) {
 		// cross-wired endpoint reporting another chain's height must not enter the
 		// shared finalized counter. Already off the hot path here (own goroutine),
 		// so the live eth_chainId call is safe to make.
-		if blockNumber-currentValue > common.DefaultToleratedBlockHeadRollback &&
+		if blockNumber-currentValue > e.majorHeadMoveThreshold() &&
 			!e.verifyChainIdOnMajorHeadMove(ctx, "finalized", currentValue, blockNumber) {
 			e.logger.Warn().
 				Int64("blockNumber", blockNumber).

--- a/architecture/evm/evm_state_poller_suggest_gate_test.go
+++ b/architecture/evm/evm_state_poller_suggest_gate_test.go
@@ -240,3 +240,63 @@ func TestSuggestFinalizedBlock_MajorJumpChainIdMismatchDroppedAndCordoned(t *tes
 	require.Eventually(t, up.isCordoned, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(t, int64(1000), p.FinalizedBlock(), "bogus major finalized jump must not enter the shared counter")
 }
+
+// --- majorHeadMoveThreshold ---
+
+// feedBlockTime drives the tracker's block-time EMA to (tsDelta/numDelta)
+// seconds per block by replaying observations through the same entry point the
+// poller uses. blockTimeMinSamples is 3, so a handful of rounds is plenty.
+func feedBlockTime(t *testing.T, p *EvmStatePoller, up common.Upstream, numDelta, tsDelta int64) {
+	t.Helper()
+	var num int64 = 1_000_000
+	var ts int64 = 1_700_000_000
+	for i := 0; i < 8; i++ {
+		num += numDelta
+		ts += tsDelta
+		p.tracker.SetLatestBlockNumber(up, num, ts)
+	}
+	require.NotZero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()),
+		"precondition: the block-time EMA must have settled")
+}
+
+func TestMajorHeadMoveThreshold(t *testing.T) {
+	t.Run("UnknownBlockTimeKeepsTheBlockCountDefault", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+
+		// Cold start: nothing has been measured, so the old constant stands and
+		// behaviour is byte-for-byte what it was before.
+		require.Zero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()))
+		assert.Equal(t, gateTolerance, p.majorHeadMoveThreshold())
+	})
+
+	t.Run("SlowChainDerivesATighterThreshold", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		feedBlockTime(t, p, up, 1, 12) // 12s blocks, i.e. Ethereum
+
+		// 60s of chain progress is 5 blocks here, against the 1024 the fixed
+		// constant would have allowed — 3.4 hours of this chain.
+		assert.Equal(t, int64(5), p.majorHeadMoveThreshold())
+	})
+
+	t.Run("FastChainIsClampedToTheOldDefault", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		feedBlockTime(t, p, up, 100, 1) // 10ms blocks — the tracker's fastest
+
+		// 60s would derive 6000 blocks, looser than before. The clamp holds it at
+		// the old constant so this change can only ever ADD verification.
+		assert.Equal(t, gateTolerance, p.majorHeadMoveThreshold())
+	})
+
+	t.Run("VerySlowChainKeepsANonZeroFloor", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		feedBlockTime(t, p, up, 1, 100) // 100s blocks
+
+		// 60s of chain progress rounds to 0 blocks; the floor keeps the gate from
+		// firing on every single advance.
+		assert.Equal(t, int64(chainIdVerifyMinBlocks), p.majorHeadMoveThreshold())
+	})
+}


### PR DESCRIPTION
`verifyChainIdOnMajorHeadMove` re-checks an endpoint's identity when a head moves further than `DefaultToleratedBlockHeadRollback` (1024 blocks). The question it is really asking — *does this move represent more chain than we could plausibly have missed?* — is about **time**, and a fixed block count cannot ask it across a multi-chain fleet.

| chain | blocks/s | 1024 blocks = |
|---|---|---|
| Ethereum | 0.083 | **3.4 hours** |
| tempo-moderato | 1.66 | 10 minutes |
| Celo | 2.14 | 8 minutes |
| Arbitrum | ~4 | 4 minutes |

A 50× spread in what one constant means. It gates almost nothing on slow chains, and it is loosest exactly where a cross-wired endpoint is hardest to notice: **two chains whose heights differ by less than the threshold produce a jump that is never verified at all.** The guard catches base-vs-BSC easily because those heights are tens of millions apart; it is blind to a mainnet/testnet pair or two chains launched around the same time with the same block time.

## The change

Derive the threshold from `chainIdVerifyChainProgress` (60s) of chain progress via the network's measured block time — `Tracker.GetNetworkBlockTime`, already maintained and already used by the poll debounce. One minute is comfortably more chain than a healthy poller can miss between 5s samples, while staying far below the height difference unrelated chains exhibit.

**Clamped so it can only ever ADD verification, never remove it:**

- **Capped** at `DefaultToleratedBlockHeadRollback` — a sub-60ms-block chain would otherwise derive a *looser* 6000-block threshold, so it keeps today's gate.
- **Floored** at `chainIdVerifyMinBlocks` — a chain slower than the window itself would derive 0 and fire on every advance.
- **Falls back** to the old constant while the block time is unknown, so cold start is byte-for-byte the previous behaviour.

All four identity gates now share the derived value — polled and suggested, on both the latest and finalized axes — so they cannot drift apart. Previously the threshold was written out at each site.

## What is deliberately NOT changed

The shared-counter rollback tolerance (`ignoreRollbackOf`, `evm_state_poller.go:153-154`) keeps the block-count constant. That one protects against a lagging node behind a load balancer dragging a *fleet-wide* shared counter down, and its magnitude is load-bearing there — tightening it is the one change in this area that could introduce a new failure mode. Different question, different threshold; it should be considered separately.

## Verification

```
go build ./...                                   # clean
go vet ./architecture/evm/...                    # clean
go test ./architecture/evm/... -count 1          # ok
go test ./upstream/... ./health/... -count 1     # ok
```

New `TestMajorHeadMoveThreshold` drives the tracker's real block-time EMA through `SetLatestBlockNumber` (the same entry point the poller uses) and pins all four branches:

| case | block time | threshold |
|---|---|---|
| cold start, nothing measured | — | 1024 (unchanged) |
| Ethereum-like | 12s | **5** |
| fastest the tracker allows | 10ms | 1024 (clamped, not 6000) |
| slower than the window | 100s | 2 (floor) |

Existing gate tests in `evm_state_poller_suggest_gate_test.go` pass unchanged: they never feed a block time, so they take the cold-start fallback and keep asserting against 1024.

## Relationship to #1077

Same root pattern — an absolute block count standing in for a question about chain progress. #1077 fixes the served-tip referee's stall gate; this fixes the identity gate. They touch different files and are independent; either can merge first.

## AI assistance

- **Model:** anthropic/claude-opus-5
- **Harness / skills:** Claude Code
- **Human-reviewed:** Approach and diff reviewed in-session before push; not an independent line-by-line audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)