### PR TITLE
fix(telemetry): emit skipped counter for block availability pre-check skips

### DIFF
--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -2752,11 +2752,9 @@ func (n *Network) handleBlockSkip(
 		attribute.Bool("skip_retryable", isRetryable),
 	)
 	finality := req.Finality(ctx)
-	telemetry.CounterHandle(telemetry.MetricUpstreamErrorTotal,
+	telemetry.MetricUpstreamSkippedTotal.WithLabelValues(
 		n.projectId, u.VendorName(), n.Label(), u.Id(), method,
-		common.ErrorFingerprint(skipErr), string(common.SeverityInfo),
-		req.CompositeType(), finality.String(),
-		req.UserId(), req.AgentName()).Inc()
+		finality.String(), req.UserId(), req.AgentName()).Inc()
 	errToStore := skipErr
 	if !isRetryable {
 		errToStore = common.NewErrUpstreamRequestSkipped(skipErr, u.Id())


### PR DESCRIPTION
## Problem

`handleBlockSkip` was emitting `erpc_upstream_request_errors_total` for every block availability pre-check skip. No request ever goes over the wire in this path — the upstream is pruned locally before any HTTP call — so these events are not upstream errors.

The practical effect: operators see `error:errupstreamblockunavailable` accumulating in the upstream error-rate chart and table for all upstreams simultaneously, inflating error rates and potentially depressing upstream selection scores for entirely healthy nodes.

## Fix

Switch from `MetricUpstreamErrorTotal` to `MetricUpstreamSkippedTotal`. The skipped counter already exists for exactly this class of event and carries the same `project/vendor/network/upstream/category/finality/user/agent_name` labels without the `error`/`severity`/`composite` dimensions that don't apply to a local pre-check.

This matches the existing routing in `upstream.go`, where `ErrCodeUpstreamRequestSkipped` already increments `MetricUpstreamSkippedTotal` (not the error counter).

## Diff

```
-telemetry.CounterHandle(telemetry.MetricUpstreamErrorTotal,
-    n.projectId, u.VendorName(), n.Label(), u.Id(), method,
-    common.ErrorFingerprint(skipErr), string(common.SeverityInfo),
-    req.CompositeType(), finality.String(),
-    req.UserId(), req.AgentName()).Inc()
+telemetry.MetricUpstreamSkippedTotal.WithLabelValues(
+    n.projectId, u.VendorName(), n.Label(), u.Id(), method,
+    finality.String(), req.UserId(), req.AgentName()).Inc()
```