### PR TITLE
feat(telemetry): extend idle-series eviction to histogram/observer handles

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -2963,6 +2963,15 @@ type MetricsConfig struct {
 	// only clearly-dead label combinations are released). Set to 0 to
 	// disable eviction entirely.
 	CounterIdleEvictionAfter *Duration `yaml:"counterIdleEvictionAfter,omitempty" json:"counterIdleEvictionAfter,omitempty"`
+
+	// HistogramIdleEvictionAfter is CounterIdleEvictionAfter's histogram
+	// twin, and matters roughly an order of magnitude more: each idle label
+	// combination pins buckets+2 series (every bucket, _sum, _count), so
+	// histogram label growth is the dominant term in a long-lived process's
+	// /metrics payload. Observer series idle for at least this duration are
+	// evicted by the same health-tracker sweep. Defaults to 24h; set to 0 to
+	// disable eviction entirely.
+	HistogramIdleEvictionAfter *Duration `yaml:"histogramIdleEvictionAfter,omitempty" json:"histogramIdleEvictionAfter,omitempty"`
 }
 
 // GetProjectConfig returns the project configuration by the specified project ID.

--- a/erpc/init.go
+++ b/erpc/init.go
@@ -55,6 +55,9 @@ func Init(
 		if cfg.Metrics.CounterIdleEvictionAfter != nil {
 			telemetry.SetCounterIdleEvictionAfter(cfg.Metrics.CounterIdleEvictionAfter.Duration())
 		}
+		if cfg.Metrics.HistogramIdleEvictionAfter != nil {
+			telemetry.SetHistogramIdleEvictionAfter(cfg.Metrics.HistogramIdleEvictionAfter.Duration())
+		}
 		// Counters are built unregistered at package init (Prometheus freezes
 		// a metric's label-set hash for the life of the registry, so we cannot
 		// register first and filter later). Install any filter, then register

--- a/health/tracker.go
+++ b/health/tracker.go
@@ -684,6 +684,13 @@ func (t *Tracker) sweepIdleObservers(cutoffMs int64) {
 	// own, more conservative threshold (metrics.counterIdleEvictionAfter,
 	// default 24h) — only the cadence is shared with this observer sweep.
 	telemetry.SweepIdleCounterHandles()
+	// Histogram/observer emissions route through telemetry.ObserverHandle;
+	// sweep those too (metrics.histogramIdleEvictionAfter, default 24h).
+	// Histograms are the dominant cardinality term: each idle label
+	// combination pins buckets+2 series, so without this sweep a long-lived
+	// process's /metrics grows monotonically until something downstream
+	// (scrape size, scrape timeout, an ingest message cap) breaks.
+	telemetry.SweepIdleObserverHandles()
 }
 
 // getUpsKeys expands a (upstream, method, finality) record into the

--- a/telemetry/handles.go
+++ b/telemetry/handles.go
@@ -36,9 +36,11 @@ type gaugeKey struct {
 }
 
 // HistogramObservable is satisfied by both *prometheus.HistogramVec and
-// *LabeledHistogram, so ObserverHandle can cache handles for either.
+// *LabeledHistogram, so ObserverHandle can cache handles for either and
+// SweepIdleObserverHandles can release their series.
 type HistogramObservable interface {
 	WithLabelValues(labels ...string) prometheus.Observer
+	DeleteLabelValues(labels ...string) bool
 }
 
 // CounterIncrementable is satisfied by both *prometheus.CounterVec and
@@ -53,10 +55,23 @@ type observerKey struct {
 	key string
 }
 
+// cachedObserverHandle pairs a child observer with the label tuple that
+// created it and an idle timestamp, so SweepIdleObserverHandles can evict
+// the cache entry AND release the underlying series via DeleteLabelValues —
+// the same lifecycle cachedCounterHandle gives counters. This matters MORE
+// for histograms than counters: each idle label combination pins
+// buckets+2 series (every bucket, _sum, _count), so histogram label growth
+// multiplies into /metrics cardinality roughly an order of magnitude faster.
+type cachedObserverHandle struct {
+	observer         prometheus.Observer
+	vals             []string
+	lastAccessedAtMs atomic.Int64
+}
+
 var (
-	counterHandleCache  sync.Map // map[counterKey]prometheus.Counter
+	counterHandleCache  sync.Map // map[counterKey]*cachedCounterHandle
 	gaugeHandleCache    sync.Map // map[gaugeKey]prometheus.Gauge
-	observerHandleCache sync.Map // map[observerKey]prometheus.Observer
+	observerHandleCache sync.Map // map[observerKey]*cachedObserverHandle
 )
 
 func labelsKey(labels []string) string {
@@ -139,6 +154,7 @@ var counterIdleEvictionAfterMs atomic.Int64
 
 func init() {
 	counterIdleEvictionAfterMs.Store(DefaultCounterIdleEvictionAfter.Milliseconds())
+	histogramIdleEvictionAfterMs.Store(DefaultHistogramIdleEvictionAfter.Milliseconds())
 }
 
 // SetCounterIdleEvictionAfter overrides the idle threshold for counter series
@@ -206,24 +222,124 @@ func GaugeHandle(gv *prometheus.GaugeVec, labels ...string) prometheus.Gauge {
 	return actual.(prometheus.Gauge)
 }
 
-// ObserverHandle returns a cached child observer for the given labels.
-// hv may be *prometheus.HistogramVec or *LabeledHistogram.
+// observerHandleCreateMu serializes ObserverHandle's miss path (create +
+// cache-store) against sweep eviction (cache-delete + DeleteLabelValues) —
+// the same orphan race CounterHandle guards with counterHandleCreateMu: a
+// miss between the sweep's cache delete and its registry delete would
+// re-cache the still-registered child right before the sweep removes it
+// from the vec, leaving a hot cached handle whose observations are never
+// scraped again. The hit path stays lock-free.
+var observerHandleCreateMu sync.Mutex
+
+// ObserverHandle returns a cached child observer for the given labels and
+// refreshes its idle timestamp. hv may be *prometheus.HistogramVec or
+// *LabeledHistogram. Callers must re-fetch the handle per use
+// (ObserverHandle(...).Observe(v)) rather than holding the returned
+// Observer — after an idle sweep evicts the series, a held child mutates an
+// object that is no longer collected.
 //
 // When hv is a *LabeledHistogram with active filtering, the cache key uses
 // the post-filter label values so multiple full-label tuples that resolve
-// to the same underlying observer share a single cache entry.
+// to the same underlying observer share a single cache entry (and the idle
+// sweep deletes that shared series exactly once).
 func ObserverHandle(hv HistogramObservable, labels ...string) prometheus.Observer {
 	keyLabels := labels
 	if lh, ok := hv.(*LabeledHistogram); ok {
 		keyLabels = lh.ActiveLabelValues(labels)
 	}
 	k := observerKey{vec: hv, key: labelsKey(keyLabels)}
+	nowMs := time.Now().UnixMilli()
 	if v, ok := observerHandleCache.Load(k); ok {
-		return v.(prometheus.Observer)
+		h := v.(*cachedObserverHandle)
+		h.lastAccessedAtMs.Store(nowMs)
+		return h.observer
 	}
-	o := hv.WithLabelValues(labels...)
-	actual, _ := observerHandleCache.LoadOrStore(k, o)
-	return actual.(prometheus.Observer)
+	observerHandleCreateMu.Lock()
+	defer observerHandleCreateMu.Unlock()
+	// Re-check under the lock: another miss may have created the entry, or
+	// a sweep may have just evicted it (in which case WithLabelValues below
+	// creates a fresh series — never a doomed one, since eviction holds the
+	// same lock across cache-delete + registry-delete).
+	if v, ok := observerHandleCache.Load(k); ok {
+		h := v.(*cachedObserverHandle)
+		h.lastAccessedAtMs.Store(nowMs)
+		return h.observer
+	}
+	h := &cachedObserverHandle{
+		observer: hv.WithLabelValues(labels...),
+		vals:     append([]string(nil), labels...),
+	}
+	h.lastAccessedAtMs.Store(nowMs)
+	observerHandleCache.Store(k, h)
+	return h.observer
+}
+
+// DefaultHistogramIdleEvictionAfter is the conservative default idle
+// threshold for histogram/observer series eviction. Histograms are the
+// dominant cardinality term on /metrics: client_golang never expires a
+// series, and each idle label combination pins buckets+2 series (every
+// bucket, _sum, _count) for the life of the process — so a long-lived
+// instance's payload grows monotonically until something downstream
+// (scrape size, scrape timeout, an ingest message cap) breaks. Overridden
+// via metrics.histogramIdleEvictionAfter (see common.MetricsConfig; wired
+// in erpc/init.go via SetHistogramIdleEvictionAfter).
+const DefaultHistogramIdleEvictionAfter = 24 * time.Hour
+
+var histogramIdleEvictionAfterMs atomic.Int64
+
+// SetHistogramIdleEvictionAfter overrides the idle threshold for
+// histogram/observer series eviction. Zero (or negative) disables eviction
+// entirely. Typically called once at startup from config.
+func SetHistogramIdleEvictionAfter(d time.Duration) {
+	histogramIdleEvictionAfterMs.Store(d.Milliseconds())
+}
+
+// SweepIdleObserverHandles evicts cached observer handles idle for at least
+// the configured threshold (DefaultHistogramIdleEvictionAfter unless
+// overridden) and deletes their label-sets from the parent vec, releasing
+// every series the combination pins (all buckets, _sum, _count) from the
+// Prometheus registry. Driven by the health tracker's idle sweep cadence,
+// alongside SweepIdleCounterHandles. Returns the number of evicted label
+// combinations; no-op (0) when eviction is disabled.
+func SweepIdleObserverHandles() int {
+	afterMs := histogramIdleEvictionAfterMs.Load()
+	if afterMs <= 0 {
+		return 0
+	}
+	return sweepIdleObserverHandlesBefore(time.Now().UnixMilli() - afterMs)
+}
+
+// sweepIdleObserverHandlesBefore evicts cached observer handles not touched
+// since cutoffMs. Cache delete and registry delete happen atomically with
+// respect to ObserverHandle's miss path (observerHandleCreateMu), so a
+// racing re-fetch either lands before eviction (refreshing the timestamp,
+// which the under-lock re-check honors) or after it (recreating the series
+// fresh — the same semantics as a process restart). A hit-path caller that
+// obtained the child just before eviction may lose the observations of that
+// single use; bounded, restart-equivalent.
+func sweepIdleObserverHandlesBefore(cutoffMs int64) int {
+	evicted := 0
+	observerHandleCache.Range(func(key, value any) bool {
+		h := value.(*cachedObserverHandle)
+		if h.lastAccessedAtMs.Load() >= cutoffMs {
+			return true
+		}
+		observerHandleCreateMu.Lock()
+		// Re-check under the lock: a miss-path fetch may have refreshed or
+		// replaced the entry since the lock-free check above.
+		v, ok := observerHandleCache.Load(key)
+		if !ok || v.(*cachedObserverHandle).lastAccessedAtMs.Load() >= cutoffMs {
+			observerHandleCreateMu.Unlock()
+			return true
+		}
+		k := key.(observerKey)
+		observerHandleCache.Delete(key)
+		k.vec.(HistogramObservable).DeleteLabelValues(v.(*cachedObserverHandle).vals...)
+		observerHandleCreateMu.Unlock()
+		evicted++
+		return true
+	})
+	return evicted
 }
 
 // ResetHandleCache clears all handle caches. Call this after re-creating metric Vecs.

--- a/telemetry/handles_test.go
+++ b/telemetry/handles_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // newTestCounterVec builds a CounterVec on a private registry so tests never
@@ -222,4 +223,153 @@ func TestCounterHandle_SweepRaceNeverOrphansHandles(t *testing.T) {
 			t.Fatalf("round %d: orphaned counter handle: before=%v after=%v — Inc through cached handle is invisible in the registry", round, before, after)
 		}
 	}
+}
+
+// newTestHistogramVec builds a HistogramVec on a private registry so tests
+// never touch the global package metrics.
+func newTestHistogramVec(t *testing.T, name string) *prometheus.HistogramVec {
+	t.Helper()
+	vec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: name, Buckets: []float64{0.1, 1}}, []string{"a", "b"})
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(vec)
+	ResetHandleCache()
+	t.Cleanup(ResetHandleCache)
+	return vec
+}
+
+// A future-cutoff sweep evicts every idle observer from BOTH the cache and
+// the parent vec. CollectAndCount counts one per label combination pinned —
+// releasing a combination must release all of its bucket/_sum/_count series.
+func TestSweepIdleObserverHandles_EvictsIdleSeries(t *testing.T) {
+	vec := newTestHistogramVec(t, "test_observer_sweep_evicts")
+
+	ObserverHandle(vec, "x", "1").Observe(0.5)
+	ObserverHandle(vec, "y", "2").Observe(0.5)
+	if got := testutil.CollectAndCount(vec); got != 2 {
+		t.Fatalf("precondition: expected 2 series, got %d", got)
+	}
+
+	evicted := sweepIdleObserverHandlesBefore(time.Now().UnixMilli() + 1000)
+	if evicted != 2 {
+		t.Fatalf("expected 2 evicted, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 0 {
+		t.Fatalf("expected 0 series after sweep, got %d — DeleteLabelValues did not release the series", got)
+	}
+}
+
+// A past-cutoff sweep evicts nothing, and the cached handle keeps observing
+// into the SAME series (sample count keeps growing rather than resetting).
+func TestSweepIdleObserverHandles_RetainsActiveSeries(t *testing.T) {
+	vec := newTestHistogramVec(t, "test_observer_sweep_retains")
+
+	ObserverHandle(vec, "x", "1").Observe(0.5)
+
+	if evicted := sweepIdleObserverHandlesBefore(time.Now().UnixMilli() - 60_000); evicted != 0 {
+		t.Fatalf("expected 0 evicted with past cutoff, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected series retained, got %d", got)
+	}
+
+	ObserverHandle(vec, "x", "1").Observe(0.5)
+	if got := sampleCount(t, vec, "x", "1"); got != 2 {
+		t.Fatalf("expected same series to continue at 2 observations, got %d", got)
+	}
+}
+
+// Re-fetching a handle refreshes its idle timestamp, exactly like counters.
+func TestObserverHandle_TouchRefreshPreventsEviction(t *testing.T) {
+	vec := newTestHistogramVec(t, "test_observer_touch_refresh")
+
+	ObserverHandle(vec, "x", "1").Observe(0.5) // created at t0
+	sleepMs(t)
+	cutoff := time.Now().UnixMilli()
+	sleepMs(t)
+	ObserverHandle(vec, "x", "1") // touch refreshes lastAccessedAtMs past cutoff
+
+	if evicted := sweepIdleObserverHandlesBefore(cutoff); evicted != 0 {
+		t.Fatalf("expected 0 evicted after touch refresh, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected series to survive sweep, got %d series", got)
+	}
+}
+
+// SetHistogramIdleEvictionAfter(0) disables the public sweep entirely.
+func TestSweepIdleObserverHandles_DisabledThresholdEvictsNothing(t *testing.T) {
+	t.Cleanup(func() { SetHistogramIdleEvictionAfter(DefaultHistogramIdleEvictionAfter) })
+	vec := newTestHistogramVec(t, "test_observer_sweep_disabled")
+
+	SetHistogramIdleEvictionAfter(0)
+	ObserverHandle(vec, "x", "1").Observe(0.5)
+	sleepMs(t)
+
+	if evicted := SweepIdleObserverHandles(); evicted != 0 {
+		t.Fatalf("expected 0 evicted with eviction disabled, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 1 {
+		t.Fatalf("expected series retained with eviction disabled, got %d", got)
+	}
+}
+
+// The public no-arg sweep respects the configured threshold.
+func TestSweepIdleObserverHandles_ConfiguredThresholdEvicts(t *testing.T) {
+	t.Cleanup(func() { SetHistogramIdleEvictionAfter(DefaultHistogramIdleEvictionAfter) })
+	vec := newTestHistogramVec(t, "test_observer_sweep_configured")
+
+	SetHistogramIdleEvictionAfter(1 * time.Millisecond)
+	ObserverHandle(vec, "x", "1").Observe(0.5)
+	time.Sleep(5 * time.Millisecond)
+
+	if evicted := SweepIdleObserverHandles(); evicted < 1 {
+		t.Fatalf("expected >=1 evicted past configured threshold, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(vec); got != 0 {
+		t.Fatalf("expected series released after threshold sweep, got %d", got)
+	}
+}
+
+// LabeledHistogram path: the cache keys on POST-filter labels (several full
+// tuples share one underlying series), the handle stores the FULL tuple, and
+// the sweep must delete through LabeledHistogram's full-schema
+// DeleteLabelValues — releasing the shared series exactly once.
+func TestSweepIdleObserverHandles_LabeledHistogramSharedSeries(t *testing.T) {
+	t.Cleanup(func() {
+		SetHistogramLabelFilter(nil, nil)
+		ResetHandleCache()
+	})
+	// Drop label "b": full tuples (x,1) and (x,2) collapse onto active tuple (x).
+	SetHistogramLabelFilter([]string{"b"}, nil)
+	lh := NewLabeledHistogram(prometheus.HistogramOpts{Name: "test_observer_sweep_labeled", Buckets: []float64{0.1, 1}}, []string{"a", "b"})
+	prometheus.NewRegistry().MustRegister(lh)
+	ResetHandleCache()
+
+	ObserverHandle(lh, "x", "1").Observe(0.5)
+	ObserverHandle(lh, "x", "2").Observe(0.5) // same active series, same cache entry
+	if got := testutil.CollectAndCount(lh); got != 1 {
+		t.Fatalf("precondition: expected 1 shared series, got %d", got)
+	}
+
+	evicted := sweepIdleObserverHandlesBefore(time.Now().UnixMilli() + 1000)
+	if evicted != 1 {
+		t.Fatalf("expected exactly 1 evicted shared entry, got %d", evicted)
+	}
+	if got := testutil.CollectAndCount(lh); got != 0 {
+		t.Fatalf("expected shared series released, got %d", got)
+	}
+}
+
+// sampleCount reads the histogram's _count for one label tuple.
+func sampleCount(t *testing.T, vec *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	h, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := h.(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
 }


### PR DESCRIPTION
## What

Extends #1031's idle-series eviction from counters to **histogram/observer handles** — the missing half, and the bigger one: each idle label combination on a histogram pins `buckets+2` series (every bucket, `_sum`, `_count`), so histogram label growth dominates a long-lived process's `/metrics` payload. `client_golang` never expires a series, which makes the payload monotonic in uptime until something downstream breaks — scrape size limits, scrape timeouts, or an ingest pipeline's max message size. All three are just different doors for the same unbounded growth.

## How — a faithful mirror of the counter design

| piece | counter (#1031) | this PR |
|---|---|---|
| cached handle with full label tuple + idle timestamp | `cachedCounterHandle` | `cachedObserverHandle` |
| per-fetch timestamp refresh, locked miss path (orphan-race guard) | `CounterHandle` + `counterHandleCreateMu` | `ObserverHandle` + `observerHandleCreateMu` |
| sweep, driven by the health tracker's existing cadence | `SweepIdleCounterHandles` | `SweepIdleObserverHandles` (called alongside, `health/tracker.go`) |
| config knob, default 24h, 0 disables | `metrics.counterIdleEvictionAfter` | `metrics.histogramIdleEvictionAfter` |

Two details worth reviewer attention:

1. **`HistogramObservable` now requires `DeleteLabelValues`.** Both implementers already satisfy it — `*prometheus.HistogramVec` natively, `*LabeledHistogram` via its existing full-schema projection (whose doc comment has said "used by the health tracker's idle-sweep loop" since #1031 — this PR makes that true). The whole repo builds, so no third implementer exists.
2. **Filtered histograms delete exactly once.** `ObserverHandle` keys the cache on POST-filter labels (several full tuples share one underlying series and one cache entry) while the handle stores the FULL tuple; the sweep deletes through `LabeledHistogram.DeleteLabelValues`, which re-projects — covered by a dedicated test (`TestSweepIdleObserverHandles_LabeledHistogramSharedSeries`).

Eviction semantics are restart-equivalent, same as counters: a swept combination that becomes active again is reborn as a fresh series at zero, which `rate()`/`increase()` already handle as a counter reset. Callers must re-fetch handles per use (`ObserverHandle(...).Observe(v)`) — the existing call sites already do.

## Tests

Mirrors the counter sweep suite: `go test ./telemetry/...` —

- `TestSweepIdleObserverHandles_EvictsIdleSeries` — sweep releases registry series, not just cache entries
- `TestSweepIdleObserverHandles_RetainsActiveSeries` — past-cutoff sweep keeps the SAME series observing (asserted via `_count`)
- `TestObserverHandle_TouchRefreshPreventsEviction`
- `TestSweepIdleObserverHandles_DisabledThresholdEvictsNothing` (0 disables)
- `TestSweepIdleObserverHandles_ConfiguredThresholdEvicts`
- `TestSweepIdleObserverHandles_LabeledHistogramSharedSeries` — shared filtered series, deleted once

`go build ./...` clean; `go test ./health/...` green (tracker touched).

## Operational note

With both sweeps in place, a process's `/metrics` payload becomes proportional to its *active* label surface instead of its lifetime-accumulated one — the acceptance check is that `scrape_samples_scraped` on a week-old instance matches a fresh one. Deployments that want faster reclamation than the conservative 24h default can lower `metrics.histogramIdleEvictionAfter` independently of the counter knob.
