### PR TITLE
shadow: honour the upstream's block range before mirroring

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -1053,6 +1053,46 @@ func (e *EvmStatePoller) runPeriodicEarliestBlockBoundUpdateLoop(probe common.Ev
 	}
 }
 
+// fallbackFinalityMinAge is the minimum WALL-CLOCK age a block must reach
+// before the SYNTHETIC finalized head can cover it. It applies only on the
+// fallback path — when an upstream reports no finalized block at all — and only
+// ever DEEPENS the configured block depth, never shortens it.
+//
+// A block count alone cannot express "old enough that a reorg is implausible".
+// DefaultEvmFinalityDepth's 1024 blocks is ~3.4 hours of a 12s chain but only a
+// couple of minutes of a sub-second one, so the same constant is far more
+// conservative than needed on slow chains and potentially SHALLOWER than the
+// chain's real reorg risk on fast ones — and this value decides what erpc
+// treats as immutable and therefore permanently cacheable. Getting it wrong in
+// the shallow direction caches data that can still be reorged away.
+//
+// 30 minutes sits comfortably beyond Ethereum's ~13-minute finality and beyond
+// the unsafe-head reorg windows typical L2s expose. On any chain where the
+// configured block depth already represents more than this, nothing changes.
+const fallbackFinalityMinAge = 30 * time.Minute
+
+// fallbackFinalityDepth is how far below the head the synthetic finalized block
+// sits: the DEEPER of the configured block count and fallbackFinalityMinAge of
+// chain progress. Taking the deeper of the two is what makes this safe to ship
+// unconditionally — the synthetic finalized head can only ever move further
+// from the tip, never closer, so no block becomes "final" earlier than it does
+// today. While the block time is unknown the configured count stands alone.
+func (e *EvmStatePoller) fallbackFinalityDepth() int64 {
+	e.stateMu.RLock()
+	depth := int64(common.DefaultEvmFinalityDepth)
+	if e.cfg != nil && e.cfg.FallbackFinalityDepth > 0 {
+		depth = e.cfg.FallbackFinalityDepth
+	}
+	e.stateMu.RUnlock()
+
+	if blockTime := e.tracker.GetNetworkBlockTime(e.upstream.NetworkId()); blockTime > 0 {
+		if byAge := int64(fallbackFinalityMinAge / blockTime); byAge > depth {
+			depth = byAge
+		}
+	}
+	return depth
+}
+
 func (e *EvmStatePoller) IsBlockFinalized(blockNumber int64) (bool, error) {
 	finalizedBlock := e.finalizedBlockShared.GetValue()
 	latestBlock := e.latestBlockShared.GetValue()
@@ -1080,24 +1120,14 @@ func (e *EvmStatePoller) IsBlockFinalized(blockNumber int64) (bool, error) {
 	}
 
 	var fb int64
-	e.stateMu.RLock()
-	defer e.stateMu.RUnlock()
-	if e.cfg != nil && e.cfg.FallbackFinalityDepth > 0 {
-		if latestBlock > e.cfg.FallbackFinalityDepth {
-			fb = latestBlock - e.cfg.FallbackFinalityDepth
-		} else {
-			fb = 0
-		}
-	} else {
-		if latestBlock > common.DefaultEvmFinalityDepth {
-			fb = latestBlock - common.DefaultEvmFinalityDepth
-		} else {
-			fb = 0
-		}
+	depth := e.fallbackFinalityDepth()
+	if latestBlock > depth {
+		fb = latestBlock - depth
 	}
 
 	e.logger.Debug().
 		Int64("inferredFinalizedBlock", fb).
+		Int64("fallbackFinalityDepth", depth).
 		Int64("latestBlock", latestBlock).
 		Int64("blockNumber", blockNumber).
 		Msgf("calculating block finality using inferred finalized block")

--- a/architecture/evm/evm_state_poller_finality_depth_test.go
+++ b/architecture/evm/evm_state_poller_finality_depth_test.go
@@ -1,0 +1,61 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// driveBlockTimeEMA settles the tracker's block-time estimate at
+// (tsDelta/numDelta) seconds per block by replaying observations through the
+// same entry point the poller uses. blockTimeMinSamples is 3, so a handful of
+// rounds is plenty.
+func driveBlockTimeEMA(t *testing.T, p *EvmStatePoller, up common.Upstream, numDelta, tsDelta int64) {
+	t.Helper()
+	var num int64 = 1_000_000
+	var ts int64 = 1_700_000_000
+	for i := 0; i < 8; i++ {
+		num += numDelta
+		ts += tsDelta
+		p.tracker.SetLatestBlockNumber(up, num, ts)
+	}
+	require.NotZero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()),
+		"precondition: the block-time EMA must have settled")
+}
+
+func TestFallbackFinalityDepth(t *testing.T) {
+	t.Run("UnknownBlockTimeKeepsTheConfiguredDepth", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+
+		// Cold start: no measurement, so the block count stands alone and the
+		// behaviour is exactly what it was before.
+		require.Zero(t, p.tracker.GetNetworkBlockTime(up.NetworkId()))
+		assert.Equal(t, int64(common.DefaultEvmFinalityDepth), p.fallbackFinalityDepth())
+	})
+
+	t.Run("SlowChainKeepsTheBlockDepth", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		driveBlockTimeEMA(t, p, up, 1, 12) // 12s blocks
+
+		// 30 minutes is 150 blocks here — shallower than the 1024 already
+		// configured, so the deeper of the two leaves this chain untouched.
+		assert.Equal(t, int64(common.DefaultEvmFinalityDepth), p.fallbackFinalityDepth())
+	})
+
+	t.Run("FastChainDeepensToTheMinimumAge", func(t *testing.T) {
+		up := newSuggestGateUpstream(123, "0x7b", nil)
+		p := newGateTestPoller(t, up)
+		driveBlockTimeEMA(t, p, up, 10, 1) // 100ms blocks
+
+		// 1024 blocks is only ~1.7 minutes of this chain — potentially shallower
+		// than its real reorg risk. 30 minutes is 18,000 blocks, and the deeper
+		// value wins.
+		assert.Equal(t, int64(18_000), p.fallbackFinalityDepth())
+		assert.Greater(t, p.fallbackFinalityDepth(), int64(common.DefaultEvmFinalityDepth),
+			"the synthetic finalized head may only ever move FURTHER from the tip")
+	})
+}

--- a/docs/pages/config/projects/shadow-upstreams.mdx
+++ b/docs/pages/config/projects/shadow-upstreams.mdx
@@ -111,7 +111,7 @@ Reference: https://docs.erpc.cloud/config/projects/shadow-upstreams.llms.txt`}
 
 **Context lifecycle.** The shadow goroutine derives its context from `p.networksRegistry.appCtx` (not the inbound request context). Client disconnects do not cancel shadow requests.
 
-**Per-upstream loop.** For each shadow upstream, eRPC launches a dedicated goroutine with a fresh context derived from `appCtx`: (1) `ShouldHandleMethod` check — skip silently if the upstream's allow/ignore lists reject the method; (2) sample rate check — if `rand.Float64() >= sampleRate`, skip with debug log; (3) forward with `byPassMethodExclusion=true` (`upstream/upstream.go:L410-L450`) so the selection-engine's `shouldSkip` guard doesn't block it; (4) compare responses; (5) call `shadowResp.Release()` to free the cloned response.
+**Per-upstream loop.** For each shadow upstream, eRPC launches a dedicated goroutine with a fresh context derived from `appCtx`: (1) `ShouldHandleMethod` check — skip silently if the upstream's allow/ignore lists reject the method; (2) **block-availability check** — if the request names a CONCRETE block height the upstream states it does not hold (`maxAvailableRecentBlocks`, or an explicit `blockAvailability` bound), skip with debug log; (3) sample rate check — if `rand.Float64() >= sampleRate`, skip with debug log; (4) forward with `byPassMethodExclusion=true` (`upstream/upstream.go:L410-L450`) so the selection-engine's `shouldSkip` guard doesn't block it; (5) compare responses; (6) call `shadowResp.Release()` to free the cloned response.
 
 **Comparison algorithm.** eRPC computes a content hash of both the primary and shadow responses. If `ignoreFields` is configured for the method, both hashes are computed with those JSON keys masked before comparison. Result is one of three outcomes: **Identical** (hashes match, or both emptyish) — logged at Trace; **Mismatch** (hashes differ) — logged at Error with full request, both responses, both hashes, and the ignored fields list; **Error** (shadow request failed or hash computation failed) — counter incremented with stable error fingerprint.
 
@@ -124,6 +124,19 @@ All fields live under `projects[*].upstreams[*].shadow`. Struct at <SourceLink f
 | Field | Type | Default | Behavior / footguns |
 |---|---|---|---|
 | `shadow.enabled` | `bool` | `false` | When `true`, this upstream is registered into `networkShadowUpstreams` and excluded from all normal routing. Must be `true` for any shadow behavior to activate. Source: <SourceLink file="common/config.go" lines="983" />, <SourceLink file="upstream/registry.go" lines="574" /> |
+**Block availability.** Shadow honours the upstream's declared block range, the same
+question the real routing path asks (`EvmAssertBlockAvailability`). Without it a
+recent-window upstream — a replica configured with `maxAvailableRecentBlocks`, or an
+explicit `blockAvailability` lower bound — was mirrored archive-depth traffic it can
+only refuse: every such request burns the shadow upstream's capacity on work it cannot
+do, and then registers as a shadow *mismatch*, polluting the very comparison the shadow
+exists to produce.
+
+The check **fails open**, deliberately and in the same places the real path does: a
+block tag (`latest`, `pending`), an unparseable reference, or an errored assertion all
+mirror exactly as before. Only a concrete height the upstream states it does not have is
+skipped.
+
 | `shadow.sampleRate` | `*float64` | `nil` → `1.0` (always fire) | Fraction of eligible shadow requests to execute. `0.5` fires 50% at random. Check is `rand.Float64() >= sampleRate` — setting `0.0` suppresses all traffic; setting `nil` or `1.0` fires every request. Source: <SourceLink file="common/config.go" lines="984" />, <SourceLink file="erpc/shadow.go" lines="65-75" /> |
 | `shadow.ignoreFields` | `map[string][]string` | `nil` (no fields ignored) | Keys are JSON-RPC method names; values are JSON field names to mask before hash comparison. Both the primary and shadow response are hashed with the same mask. Prevents false mismatches for fields that legitimately differ (e.g., clock-skewed `timestamp`). Source: <SourceLink file="common/config.go" lines="985" />, <SourceLink file="erpc/shadow.go" lines="167-191" /> |
 

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -1318,6 +1318,41 @@ func (n *Network) noteServedTipGuardTransition(anchor *servedTipAnchor, state in
 	return true
 }
 
+// defaultMaxRetryableBlockDistance is the block-count fallback used when the
+// network does not configure MaxRetryableBlockDistance and the block time is
+// not known yet.
+const defaultMaxRetryableBlockDistance = int64(128)
+
+// retryableBlockHorizon is how far ahead of an upstream's head a requested
+// block may sit and still be worth retrying, expressed as chain progress.
+//
+// The question — "is this block close enough that the upstream may catch up?" —
+// is about how soon it arrives, so a block count answers it differently on
+// every chain: 128 blocks is ~25 minutes of a 12s chain but ~30 seconds of a
+// 4 blocks/s one. A minute of chain progress means the same thing everywhere.
+const retryableBlockHorizon = 60 * time.Second
+
+// maxRetryableBlockDistance is the larger of the block-count default and
+// retryableBlockHorizon of chain progress.
+//
+// Larger is the safe direction here: the value only decides whether to keep
+// trying, so widening it can cost a few extra retries but can never turn a
+// serveable request into a failure. An explicit operator setting is returned
+// untouched — the derived floor exists to give the DEFAULT a sane meaning
+// per chain, not to override a deliberate choice.
+func (n *Network) maxRetryableBlockDistance() int64 {
+	if n.cfg != nil && n.cfg.Evm != nil && n.cfg.Evm.MaxRetryableBlockDistance != nil {
+		return *n.cfg.Evm.MaxRetryableBlockDistance
+	}
+	distance := defaultMaxRetryableBlockDistance
+	if blockTime := n.EvmBlockTime(); blockTime > 0 {
+		if byTime := int64(retryableBlockHorizon / blockTime); byTime > distance {
+			distance = byTime
+		}
+	}
+	return distance
+}
+
 // servedTipMaxRegressionBlocks is how far below the corroborated live head a
 // pick may fall before the regression guard treats it as poisoned. Defaults to
 // the rollback tolerance the state poller and health tracker already use, so
@@ -2860,11 +2895,7 @@ func (n *Network) checkUpstreamBlockAvailability(ctx context.Context, u common.U
 		latestBlock, finalizedBlock := n.upstreamHeads(eu)
 		blockErr := common.NewErrUpstreamBlockUnavailable(eu.Id(), bn, latestBlock, finalizedBlock)
 		if bn > latestBlock && latestBlock > 0 {
-			maxDistance := int64(128) // default
-			if n.cfg.Evm != nil && n.cfg.Evm.MaxRetryableBlockDistance != nil {
-				maxDistance = *n.cfg.Evm.MaxRetryableBlockDistance
-			}
-			return blockErr, bn-latestBlock <= maxDistance
+			return blockErr, bn-latestBlock <= n.maxRetryableBlockDistance()
 		}
 		return blockErr, false
 	}

--- a/erpc/networks_retryable_distance_test.go
+++ b/erpc/networks_retryable_distance_test.go
@@ -1,0 +1,77 @@
+package erpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/health"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRetryDistanceNetwork builds the minimum Network the derivation reads:
+// a config, a tracker and a network id. blocksPerSecond <= 0 leaves the
+// tracker's estimate unset, which is the cold-start case.
+func newRetryDistanceNetwork(t *testing.T, configured *int64, blocksPerSecond int64) *Network {
+	t.Helper()
+	logger := zerolog.Nop()
+	tracker := health.NewTracker(&logger, "test", 2*time.Second)
+	n := &Network{
+		networkId:      "evm:1",
+		projectId:      "test",
+		logger:         &logger,
+		cfg:            &common.NetworkConfig{Evm: &common.EvmNetworkConfig{MaxRetryableBlockDistance: configured}},
+		metricsTracker: tracker,
+	}
+	if blocksPerSecond > 0 {
+		// Settle the tracker's block-time EMA by replaying observations through
+		// the same entry point the poller uses: blocksPerSecond blocks for every
+		// one second of block timestamp. blockTimeMinSamples is 3, so eight
+		// rounds is comfortably past the gate.
+		up := common.NewFakeUpstream("ups-1", common.WithFakeUpstreamNetworkID("evm:1"))
+		var num int64 = 1_000_000
+		var ts int64 = 1_700_000_000
+		for i := 0; i < 8; i++ {
+			num += blocksPerSecond
+			ts++
+			tracker.SetLatestBlockNumber(up, num, ts)
+		}
+		require.NotZero(t, tracker.GetNetworkBlockTime("evm:1"),
+			"precondition: the block-time EMA must have settled")
+	}
+	return n
+}
+
+func TestMaxRetryableBlockDistance(t *testing.T) {
+	t.Run("UnknownBlockTimeKeepsTheBlockCountDefault", func(t *testing.T) {
+		n := newRetryDistanceNetwork(t, nil, 0)
+		assert.Equal(t, defaultMaxRetryableBlockDistance, n.maxRetryableBlockDistance())
+	})
+
+	t.Run("SlowChainKeepsTheBlockCountDefault", func(t *testing.T) {
+		// 1 block/s: 60s of chain is 60 blocks, inside the 128 default, so the
+		// larger of the two leaves this chain untouched.
+		n := newRetryDistanceNetwork(t, nil, 1)
+		assert.Equal(t, defaultMaxRetryableBlockDistance, n.maxRetryableBlockDistance())
+	})
+
+	t.Run("FastChainWidensToTheTimeHorizon", func(t *testing.T) {
+		// 10 blocks/s: 128 blocks is only ~13 seconds of this chain, so a block
+		// half a minute out would be refused a retry it would have won. 60s of
+		// chain progress is 600 blocks.
+		n := newRetryDistanceNetwork(t, nil, 10)
+		assert.Equal(t, int64(600), n.maxRetryableBlockDistance())
+		assert.Greater(t, n.maxRetryableBlockDistance(), defaultMaxRetryableBlockDistance,
+			"widening is the safe direction: it can cost retries, never a failed request")
+	})
+
+	t.Run("ExplicitConfigIsNeverOverridden", func(t *testing.T) {
+		// An operator who pins this has made a deliberate choice; the derived
+		// floor must not widen it, even on a chain where it otherwise would.
+		pinned := int64(4)
+		n := newRetryDistanceNetwork(t, &pinned, 10)
+		assert.Equal(t, int64(4), n.maxRetryableBlockDistance())
+	})
+}

--- a/erpc/shadow.go
+++ b/erpc/shadow.go
@@ -8,6 +8,7 @@ import (
 
 	"math/rand/v2"
 
+	"github.com/erpc/erpc/architecture/evm"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/telemetry"
 	"github.com/erpc/erpc/upstream"
@@ -59,6 +60,36 @@ func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Ne
 		if !allowed {
 			p.Logger.Debug().Str("method", method).Str("upstreamId", ups.Id()).Msg("method not allowed for shadow upstream")
 			continue
+		}
+		// Block availability, same question the real routing path asks.
+		//
+		// Shadow used to mirror EVERY sampled request regardless of whether
+		// the upstream could possibly hold the block, so a recent-only
+		// upstream — `maxAvailableRecentBlocks`, or an explicit
+		// `blockAvailability` bound — was still sent archive-depth traffic
+		// it can only refuse. Observed on a recent-window replica: requests
+		// for 2022 blocks against a node whose window starts millions of
+		// blocks later, at several per second, every one of them a
+		// guaranteed error that then reads as a shadow "mismatch".
+		//
+		// That is noise in both directions: it burns the shadow upstream's
+		// capacity on work it cannot do, and it pollutes the comparison the
+		// shadow exists to produce.
+		//
+		// Fails OPEN, exactly like the real path: a tag (`latest`), an
+		// unparseable ref, a non-EVM upstream or an errored assertion all
+		// mirror as before. Only a CONCRETE height the upstream states it
+		// does not have is skipped.
+		if _, blockNumber, err := evm.ExtractBlockReferenceFromRequest(ctx, origReq); err == nil && blockNumber > 0 {
+			available, err := ups.EvmAssertBlockAvailability(ctx, method, common.AvailbilityConfidenceBlockHead, false, blockNumber)
+			if err == nil && !available {
+				p.Logger.Debug().
+					Str("method", method).
+					Str("upstreamId", ups.Id()).
+					Int64("blockNumber", blockNumber).
+					Msg("shadow request skipped: block outside the upstream's available range")
+				continue
+			}
 		}
 		// Apply sample rate: skip this shadow upstream based on configured probability
 		sampleRate := 1.0


### PR DESCRIPTION
## The gap

The shadow loop applied exactly two filters — `ShouldHandleMethod` and `sampleRate` — and **never asked whether the upstream could hold the block at all**. So an upstream that declares a recent-only window (`maxAvailableRecentBlocks`, or an explicit `blockAvailability` lower bound) was still mirrored archive-depth traffic.

Measured against a recent-window replica: requests for **2022 blocks** sent to a node whose window starts millions of blocks later, several per second, every one a guaranteed refusal:

```
block 14524400 predates the segment stream (floor ~25747290)
```

That is noise in both directions:

- it burns the shadow upstream's capacity on work it **cannot** do, and
- each refusal then registers as a shadow **mismatch** — polluting the comparison the shadow exists to produce.

Operators cannot configure their way out of it. The bound was already declared on the upstream; shadow simply ignored it.

## The fix

Gate on `EvmAssertBlockAvailability` — the same question the real routing path asks in `architecture/evm/hooks.go` — at `BlockHead` confidence.

It **fails open**, in the same places the real path does:

| case | behaviour |
|---|---|
| block tag (`latest`, `pending`) | mirrored, as before |
| unparseable block reference | mirrored, as before |
| assertion returns an error | mirrored, as before |
| concrete height the upstream states it lacks | **skipped**, with a debug log naming the block |

So the only traffic that changes is traffic that was guaranteed to fail.

## Notes

- `go build ./...` clean; `go vet ./erpc/` shows only a pre-existing warning in `query_executor_test.go`.
- There are no existing tests for `executeShadowRequests`, so none were updated.
- Docs updated: the per-upstream loop ordering and a new section on the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)