### PR TITLE
fix(shadow): pin latest-tag to the serving upstream's polled head

### DIFF
--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -193,21 +193,7 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 					cloneResp.SetHedges(resp.Hedges())
 					cloneResp.SetEvmBlockRef(resp.EvmBlockRef())
 					cloneResp.SetEvmBlockNumber(resp.EvmBlockNumber())
-					// Capture the SERVING upstream's own polled head now,
-					// synchronously: this is the closest observable proxy for
-					// the height at which that upstream just evaluated a
-					// "latest" tag. The shadow goroutine may run arbitrarily
-					// later (semaphore queueing), so reading any head inside
-					// it would drift past the height the primary answered at.
-					var primaryHead int64
-					if ups := resp.Upstream(); ups != nil {
-						if evmUps, ok := ups.(common.EvmUpstream); ok {
-							if sp := evmUps.EvmStatePoller(); sp != nil {
-								primaryHead = sp.LatestBlock()
-							}
-						}
-					}
-					go p.executeShadowRequests(ctx, network, shadowUpstreams, cloneResp, primaryHead)
+					go p.executeShadowRequests(ctx, network, shadowUpstreams, cloneResp)
 				}
 			}
 		}

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -193,7 +193,21 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 					cloneResp.SetHedges(resp.Hedges())
 					cloneResp.SetEvmBlockRef(resp.EvmBlockRef())
 					cloneResp.SetEvmBlockNumber(resp.EvmBlockNumber())
-					go p.executeShadowRequests(ctx, network, shadowUpstreams, cloneResp)
+					// Capture the SERVING upstream's own polled head now,
+					// synchronously: this is the closest observable proxy for
+					// the height at which that upstream just evaluated a
+					// "latest" tag. The shadow goroutine may run arbitrarily
+					// later (semaphore queueing), so reading any head inside
+					// it would drift past the height the primary answered at.
+					var primaryHead int64
+					if ups := resp.Upstream(); ups != nil {
+						if evmUps, ok := ups.(common.EvmUpstream); ok {
+							if sp := evmUps.EvmStatePoller(); sp != nil {
+								primaryHead = sp.LatestBlock()
+							}
+						}
+					}
+					go p.executeShadowRequests(ctx, network, shadowUpstreams, cloneResp, primaryHead)
 				}
 			}
 		}

--- a/erpc/shadow.go
+++ b/erpc/shadow.go
@@ -54,7 +54,7 @@ func pinBlockTagInBody(body []byte, idx int, height int64) ([]byte, bool) {
 	return out, true
 }
 
-func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Network, shadowUpstreams []*upstream.Upstream, resp *common.NormalizedResponse, primaryHead int64) {
+func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Network, shadowUpstreams []*upstream.Upstream, resp *common.NormalizedResponse) {
 	defer func() {
 		if r := recover(); r != nil {
 			p.Logger.Error().Msgf("panic while executing shadow requests: %v", r)
@@ -89,6 +89,23 @@ func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Ne
 	}
 
 	resp.RUnlock()
+
+	// The SERVING upstream's polled head, read once at mirror entry: the
+	// closest observable proxy for the height at which the primary just
+	// evaluated a "latest" tag (used by the PinBlockTag rewrite below when
+	// the response body carries no number of its own). Entry is the right
+	// moment: only a goroutine spawn and the hash above separate it from
+	// the primary's answer — µs-to-ms against a poller that updates ~1/s —
+	// while a read deeper in the per-upstream fan-out would drift further
+	// for no gain.
+	primaryHead := int64(0)
+	if ups := resp.Upstream(); ups != nil {
+		if evmUps, ok := ups.(common.EvmUpstream); ok {
+			if sp := evmUps.EvmStatePoller(); sp != nil {
+				primaryHead = sp.LatestBlock()
+			}
+		}
+	}
 
 	// Fire shadow requests concurrently
 	for _, ups := range shadowUpstreams {

--- a/erpc/shadow.go
+++ b/erpc/shadow.go
@@ -54,7 +54,7 @@ func pinBlockTagInBody(body []byte, idx int, height int64) ([]byte, bool) {
 	return out, true
 }
 
-func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Network, shadowUpstreams []*upstream.Upstream, resp *common.NormalizedResponse) {
+func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Network, shadowUpstreams []*upstream.Upstream, resp *common.NormalizedResponse, primaryHead int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			p.Logger.Error().Msgf("panic while executing shadow requests: %v", r)
@@ -192,16 +192,20 @@ func (p *PreparedProject) executeShadowRequests(ctx context.Context, network *Ne
 			// it at a different head, so any read of volatile state diverges by
 			// construction and reports a mismatch that says nothing about
 			// correctness. The primary's resolved number is exact when its
-			// response carries one; the network's tracked head at mirror time
-			// is the closest available approximation otherwise. Fail-open on
-			// every gap, like the rest of this path.
+			// response carries one; otherwise the SERVING upstream's own polled
+			// head, captured synchronously at forward time, is the closest
+			// observable proxy. Never a network-wide head: that is the MAX over
+			// all upstreams, so whenever any other vendor leads the primary it
+			// pins a height the primary never evaluated — a manufactured
+			// mismatch on every block boundary. No usable height means no pin
+			// (fail-open, like every other guard on this path).
 			if shadowCfg := ups.Config().Shadow; shadowCfg != nil && shadowCfg.PinBlockTag {
 				if idx, ok := shadowTagParamIndex[method]; ok {
 					height := int64(0)
 					if bn, ok2 := resp.EvmBlockNumber().(int64); ok2 && bn > 0 {
 						height = bn
-					} else if network != nil {
-						height = network.EvmHighestLatestBlockNumber(shadowCtx)
+					} else if primaryHead > 0 {
+						height = primaryHead
 					}
 					if height > 0 {
 						if pinned, changed := pinBlockTagInBody(shadowReq.Body(), idx, height); changed {


### PR DESCRIPTION
## Problem

#1100 added `pinBlockTag`: mirrored `latest`-tag selectors are rewritten to a concrete height so the shadow evaluates the same state the primary did. When the primary's response carried no block number (e.g. `eth_call`), the pin fell back to the network's highest tracked head at mirror time.

That fallback is a MAX over ALL upstreams. Whenever any other vendor's head leads the serving upstream — i.e. on essentially every block boundary — the pin lands on a height the primary never evaluated. The shadow then reads state one block ahead of the primary's answer, and every volatile read reports a mismatch that says nothing about correctness. Enabling the feature raised the mismatch rate ~25x in production measurement; it is currently disabled in config because of this.

## Fix

- The pin height comes from the response's own resolved number when present, else from the **serving** upstream's state poller head.
- That head is read **once at mirror entry** inside `executeShadowRequests` (the clone already carries the serving upstream), keeping all pin logic encapsulated in shadow.go. Entry is separated from the primary's answer by only a goroutine spawn and the response hash — µs-to-ms against a poller that updates ~1/s — while a read deeper in the per-upstream fan-out would drift further for no gain.
- No usable height → no pin (fail-open, matching every other guard on this path).

Residual skew is bounded by the primary's own poll interval (the poller can be at most one poll behind the node's evaluation head), instead of unbounded by whichever vendor happens to lead the network.

## Testing

- `go build ./...`, `go test ./erpc/ -run TestPinBlockTagInBody -count=1` pass.
- `pinBlockTagInBody` itself is unchanged; this PR only changes where the height comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
