### PR TITLE
feat(upstream): headLagToleranceBlocks — availability-gate tolerance for tight head-followers

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1315,6 +1315,13 @@ type EvmUpstreamConfig struct {
 	// Use for nodes that always return a syncing object (e.g. Pharos/Antora) where the response is
 	// misleading and causes circuit breaker false positives.
 	SkipSyncingCheck *bool `yaml:"skipSyncingCheck,omitempty" json:"skipSyncingCheck"`
+	// HeadLagToleranceBlocks lets the block-availability gate send requests pinned up to N blocks
+	// ABOVE this upstream's observed head instead of rerouting them as stale. Useful for upstreams
+	// that follow the chain tightly but become able to serve a new block a moment after it is
+	// announced elsewhere (they hold or briefly wait for the block internally): with a hard
+	// head comparison every request pinned at head+1 in that moment is rerouted even though the
+	// upstream would have answered it. 0 (default) keeps the exact head comparison.
+	HeadLagToleranceBlocks int64 `yaml:"headLagToleranceBlocks,omitempty" json:"headLagToleranceBlocks"`
 	// Deprecated: never read at runtime. Configure data integrity via the network
 	// `integrity` block instead. Retained only so existing YAML still parses.
 	DeprecatedIntegrity *UpstreamIntegrityConfig `yaml:"integrity,omitempty" json:"integrity"`

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -490,6 +490,20 @@ export interface GrpcConnectorConfig {
   headers?: { [key: string]: string};
   getTimeout?: Duration;
   /**
+   * NetworkId pins every server in this connector to one network and skips
+   * the eth_chainId bootstrap probe.
+   * Required for SVM. Solana has no numeric chain id — cluster identity is
+   * the genesis hash — and eth_chainId returns Unimplemented, so the probe
+   * fails and no client is ever registered. Probing GetGenesisHash instead
+   * is not an option either: the BDS reader deliberately does not publish
+   * one until it can verify its own, so identity here has to be asserted by
+   * configuration rather than discovered.
+   * Leave unset for EVM to keep the probe, which also arms the per-request
+   * chain-identity assertion that catches an endpoint cross-wired LATER — a
+   * static binding cannot.
+   */
+  networkId?: string;
+  /**
    * PoolSize is the number of independent gRPC connections opened to each
    * backing server, selected round-robin per request. Larger values raise the
    * concurrent-stream ceiling and shrink the blast radius of a single wedged
@@ -959,6 +973,15 @@ export interface EvmUpstreamConfig {
    * misleading and causes circuit breaker false positives.
    */
   skipSyncingCheck?: boolean;
+  /**
+   * HeadLagToleranceBlocks lets the block-availability gate send requests pinned up to N blocks
+   * ABOVE this upstream's observed head instead of rerouting them as stale. Useful for upstreams
+   * that follow the chain tightly but become able to serve a new block a moment after it is
+   * announced elsewhere (they hold or briefly wait for the block internally): with a hard
+   * head comparison every request pinned at head+1 in that moment is rerouted even though the
+   * upstream would have answered it. 0 (default) keeps the exact head comparison.
+   */
+  headLagToleranceBlocks?: number /* int64 */;
   /**
    * Deprecated: never read at runtime. Configure data integrity via the network
    * `integrity` block instead. Retained only so existing YAML still parses.

--- a/upstream/evm_upstream_ops.go
+++ b/upstream/evm_upstream_ops.go
@@ -220,7 +220,7 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 		// on capability gaps; the proven-lag metric keeps that visible.
 		//
 		proven := u.stateProvenBlock.Load()
-		if proven > 0 && blockNumber > proven {
+		if proven > 0 && blockNumber > proven+cfg.Evm.HeadLagToleranceBlocks {
 			telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
 				u.ProjectId,
 				u.VendorName(),
@@ -253,8 +253,14 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 		// UPPER BOUND: Check if block is before the latest block
 		//
 		latestBlock := statePoller.LatestBlock()
-		// If the requested block is beyond the current latest block, try force-polling once
-		if blockNumber > latestBlock && forceFreshIfStale {
+		// An upstream may declare it can serve a few blocks past its observed
+		// head (headLagToleranceBlocks) — it holds or briefly waits for the
+		// block internally. The gate then only reroutes requests pinned
+		// beyond head+tolerance.
+		tolerance := cfg.Evm.HeadLagToleranceBlocks
+		// If the requested block is beyond the current latest block (plus
+		// tolerance), try force-polling once
+		if blockNumber > latestBlock+tolerance && forceFreshIfStale {
 			var err error
 			latestBlock, err = statePoller.PollLatestBlockNumber(ctx)
 			if err != nil {
@@ -262,7 +268,8 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 			}
 		}
 		// Check if the requested block is still beyond the latest known block
-		if blockNumber > latestBlock {
+		// (plus tolerance)
+		if blockNumber > latestBlock+tolerance {
 			// Upper bound issue - block is beyond latest
 			telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
 				u.ProjectId,
@@ -288,8 +295,9 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 			}
 		}
 
-		// If MaxAvailableRecentBlocks is not configured, assume the node can handle the block if it's <= latest
-		return blockNumber <= latestBlock, nil
+		// If MaxAvailableRecentBlocks is not configured, assume the node can handle the block if it's
+		// <= latest (plus the declared head-lag tolerance)
+		return blockNumber <= latestBlock+tolerance, nil
 	default:
 		return false, fmt.Errorf("unsupported block availability confidence: %s", confidence)
 	}

--- a/upstream/upstream_block_availability_test.go
+++ b/upstream/upstream_block_availability_test.go
@@ -1205,3 +1205,52 @@ func BenchmarkEvmAssertBlockAvailability(b *testing.B) {
 		}
 	})
 }
+
+func TestEvmAssertBlockAvailability_HeadLagTolerance(t *testing.T) {
+	newUpstream := func(tolerance int64) *Upstream {
+		return &Upstream{
+			config: &common.UpstreamConfig{
+				Type: common.UpstreamTypeEvm,
+				Evm: &common.EvmUpstreamConfig{
+					HeadLagToleranceBlocks: tolerance,
+				},
+			},
+			logger:         &zerolog.Logger{},
+			evmStatePoller: &mockEvmStatePollerEnhanced{latestBlock: 1000, finalizedBlock: 900},
+		}
+	}
+
+	t.Run("DefaultZeroKeepsExactHeadComparison", func(t *testing.T) {
+		upstream := newUpstream(0)
+		canHandle, err := upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceBlockHead, false, 1001)
+		assert.NoError(t, err)
+		assert.False(t, canHandle)
+	})
+
+	t.Run("WithinToleranceIsServable", func(t *testing.T) {
+		upstream := newUpstream(2)
+		for _, block := range []int64{1000, 1001, 1002} {
+			canHandle, err := upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceBlockHead, false, block)
+			assert.NoError(t, err)
+			assert.True(t, canHandle, "block %d should be within head+2 tolerance", block)
+		}
+	})
+
+	t.Run("BeyondToleranceIsStale", func(t *testing.T) {
+		upstream := newUpstream(2)
+		canHandle, err := upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceBlockHead, false, 1003)
+		assert.NoError(t, err)
+		assert.False(t, canHandle)
+	})
+
+	t.Run("ToleranceAppliesToStateProvenHead", func(t *testing.T) {
+		upstream := newUpstream(1)
+		upstream.stateProvenBlock.Store(1000)
+		canHandle, err := upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceStateProven, false, 1001)
+		assert.NoError(t, err)
+		assert.True(t, canHandle)
+		canHandle, err = upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceStateProven, false, 1002)
+		assert.NoError(t, err)
+		assert.False(t, canHandle)
+	})
+}


### PR DESCRIPTION
## Problem

The block-availability gate compares a request's pinned block against the upstream's polled head **exactly**. A request pinned at `head+1` — in the window between another provider announcing a block and this upstream's poller observing it — is rerouted as `stale_upper_bound`, even when the upstream would have answered it (many nodes hold or briefly wait internally for a block that is moments from being servable).

For upstreams that follow the head tightly (sub-block average lag), this reroutes a meaningful share of tip-pinned traffic that would have been served.

## Change

`evm.headLagToleranceBlocks` (default `0` = exact comparison, existing behavior) declares how many blocks past the observed head the gate may still send. Applied on both the `blockHead` and `stateProven` confidence paths, including the no-`maxAvailableRecentBlocks` fallthrough.

- `common/config.go`: new field, rides the existing wholesale `Copy()`.
- `upstream/evm_upstream_ops.go`: tolerance in the three head comparisons.
- Tests: `TestEvmAssertBlockAvailability_HeadLagTolerance` (default-zero exactness, within-tolerance servable, beyond-tolerance stale, stateProven path).
- `typescript/config/src/generated.ts`: tygo regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)