### PR TITLE
fix(evm): normalize jsonrpsee "Response is too big" as request-too-large

### DIFF
--- a/architecture/evm/error_normalizer.go
+++ b/architecture/evm/error_normalizer.go
@@ -88,7 +88,21 @@ func ExtractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 			strings.Contains(msg, "too many results") ||
 			strings.Contains(msg, "try paginating") ||
 			(strings.Contains(msg, "maximum") && strings.Contains(msg, "blocks distance")) ||
-			strings.Contains(msg, "eth_getLogs is limited") {
+			strings.Contains(msg, "eth_getLogs is limited") ||
+			// jsonrpsee — which reth and everything built on it uses — rejects an
+			// oversized response body with "Response is too big" and carries the
+			// byte cap in Data ("Exceeded max limit of 167772160"). That is a SIZE
+			// complaint, so narrowing the block range is exactly the right remedy
+			// and the eth_getLogs / trace_filter splitters already know how. It
+			// matched none of the range-shaped phrases above, so it fell through to
+			// a generic server-side exception, which does not split and surfaces to
+			// the caller as a hard failure.
+			//
+			// Matched on "is too big" rather than the full sentence so a reworded
+			// subject ("Result is too big") still lands here, and deliberately NOT
+			// on the Data prefix "Exceeded max limit of" — that phrasing is not
+			// specific to size and would swallow rate/quota complaints.
+			strings.Contains(msg, "is too big") {
 			return common.NewErrEndpointRequestTooLarge(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),

--- a/architecture/evm/error_normalizer_test.go
+++ b/architecture/evm/error_normalizer_test.go
@@ -134,3 +134,54 @@ func TestExtractJsonRpcError_InsufficientFunds_TracingMethodsRetryable(t *testin
 		})
 	}
 }
+
+// TestExtractJsonRpcError_ResponseTooBig_JsonRpseeSizeCap verifies that
+// jsonrpsee's oversized-response rejection — used by reth and anything else
+// built on it — normalizes to ErrEndpointRequestTooLarge, so the eth_getLogs /
+// trace_filter splitters narrow the range instead of the caller taking a hard
+// failure. Before this, the message matched none of the range-shaped phrases
+// and fell through to a generic server-side exception, which does not split.
+func TestExtractJsonRpcError_ResponseTooBig_JsonRpseeSizeCap(t *testing.T) {
+	t.Parallel()
+
+	r := &http.Response{StatusCode: 200, Header: http.Header{}}
+	jrErr := common.NewErrJsonRpcExceptionExternal(
+		-32008,
+		"Response is too big",
+		"Exceeded max limit of 167772160",
+	)
+	jr := common.MustNewJsonRpcResponse(1, nil, jrErr)
+
+	err := ExtractJsonRpcError(r, nil, jr, nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !common.HasErrorCode(err, common.ErrCodeEndpointRequestTooLarge) {
+		t.Fatalf("expected ErrEndpointRequestTooLarge, got %T: %v", err, err)
+	}
+}
+
+// TestExtractJsonRpcError_ExceededMaxLimit_IsNotASizeComplaint pins the
+// deliberate narrowness of the match above. "Exceeded max limit of ..." is the
+// Data half of the jsonrpsee message, but the phrasing says nothing about SIZE
+// — matching on it would turn a quota or rate complaint into a range-splitting
+// retry, which neither fixes the problem nor reports it honestly.
+func TestExtractJsonRpcError_ExceededMaxLimit_IsNotASizeComplaint(t *testing.T) {
+	t.Parallel()
+
+	r := &http.Response{StatusCode: 200, Header: http.Header{}}
+	jrErr := common.NewErrJsonRpcExceptionExternal(
+		int(common.JsonRpcErrorServerSideException),
+		"Exceeded max limit of 100 requests per second",
+		"",
+	)
+	jr := common.MustNewJsonRpcResponse(1, nil, jrErr)
+
+	err := ExtractJsonRpcError(r, nil, jr, nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if common.HasErrorCode(err, common.ErrCodeEndpointRequestTooLarge) {
+		t.Fatalf("a rate/quota complaint must not normalize to ErrEndpointRequestTooLarge, got %v", err)
+	}
+}


### PR DESCRIPTION
An upstream that rejects an **oversized response body** falls through the range-too-large classifier and surfaces as a generic `ErrEndpointServerSideException`, which does not split. The caller gets a hard failure for a request that splitting would have answered.

## The gap

jsonrpsee — which reth and everything built on it uses — caps the response body and rejects with:

```
-32008  "Response is too big"   Data: "Exceeded max limit of 167772160"
```

That is a **size** complaint, so narrowing the block range is exactly the right remedy, and the `eth_getLogs` / `trace_filter` splitters already know how to do it. It just never reached them: none of the existing phrases (`"range too large"`, `"exceeds max results"`, …) describe a *response that is too big* rather than a *range that is too wide*.

## How narrow this actually is

On a reth upstream the sibling errors already normalize correctly, which is why this went unnoticed:

| upstream error | matches today | outcome |
|---|---|---|
| `Block range too large; currently limited to 100 blocks` | `"range too large"` | ✅ splits |
| `query exceeds max results 20000, retry with the range X-Y` (`eth_getLogs`) | `"exceeds max results"` | ✅ splits |
| **`-32008 Response is too big`** | **nothing** | ❌ hard-fails |

So it shows up **only on `trace_filter` / `arbtrace_filter`**, and only for ranges whose traces are individually large enough to blow the byte cap. Observed on a chain where traces run several MB per block, so a few dozen blocks is enough.

## Why `"is too big"` and not the Data prefix

Matched on `"is too big"` rather than the full sentence, so a reworded subject (`"Result is too big"`) still lands here.

Deliberately **not** matched on `"Exceeded max limit of"`: that phrasing says nothing about size, and matching it would swallow quota and rate complaints — turning them into range-splitting retries that neither fix the problem nor report it honestly. `TestExtractJsonRpcError_ExceededMaxLimit_IsNotASizeComplaint` pins that boundary.

## Verification

- `TestExtractJsonRpcError_ResponseTooBig_JsonRpseeSizeCap` — reverting the one-line predicate makes it fail with `got *common.ErrEndpointServerSideException`, i.e. it reproduces the exact bug.
- `TestExtractJsonRpcError_ExceededMaxLimit_IsNotASizeComplaint` — guards the narrowness above.
- `go test ./architecture/evm/` passes in full; no existing case reclassifies.

## Note

#1056 also touches `architecture/evm/error_normalizer.go` (observability of the fallthrough path). They are independent changes — this one adds a predicate to the request-too-large block — but they will want sequencing if both land.