### PR TITLE
fix(evm,health,data): stop a bad upstream from skewing head tracking

### DIFF
--- a/data/shared_state_variable.go
+++ b/data/shared_state_variable.go
@@ -203,6 +203,34 @@ func (c *counterInt64) processNewState(source string, st CounterInt64State) bool
 		}
 	}
 
+	// A head counter never legitimately moves to zero or below. Zero is the zero
+	// VALUE of an unset CounterInt64State, not an observation of a chain, and it
+	// arrives here from ordinary sources: an instance that pushes its counter
+	// before its first poll, or a connector handing back an empty record with a
+	// live timestamp. Left alone it reads as a rollback the size of the whole
+	// chain, which is necessarily larger than ignoreRollbackOf, so the branch
+	// below -- whose entire job is to admit only real reorgs -- waves it through,
+	// and every instance that receives it drops its head to 0.
+	//
+	// The floor is scoped to counters that ignore small rollbacks. The
+	// earliest-block counter is created with ignoreRollbackOf=0 and legitimately
+	// sits at 0 on an archive node, so it keeps the old behaviour.
+	if newVal <= 0 && c.ignoreRollbackOf > 0 {
+		// Same bookkeeping as a rejected small rollback: our higher local value
+		// must out-rank the remote state, or reconciliation hands the zero back
+		// to us on the next tick and the counter flaps.
+		if isRemoteUpdate {
+			c.advanceTimestampPast(st.UpdatedAt)
+		}
+		c.registry.logger.Warn().
+			Str("source", source).
+			Str("key", c.key).
+			Int64("currentValue", currentValue).
+			Int64("newVal", newVal).
+			Msg("rejected non-positive value for a head counter (remote)")
+		return false
+	}
+
 	// Rollback handling: only accept rollbacks where gap exceeds the threshold.
 	// - ignoreRollbackOf=0 (earliest): gap > 0 is always true, so ALL rollbacks accepted
 	// - ignoreRollbackOf=1024 (latest/finalized): only accept large rollbacks (real reorgs)
@@ -296,6 +324,18 @@ func (c *counterInt64) processNewValue(source string, newVal int64) bool {
 				return false
 			}
 		}
+	}
+
+	// See processNewState: zero is an unset state, not a head. Same floor, same
+	// scoping to counters that ignore small rollbacks.
+	if newVal <= 0 && c.ignoreRollbackOf > 0 {
+		c.registry.logger.Warn().
+			Str("source", source).
+			Str("key", c.key).
+			Int64("currentValue", currentValue).
+			Int64("newVal", newVal).
+			Msg("rejected non-positive value for a head counter (local)")
+		return false
 	}
 
 	// Rollback handling: only accept rollbacks where gap exceeds the threshold.

--- a/data/shared_state_variable_test.go
+++ b/data/shared_state_variable_test.go
@@ -1742,3 +1742,123 @@ func TestCounterInt64_FresherLocalPushesToStaleRemote(t *testing.T) {
 		setCallMu.Unlock()
 	})
 }
+
+// TestCounterInt64_ZeroIsNotAHeadObservation covers the case where a shared head
+// counter is asked to move to zero.
+//
+// Zero is the zero VALUE of an unset CounterInt64State, not an observation of a
+// chain. When it reaches a head counter it is read as a rollback the size of the
+// entire chain, which is by definition larger than ignoreRollbackOf, so the
+// "only real reorgs get applied" rule waves it through and the shared head goes
+// to 0 across every instance that receives it.
+//
+// Observed in production on the goldsky ECS edge on 2026-08-18: upstreams on
+// unrelated networks and unrelated vendors recorded
+// erpc_upstream_block_head_large_rollback values equal to their chain's full
+// height (gravity-mainnet 129,890,975 against a head of 129,890,991;
+// zksync-mainnet 71,589,976 against 71,589,993), in region-synchronised bursts
+// that lined up with task restarts rather than with anything happening on-chain.
+func TestCounterInt64_ZeroIsNotAHeadObservation(t *testing.T) {
+	newHeadCounter := func(current int64) *counterInt64 {
+		c := &counterInt64{
+			ignoreRollbackOf: 1024, // latest/finalized heads: DefaultToleratedBlockHeadRollback
+			registry: &sharedStateRegistry{
+				logger:     &log.Logger,
+				instanceId: "test",
+			},
+		}
+		c.value.Store(current)
+		c.updatedAtUnixMs.Store(1)
+		return c
+	}
+
+	t.Run("remote zero does not roll the head back", func(t *testing.T) {
+		counter := newHeadCounter(129_890_991)
+
+		var rollbacks int
+		counter.OnLargeRollback(func(int64, int64) { rollbacks++ })
+
+		// Exactly what a restarting instance pushes when it has not polled yet:
+		// a well-formed state, a fresher timestamp, and an empty value.
+		updated := counter.processNewState(UpdateSourceRemoteSync, CounterInt64State{
+			Value:     0,
+			UpdatedAt: 2,
+			UpdatedBy: "instance-that-just-started",
+		})
+
+		assert.False(t, updated, "a zero head must be rejected, not applied")
+		assert.Equal(t, int64(129_890_991), counter.GetValue(), "head must survive a remote zero")
+		assert.Zero(t, rollbacks, "a zero head is not a reorg and must not fire the rollback callback")
+	})
+
+	t.Run("the rejected zero must not keep winning reconciliation", func(t *testing.T) {
+		counter := newHeadCounter(129_890_991)
+
+		counter.processNewState(UpdateSourceRemoteSync, CounterInt64State{
+			Value:     0,
+			UpdatedAt: 500,
+			UpdatedBy: "instance-that-just-started",
+		})
+
+		// Same handling as a rejected small rollback: our higher local value has
+		// to out-rank the remote zero, or reconciliation pushes the zero straight
+		// back at us on the next tick and the counter flaps forever.
+		assert.Greater(t, counter.updatedAtMs(), int64(500),
+			"local timestamp must advance past the rejected remote state")
+	})
+
+	t.Run("local zero does not roll the head back", func(t *testing.T) {
+		counter := newHeadCounter(71_589_993)
+
+		var rollbacks int
+		counter.OnLargeRollback(func(int64, int64) { rollbacks++ })
+
+		updated := counter.processNewValue(UpdateSourceTryUpdate, 0)
+
+		assert.False(t, updated, "a zero head must be rejected on the local path too")
+		assert.Equal(t, int64(71_589_993), counter.GetValue())
+		assert.Zero(t, rollbacks)
+	})
+
+	t.Run("negative values are rejected too", func(t *testing.T) {
+		counter := newHeadCounter(1_000_000)
+
+		assert.False(t, counter.processNewValue(UpdateSourceTryUpdate, -1))
+		assert.Equal(t, int64(1_000_000), counter.GetValue())
+	})
+
+	t.Run("a real reorg is still applied", func(t *testing.T) {
+		counter := newHeadCounter(1_000_000)
+
+		var rollbacks int
+		counter.OnLargeRollback(func(int64, int64) { rollbacks++ })
+
+		// The guard must not blunt the behaviour it sits next to: a genuine deep
+		// reorg is a positive value and still exceeds ignoreRollbackOf.
+		updated := counter.processNewValue(UpdateSourceTryUpdate, 995_000)
+
+		assert.True(t, updated, "a real reorg must still be applied")
+		assert.Equal(t, int64(995_000), counter.GetValue())
+		assert.Equal(t, 1, rollbacks)
+	})
+
+	t.Run("earliest-block counters may still hold zero", func(t *testing.T) {
+		// evm_state_poller creates the earliest-block counter with
+		// ignoreRollbackOf=0. An archive node's earliest block IS 0, so the floor
+		// must not apply there.
+		counter := &counterInt64{
+			ignoreRollbackOf: 0,
+			registry: &sharedStateRegistry{
+				logger:     &log.Logger,
+				instanceId: "test",
+			},
+		}
+		counter.value.Store(5_000_000)
+		counter.updatedAtUnixMs.Store(1)
+
+		updated := counter.processNewValue(UpdateSourceTryUpdate, 0)
+
+		assert.True(t, updated, "earliest-block counters legitimately move to 0")
+		assert.Equal(t, int64(0), counter.GetValue())
+	})
+}

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -708,6 +708,9 @@ func (t *Tracker) sweepIdleObservers(cutoffMs int64) {
 // used to be implicit).
 func (t *Tracker) getUpsKeys(upstream common.Upstream, method string, finality common.DataFinalityState) []upstreamKey {
 	if !t.trackByFinality.Load() {
+		if method == "*" {
+			return []upstreamKey{{upstream, "*", common.DataFinalityStateAll}}
+		}
 		return []upstreamKey{
 			{upstream, method, common.DataFinalityStateAll},
 			{upstream, "*", common.DataFinalityStateAll},
@@ -719,6 +722,18 @@ func (t *Tracker) getUpsKeys(upstream common.Upstream, method string, finality c
 	if finality == common.DataFinalityStateAll {
 		return []upstreamKey{
 			{upstream, method, common.DataFinalityStateAll},
+			{upstream, "*", common.DataFinalityStateAll},
+		}
+	}
+	// Same reason, other axis: when the caller has no specific method the
+	// per-method and any-method entries ARE the same key, so the 4-key set
+	// degenerates to two keys written twice each and every Add lands twice.
+	// Callers that record something not attributable to one method (a head
+	// rollback belongs to the upstream, not to eth_call) pass "*" and would
+	// otherwise be counted double against every other misbehaviour.
+	if method == "*" {
+		return []upstreamKey{
+			{upstream, "*", finality},
 			{upstream, "*", common.DataFinalityStateAll},
 		}
 	}
@@ -753,6 +768,10 @@ func (t *Tracker) IsFinalityTracked() bool {
 
 func (t *Tracker) getNtwKeys(up common.Upstream, method string) []networkKey {
 	net := up.NetworkId()
+	if method == "*" {
+		// Same degeneracy as getUpsKeys: both entries are the same key.
+		return []networkKey{{net, "*"}}
+	}
 	return []networkKey{
 		{net, method},
 		{net, "*"}, // all methods on this network
@@ -1711,4 +1730,26 @@ func (t *Tracker) RecordBlockHeadLargeRollback(upstream common.Upstream, finalit
 		Msgf("recording block rollback in tracker")
 
 	t.getRollbackGauge(upstream, finality).Set(float64(rollback))
+
+	// A large head rollback is also a misbehaviour, and recording it as one is
+	// what lets the EXISTING machinery act on it. Until now this method only set
+	// a gauge, so an upstream could roll its head back every few seconds and stay
+	// fully weighted: its head kept voting in the served-tip ballot and it kept
+	// being picked to answer "latest" from whichever node pool it landed on.
+	//
+	// MisbehaviorsTotal is already a rolling counter on TrackedMetrics, already
+	// carried by routing.scoreMultipliers (`misbehaviors`), and already visible
+	// to selectionPolicy evalFunc. So one rollback -- a real, rare, legitimate
+	// deep reorg -- barely moves the score, while an endpoint flapping between
+	// two node pools accumulates until the operator's own policy deprioritises or
+	// drops it. The threshold stays where it belongs, in configuration, instead
+	// of being a constant compiled in here.
+	//
+	// Stratified by head axis so a finalized-head rollback does not penalise the
+	// upstream for realtime traffic and vice versa.
+	state := common.DataFinalityStateRealtime
+	if finality == "finalized" {
+		state = common.DataFinalityStateFinalized
+	}
+	t.RecordUpstreamMisbehavior(upstream, "*", state)
 }

--- a/health/tracker_blockhead_rollback_test.go
+++ b/health/tracker_blockhead_rollback_test.go
@@ -264,3 +264,72 @@ func TestTrackerBlockTimeReanchorsAfterHeadRollback(t *testing.T) {
 		"EMA must move toward the new 3s/block cadence instead of staying frozen")
 	assert.Less(t, int64(bt), int64(2*time.Second))
 }
+
+// A large head rollback is not just something to chart. Until it was recorded as
+// a misbehaviour, RecordBlockHeadLargeRollback only set a gauge, so an upstream
+// could roll its head back every few seconds and stay fully weighted -- its head
+// kept voting in the served-tip ballot and it kept being picked to answer
+// "latest" from whichever node pool it landed on.
+//
+// MisbehaviorsTotal is the signal the rest of eRPC already acts on: it is
+// carried by routing.scoreMultipliers (`misbehaviors`) and visible to
+// selectionPolicy evalFunc. Feeding rollbacks into it means one rare deep reorg
+// barely moves the score while a flapping endpoint accumulates until the
+// operator's own policy deprioritises or drops it -- the threshold stays in
+// configuration rather than being compiled in here.
+//
+// Production shape, goldsky ECS edge 2026-08-18: one Dwellir endpoint on
+// darwinia logged 610 large latest-head rollbacks in three hours (~3,341-block
+// sawtooth every ~18s, seen identically from four deployments) while every other
+// upstream in the fleet that hour recorded exactly one.
+func TestTrackerBlockHeadLargeRollbackIsAMisbehavior(t *testing.T) {
+	misbehaviors := func(tr *Tracker, ups common.Upstream, finality common.DataFinalityState) int64 {
+		return tr.GetUpstreamMethodMetrics(ups, "*", finality).MisbehaviorsTotal.Load()
+	}
+
+	t.Run("a latest-head rollback counts against realtime", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-misbehavior-latest")
+		ups := common.NewFakeUpstream("a")
+
+		assert.Zero(t, misbehaviors(tracker, ups, common.DataFinalityStateRealtime))
+
+		tracker.RecordBlockHeadLargeRollback(ups, "latest", 12_760_481, 12_757_135)
+
+		assert.Equal(t, int64(1), misbehaviors(tracker, ups, common.DataFinalityStateRealtime),
+			"a large head rollback must reach the signal routing and selectionPolicy already read")
+	})
+
+	t.Run("repeated rollbacks accumulate", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-misbehavior-repeat")
+		ups := common.NewFakeUpstream("a")
+
+		// A flapping endpoint separates itself from a one-off reorg by volume,
+		// which is exactly what a rolling counter is for.
+		for i := 0; i < 25; i++ {
+			tracker.RecordBlockHeadLargeRollback(ups, "latest", 12_760_481, 12_757_135)
+		}
+
+		assert.Equal(t, int64(25), misbehaviors(tracker, ups, common.DataFinalityStateRealtime))
+	})
+
+	t.Run("the two head axes are stratified", func(t *testing.T) {
+		tracker := newRollbackTestTracker(t, "test-rollback-misbehavior-axes")
+		tracker.EnableFinalityTracking() // per-finality buckets only exist in 4-key mode
+		ups := common.NewFakeUpstream("a")
+
+		// prism-style upstreams correct their finalized boundary routinely while
+		// their latest head is perfectly sound, so the two axes must land in their
+		// own buckets and a policy can weigh them differently.
+		tracker.RecordBlockHeadLargeRollback(ups, "finalized", 12_760_481, 12_757_135)
+		for i := 0; i < 3; i++ {
+			tracker.RecordBlockHeadLargeRollback(ups, "latest", 12_760_481, 12_757_135)
+		}
+
+		assert.Equal(t, int64(1), misbehaviors(tracker, ups, common.DataFinalityStateFinalized),
+			"the finalized axis carries only its own rollback")
+		assert.Equal(t, int64(3), misbehaviors(tracker, ups, common.DataFinalityStateRealtime),
+			"the latest axis carries only its own rollbacks")
+		assert.Equal(t, int64(4), misbehaviors(tracker, ups, common.DataFinalityStateAll),
+			"the all-finalities rollup carries both")
+	})
+}


### PR DESCRIPTION
Two defects in the head-tracking path that let a misbehaving upstream affect served results. Both are fixed here; both are covered by tests that fail on the unfixed tree.

Neither adds a new exclusion mechanism — the second one feeds the existing one.

---

## 1. A shared head counter accepted zero as an observation

Zero is the zero **value** of an unset `CounterInt64State`, not a chain head. Nothing rejected it, so it reached the rollback branch as a gap the size of the entire chain — necessarily larger than `ignoreRollbackOf`, which meant the one check whose job is to admit only real reorgs waved it through, and the CAS applied it.

```go
gap := currentValue - newVal         // newVal == 0  =>  gap == currentValue
if gap <= c.ignoreRollbackOf { ... }  // 129,890,991 <= 1024 is false
// ...so this is treated as a real reorg and applied
```

Worse than a single bad upstream: the counter is **shared**, so a zero from any instance dropped that upstream's head to 0 on every instance that received it.

It arrives from ordinary sources — an instance that pushes its counter before its first poll, or a connector handing back an empty record with a live timestamp. `buildInitialValueTask` already screens `st.UpdatedAt <= 0` but never looks at `st.Value`, and the `WatchCounterInt64` path screens nothing.

**Fix:** floor both paths at `newVal > 0`, scoped to counters that ignore small rollbacks. `evm_state_poller` builds the earliest-block counter with `ignoreRollbackOf=0` and an archive node's earliest block genuinely **is** 0, so that counter is untouched. A rejected remote zero advances the local timestamp exactly as a rejected small rollback does, or reconciliation hands the zero straight back on the next tick.

## 2. A large head rollback was charted but never acted on

`RecordBlockHeadLargeRollback` set a gauge and did nothing else. An upstream could roll its head back every few seconds and remain fully weighted — its head kept voting in the served-tip ballot, and it stayed eligible to answer `latest` from whichever node pool it landed on.

**Fix:** record it as a misbehaviour. `MisbehaviorsTotal` is the signal the rest of eRPC already acts on — carried by `routing.scoreMultipliers` (`misbehaviors`) and visible to `selectionPolicy` `evalFunc`. One rare deep reorg barely moves the score; an endpoint flapping between two pools accumulates until the operator's own policy deprioritises or drops it.

**No new mechanism and no threshold compiled in.** An earlier revision of this PR added a bespoke cordon with its own `3 within 10 minutes` constant; that was the wrong shape — exclusion belongs to the selection policy, and the threshold belongs in configuration where it already lives. This just makes the existing machinery aware of a signal it was previously blind to.

Stratified by head axis, so a finalized-head correction does not penalise an upstream for realtime traffic — prism-style upstreams correct their finalized boundary routinely while their latest head is sound.

### Drive-by, required by the above

`getUpsKeys` / `getNtwKeys` degenerate when the caller passes `method="*"`: the per-method and any-method entries are then the **same key**, so the 4-key set becomes two keys written twice each and every `Add` lands twice. A head rollback belongs to the upstream, not to `eth_call`, so it must pass `"*"` and would otherwise count double against every other misbehaviour. This extends the identical-write guard the function already applies for `DataFinalityStateAll`.

---

## Evidence

goldsky ECS edge, 2026-08-18.

**Defect 1** — upstreams on unrelated networks and unrelated vendors recorded `erpc_upstream_block_head_large_rollback` values equal to their chain's full height:

| network / upstream | recorded rollback | head at the time |
|---|---|---|
| gravity-mainnet / gravity-mainnet-public-zan | 129,890,975 | 129,890,991 |
| zksync-mainnet / zksync-io-era | 71,589,976 | 71,589,993 |

They arrived in **region-synchronised bursts** — 9 series in one region inside one 10-minute window, spanning 5 unrelated networks and 5 unrelated vendors — tracking task restarts rather than anything on-chain, and producing **no** tracker log, unlike genuine rollbacks.

**Defect 2** — the rollback rate separates the two populations cleanly:

| upstream | large latest rollbacks / hour |
|---|---|
| darwinia / dwellir-evm:46 (us-east-1) | 65 |
| darwinia / dwellir-evm:46 (eu-central-1) | 48 |
| darwinia / dwellir-evm:46 (us-west-2) | 21 |
| *every other upstream in the fleet* | **1** |

610 rollbacks in three hours from that one endpoint — a ~3,341-block sawtooth every ~18 seconds, observed identically from four independent deployments, which is what rules out an eRPC-side cause. That is the shape a policy can now see and act on; a single reorg is not.

## Verification

Tests were written first and **fail on the unfixed tree** — 4 subtests for defect 1, 4 for defect 2.

Defect 1's failures state the consequence outright:

```
--- FAIL: .../remote_zero_does_not_roll_the_head_back        expected: 71589993, actual: 0
--- FAIL: .../the_rejected_zero_must_not_keep_winning_reconciliation
--- FAIL: .../local_zero_does_not_roll_the_head_back
--- FAIL: .../negative_values_are_rejected_too               expected: 1000000, actual: -1
--- PASS: .../a_real_reorg_is_still_applied
--- PASS: .../earliest-block_counters_may_still_hold_zero
```

The two controls pass **before and after**, so the suite pins existing correct behaviour rather than restating the new code. Defect 2's suite pins that repeated rollbacks accumulate, that the two axes land in their own buckets, and that the all-finalities rollup carries both — the last of which is what caught the `method="*"` double-count.

Full runs, no regressions:

```
ok  github.com/erpc/erpc/health     21.633s
ok  github.com/erpc/erpc/data       52.058s
ok  github.com/erpc/erpc/upstream    9.049s
ok  github.com/erpc/erpc/consensus   1.601s
```

## Related, not fixed here

`MetricUpstreamBlockHeadLargeRollback` is a gauge that is never reset, so one event stays latched for the life of the process and `rate()`/`increase()` are meaningless on it — its own comment says so. Converting it to a counter is a metric-contract change and deserves its own review.

## AI assistance

- **Model:** anthropic/claude-opus-5
- **Harness / skills:** Claude Code
- **Human-reviewed:** no — opened at the maintainer's request straight from the investigation; the diff has not been read line-by-line by a human yet.
