### PR TITLE
feat(evm): give two block-count defaults a chain-relative floor

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -1053,6 +1053,46 @@ func (e *EvmStatePoller) runPeriodicEarliestBlockBoundUpdateLoop(probe common.Ev
 	}
 }
 
+// fallbackFinalityMinAge is the minimum WALL-CLOCK age a block must reach
+// before the SYNTHETIC finalized head can cover it. It applies only on the
+// fallback path — when an upstream reports no finalized block at all — and only
+// ever DEEPENS the configured block depth, never shortens it.
+//
+// A block count alone cannot express "old enough that a reorg is implausible".
+// DefaultEvmFinalityDepth's 1024 blocks is ~3.4 hours of a 12s chain but only a
+// couple of minutes of a sub-second one, so the same constant is far more
+// conservative than needed on slow chains and potentially SHALLOWER than the
+// chain's real reorg risk on fast ones — and this value decides what erpc
+// treats as immutable and therefore permanently cacheable. Getting it wrong in
+// the shallow direction caches data that can still be reorged away.
+//
+// 30 minutes sits comfortably beyond Ethereum's ~13-minute finality and beyond
+// the unsafe-head reorg windows typical L2s expose. On any chain where the
+// configured block depth already represents more than this, nothing changes.
+const fallbackFinalityMinAge = 30 * time.Minute
+
+// fallbackFinalityDepth is how far below the head the synthetic finalized block
+// sits: the DEEPER of the configured block count and fallbackFinalityMinAge of
+// chain progress. Taking the deeper of the two is what makes this safe to ship
+// unconditionally — the synthetic finalized head can only ever move further
+// from the tip, never closer, so no block becomes "final" earlier than it does
+// today. While the block time is unknown the configured count stands alone.
+func (e *EvmStatePoller) fallbackFinalityDepth() int64 {
+	e.stateMu.RLock()
+	depth := int64(common.DefaultEvmFinalityDepth)
+	if e.cfg != nil && e.cfg.FallbackFinalityDepth > 0 {
+		depth = e.cfg.FallbackFinalityDepth
+	}
+	e.stateMu.RUnlock()
+
+	if blockTime := e.tracker.GetNetworkBlockTime(e.upstream.NetworkId()); blockTime > 0 {
+		if byAge := int64(fallbackFinalityMinAge / blockTime); byAge > depth {
+			depth = byAge
+		}
+	}
+	return depth
+}
+
 func (e *EvmStatePoller) IsBlockFinalized(blockNumber int64) (bool, error) {
 	finalizedBlock := e.finalizedBlockShared.GetValue()
 	latestBlock := e.latestBlockShared.GetValue()
@@ -1080,24 +1120,14 @@ func (e *EvmStatePoller) IsBlockFinalized(blockNumber int64) (bool, error) {
 	}
 
 	var fb int64
-	e.stateMu.RLock()
-	defer e.stateMu.RUnlock()
-	if e.cfg != nil && e.cfg.FallbackFinalityDepth > 0 {
-		if latestBlock > e.cfg.FallbackFinalityDepth {
-			fb = latestBlock - e.cfg.FallbackFinalityDepth
-		} else {
-			fb = 0
-		}
-	} else {
-		if latestBlock > common.DefaultEvmFinalityDepth {
-			fb = latestBlock - common.DefaultEvmFinalityDepth
-		} else {
-			fb = 0
-		}
+	depth := e.fallbackFinalityDepth()
+	if latestBlock > depth {
+		fb = latestBlock - depth
 	}
 
 	e.logger.Debug().
 		Int64("inferredFinalizedBlock", fb).
+		Int64("fallbackFinalityDepth", depth).
 		Int64("latestBlock", latestBlock).
 		Int64("blockNumber", blockNumber).
 		Msgf("calculating block finality using inferred finalized block")

--- a/architecture/evm/evm_state_poller_finality_depth_test.go
+++ b/architecture/evm/evm_state_poller_finality_depth_test.go
@@ -1,0 +1,61 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// driveBlockTimeEMA settles the tracker's block-time estimate at
+// (tsDelta/numDelta) seconds per block by replaying observations through the
+// same entry point the poller uses. blockTimeMinSamples is 3, so a handful of
+// rounds is plenty.
+func driveBlockTimeEMA(t *testing.T, p *EvmStatePoller, up common.Upstream, numDelta, tsDelta int64) {
+	t.Helper()
+	var num int64 = 1_000_000
+	var ts int64 = 1_700_000_000
+	for i := 0; i < 8; i++ {
+		num += numDelta
+		ts += tsDelta
+		p.tracker.SetLatestBlockNumber(up, num, ts)
+	}
+	require.NotZero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()),
+		"precondition: the block-time EMA must have settled")
+}
+
+func TestFallbackFinalityDepth(t *testing.T) {
+	t.Run("UnknownBlockTimeKeepsTheConfiguredDepth", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+
+		// Cold start: no measurement, so the block count stands alone and the
+		// behaviour is exactly what it was before.
+		require.Zero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()))
+		assert.Equal(t, int64(common.DefaultEvmFinalityDepth), p.fallbackFinalityDepth())
+	})
+
+	t.Run("SlowChainKeepsTheBlockDepth", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		driveBlockTimeEMA(t, p, up, 1, 12) // 12s blocks
+
+		// 30 minutes is 150 blocks here — shallower than the 1024 already
+		// configured, so the deeper of the two leaves this chain untouched.
+		assert.Equal(t, int64(common.DefaultEvmFinalityDepth), p.fallbackFinalityDepth())
+	})
+
+	t.Run("FastChainDeepensToTheMinimumAge", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		driveBlockTimeEMA(t, p, up, 10, 1) // 100ms blocks
+
+		// 1024 blocks is only ~1.7 minutes of this chain — potentially shallower
+		// than its real reorg risk. 30 minutes is 18,000 blocks, and the deeper
+		// value wins.
+		assert.Equal(t, int64(18_000), p.fallbackFinalityDepth())
+		assert.Greater(t, p.fallbackFinalityDepth(), int64(common.DefaultEvmFinalityDepth),
+			"the synthetic finalized head may only ever move FURTHER from the tip")
+	})
+}

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1318,6 +1318,41 @@ func (n *Network) noteServedTipGuardTransition(anchor *servedTipAnchor, state in
 	return true
 }
 
+// defaultMaxRetryableBlockDistance is the block-count fallback used when the
+// network does not configure MaxRetryableBlockDistance and the block time is
+// not known yet.
+const defaultMaxRetryableBlockDistance = int64(128)
+
+// retryableBlockHorizon is how far ahead of an upstream's head a requested
+// block may sit and still be worth retrying, expressed as chain progress.
+//
+// The question — "is this block close enough that the upstream may catch up?" —
+// is about how soon it arrives, so a block count answers it differently on
+// every chain: 128 blocks is ~25 minutes of a 12s chain but ~30 seconds of a
+// 4 blocks/s one. A minute of chain progress means the same thing everywhere.
+const retryableBlockHorizon = 60 * time.Second
+
+// maxRetryableBlockDistance is the larger of the block-count default and
+// retryableBlockHorizon of chain progress.
+//
+// Larger is the safe direction here: the value only decides whether to keep
+// trying, so widening it can cost a few extra retries but can never turn a
+// serveable request into a failure. An explicit operator setting is returned
+// untouched — the derived floor exists to give the DEFAULT a sane meaning
+// per chain, not to override a deliberate choice.
+func (n *Network) maxRetryableBlockDistance() int64 {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.MaxRetryableBlockDistance != nil {
+		return *n.cfg.Evm.MaxRetryableBlockDistance
+	}
+	distance := defaultMaxRetryableBlockDistance
+	if blockTime := n.EvmBlockTime(); blockTime > 0 {
+		if byTime := int64(retryableBlockHorizon / blockTime); byTime > distance {
+			distance = byTime
+		}
+	}
+	return distance
+}
+
 // servedTipMaxRegressionBlocks is how far below the corroborated live head a
 // pick may fall before the regression guard treats it as poisoned. Defaults to
 // the rollback tolerance the state poller and health tracker already use, so
@@ -2860,11 +2895,7 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 		latestBlock, finalizedBlock := n.upstreamHeads(eu)
 		blockErr := common.NewErrUpstreamBlockUnavailable(eu.Id(), bn, latestBlock, finalizedBlock)
 		if bn > latestBlock && latestBlock > 0 {
-			maxDistance := int64(128) // default
-			if n.cfg.Evm != nil && n.cfg.Evm.MaxRetryableBlockDistance != nil {
-				maxDistance = *n.cfg.Evm.MaxRetryableBlockDistance
-			}
-			return blockErr, bn-latestBlock <= maxDistance
+			return blockErr, bn-latestBlock <= n.maxRetryableBlockDistance()
 		}
 		return blockErr, false
 	}

--- a/erpc/networks_retryable_distance_test.go
+++ b/erpc/networks_retryable_distance_test.go
@@ -1,0 +1,77 @@
+package erpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRetryDistanceNetwork builds the minimum Network the derivation reads:
+// a config, a tracker and a network id. blocksPerSecond <= 0 leaves the
+// tracker's estimate unset, which is the cold-start case.
+func newRetryDistanceNetwork(t *testing.T, configured *int64, blocksPerSecond int64) *Network {
+	t.Helper()
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", 2*time.Second)
+	n := &Network{
+		networkId:      "evm:1",
+		projectId:      "test",
+		logger:         &logger,
+		cfg:            &common.NetworkConfig{Evm: &common.EvmNetworkConfig{MaxRetryableBlockDistance: configured}},
+		metricsTracker: tracker,
+	}
+	if blocksPerSecond > 0 {
+		// Settle the tracker's block-time EMA by replaying observations through
+		// the same entry point the poller uses: blocksPerSecond blocks for every
+		// one second of block timestamp. blockTimeMinSamples is 3, so eight
+		// rounds is comfortably past the gate.
+		up := common.NewFakeUpstream("ups-1", common.WithFakeUpstreamNetworkID("evm:1"))
+		var num int64 = 1_000_000
+		var ts int64 = 1_700_000_000
+		for i := 0; i < 8; i++ {
+			num += blocksPerSecond
+			ts++
+			tracker.SetLatestBlockNumber(up, num, ts)
+		}
+		require.NotZero(t, tracker.GetNetworkBlockTime("evm:1"),
+			"precondition: the block-time EMA must have settled")
+	}
+	return n
+}
+
+func TestMaxRetryableBlockDistance(t *testing.T) {
+	t.Run("UnknownBlockTimeKeepsTheBlockCountDefault", func(t *testing.T) {
+		n := newRetryDistanceNetwork(t, nil, 0)
+		assert.Equal(t, defaultMaxRetryableBlockDistance, n.maxRetryableBlockDistance())
+	})
+
+	t.Run("SlowChainKeepsTheBlockCountDefault", func(t *testing.T) {
+		// 1 block/s: 60s of chain is 60 blocks, inside the 128 default, so the
+		// larger of the two leaves this chain untouched.
+		n := newRetryDistanceNetwork(t, nil, 1)
+		assert.Equal(t, defaultMaxRetryableBlockDistance, n.maxRetryableBlockDistance())
+	})
+
+	t.Run("FastChainWidensToTheTimeHorizon", func(t *testing.T) {
+		// 10 blocks/s: 128 blocks is only ~13 seconds of this chain, so a block
+		// half a minute out would be refused a retry it would have won. 60s of
+		// chain progress is 600 blocks.
+		n := newRetryDistanceNetwork(t, nil, 10)
+		assert.Equal(t, int64(600), n.maxRetryableBlockDistance())
+		assert.Greater(t, n.maxRetryableBlockDistance(), defaultMaxRetryableBlockDistance,
+			"widening is the safe direction: it can cost retries, never a failed request")
+	})
+
+	t.Run("ExplicitConfigIsNeverOverridden", func(t *testing.T) {
+		// An operator who pins this has made a deliberate choice; the derived
+		// floor must not widen it, even on a chain where it otherwise would.
+		pinned := int64(4)
+		n := newRetryDistanceNetwork(t, &pinned, 10)
+		assert.Equal(t, int64(4), n.maxRetryableBlockDistance())
+	})
+}


### PR DESCRIPTION
Both values below are block counts standing in for a question about **elapsed chain time**, so one constant means wildly different things across a fleet:

| chain | blocks/s | 1024 blocks = | 128 blocks = |
|---|---|---|---|
| Ethereum | 0.083 | 3.4 hours | 25 min |
| Celo | 2.14 | 8 min | 1 min |
| a 100ms chain | 10 | 1.7 min | 13 s |

Each default now takes the **safer** of the configured block count and the equivalent chain progress, so neither can regress.

## 1. Fallback finality depth — the shallow direction is a correctness bug

When an upstream reports no finalized block at all, erpc synthesises one at `latest - 1024` ([`IsBlockFinalized`](architecture/evm/evm_state_poller.go)). That value decides what is treated as immutable and therefore **permanently cacheable**.

1024 blocks is only a couple of minutes on a sub-second chain — potentially *shallower* than that chain's real reorg risk, which caches data that can still be reorged away. On Ethereum it is 3.4 hours, far more conservative than needed.

The depth is now the **deeper** of the configured count and `fallbackFinalityMinAge` (30m) of chain progress. The synthetic finalized head can therefore only ever move *further* from the tip, never closer — **no block becomes final earlier than it does today**, on any chain. 30 minutes sits beyond Ethereum's ~13-minute finality and beyond the unsafe-head reorg windows typical L2s expose.

## 2. Max retryable block distance — widening is the safe direction

Whether a block just ahead of an upstream's head is worth retrying is a question about *how soon it arrives*, but the default is 128 blocks — ~25 minutes of a 12s chain and ~13 seconds of a 10 blocks/s one, where a block half a minute out is refused a retry it would have won.

The default is now the **larger** of 128 and `retryableBlockHorizon` (60s) of chain progress. Larger is the safe direction: the value only decides whether to *keep trying*, so widening can cost a few extra retries but can never turn a serveable request into a failure.

**An explicitly configured value is returned untouched.** The floor exists to give the *default* a sane per-chain meaning, not to override a deliberate operator choice.

Both derivations fall back to the plain block count while the block time is unknown, so cold start is byte-for-byte unchanged.

## Deliberately NOT converted

Listing these because "block count" is not automatically wrong — for several of these it is the right unit, and for one the magnitude is load-bearing:

- **`ignoreRollbackOf`** (shared counter, 1024) — protects a *fleet-wide* counter from a lagging node behind a load balancer dragging the head down. Tightening it is the one change in this area that could introduce a new failure mode.
- **The served-tip regression guard** — changing it changes *when the guard engages*, which is a behavioural change rather than a floor.
- **`getLogs` ranges, node-retention windows, trace depth, scan caps** — provider limits, pruning config and bounded work are genuinely expressed in blocks.

Each needs its own decision rather than riding along here.

## Verification

```
go build ./...                                            # clean
go test ./architecture/evm/... -count 1                   # ok
go test ./erpc/ -run 'Availability|Finaliz|Retry|ServedTip'  # ok (150s)
```

Both derivations are pinned by tests that drive the tracker's **real** block-time EMA through the same entry point the poller uses, rather than stubbing it:

`TestFallbackFinalityDepth` — cold start → 1024 unchanged; 12s chain → 1024 unchanged (30m is only 150 blocks there); 100ms chain → **18,000**, with an explicit assertion that the depth only ever grows.

`TestMaxRetryableBlockDistance` — cold start → 128; 1 block/s → 128 unchanged; 10 blocks/s → **600**, with an assertion that it only ever widens; explicit config → returned untouched.

## Related

Same root pattern as #1077 (served-tip stall gate) and #1078 (chain-identity verification threshold). All three are independent — different files, all branched off `main`.

Note for whoever merges: #1078 adds a `feedBlockTime` test helper in `architecture/evm`; this PR's equivalent is deliberately named `driveBlockTimeEMA` so the two cannot collide whichever order they land. Worth deduplicating once both are in.

## AI assistance

- **Model:** anthropic/claude-opus-5
- **Harness / skills:** Claude Code
- **Human-reviewed:** Approach and diff reviewed in-session before push; not an independent line-by-line audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)