### PR TITLE
feat(shadow): pinBlockTag — evaluate mirrored tag selectors at the primary's height

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1153,6 +1153,14 @@ type ShadowUpstreamConfig struct {
 	Enabled      bool                `yaml:"enabled" json:"enabled"`
 	SampleRate   *float64            `yaml:"sampleRate,omitempty" json:"sampleRate,omitempty"`
 	IgnoreFields map[string][]string `yaml:"ignoreFields,omitempty" json:"ignoreFields"`
+	// PinBlockTag rewrites a tag block selector ("latest"/"pending") in the mirrored copy to a
+	// concrete height before forwarding: the primary's resolved block number when its response
+	// carries one, else the network's tracked head at mirror time. Without it the shadow executes
+	// the tag at its OWN head wall-clock-later than the primary did, so any read of volatile state
+	// (pool reserves, oracle prices — most visibly large multicalls) diverges by construction and
+	// reports a mismatch that says nothing about correctness. Default false = mirror byte-identical
+	// requests, exactly as before.
+	PinBlockTag bool `yaml:"pinBlockTag,omitempty" json:"pinBlockTag,omitempty"`
 }
 
 // Deprecated: UpstreamIntegrityConfig is a non-functional legacy stub (never

--- a/erpc/shadow.go
+++ b/erpc/shadow.go
@@ -14,6 +14,46 @@ import (
 	"github.com/erpc/erpc/upstream"
 )
 
+// Tag-selector parameter position for the state methods the mirror rewrites
+// when ShadowUpstreamConfig.PinBlockTag is on. Methods absent here are
+// forwarded untouched — for eth_getBlockByNumber and friends, pinning the tag
+// would change the QUESTION, not just the evaluation height.
+var shadowTagParamIndex = map[string]int{
+	"eth_call":                1,
+	"eth_getBalance":          1,
+	"eth_getCode":             1,
+	"eth_getTransactionCount": 1,
+	"eth_getStorageAt":        2,
+}
+
+// pinBlockTagInBody rewrites params[idx] from "latest" to the given concrete
+// height in a JSON-RPC request body. Returns the rewritten body and whether a
+// rewrite happened; any parse trouble or a non-"latest" selector returns the
+// body unchanged (fail-open, like every other shadow-path guard).
+func pinBlockTagInBody(body []byte, idx int, height int64) ([]byte, bool) {
+	if len(body) == 0 || height <= 0 {
+		return body, false
+	}
+	var req map[string]interface{}
+	if err := common.SonicCfg.Unmarshal(body, &req); err != nil {
+		return body, false
+	}
+	params, ok := req["params"].([]interface{})
+	if !ok || len(params) <= idx {
+		return body, false
+	}
+	tag, ok := params[idx].(string)
+	if !ok || tag != "latest" {
+		return body, false
+	}
+	params[idx] = fmt.Sprintf("0x%x", height)
+	out, err := common.SonicCfg.Marshal(req)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
 func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Network, shadowUpstreams []*upstream.Upstream, resp *common.NormalizedResponse) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -145,6 +185,37 @@ func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Ne
 
 			// Set network reference for completeness (not strictly required for forwarding)
 			shadowReq.SetNetwork(origReq.Network())
+
+			// Pin a "latest" selector to a concrete height before forwarding
+			// (ShadowUpstreamConfig.PinBlockTag). The primary evaluated the tag
+			// at ITS head; the shadow runs wall-clock-later and would evaluate
+			// it at a different head, so any read of volatile state diverges by
+			// construction and reports a mismatch that says nothing about
+			// correctness. The primary's resolved number is exact when its
+			// response carries one; the network's tracked head at mirror time
+			// is the closest available approximation otherwise. Fail-open on
+			// every gap, like the rest of this path.
+			if shadowCfg := ups.Config().Shadow; shadowCfg != nil && shadowCfg.PinBlockTag {
+				if idx, ok := shadowTagParamIndex[method]; ok {
+					height := int64(0)
+					if bn, ok2 := resp.EvmBlockNumber().(int64); ok2 && bn > 0 {
+						height = bn
+					} else if network != nil {
+						height = network.EvmHighestLatestBlockNumber(shadowCtx)
+					}
+					if height > 0 {
+						if pinned, changed := pinBlockTagInBody(shadowReq.Body(), idx, height); changed {
+							repinned := common.NewNormalizedRequest(pinned)
+							if dirs := origReq.Directives(); dirs != nil {
+								repinned.SetDirectives(dirs.Clone())
+							}
+							repinned.CopyHttpContextFrom(origReq)
+							repinned.SetNetwork(origReq.Network())
+							shadowReq = repinned
+						}
+					}
+				}
+			}
 
 			// Execute the request against the shadow upstream (do bypass exclusion because we have to enforce method exclusion locally here - to ignore the shadow flag checking)
 			shadowResp, errForward := ups.Forward(shadowCtx, shadowReq, true, false)

--- a/erpc/shadow_pin_test.go
+++ b/erpc/shadow_pin_test.go
@@ -1,0 +1,50 @@
+package erpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPinBlockTagInBody(t *testing.T) {
+	t.Run("PinsLatestForEthCall", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xabc","data":"0x1"},"latest"]}`)
+		out, changed := pinBlockTagInBody(body, 1, 0x189cbe5)
+		assert.True(t, changed)
+		assert.Contains(t, string(out), `"0x189cbe5"`)
+		assert.NotContains(t, string(out), `"latest"`)
+	})
+
+	t.Run("PinsStorageSlotIndexTwo", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":7,"method":"eth_getStorageAt","params":["0xabc","0x0","latest"]}`)
+		out, changed := pinBlockTagInBody(body, 2, 100)
+		assert.True(t, changed)
+		assert.Contains(t, string(out), `"0x64"`)
+	})
+
+	t.Run("ConcreteHeightUntouched", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xabc"},"0x1234"]}`)
+		out, changed := pinBlockTagInBody(body, 1, 100)
+		assert.False(t, changed)
+		assert.Equal(t, body, out)
+	})
+
+	t.Run("PendingUntouched", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xabc"},"pending"]}`)
+		_, changed := pinBlockTagInBody(body, 1, 100)
+		assert.False(t, changed)
+	})
+
+	t.Run("MissingParamUntouched", func(t *testing.T) {
+		body := []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xabc"}]}`)
+		_, changed := pinBlockTagInBody(body, 1, 100)
+		assert.False(t, changed)
+	})
+
+	t.Run("GarbageUntouched", func(t *testing.T) {
+		body := []byte(`{not json`)
+		out, changed := pinBlockTagInBody(body, 1, 100)
+		assert.False(t, changed)
+		assert.Equal(t, []byte(`{not json`), out)
+	})
+}

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -490,6 +490,20 @@ export interface GrpcConnectorConfig {
   headers?: { [key: string]: string};
   getTimeout?: Duration;
   /**
+   * NetworkId pins every server in this connector to one network and skips
+   * the eth_chainId bootstrap probe.
+   * Required for SVM. Solana has no numeric chain id — cluster identity is
+   * the genesis hash — and eth_chainId returns Unimplemented, so the probe
+   * fails and no client is ever registered. Probing GetGenesisHash instead
+   * is not an option either: the BDS reader deliberately does not publish
+   * one until it can verify its own, so identity here has to be asserted by
+   * configuration rather than discovered.
+   * Leave unset for EVM to keep the probe, which also arms the per-request
+   * chain-identity assertion that catches an endpoint cross-wired LATER — a
+   * static binding cannot.
+   */
+  networkId?: string;
+  /**
    * PoolSize is the number of independent gRPC connections opened to each
    * backing server, selected round-robin per request. Larger values raise the
    * concurrent-stream ceiling and shrink the blast radius of a single wedged
@@ -885,6 +899,16 @@ export interface ShadowUpstreamConfig {
   enabled: boolean;
   sampleRate?: number /* float64 */;
   ignoreFields?: { [key: string]: string[]};
+  /**
+   * PinBlockTag rewrites a tag block selector ("latest"/"pending") in the mirrored copy to a
+   * concrete height before forwarding: the primary's resolved block number when its response
+   * carries one, else the network's tracked head at mirror time. Without it the shadow executes
+   * the tag at its OWN head wall-clock-later than the primary did, so any read of volatile state
+   * (pool reserves, oracle prices — most visibly large multicalls) diverges by construction and
+   * reports a mismatch that says nothing about correctness. Default false = mirror byte-identical
+   * requests, exactly as before.
+   */
+  pinBlockTag?: boolean;
 }
 /**
  * Deprecated: UpstreamIntegrityConfig is a non-functional legacy stub (never


### PR DESCRIPTION
## Problem

Shadow mirrors forward a byte-identical copy, so a `latest` selector is re-evaluated at the shadow upstream's own head — wall-clock-later than the primary's answer. Any read of volatile state (pool reserves, oracle prices, most visibly large `aggregate3` multicalls) then diverges **by construction**, and `shadow_response_mismatch_total` reports a comparison artifact rather than a correctness signal. On a live mirror this class runs at a steady ~10/min floor that no upstream-side fix can remove.

## Change

`shadow.pinBlockTag` (default `false` = byte-identical mirroring, unchanged) rewrites `latest` in the mirrored copy to a concrete height before forwarding:

1. the primary's resolved block number when its response carries one (same source as the block-hash availability gating), else
2. the network's tracked head at mirror time — the closest available approximation for methods like `eth_call` whose responses carry no number.

State methods only (`eth_call`, `eth_getBalance`, `eth_getCode`, `eth_getTransactionCount`, `eth_getStorageAt`); for `eth_getBlockByNumber` pinning would change the question, not the evaluation height. Fail-open on every gap: parse trouble, a non-`latest` selector, or no resolvable height forwards the copy untouched.

- `common/config.go`: `ShadowUpstreamConfig.PinBlockTag`.
- `erpc/shadow.go`: the rewrite + wiring.
- `erpc/shadow_pin_test.go`: rewrite-helper coverage.
- TS types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)