### PR TITLE
fix(common): prevent JSON-RPC CacheHash aliasing

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1478,24 +1478,63 @@ func (r *JsonRpcRequest) PeekByPath(path ...interface{}) (interface{}, error) {
 	return current, nil
 }
 
+// hashValue writes a deterministic, structure-preserving encoding of v into h,
+// used to derive request-identity keys (CacheHash / in-flight multiplexing).
+//
+// The old encoding recursively flattened params into the hash stream with no
+// type tags, lengths, or container markers, so structurally distinct requests
+// collapsed to the same byte stream and therefore the same key (#1034):
+// topics [[A,B]] and [A,B] were indistinguishable, "ab"+"c" aliased "a"+"bc",
+// and %f rounded 25.0000001 to "25.000000". Because that key drives both the
+// persistent cache and in-flight multiplexing, a follower request could be
+// handed the leader's response.
+//
+// This encoding is injective across JSON value shapes: every value carries a
+// one-byte type tag, every string/number/container is length- or count-
+// delimited, and object keys are emitted in sorted order. Two self-delimiting
+// tokens cannot concatenate into a third, so different params can never produce
+// the same bytes.
+//
+//	null    -> "N"
+//	bool    -> "B0" | "B1"
+//	number  -> "F" <len> ":" <shortest-round-tripping decimal>
+//	string  -> "S" <len> ":" <lowercased bytes>
+//	array   -> "A" <count> ":" <encoded element>...
+//	object  -> "O" <count> ":" ("K" <len> ":" <key>) <encoded value> ...
+//
+// String params are lowercased, preserving the long-standing EVM hex
+// normalization: a checksummed address and its lowercase form are the same
+// request and share a cache entry / multiplex group. The type tags make that
+// safe against cross-type aliasing that lowercasing alone would create — the
+// string "true" (S4:true) and the boolean true (B1) no longer collide. (SVM
+// needs the opposite, case-preserving key; see svmRequestKey, which is why it
+// does not route through this function.)
 func hashValue(h io.Writer, v interface{}) error {
 	switch t := v.(type) {
+	case nil:
+		_, err := io.WriteString(h, "N")
+		return err
 	case bool:
-		_, err := io.WriteString(h, fmt.Sprintf("%t", t))
+		s := "B0"
+		if t {
+			s = "B1"
+		}
+		_, err := io.WriteString(h, s)
 		return err
 	case int:
-		_, err := io.WriteString(h, fmt.Sprintf("%d", t))
-		return err
+		return writeHashToken(h, 'F', strconv.FormatInt(int64(t), 10))
 	case float64:
-		_, err := io.WriteString(h, fmt.Sprintf("%f", t))
-		return err
+		// 'g'/-1 emits the shortest decimal that round-trips to the same
+		// float64, preserving full precision (25 vs 25.0000001) unlike %f.
+		return writeHashToken(h, 'F', strconv.FormatFloat(t, 'g', -1, 64))
 	case string:
-		_, err := io.WriteString(h, strings.ToLower(t))
-		return err
+		return writeHashToken(h, 'S', strings.ToLower(t))
 	case []interface{}:
+		if err := writeHashHeader(h, 'A', len(t)); err != nil {
+			return err
+		}
 		for _, i := range t {
-			err := hashValue(h, i)
-			if err != nil {
+			if err := hashValue(h, i); err != nil {
 				return err
 			}
 		}
@@ -1506,22 +1545,51 @@ func hashValue(h io.Writer, v interface{}) error {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
+		if err := writeHashHeader(h, 'O', len(keys)); err != nil {
+			return err
+		}
 		for _, k := range keys {
-			if _, err := h.Write([]byte(k)); err != nil {
+			// Keys are emitted verbatim (not lowercased): they are JSON-RPC
+			// field names, not EVM hex values. Length-prefixing keeps a key
+			// from bleeding into the following value.
+			if err := writeHashToken(h, 'K', k); err != nil {
 				return err
 			}
-			err := hashValue(h, t[k])
-			if err != nil {
+			if err := hashValue(h, t[k]); err != nil {
 				return err
 			}
 		}
 		return nil
-	case nil:
-		_, err := h.Write([]byte("null"))
-		return err
 	default:
 		return fmt.Errorf("unsupported type for value during hash: %+v", v)
 	}
+}
+
+// writeHashHeader writes a container header — the type tag, the element count,
+// and a ':' terminator (e.g. "A3:" or "O2:") — into the hash stream.
+func writeHashHeader(h io.Writer, tag byte, n int) error {
+	var buf [24]byte
+	b := append(buf[:0], tag)
+	b = strconv.AppendInt(b, int64(n), 10)
+	b = append(b, ':')
+	_, err := h.Write(b)
+	return err
+}
+
+// writeHashToken writes a length-delimited leaf token — the type tag, the byte
+// length of s, a ':' terminator, and then s itself. The length prefix is what
+// makes adjacent tokens unambiguous: "ab"+"c" (S2:abS1:c) can never match
+// "a"+"bc" (S1:aS2:bc).
+func writeHashToken(h io.Writer, tag byte, s string) error {
+	var buf [24]byte
+	b := append(buf[:0], tag)
+	b = strconv.AppendInt(b, int64(len(s)), 10)
+	b = append(b, ':')
+	if _, err := h.Write(b); err != nil {
+		return err
+	}
+	_, err := io.WriteString(h, s)
+	return err
 }
 
 // findUpstreamsExhausted locates the ErrUpstreamsExhausted bundle that carries

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1412,14 +1412,19 @@ func (r *JsonRpcRequest) CacheHash(ctx ...context.Context) (string, error) {
 		}
 	}
 
-	hasher := sha256.New()
+	// Encode into a single pooled buffer, then hash once. Streaming each token
+	// straight into an io.Writer forces the small length/tag scratch to escape
+	// to the heap on every token; a concrete *bytes.Buffer lets the digits be
+	// written byte-by-byte with no per-token allocation. This mirrors the
+	// pooled-buffer pattern canonicalizeTo already uses for responses.
+	buf := util.BorrowBuf()
+	defer util.ReturnBuf(buf)
 	for _, p := range r.Params {
-		err := hashValue(hasher, p)
-		if err != nil {
+		if err := hashValue(buf, p); err != nil {
 			return "", err
 		}
 	}
-	b := sha256.Sum256(hasher.Sum(nil))
+	b := sha256.Sum256(buf.Bytes())
 	ch := fmt.Sprintf("%s:%x", r.Method, b)
 	r.cacheHash.Store(ch)
 	return ch, nil
@@ -1509,32 +1514,33 @@ func (r *JsonRpcRequest) PeekByPath(path ...interface{}) (interface{}, error) {
 // string "true" (S4:true) and the boolean true (B1) no longer collide. (SVM
 // needs the opposite, case-preserving key; see svmRequestKey, which is why it
 // does not route through this function.)
-func hashValue(h io.Writer, v interface{}) error {
+func hashValue(buf *bytes.Buffer, v interface{}) error {
 	switch t := v.(type) {
 	case nil:
-		_, err := io.WriteString(h, "N")
-		return err
+		buf.WriteByte('N')
+		return nil
 	case bool:
-		s := "B0"
 		if t {
-			s = "B1"
+			buf.WriteString("B1")
+		} else {
+			buf.WriteString("B0")
 		}
-		_, err := io.WriteString(h, s)
-		return err
+		return nil
 	case int:
-		return writeHashToken(h, 'F', strconv.FormatInt(int64(t), 10))
+		writeHashToken(buf, 'F', strconv.FormatInt(int64(t), 10))
+		return nil
 	case float64:
 		// 'g'/-1 emits the shortest decimal that round-trips to the same
 		// float64, preserving full precision (25 vs 25.0000001) unlike %f.
-		return writeHashToken(h, 'F', strconv.FormatFloat(t, 'g', -1, 64))
+		writeHashToken(buf, 'F', strconv.FormatFloat(t, 'g', -1, 64))
+		return nil
 	case string:
-		return writeHashToken(h, 'S', strings.ToLower(t))
+		writeHashToken(buf, 'S', strings.ToLower(t))
+		return nil
 	case []interface{}:
-		if err := writeHashHeader(h, 'A', len(t)); err != nil {
-			return err
-		}
+		writeHashHeader(buf, 'A', len(t))
 		for _, i := range t {
-			if err := hashValue(h, i); err != nil {
+			if err := hashValue(buf, i); err != nil {
 				return err
 			}
 		}
@@ -1545,17 +1551,13 @@ func hashValue(h io.Writer, v interface{}) error {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		if err := writeHashHeader(h, 'O', len(keys)); err != nil {
-			return err
-		}
+		writeHashHeader(buf, 'O', len(keys))
 		for _, k := range keys {
 			// Keys are emitted verbatim (not lowercased): they are JSON-RPC
 			// field names, not EVM hex values. Length-prefixing keeps a key
 			// from bleeding into the following value.
-			if err := writeHashToken(h, 'K', k); err != nil {
-				return err
-			}
-			if err := hashValue(h, t[k]); err != nil {
+			writeHashToken(buf, 'K', k)
+			if err := hashValue(buf, t[k]); err != nil {
 				return err
 			}
 		}
@@ -1566,30 +1568,43 @@ func hashValue(h io.Writer, v interface{}) error {
 }
 
 // writeHashHeader writes a container header — the type tag, the element count,
-// and a ':' terminator (e.g. "A3:" or "O2:") — into the hash stream.
-func writeHashHeader(h io.Writer, tag byte, n int) error {
-	var buf [24]byte
-	b := append(buf[:0], tag)
-	b = strconv.AppendInt(b, int64(n), 10)
-	b = append(b, ':')
-	_, err := h.Write(b)
-	return err
+// and a ':' terminator (e.g. "A3:" or "O2:").
+func writeHashHeader(buf *bytes.Buffer, tag byte, n int) {
+	buf.WriteByte(tag)
+	writeUint(buf, uint64(n))
+	buf.WriteByte(':')
 }
 
 // writeHashToken writes a length-delimited leaf token — the type tag, the byte
 // length of s, a ':' terminator, and then s itself. The length prefix is what
 // makes adjacent tokens unambiguous: "ab"+"c" (S2:abS1:c) can never match
 // "a"+"bc" (S1:aS2:bc).
-func writeHashToken(h io.Writer, tag byte, s string) error {
-	var buf [24]byte
-	b := append(buf[:0], tag)
-	b = strconv.AppendInt(b, int64(len(s)), 10)
-	b = append(b, ':')
-	if _, err := h.Write(b); err != nil {
-		return err
+func writeHashToken(buf *bytes.Buffer, tag byte, s string) {
+	buf.WriteByte(tag)
+	writeUint(buf, uint64(len(s)))
+	buf.WriteByte(':')
+	buf.WriteString(s)
+}
+
+// writeUint appends the decimal digits of n to buf one byte at a time. The
+// scratch array is indexed only (never passed as a slice to an escaping call),
+// so it stays on the stack — this is what keeps the encoder allocation-free per
+// token, unlike strconv.AppendInt into a heap-escaping buffer.
+func writeUint(buf *bytes.Buffer, n uint64) {
+	if n == 0 {
+		buf.WriteByte('0')
+		return
 	}
-	_, err := io.WriteString(h, s)
-	return err
+	var tmp [20]byte
+	i := len(tmp)
+	for n > 0 {
+		i--
+		tmp[i] = byte('0' + n%10)
+		n /= 10
+	}
+	for ; i < len(tmp); i++ {
+		buf.WriteByte(tmp[i])
+	}
 }
 
 // findUpstreamsExhausted locates the ErrUpstreamsExhausted bundle that carries

--- a/common/json_rpc_cachehash_bench_test.go
+++ b/common/json_rpc_cachehash_bench_test.go
@@ -1,0 +1,62 @@
+package common
+
+import "testing"
+
+var benchmarkCacheHashSink string
+
+func BenchmarkCacheHash_Simple(b *testing.B) {
+	req := NewJsonRpcRequest(
+		"eth_getBalance",
+		[]interface{}{
+			"0x0000000000000000000000000000000000000001",
+			"latest",
+		},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		req.InvalidateCacheHash()
+
+		hash, err := req.CacheHash()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		benchmarkCacheHashSink = hash
+	}
+}
+
+func BenchmarkCacheHash_EthGetLogs(b *testing.B) {
+	req := NewJsonRpcRequest(
+		"eth_getLogs",
+		[]interface{}{
+			map[string]interface{}{
+				"fromBlock": "0x64",
+				"toBlock":   "0x64",
+				"address":   "0x0000000000000000000000000000000000000001",
+				"topics": []interface{}{
+					[]interface{}{
+						"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					},
+				},
+			},
+		},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		req.InvalidateCacheHash()
+
+		hash, err := req.CacheHash()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		benchmarkCacheHashSink = hash
+	}
+}

--- a/common/json_rpc_test.go
+++ b/common/json_rpc_test.go
@@ -1014,3 +1014,127 @@ func TestJsonRpcRequest_UnmarshalID_NumericPrecision(t *testing.T) {
 		})
 	}
 }
+
+// cacheHashOfRequest decodes a full JSON-RPC request through the same Sonic
+// path the server uses (JsonRpcRequest.UnmarshalJSON) and returns its CacheHash.
+// Going through the real decode path is what makes these regression tests
+// meaningful: they exercise the exact Go value shapes (float64 numbers, nested
+// []interface{}, map[string]interface{}) the request pipeline produces.
+func cacheHashOfRequest(t *testing.T, rawReq string) string {
+	t.Helper()
+	var req JsonRpcRequest
+	require.NoError(t, SonicCfg.UnmarshalFromString(rawReq, &req))
+	h, err := req.CacheHash()
+	require.NoError(t, err)
+	return h
+}
+
+// cacheHashOfParams builds a request from a method and a raw JSON params array
+// and returns its CacheHash. Used for the focused structural collision cases.
+func cacheHashOfParams(t *testing.T, method, rawParams string) string {
+	t.Helper()
+	return cacheHashOfRequest(t, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":%q,"params":%s}`, method, rawParams))
+}
+
+// TestJsonRpcRequest_CacheHash_NestedTopicsCollision reproduces the first
+// collision reported in #1034: for eth_getLogs, `topics: [[A, B]]` (topic[0] is
+// "A OR B") and `topics: [A, B]` (topic[0]=A, topic[1]=B) are semantically
+// different filters, but the old flattening hasher dropped the nested-array
+// boundary and produced the same CacheHash — so the second request could be
+// multiplexed onto / served the first request's response.
+func TestJsonRpcRequest_CacheHash_NestedTopicsCollision(t *testing.T) {
+	reqA := `{
+		"jsonrpc": "2.0", "id": 1, "method": "eth_getLogs",
+		"params": [{
+			"fromBlock": "0x64", "toBlock": "0x64",
+			"address": "0x0000000000000000000000000000000000000001",
+			"topics": [[
+				"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			]]
+		}]
+	}`
+	reqB := `{
+		"jsonrpc": "2.0", "id": 1, "method": "eth_getLogs",
+		"params": [{
+			"fromBlock": "0x64", "toBlock": "0x64",
+			"address": "0x0000000000000000000000000000000000000001",
+			"topics": [
+				"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			]
+		}]
+	}`
+
+	hashA := cacheHashOfRequest(t, reqA)
+	hashB := cacheHashOfRequest(t, reqB)
+	require.NotEqual(t, hashA, hashB,
+		"nested topics [[A,B]] must not share a CacheHash with flat topics [A,B]")
+}
+
+// TestJsonRpcRequest_CacheHash_FloatPrecisionCollision reproduces the second
+// collision reported in #1034: the old hasher formatted float64 params with
+// "%f" (six decimal places), so eth_feeHistory reward percentiles [25] and
+// [25.0000001] collapsed to the byte string "25.000000" and hashed identically.
+func TestJsonRpcRequest_CacheHash_FloatPrecisionCollision(t *testing.T) {
+	hashA := cacheHashOfParams(t, "eth_feeHistory", `["0x10", "0x64", [25]]`)
+	hashB := cacheHashOfParams(t, "eth_feeHistory", `["0x10", "0x64", [25.0000001]]`)
+	require.NotEqual(t, hashA, hashB,
+		"float params 25 and 25.0000001 must not collapse to the same CacheHash")
+}
+
+// TestJsonRpcRequest_CacheHash_StructuralCollisions covers the remaining ways
+// the old ambiguous flattening could alias structurally distinct params:
+// missing element boundaries, missing type tags, and missing container
+// boundaries. Each pair is semantically different and must hash differently.
+func TestJsonRpcRequest_CacheHash_StructuralCollisions(t *testing.T) {
+	cases := []struct {
+		name    string
+		paramsA string
+		paramsB string
+	}{
+		// Array element boundaries: "ab"+"c" vs "a"+"bc" flatten to the same
+		// "abc" byte run without length/element delimiters.
+		{"array element boundaries", `["ab", "c"]`, `["a", "bc"]`},
+		// Type tags: a string that looks like another JSON scalar must not
+		// alias that scalar.
+		{"string vs number", `["1"]`, `[1]`},
+		{"string vs bool", `["true"]`, `[true]`},
+		{"string vs null", `["null"]`, `[null]`},
+		// Container boundaries: a nested array must not flatten into its parent.
+		{"nested vs flat array", `[["a", "b"]]`, `["a", "b"]`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hashA := cacheHashOfParams(t, "eth_call", c.paramsA)
+			hashB := cacheHashOfParams(t, "eth_call", c.paramsB)
+			require.NotEqual(t, hashA, hashB,
+				"%s: %s must not share a CacheHash with %s", c.name, c.paramsA, c.paramsB)
+		})
+	}
+}
+
+// TestJsonRpcRequest_CacheHash_ObjectKeyOrderStable asserts the encoding stays
+// deterministic across JSON object key order (and Go map iteration order):
+// {"a":1,"b":2} and {"b":2,"a":1} are the same request and must hash equally.
+func TestJsonRpcRequest_CacheHash_ObjectKeyOrderStable(t *testing.T) {
+	hashA := cacheHashOfParams(t, "eth_call", `[{"a":1,"b":2}]`)
+	hashB := cacheHashOfParams(t, "eth_call", `[{"b":2,"a":1}]`)
+	require.Equal(t, hashA, hashB,
+		"object key order is not semantically meaningful and must not change the CacheHash")
+}
+
+// TestJsonRpcRequest_CacheHash_EvmHexCaseInsensitive documents the deliberate
+// decision to keep lowercasing string params: EVM hex is case-insensitive, so a
+// checksummed address and its lowercase form are the same request and should
+// share a cache entry / multiplex group. This is the EVM counterpart to SVM's
+// case-preserving key (see svmRequestKey).
+func TestJsonRpcRequest_CacheHash_EvmHexCaseInsensitive(t *testing.T) {
+	hashUpper := cacheHashOfParams(t, "eth_getBalance",
+		`["0xAbC0000000000000000000000000000000000001", "latest"]`)
+	hashLower := cacheHashOfParams(t, "eth_getBalance",
+		`["0xabc0000000000000000000000000000000000001", "latest"]`)
+	require.Equal(t, hashUpper, hashLower,
+		"EVM hex params are case-insensitive and must share a CacheHash")
+}


### PR DESCRIPTION
## Summary

Fix `JsonRpcRequest.CacheHash` so distinct valid JSON-RPC requests cannot map to the same cache/multiplex key due to ambiguous parameter encoding.

Previously, request parameters were recursively written into the hash stream without preserving enough structural information such as type, container boundaries, or element boundaries. `float64` values were also formatted using `%f`, which could lose precision.

As a result, semantically different requests could produce identical bytes before SHA-256 hashing and therefore share the same `CacheHash`.

This affects both persistent caching and in-flight request multiplexing.

Related #1034

## Root Cause

The previous `hashValue` implementation flattened parameter values directly into a single hash stream.

For example, these two different topic structures:

```json
[
  [
    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
  ]
]
```

and:

```json
[
  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
]
```

could produce the same input bytes because array/container boundaries were not encoded.

The same problem also existed for values such as:

```json
[25]
```

and:

```json
[25.0000001]
```

because `%f` could serialize both as:

```text
25.000000
```

This is not a SHA-256 collision. The problem was the ambiguous serialization before hashing.

## Changes

- Make JSON-RPC request hashing structure-aware
- Preserve JSON value types and container boundaries
- Preserve array ordering and element boundaries
- Keep object hashing deterministic by sorting keys
- Preserve full floating-point precision
- Prevent ambiguous concatenation of request values
- Add regression tests for the collisions reported in #1034

## Before

Two semantically different `eth_getLogs` requests could produce the same cache key:

```text
topics = [["A", "B"]]

topics = ["A", "B"]
```

Both could be flattened into equivalent bytes and therefore produce the same `CacheHash`.

Similarly:

```json
["0x10", "0x64", [25]]
```

and:

```json
["0x10", "0x64", [25.0000001]]
```

could produce the same key because float formatting lost precision.

This meant:

```text
Request A
    ↓
CacheHash X

Request B
    ↓
CacheHash X
```

and the requests could incorrectly share a multiplexed or cached response.

## After

The request encoding now preserves the information required to distinguish request identity.

The same examples now produce different hashes:

```text
topics = [["A", "B"]]
        ↓
CacheHash A

topics = ["A", "B"]
        ↓
CacheHash B

CacheHash A != CacheHash B
```

and:

```text
25
        ↓
CacheHash A

25.0000001
        ↓
CacheHash B

CacheHash A != CacheHash B
```

## Compatibility

Changing the request encoding changes the generated `CacheHash` values.

Existing persistent cache entries created with the old hashing scheme will not be reused by the new implementation and will effectively become cold/stale entries until they expire or are evicted.

No cache migration is required because the old entries are not referenced by the new keys.

## Scope

This PR is intentionally limited to JSON-RPC request identity hashing and its regression tests.

It does not change:

- cache storage behavior
- request routing
- multiplexing logic
- upstream selection
- response canonicalization
- unrelated SVM behavior