### PR TITLE
feat(evm): project-level blockAvailability + -32014 for unavailable blocks

### DIFF
--- a/common/block_availability_project_test.go
+++ b/common/block_availability_project_test.go
@@ -1,0 +1,222 @@
+package common
+
+import (
+	"time"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Project-level block availability is configured once under
+// `projects[].upstreamDefaults.evm.blockAvailability` and inherited by every
+// upstream that does not declare its own window. Enforcement itself is the
+// existing per-upstream path — these tests only pin the inheritance rules and
+// their precedence, because getting the precedence wrong silently widens or
+// narrows the served range on every upstream at once.
+func TestEvmUpstreamConfig_SetDefaults_InheritsBlockAvailability(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+	projectDefaults := func() *EvmUpstreamConfig {
+		return &EvmUpstreamConfig{
+			BlockAvailability: &EvmBlockAvailabilityConfig{
+				Lower: &EvmAvailabilityBoundConfig{LatestBlockMinus: i64(604800)},
+			},
+		}
+	}
+	lowerMinus := func(t *testing.T, e *EvmUpstreamConfig) int64 {
+		t.Helper()
+		require.NotNil(t, e.BlockAvailability, "expected a resolved blockAvailability")
+		require.NotNil(t, e.BlockAvailability.Lower, "expected a resolved lower bound")
+		require.NotNil(t, e.BlockAvailability.Lower.LatestBlockMinus)
+		return *e.BlockAvailability.Lower.LatestBlockMinus
+	}
+
+	t.Run("inherited when the upstream declares no window", func(t *testing.T) {
+		e := &EvmUpstreamConfig{ChainId: 1}
+		require.NoError(t, e.SetDefaults(projectDefaults()))
+		assert.EqualValues(t, 604800, lowerMinus(t, e))
+	})
+
+	// Bounds are recomputed per upstream at runtime against that upstream's own
+	// state poller, so a shared pointer would let one upstream's mutation leak
+	// into every sibling.
+	t.Run("copied, never shared with the defaults object", func(t *testing.T) {
+		defs := projectDefaults()
+		e := &EvmUpstreamConfig{ChainId: 1}
+		require.NoError(t, e.SetDefaults(defs))
+		assert.NotSame(t, defs.BlockAvailability, e.BlockAvailability)
+		assert.NotSame(t, defs.BlockAvailability.Lower, e.BlockAvailability.Lower)
+	})
+
+	t.Run("upstream's own blockAvailability wins", func(t *testing.T) {
+		e := &EvmUpstreamConfig{
+			ChainId: 1,
+			BlockAvailability: &EvmBlockAvailabilityConfig{
+				Lower: &EvmAvailabilityBoundConfig{LatestBlockMinus: i64(128)},
+			},
+		}
+		require.NoError(t, e.SetDefaults(projectDefaults()))
+		assert.EqualValues(t, 128, lowerMinus(t, e))
+	})
+
+	// The deprecated per-upstream knob is still an explicit statement about that
+	// upstream, so it outranks the project-wide default.
+	t.Run("upstream's own maxAvailableRecentBlocks wins", func(t *testing.T) {
+		e := &EvmUpstreamConfig{ChainId: 1, MaxAvailableRecentBlocks: 256}
+		require.NoError(t, e.SetDefaults(projectDefaults()))
+		assert.EqualValues(t, 256, lowerMinus(t, e))
+	})
+
+	// nodeType:full otherwise derives a 128-block window. An explicitly
+	// configured project default is not a guess and must outrank it.
+	t.Run("inherited window outranks the nodeType full default", func(t *testing.T) {
+		e := &EvmUpstreamConfig{ChainId: 1, NodeType: EvmNodeTypeFull}
+		require.NoError(t, e.SetDefaults(projectDefaults()))
+		assert.EqualValues(t, 604800, lowerMinus(t, e))
+		assert.Zero(t, e.MaxAvailableRecentBlocks,
+			"nodeType must not also derive a legacy 128 window that clamps this one")
+	})
+
+	t.Run("no defaults leaves existing behaviour untouched", func(t *testing.T) {
+		e := &EvmUpstreamConfig{ChainId: 1, NodeType: EvmNodeTypeFull}
+		require.NoError(t, e.SetDefaults(nil))
+		assert.EqualValues(t, 128, lowerMinus(t, e))
+	})
+}
+
+// A block below every upstream's availability window must reach the client as
+// missing data. Before this mapping it fell through to the generic -32603
+// "server side exception", which is indistinguishable from eRPC itself failing.
+func TestTranslateToJsonRpcException_BlockUnavailableIsMissingData(t *testing.T) {
+	blockUnavailable := func(id string) error {
+		return NewErrUpstreamBlockUnavailable(id, 100, 1_000_000, 999_000)
+	}
+
+	t.Run("bare cause", func(t *testing.T) {
+		got := clientWireCode(t, TranslateToJsonRpcException(blockUnavailable("up-a")))
+		assert.EqualValues(t, JsonRpcErrorMissingData, got)
+	})
+
+	// The production path: every upstream skipped the block, so the network hands
+	// translation an exhausted bundle — and the retry loop wraps that again.
+	t.Run("exhausted bundle and its retry-exceeded wrapper", func(t *testing.T) {
+		order := []string{"up-a", "up-b", "up-c"}
+		causes := map[string]error{}
+		for _, id := range order {
+			causes[id] = blockUnavailable(id)
+		}
+		exhausted := newExhausted(t, order, causes)
+
+		assert.EqualValues(t, JsonRpcErrorMissingData,
+			clientWireCode(t, TranslateToJsonRpcException(exhausted)))
+		assert.EqualValues(t, JsonRpcErrorMissingData,
+			clientWireCode(t, TranslateToJsonRpcException(
+				NewErrFailsafeRetryExceeded(ScopeNetwork, exhausted, nil))))
+	})
+
+	// Membership in a multi-error bundle means ONE upstream hit the condition, not
+	// that it is the verdict. Reporting -32014 for these would hand the client a
+	// definitive "this block does not exist" while hiding a real consensus or
+	// infrastructure failure — the worst possible way to be wrong here, because a
+	// consumer can act on it by permanently skipping the block.
+	t.Run("mixed bundles are not reported as missing data", func(t *testing.T) {
+		unavailable := NewErrUpstreamBlockUnavailable("up-a", 100, 1_000_000, 999_000)
+		timeout := NewErrEndpointRequestTimeout(5*time.Second, nil)
+
+		for _, tc := range []struct {
+			name string
+			err  error
+		}{
+			{"consensus dispute", NewErrConsensusDispute("dispute", nil, []error{unavailable, timeout})},
+			{"low participants", NewErrConsensusLowParticipants("low", nil, []error{unavailable, timeout})},
+			{"exhausted dominated by timeouts", newExhausted(t,
+				[]string{"up-a", "up-b", "up-c"},
+				map[string]error{
+					"up-a": unavailable,
+					"up-b": timeout,
+					"up-c": NewErrEndpointRequestTimeout(6*time.Second, nil),
+				})},
+			// A plurality is not unanimity: up-c never answered, so eRPC cannot
+			// claim the block is definitively absent. The dominance scan picks
+			// block-unavailable here, which is exactly why the verdict has to be
+			// decided before that scan runs.
+			{"exhausted with an unavailable plurality", newExhausted(t,
+				[]string{"up-a", "up-b", "up-c"},
+				map[string]error{
+					"up-a": unavailable,
+					"up-b": NewErrUpstreamBlockUnavailable("up-b", 100, 1_000_000, 999_000),
+					"up-c": timeout,
+				})},
+			{"exhausted with a tie", newExhausted(t,
+				[]string{"up-a", "up-b"},
+				map[string]error{"up-a": unavailable, "up-b": timeout})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.NotEqualValues(t, JsonRpcErrorMissingData,
+					clientWireCode(t, TranslateToJsonRpcException(tc.err)),
+					"a single unavailable upstream must not speak for the whole request")
+			})
+		}
+	})
+}
+
+// The inheritance must be asserted through the real project-initialisation path,
+// not by calling EvmUpstreamConfig.SetDefaults directly: ProjectConfig.SetDefaults
+// normalises upstreamDefaults FIRST, which materialises MaxAvailableRecentBlocks
+// from `nodeType: full`, and ApplyDefaults then copies that value onto each
+// upstream. A unit-level test never sees that sequence, and the legacy back-compat
+// mapping silently replaced the configured window with the 128-block default.
+func TestProjectConfig_SetDefaults_BlockAvailabilityReachesUpstreams(t *testing.T) {
+	v := int64(604800)
+	window := func() *EvmBlockAvailabilityConfig {
+		return &EvmBlockAvailabilityConfig{
+			Lower: &EvmAvailabilityBoundConfig{LatestBlockMinus: &v},
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		defEvm   *EvmUpstreamConfig
+		upstream *UpstreamConfig
+	}{
+		{
+			name:     "upstream declares no evm block",
+			defEvm:   &EvmUpstreamConfig{NodeType: EvmNodeTypeFull, BlockAvailability: window()},
+			upstream: &UpstreamConfig{Id: "u1", Endpoint: "http://rpc1.localhost"},
+		},
+		{
+			name:     "upstream declares a partial evm block",
+			defEvm:   &EvmUpstreamConfig{NodeType: EvmNodeTypeFull, BlockAvailability: window()},
+			upstream: &UpstreamConfig{Id: "u1", Endpoint: "http://rpc1.localhost", Evm: &EvmUpstreamConfig{ChainId: 1}},
+		},
+		{
+			name:     "defaults carry no nodeType",
+			defEvm:   &EvmUpstreamConfig{BlockAvailability: window()},
+			upstream: &UpstreamConfig{Id: "u1", Endpoint: "http://rpc1.localhost"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &ProjectConfig{
+				Id:               "main",
+				UpstreamDefaults: &UpstreamConfig{Evm: tc.defEvm},
+				Upstreams:        []*UpstreamConfig{tc.upstream},
+			}
+			require.NoError(t, p.SetDefaults(nil))
+
+			e := p.Upstreams[0].Evm
+			got := e.BlockAvailability
+			require.NotNil(t, got)
+			require.NotNil(t, got.Lower)
+			require.NotNil(t, got.Lower.LatestBlockMinus)
+			assert.EqualValues(t, 604800, *got.Lower.LatestBlockMinus,
+				"configured project window must survive to the upstream")
+			// The field's presence is not the guarantee. EvmAssertBlockAvailability
+			// applies MaxAvailableRecentBlocks as a SECOND independent lower bound on
+			// top of the resolved ones, so a leftover 128 here would clamp the
+			// effective window back to 128 while this config still reads as 604800.
+			assert.Zero(t, e.MaxAvailableRecentBlocks,
+				"legacy field must not independently narrow the configured window")
+		})
+	}
+}

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -1755,11 +1755,20 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 	// TODO Should we refactor so this won't happen?
 	if u.Evm == nil && defaults.Evm != nil {
 		u.Evm = &EvmUpstreamConfig{
-			ChainId:                  defaults.Evm.ChainId,
-			NodeType:                 defaults.Evm.NodeType,
-			StatePollerInterval:      defaults.Evm.StatePollerInterval,
-			StatePollerDebounce:      defaults.Evm.StatePollerDebounce,
-			MaxAvailableRecentBlocks: defaults.Evm.MaxAvailableRecentBlocks,
+			ChainId:             defaults.Evm.ChainId,
+			NodeType:            defaults.Evm.NodeType,
+			StatePollerInterval: defaults.Evm.StatePollerInterval,
+			StatePollerDebounce: defaults.Evm.StatePollerDebounce,
+			// Carried here rather than left to SetDefaults: by the time SetDefaults
+			// runs, MaxAvailableRecentBlocks has already been copied onto this
+			// upstream, and the legacy back-compat mapping would otherwise
+			// synthesise a window from it and shadow the configured one.
+			BlockAvailability: defaults.Evm.BlockAvailability.Copy(),
+			// Only when no explicit window came with it. MaxAvailableRecentBlocks is
+			// enforced as an independent second lower bound by
+			// EvmAssertBlockAvailability, so carrying both would narrow the
+			// configured window to whichever is smaller.
+			MaxAvailableRecentBlocks: maxRecentBlocksFor(defaults.Evm),
 		}
 		if err := u.Evm.SetDefaults(defaults.Evm); err != nil {
 			return fmt.Errorf("failed to set defaults for evm upstream: %w", err)
@@ -1771,7 +1780,16 @@ func (u *UpstreamConfig) ApplyDefaults(defaults *UpstreamConfig) error {
 		if u.Evm.StatePollerDebounce == 0 && defaults.Evm.StatePollerDebounce != 0 {
 			u.Evm.StatePollerDebounce = defaults.Evm.StatePollerDebounce
 		}
-		if u.Evm.MaxAvailableRecentBlocks == 0 && defaults.Evm.MaxAvailableRecentBlocks != 0 {
+		// Must precede the MaxAvailableRecentBlocks copy below: once that value is
+		// inherited, this upstream is indistinguishable from one that set it itself,
+		// and SetDefaults' legacy back-compat mapping would synthesise a window from
+		// it that shadows the configured one.
+		if u.Evm.BlockAvailability == nil && u.Evm.MaxAvailableRecentBlocks == 0 &&
+			defaults.Evm.BlockAvailability != nil {
+			u.Evm.BlockAvailability = defaults.Evm.BlockAvailability.Copy()
+		}
+		if u.Evm.MaxAvailableRecentBlocks == 0 && u.Evm.BlockAvailability == nil &&
+			defaults.Evm.MaxAvailableRecentBlocks != 0 {
 			u.Evm.MaxAvailableRecentBlocks = defaults.Evm.MaxAvailableRecentBlocks
 		}
 		if u.Evm.GetLogsAutoSplittingRangeThreshold == 0 && defaults.Evm.GetLogsAutoSplittingRangeThreshold != 0 {
@@ -1976,6 +1994,19 @@ func (u *UpstreamConfig) SetDefaults(defaults *UpstreamConfig) error {
 	return nil
 }
 
+// maxRecentBlocksFor returns the legacy MaxAvailableRecentBlocks to carry from a
+// defaults template, which is none when that template also carries an explicit
+// blockAvailability window. The two express the same lower bound but are enforced
+// separately — EvmAssertBlockAvailability applies MaxAvailableRecentBlocks on top
+// of the resolved bounds — so propagating both would clamp the configured window
+// to whichever is smaller.
+func maxRecentBlocksFor(defaults *EvmUpstreamConfig) int64 {
+	if defaults == nil || defaults.BlockAvailability != nil {
+		return 0
+	}
+	return defaults.MaxAvailableRecentBlocks
+}
+
 func (e *EvmUpstreamConfig) SetDefaults(defaults *EvmUpstreamConfig) error {
 	if e.StatePollerInterval == 0 {
 		if defaults != nil && defaults.StatePollerInterval != 0 {
@@ -1995,7 +2026,27 @@ func (e *EvmUpstreamConfig) SetDefaults(defaults *EvmUpstreamConfig) error {
 		}
 	}
 
-	if e.MaxAvailableRecentBlocks == 0 {
+	// Inherit blockAvailability from upstreamDefaults when this upstream declares no
+	// availability config of its own — neither the modern blockAvailability nor the
+	// deprecated maxAvailableRecentBlocks. This is what makes the bound configurable
+	// once per project (`projects[].upstreamDefaults.evm.blockAvailability`) instead
+	// of repeated on every upstream. Copied, not shared: bounds are recomputed per
+	// upstream at runtime against that upstream's own state poller.
+	//
+	// Runs before the MaxAvailableRecentBlocks defaulting below so the inherited
+	// value wins over the NodeType-derived 128-block window, while an upstream that
+	// sets either field explicitly keeps its own.
+	if e.BlockAvailability == nil && e.MaxAvailableRecentBlocks == 0 &&
+		defaults != nil && defaults.BlockAvailability != nil {
+		e.BlockAvailability = defaults.BlockAvailability.Copy()
+	}
+
+	// Guarded on BlockAvailability being unset: EvmAssertBlockAvailability enforces
+	// MaxAvailableRecentBlocks as a SECOND, independent lower bound on top of the
+	// resolved bounds, so deriving it here next to an explicit window would silently
+	// narrow that window to whichever is smaller — e.g. a configured 604800 reduced
+	// to the 128 implied by `nodeType: full`.
+	if e.MaxAvailableRecentBlocks == 0 && e.BlockAvailability == nil {
 		if defaults != nil && defaults.MaxAvailableRecentBlocks != 0 {
 			e.MaxAvailableRecentBlocks = defaults.MaxAvailableRecentBlocks
 		} else {

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1541,9 +1541,75 @@ func findUpstreamsExhausted(err error) *ErrUpstreamsExhausted {
 	return nil
 }
 
+// hasLinearErrorCode reports whether err, or any error on its SINGLE-cause chain,
+// carries one of codes. It stops at multi-error wrappers (ErrUpstreamsExhausted,
+// consensus bundles, errors.Join) rather than descending into them, because
+// membership in a bundle only says one upstream hit the condition — not that the
+// condition is the verdict for the request. Mirrors the traversal rule
+// IsRetryableTowardNetwork uses for the same reason.
+func hasLinearErrorCode(err error, codes ...ErrorCode) bool {
+	for cur := err; cur != nil; {
+		se, ok := cur.(StandardError)
+		if !ok {
+			return false
+		}
+		base := se.Base()
+		if base == nil {
+			return false
+		}
+		for _, c := range codes {
+			if base.Code == c {
+				return true
+			}
+		}
+		next := se.GetCause()
+		if _, isMulti := next.(interface{ Unwrap() []error }); isMulti {
+			return false
+		}
+		cur = next
+	}
+	return false
+}
+
+// isBlockUnavailableVerdict reports whether "this block is outside the served
+// window" is the answer for the WHOLE request, rather than something one upstream
+// happened to say.
+//
+// For a multi-upstream bundle that requires every non-skipped cause to agree. A
+// plurality is not enough: -32014 tells a client the data is definitively absent,
+// and a consumer may act on that by permanently skipping the block, so a single
+// dissenting timeout or server error — an upstream that never actually answered —
+// must fall back to a generic failure the client will retry. Skips carry no
+// verdict (the upstream was never asked) and are ignored.
+//
+// Must be evaluated BEFORE the dominance scan in TranslateToJsonRpcException,
+// which collapses the bundle to one representative cause and thereby makes a
+// plurality indistinguishable from unanimity.
+func isBlockUnavailableVerdict(err error) bool {
+	erx := findUpstreamsExhausted(err)
+	if erx == nil {
+		return hasLinearErrorCode(err, ErrCodeUpstreamBlockUnavailable)
+	}
+	agreed := 0
+	for _, cause := range erx.Errors() {
+		if HasErrorCode(cause, ErrCodeUpstreamRequestSkipped) {
+			continue
+		}
+		if !hasLinearErrorCode(cause, ErrCodeUpstreamBlockUnavailable) {
+			return false
+		}
+		agreed++
+	}
+	return agreed > 0
+}
+
 // TranslateToJsonRpcException is mainly responsible to translate internal eRPC errors (not those coming from upstreams) to
 // a proper json-rpc error with correct numeric code.
 func TranslateToJsonRpcException(err error) error {
+	// Decided against the intact bundle: the dominance scan below replaces err
+	// with a single representative cause, after which unanimity is unrecoverable.
+	blockUnavailableIsVerdict := isBlockUnavailableVerdict(err)
+
 	if erx := findUpstreamsExhausted(err); erx != nil {
 		// Scan an UpstreamsExhausted error to detect the most frequent error among upstreams
 		// This selection helps provide somewhat user-friendly error message vs just saying that "all upstreams failed"
@@ -1642,6 +1708,32 @@ func TranslateToJsonRpcException(err error) error {
 			0,
 			JsonRpcErrorUnsupportedException,
 			"method ignored by upstream: "+reason,
+			err,
+			nil,
+		)
+	}
+	// A block outside every upstream's availability window (pruned history, or an
+	// explicit blockAvailability bound) is missing data, not an internal failure.
+	// Without this it falls through to the generic -32603 server-side exception,
+	// which reads as "eRPC broke" and is indistinguishable from a real outage.
+	// -32014 is the code eRPC already uses for this condition elsewhere (see
+	// architecture/evm/block_range.go), so it round-trips correctly back to
+	// ErrEndpointMissingData when one eRPC sits behind another.
+	//
+	// Gated on the pre-collapse verdict rather than a code match on err: only an
+	// unanimous bundle (or a plain block-unavailable error) may claim the data is
+	// definitively absent. See isBlockUnavailableVerdict.
+	if blockUnavailableIsVerdict {
+		var reason string
+		if se, ok := err.(StandardError); ok {
+			reason = se.DeepestMessage()
+		} else {
+			reason = err.Error()
+		}
+		return NewErrJsonRpcExceptionInternal(
+			0,
+			JsonRpcErrorMissingData,
+			"block not available: "+reason,
 			err,
 			nil,
 		)

--- a/docs/pages/config/projects/upstreams.mdx
+++ b/docs/pages/config/projects/upstreams.mdx
@@ -137,6 +137,34 @@ skip into `ErrUpstreamBlockUnavailable`, retryable when the block is within 128 
 of the tip (configurable via `networks[].evm.maxRetryableBlockDistance`).
 (<SourceLink file="erpc/networks.go" lines="1919-1987" />)
 
+Set it once for a whole project under `upstreamDefaults` instead of repeating it on
+every upstream — useful when a pool is uniformly pruned (e.g. nodes started with a
+retention window). An upstream that declares its own `blockAvailability` **or** the
+deprecated `maxAvailableRecentBlocks` keeps its own value; the project default only
+fills upstreams that declare neither, and it takes precedence over the 128-block
+window otherwise derived from `nodeType: full`.
+(<SourceLink file="common/defaults.go" lines="2029-2042" />)
+
+```yaml
+projects:
+  - id: main
+    upstreamDefaults:
+      evm:
+        blockAvailability:
+          lower:
+            latestBlockMinus: 604800 # serve only the most recent ~604800 blocks
+```
+
+When every upstream skips the block, the client receives a JSON-RPC error with code
+`-32014` ("block not available") rather than a generic internal error, so a pruned
+range is distinguishable from eRPC itself failing.
+(<SourceLink file="common/json_rpc.go" lines="1715-1740" />)
+
+Every upstream must agree. If one of them instead timed out or returned a server
+error, that upstream never answered, so the request falls back to a generic
+retryable error rather than claiming the block is definitively absent.
+(<SourceLink file="common/json_rpc.go" lines="1588-1606" />)
+
 **Cordoning.** Cordon state lives on the health tracker as an explicit flag — it is
 NOT a rolling-window metric and survives window rotation and idle eviction. Admin
 RPCs via the [Admin API](/operation/admin): `erpc_cordonUpstream`,


### PR DESCRIPTION
Supersedes #1080, which added a parallel network-level gate. This does the same job in **60 lines with no new config field**, by closing two gaps in code that already exists.

## The two gaps

**1. `blockAvailability` couldn't be set once per project.** `projects[].upstreamDefaults` is already a full `UpstreamConfig`, but `EvmUpstreamConfig.SetDefaults` inherited `MaxAvailableRecentBlocks` and never `BlockAvailability` — so a uniformly-pruned pool had to repeat the window on every upstream.

**2. An unavailable block reported itself as an internal error.** `ErrUpstreamBlockUnavailable` had no entry in `TranslateToJsonRpcException`, so a block below every upstream's window fell through to the generic `-32603` server-side exception — indistinguishable from eRPC itself failing.

## Config

```yaml
projects:
  - id: main
    upstreamDefaults:
      evm:
        blockAvailability:
          lower:
            latestBlockMinus: 604800   # serve only the most recent ~604800 blocks
```

Precedence: an upstream that declares its own `blockAvailability` **or** the deprecated `maxAvailableRecentBlocks` keeps its own value. The project default only fills upstreams that declare neither, and outranks the 128-block window otherwise derived from `nodeType: full`. Copied, not shared — bounds are recomputed per upstream against that upstream's own state poller.

## Response

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32014,"message":"block not available: ..."}}
```

`-32014` is the code eRPC already uses for this condition in `architecture/evm/block_range.go`, so it round-trips back to `ErrEndpointMissingData` when one eRPC sits behind another. (`-32001` would not: `architecture/evm/error_normalizer.go` classifies an incoming `-32001` as `ErrEndpointUnsupported`, which would make a chained eRPC mark the method unsupported.)

## What this deliberately does not add

Enforcement is unchanged — the existing per-upstream gate does the work, including the range-method (`eth_getLogs`, `trace_filter`) and block-tag paths it already handles correctly. No new network-level gate, no duplicated bound computation, no new validation, no TypeScript regeneration.

## Motivation

Internal nodes on unichain-mainnet prune history older than ~7 days (`RETH_RETAIN_BLOCKS: 604800`). Configuring the matching window meant editing every upstream, and pruned-block requests surfaced as `-32603`, so operators could not tell a pruned range from an outage.

## Changes

| File | |
|---|---|
| `common/defaults.go` | inherit `BlockAvailability` from `upstreamDefaults` (+15) |
| `common/json_rpc.go` | map `ErrCodeUpstreamBlockUnavailable` → `-32014` (+22) |
| `common/block_availability_project_test.go` | 8 subtests: inheritance, deep-copy, all 4 precedence rules, wire code bare + through the exhausted/retry-exceeded bundle |
| `docs/pages/config/projects/upstreams.mdx` | project-level config + the `-32014` contract (+23) |

## Test plan

- [x] `go build ./...` clean
- [x] `./common/...`, `./upstream/...`, `./architecture/...`, `./consensus/...` pass
- [x] New tests 8/8 pass
- [x] `TestConsensusPolicy/prefer_non_empty_when_both_groups_above_threshold` verified 3/3 on plain `main` and 3/3 with this patch — an earlier failure was contention flake from two heavy suites running concurrently, not this change
- [x] Full `erpc` package passes locally in isolation (`ok  github.com/erpc/erpc/erpc  827.498s`, exit 0)

## Model and tooling

- AI model: Claude Opus 5 via Claude Code
- Human author: Andre Claro

🤖 Generated with [Claude Code](https://claude.com/claude-code)
