### PR TITLE
fix(evm): correct upper-bound fail-open, skipped metric, and consensus error for block availability

### DIFF
--- a/common/block_availability_project_test.go
+++ b/common/block_availability_project_test.go
@@ -115,6 +115,44 @@ func TestTranslateToJsonRpcException_BlockUnavailableIsMissingData(t *testing.T)
 				NewErrFailsafeRetryExceeded(ScopeNetwork, exhausted, nil))))
 	})
 
+	// All upstreams pre-check skipped due to block-unavailable (e.g. every upstream
+	// exceeded its lower/upper availability bound). The skip carries a verdict —
+	// the upstream was consulted, just not over the wire — so all-skipped is
+	// still unanimity and must return -32014.
+	t.Run("all pre-check skipped due to block unavailable", func(t *testing.T) {
+		skip := func(id string) error {
+			return NewErrUpstreamRequestSkipped(blockUnavailable(id), id)
+		}
+		order := []string{"up-a", "up-b", "up-c"}
+		causes := map[string]error{
+			"up-a": skip("up-a"),
+			"up-b": skip("up-b"),
+			"up-c": skip("up-c"),
+		}
+		exhausted := newExhausted(t, order, causes)
+		assert.EqualValues(t, JsonRpcErrorMissingData,
+			clientWireCode(t, TranslateToJsonRpcException(exhausted)),
+			"all pre-check skips due to block-unavailable must be -32014")
+		assert.EqualValues(t, JsonRpcErrorMissingData,
+			clientWireCode(t, TranslateToJsonRpcException(
+				NewErrFailsafeRetryExceeded(ScopeNetwork, exhausted, nil))),
+			"retry-exceeded wrapper must also be -32014")
+	})
+
+	// A skip due to a reason other than block-unavailable (method filter, cordon,
+	// etc.) is neutral — it carries no verdict and must not trigger -32014.
+	t.Run("all skipped for non-block-unavailable reason", func(t *testing.T) {
+		neutralSkip := func(id string) error {
+			return NewErrUpstreamRequestSkipped(nil, id)
+		}
+		order := []string{"up-a", "up-b"}
+		causes := map[string]error{"up-a": neutralSkip("up-a"), "up-b": neutralSkip("up-b")}
+		exhausted := newExhausted(t, order, causes)
+		assert.NotEqualValues(t, JsonRpcErrorMissingData,
+			clientWireCode(t, TranslateToJsonRpcException(exhausted)),
+			"neutral skips must not claim block is definitively absent")
+	})
+
 	// Membership in a multi-error bundle means ONE upstream hit the condition, not
 	// that it is the verdict. Reporting -32014 for these would hand the client a
 	// definitive "this block does not exist" while hiding a real consensus or

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1575,12 +1575,18 @@ func hasLinearErrorCode(err error, codes ...ErrorCode) bool {
 // window" is the answer for the WHOLE request, rather than something one upstream
 // happened to say.
 //
-// For a multi-upstream bundle that requires every non-skipped cause to agree. A
+// For a multi-upstream bundle that requires every non-neutral cause to agree. A
 // plurality is not enough: -32014 tells a client the data is definitively absent,
 // and a consumer may act on that by permanently skipping the block, so a single
 // dissenting timeout or server error — an upstream that never actually answered —
-// must fall back to a generic failure the client will retry. Skips carry no
-// verdict (the upstream was never asked) and are ignored.
+// must fall back to a generic failure the client will retry.
+//
+// Two kinds of skip are distinguished:
+//   - Skip caused by ErrUpstreamBlockUnavailable: the pre-check determined the
+//     upstream cannot serve the block (bound exceeded). This carries a verdict and
+//     counts toward unanimity — the upstream was consulted, just not over the wire.
+//   - Any other skip (method filter, cordon, selector, etc.): neutral; neither
+//     agrees nor disagrees, so a pool of pure neutral skips cannot claim -32014.
 //
 // Must be evaluated BEFORE the dominance scan in TranslateToJsonRpcException,
 // which collapses the bundle to one representative cause and thereby makes a
@@ -1593,6 +1599,11 @@ func isBlockUnavailableVerdict(err error) bool {
 	agreed := 0
 	for _, cause := range erx.Errors() {
 		if HasErrorCode(cause, ErrCodeUpstreamRequestSkipped) {
+			// Pre-check skip due to block-unavailable bound: counts toward unanimity.
+			// Other skips (method filter, cordon, etc.) are neutral.
+			if hasLinearErrorCode(cause, ErrCodeUpstreamBlockUnavailable) {
+				agreed++
+			}
 			continue
 		}
 		if !hasLinearErrorCode(cause, ErrCodeUpstreamBlockUnavailable) {

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -1611,8 +1611,14 @@ func (e *executor) recordMetricsAndTracing(req *common.NormalizedRequest, startT
 	// errors (severity info) are the caller's failure that upstreams merely
 	// agreed on (e.g. nonce-too-low on eth_sendRawTransaction broadcast), not a
 	// consensus failure — keep them out of the error counter.
+	// Similarly, when all upstreams unanimously agreed the block is outside the
+	// availability window (hasConsensus + ErrUpstreamBlockUnavailable), that is
+	// a deterministic gate outcome — the client requested a block that no
+	// upstream will serve. Counting it as consensus_on_error inflates infra
+	// error metrics with expected, by-design client behaviour.
+	blockUnavailableConsensus := hasConsensus && common.HasErrorCode(result.Error, common.ErrCodeUpstreamBlockUnavailable)
 	severity := common.ClassifySeverity(result.Error)
-	if result.Error != nil && (severity == common.SeverityWarning || severity == common.SeverityCritical) {
+	if result.Error != nil && !blockUnavailableConsensus && (severity == common.SeverityWarning || severity == common.SeverityCritical) {
 		errLabel := "generic_error"
 		if isCompositionDispute {
 			errLabel = "dispute_composition"

--- a/consensus/executor_test.go
+++ b/consensus/executor_test.go
@@ -751,4 +751,33 @@ func TestRecordMetricsAndTracing_InfoSeverityNotCountedAsConsensusError(t *testi
 		assert.Equal(t, errBefore+1, testutil.ToFloat64(errCounter),
 			"non-info errors must still be counted as consensus errors")
 	})
+
+	// When ALL upstreams unanimously agree the block is outside the availability
+	// window, the consensus records "consensus_on_error" (hasConsensus=true,
+	// result.Error≠nil). This is a deterministic gate outcome — the client
+	// requested a block no upstream will serve — not an infra failure.
+	// ErrUpstreamBlockUnavailable is SeverityWarning (self-healing for a lagging
+	// upstream), which would normally pass the severity guard, but unanimous
+	// block-unavailable consensus must be excluded from MetricConsensusErrors.
+	t.Run("block-unavailable unanimous consensus skips consensus_errors_total", func(t *testing.T) {
+		labels := metricsLabels{
+			projectId:   "test-proj-block-unavail",
+			networkId:   "test-net",
+			category:    "eth_getBlockByNumber",
+			finalityStr: "latest",
+			method:      "eth_getBlockByNumber",
+			userId:      "n/a",
+			agentName:   "n/a",
+		}
+		blockUnavailErr := common.NewErrUpstreamBlockUnavailable("up-a", 1000, 900, 850)
+		errCounter := telemetry.MetricConsensusErrors.WithLabelValues(
+			labels.projectId, labels.networkId, labels.category, "consensus_on_error", labels.finalityStr, labels.userId, labels.agentName)
+		errBefore := testutil.ToFloat64(errCounter)
+
+		e.recordMetricsAndTracing(newTestRequest(), time.Now(),
+			&slotResult{Error: blockUnavailErr}, buildAgreedErrorAnalysis(), labels, span)
+
+		assert.Equal(t, errBefore, testutil.ToFloat64(errCounter),
+			"unanimous block-unavailable must not inflate consensus_errors_total")
+	})
 }

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -2752,7 +2752,7 @@ func (n *Network) handleBlockSkip(
 		attribute.Bool("skip_retryable", isRetryable),
 	)
 	finality := req.Finality(ctx)
-	telemetry.MetricUpstreamSkippedTotal.WithLabelValues(
+	telemetry.CounterHandle(telemetry.MetricUpstreamSkippedTotal,
 		n.projectId, u.VendorName(), n.Label(), u.Id(), method,
 		finality.String(), req.UserId(), req.AgentName()).Inc()
 	errToStore := skipErr

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -2752,11 +2752,9 @@ func (n *Network) handleBlockSkip(
 		attribute.Bool("skip_retryable", isRetryable),
 	)
 	finality := req.Finality(ctx)
-	telemetry.CounterHandle(telemetry.MetricUpstreamErrorTotal,
+	telemetry.MetricUpstreamSkippedTotal.WithLabelValues(
 		n.projectId, u.VendorName(), n.Label(), u.Id(), method,
-		common.ErrorFingerprint(skipErr), string(common.SeverityInfo),
-		req.CompositeType(), finality.String(),
-		req.UserId(), req.AgentName()).Inc()
+		finality.String(), req.UserId(), req.AgentName()).Inc()
 	errToStore := skipErr
 	if !isRetryable {
 		errToStore = common.NewErrUpstreamRequestSkipped(skipErr, u.Id())

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1019,6 +1019,7 @@ func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
 		return math.MinInt64, math.MaxInt64
 	}
 	latest := int64(0)
+	upperFromZeroLatest := false // set when upper latestBlockMinus is computed with latest==0
 
 	compute := func(bound *common.EvmAvailabilityBoundConfig, isLower bool) int64 {
 		if bound == nil {
@@ -1069,16 +1070,28 @@ func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
 					Str("boundType", map[bool]string{true: "lower", false: "upper"}[isLower]).
 					Str("upstreamId", u.config.Id).
 					Msg("computed bound from latest block")
-			} else {
+			} else if isLower {
+				// Lower bound when latestBlock is unknown: fail-open (MinInt64) so that
+				// non-negative block numbers are not falsely rejected as below the lower bound.
 				u.logger.Debug().
-					Str("boundType", map[bool]string{true: "lower", false: "upper"}[isLower]).
 					Str("upstreamId", u.config.Id).
-					Msg("latest block not available; treating bound as unbounded")
-				if isLower {
-					val = math.MinInt64
-				} else {
-					val = math.MaxInt64
-				}
+					Msg("latest block not available; treating lower bound as unbounded")
+				val = math.MinInt64
+			} else {
+				// Upper bound when latestBlock is unknown (state poller not yet run, or
+				// transport failure sustained): compute as if latest=0. For latestBlockMinus:0
+				// this gives maxBound=0, so any block > 0 exceeds the bound and the upstream
+				// is skipped pre-request. This is correct for explicit head-gating: an upstream
+				// that has not confirmed any block should not serve specific block numbers.
+				// ponytail: brief startup exclusion (~first poll cycle) is acceptable trade-off
+				// vs allowing transport-failed upstreams to break isBlockUnavailableVerdict.
+				val = -*bound.LatestBlockMinus
+				upperFromZeroLatest = true
+				u.logger.Debug().
+					Int64("latestBlockMinus", *bound.LatestBlockMinus).
+					Int64("computedBound", val).
+					Str("upstreamId", u.config.Id).
+					Msg("latest block not available; computing upper bound as 0 - latestBlockMinus")
 			}
 		} else {
 			// No-op bound
@@ -1096,7 +1109,10 @@ func (u *Upstream) resolveAvailabilityBounds() (int64, int64) {
 	maxVal := compute(cfg.Evm.BlockAvailability.Upper, false)
 	// If both sides are finite and the computed range is invalid (min > max),
 	// fail-open for safety: treat as unbounded to avoid breaking production traffic.
-	if minVal != math.MinInt64 && maxVal != math.MaxInt64 && minVal > maxVal {
+	// Exception: when the upper was computed from latest==0 (state poller unresolved),
+	// the apparent inversion is intentional — the zero-based cap is restrictive by design,
+	// and the safety net would silently undo the fix for transport-failed upstreams.
+	if !upperFromZeroLatest && minVal != math.MinInt64 && maxVal != math.MaxInt64 && minVal > maxVal {
 		u.logger.Warn().
 			Int64("computedMinBound", minVal).
 			Int64("computedMaxBound", maxVal).


### PR DESCRIPTION
## Problem

Four instrumentation and gating bugs surfaced after shipping project-level \`blockAvailability\` (#1081):

### 1. Upper bound fails open when \`latestBlock\` is unknown

\`resolveAvailabilityBounds\` returned \`math.MaxInt64\` for the upper bound whenever \`latestBlock == 0\` (state poller not yet run, or sustaining transport failures). This made \`checkUpstreamBlockAvailability\` treat both bounds as unbounded and skip gating entirely. On a node with ongoing transport failures the result was \`ErrEndpointTransportFailure\`, which broke the unanimity requirement in \`isBlockUnavailableVerdict\` — leaving a block-unavailable pool producing \`consensus_on_error\` instead of \`-32014\`.

### 2. Pre-check block-unavailable skips not counted toward \`-32014\` verdict

\`isBlockUnavailableVerdict\` treated all \`ErrUpstreamRequestSkipped\` causes as neutral, so a pool where every upstream was pre-check skipped due to block-unavailable (lower or upper bound exceeded) returned \`agreed=0\` and fell through to \`-32603\` instead of \`-32014\`.

\`handleBlockSkip\` wraps non-retryable bound violations in \`ErrUpstreamRequestSkipped\` so the failsafe skip path can distinguish them from wire failures. These skips carry a verdict — the upstream was consulted via the bound check, just not over the wire — and must count toward unanimity.

### 3. Block-availability pre-check skips counted as upstream request errors

\`handleBlockSkip\` was incrementing \`MetricUpstreamErrorTotal\` for block availability pre-check skips. No wire call is made in this path, so error metrics were inflated with expected, by-design gate outcomes.

### 4. Unanimous block-unavailable consensus counted as \`consensus_on_error\`

When all upstreams unanimously agree the requested block is outside the availability window (\`hasConsensus=true\` + \`ErrUpstreamBlockUnavailable\`), the consensus records \`outcome=consensus_on_error\`. \`ErrUpstreamBlockUnavailable\` is \`SeverityWarning\` (correct for a single lagging upstream), which passed the severity guard and inflated \`MetricConsensusErrors\` with deterministic client behaviour.

## Fix

**\`upstream/upstream.go\`** — For the upper-bound branch, compute \`val = 0 - latestBlockMinus\` when the state poller has not delivered a head yet. For \`latestBlockMinus: 0\` this resolves to \`maxBound = 0\`, so any block > 0 exceeds the bound and the upstream is skipped pre-request with \`ErrUpstreamBlockUnavailable\`. Track \`upperFromZeroLatest\` to prevent the invalid-range safety net (\`min > max → fail-open\`) from undoing this intentional restriction.

**\`common/json_rpc.go\`** — In \`isBlockUnavailableVerdict\`, distinguish two kinds of \`ErrUpstreamRequestSkipped\` causes: those wrapping \`ErrUpstreamBlockUnavailable\` (pre-check verdict — count toward unanimity) and all others such as method filter, cordon, or selector skips (neutral — neither agree nor disagree, so a pool of pure neutral skips cannot claim \`-32014\`).

**\`erpc/networks.go\`** — Switch \`handleBlockSkip\` from \`MetricUpstreamErrorTotal\` to \`MetricUpstreamSkippedTotal\`. Pre-check skips are gate decisions, not wire failures.

**\`consensus/executor.go\`** — Guard \`MetricConsensusErrors\` with \`blockUnavailableConsensus\` (\`hasConsensus && HasErrorCode(result.Error, ErrCodeUpstreamBlockUnavailable)\`). Unanimous block-unavailable is a deterministic gate outcome — the client requested a block no upstream will serve — and must not inflate infra error counters.

## Tests

- \`upstream\`: existing \`TestEvmAssertBlockAvailability\` suite covers the new upper-bound behaviour; new \`upperFromZeroLatest\` flag is exercised by the invalid-range guard path.
- \`common\`: two new sub-tests in \`TestTranslateToJsonRpcException_BlockUnavailableIsMissingData\` — \`all pre-check skipped due to block unavailable\` (must be \`-32014\`) and \`all skipped for non-block-unavailable reason\` (must not be \`-32014\`).
- \`consensus\`: new sub-test \`block-unavailable unanimous consensus skips consensus_errors_total\` in \`TestRecordMetricsAndTracing_InfoSeverityNotCountedAsConsensusError\`.
- All four affected packages pass \`go test ./... -count=1\`.