### PR TITLE
feat(integrity): autoCorrectWhenPossible + recordOnly/hardReject verdict split

### DIFF
--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -239,7 +239,7 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 	// corroboration force-fetch) are skipped to avoid recursing into the engine.
 	dirs := rq.Directives()
 	if integrity.HasChecks(methodLower) && (dirs == nil || !dirs.IsInternal) {
-		if cs, policy, observeOnly := resolveIntegrity(n, dirs); len(cs) > 0 {
+		if cs, policy, observeOnly, autoCorrect := resolveIntegrity(n, dirs); len(cs) > 0 {
 			// Integrity state + corroboration are scoped to the node GROUP the request
 			// was pinned to (use-upstream selector), reusing erpc's served-tip grouping
 			// so a receipt from one group is only checked against same-group
@@ -257,6 +257,7 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 				Resolver:    newIntegrityResolver(ctx, n, u, selector),
 				Reorg:       policy,
 				ObserveOnly: observeOnly,
+				AutoCorrect: autoCorrect,
 			}
 			if view != nil {
 				input.History = view
@@ -280,7 +281,7 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 			res := integrity.Validate(vctx, input)
 			rq.AddIntegrityOverhead(time.Since(vStart))
 			annotateIntegritySpan(span, res)
-			// Record the rejected/soft-flagged ("original") body on the violating
+			// Record the rejected/recorded ("original") body on the violating
 			// attempt's span, for a by-hand sanity check. Only on a violation here:
 			// a recovering pass runs concurrently (hedged) so its IntegrityCaught
 			// flag may not be set yet — the "corrected" served body is recorded once
@@ -298,7 +299,7 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 				}
 			}
 			span.End()
-			// Per-check attempts/outcomes (pass/skip/reject/soft_flag/reconfirmed/
+			// Per-check attempts/outcomes (pass/skip/reject/reject_recoverable/record_only/reconfirmed/
 			// off) — sum = total attempts. "pass" means an actual verification ran;
 			// "skip" means the check couldn't evaluate (cold cache, missing wiring).
 			// Higher volume than the violation counter below.
@@ -310,13 +311,13 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 			for _, rec := range res.Recorded {
 				verdict := rec.Verdict
 				if verdict == "" {
-					verdict = "soft_flag"
+					verdict = "record_only"
 				}
-				msg := "integrity: recorded reorg-sensitive mismatch (served, not rejected)"
+				msg := "integrity: recorded mismatch (served, not rejected)"
 				if verdict == "would_reject" {
 					// Observe-only: this WOULD have failed the request under
 					// enforcement. Logged distinctly so the enforcement-readiness
-					// review can find them without untangling routine soft-flags.
+					// review can find them without untangling routine record-only flags.
 					msg = "integrity: observe-only suppressed a rejection (served; enforcement would have failed this request)"
 				}
 				telemetry.MetricIntegrityViolation.WithLabelValues(
@@ -329,8 +330,19 @@ func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.U
 				exportIntegrityCatch(ctx, n, u, rs, methodLower, verdict, rec.CheckID, rec.Class.String(), rec.Finality, rec.Reason)
 			}
 			if res.Err != nil {
+				rejectVerdict := "reject"
+				if res.FallbackEligible {
+					rejectVerdict = "reject_recoverable"
+					// A recordOnly verdict escalated by autoCorrectWhenPossible:
+					// stash the flagged original so project.Forward can serve it
+					// if every alternative upstream is exhausted — the client
+					// must never pay an error for a mismatch the policy says to
+					// serve. The stash keeps the NEWEST eligible original (any
+					// of them satisfies the policy).
+					rq.SetIntegrityFallbackResponse(rs, res.RejectedCheckID, res.Finality, res.RejectedReason)
+				}
 				telemetry.MetricIntegrityViolation.WithLabelValues(
-					n.ProjectId(), u.VendorName(), n.Label(), u.Id(), methodLower, res.RejectedCheckID, "reject", res.Finality,
+					n.ProjectId(), u.VendorName(), n.Label(), u.Id(), methodLower, res.RejectedCheckID, rejectVerdict, res.Finality,
 				).Inc()
 				// Remember we caught a bad response (and which check); project.Forward
 				// then counts it as saved (a retry succeeded) or failed (no good
@@ -436,7 +448,7 @@ func annotateIntegritySpan(span trace.Span, res integrity.Result) {
 	if res.Err != nil {
 		outcome = "reject"
 	} else if len(res.Recorded) > 0 {
-		outcome = "soft_flag"
+		outcome = "record_only"
 	}
 	span.SetAttributes(
 		attribute.Int("integrity.checks", len(res.Outcomes)),
@@ -449,7 +461,7 @@ func annotateIntegritySpan(span trace.Span, res integrity.Result) {
 		return
 	}
 	for _, rec := range res.Recorded {
-		span.AddEvent("integrity.soft_flag", trace.WithAttributes(
+		span.AddEvent("integrity.record_only", trace.WithAttributes(
 			attribute.String("check", rec.CheckID),
 			attribute.String("reason", rec.Reason),
 		))

--- a/architecture/evm/integrity/autocorrect_test.go
+++ b/architecture/evm/integrity/autocorrect_test.go
@@ -1,0 +1,74 @@
+package integrity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// autoCorrectWhenPossible splits "seek a valid replacement" from "what to do
+// when none exists". The engine's share of the contract: a recordOnly verdict
+// under AutoCorrect must REJECT (so the failsafe hunts a replacement) while
+// marking the rejection FALLBACK-ELIGIBLE (so exhaustion serves the flagged
+// original instead of an error). Without AutoCorrect the verdict serves
+// immediately, corrected by nothing.
+
+func autocorrectValidate(t *testing.T, autoCorrect, observeOnly bool, override *Behavior) Result {
+	t.Helper()
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[` + observeFilter + `]}`))
+	jrr := common.MustNewJsonRpcResponseFromBytes([]byte("1"), []byte(observeBadLogs), nil)
+	rs := common.NewNormalizedResponse().WithRequest(req).WithJsonRpcResponse(jrr)
+	var params []any
+	require.NoError(t, common.SonicCfg.Unmarshal([]byte(`[`+observeFilter+`]`), &params))
+	cs := CheckSet{"getLogsFilterSanity": CheckConfig{Enabled: true, FailOverride: override}}
+	return Validate(context.Background(), Input{
+		Method:      "eth_getLogs",
+		Upstream:    common.NewFakeUpstream("u"),
+		Response:    rs,
+		Checks:      cs,
+		Params:      params,
+		Reorg:       rejectAll,
+		ObserveOnly: observeOnly,
+		AutoCorrect: autoCorrect,
+	})
+}
+
+func TestAutoCorrect_EscalatesRecordOnlyToRecoverableReject(t *testing.T) {
+	record := BehaviorRecord
+	res := autocorrectValidate(t, true, false, &record)
+	require.Error(t, res.Err, "AutoCorrect must reject so the failsafe hunts a replacement")
+	assert.True(t, common.HasErrorCode(res.Err, common.ErrCodeEndpointContentValidation))
+	assert.True(t, res.FallbackEligible, "the rejection must be fallback-eligible: exhaustion serves the original")
+	assert.Equal(t, "reject_recoverable", outcomeOf(res, "getLogsFilterSanity"))
+	assert.Equal(t, "getLogsFilterSanity", res.RejectedCheckID)
+	assert.NotEmpty(t, res.RejectedReason, "the fallback serve is recorded with the original violation reason")
+}
+
+func TestAutoCorrect_OffServesAndRecordsImmediately(t *testing.T) {
+	record := BehaviorRecord
+	res := autocorrectValidate(t, false, false, &record)
+	require.NoError(t, res.Err, "without AutoCorrect a recordOnly verdict serves immediately")
+	assert.False(t, res.FallbackEligible)
+	assert.Equal(t, "record_only", outcomeOf(res, "getLogsFilterSanity"))
+	require.Len(t, res.Recorded, 1)
+	assert.Equal(t, "record_only", res.Recorded[0].Verdict)
+}
+
+func TestAutoCorrect_HardRejectIsNeverFallbackEligible(t *testing.T) {
+	res := autocorrectValidate(t, true, false, nil) // deterministic default = hardReject
+	require.Error(t, res.Err)
+	assert.False(t, res.FallbackEligible, "a hardReject verdict must stay correct-or-die")
+	assert.Equal(t, "reject", outcomeOf(res, "getLogsFilterSanity"))
+}
+
+func TestAutoCorrect_ObserveOnlyStillOutranksEverything(t *testing.T) {
+	record := BehaviorRecord
+	res := autocorrectValidate(t, true, true, &record)
+	require.NoError(t, res.Err, "observe-only must never fail a request, AutoCorrect included")
+	assert.False(t, res.FallbackEligible)
+	assert.Equal(t, "record_only", outcomeOf(res, "getLogsFilterSanity"),
+		"a recordOnly verdict under observe records as record_only: even under enforcement it would have ended served (via fallback), so would_reject would overstate the enforcement cost")
+}

--- a/architecture/evm/integrity/engine.go
+++ b/architecture/evm/integrity/engine.go
@@ -29,6 +29,13 @@ type Input struct {
 	// recorded as "would_reject", but the response is always served. Absolute —
 	// it outranks a per-check onFailure and covers Deterministic checks too.
 	ObserveOnly bool
+	// AutoCorrect escalates a recordOnly verdict into a FALLBACK-ELIGIBLE
+	// rejection: the caller's failsafe machinery hunts a validated replacement,
+	// and only if every alternative is exhausted does the caller serve the
+	// flagged original (see Result.FallbackEligible). Without it a recordOnly
+	// violation serves the original immediately, corrected by nothing.
+	// ObserveOnly outranks this like it outranks everything else.
+	AutoCorrect bool
 }
 
 // Recorded is a reorg-sensitive mismatch that was observed but not rejected
@@ -40,10 +47,10 @@ type Recorded struct {
 	Class    FailureClass
 	Finality string // "finalized"/"unfinalized"/"unknown" — for the violation metric
 	// Verdict is the label this record carries in the violation metric/log:
-	// "soft_flag" (a reorg-sensitive mismatch served by policy) or
-	// "would_reject" (observe-only suppressed a real rejection). Distinguishing
-	// them is the point of observe mode — one is routine, the other is the
-	// enforcement cost estimate.
+	// "record_only" (a mismatch served by policy) or "would_reject"
+	// (observe-only suppressed a real rejection). Distinguishing them is the
+	// point of observe mode — one is routine, the other is the enforcement
+	// cost estimate.
 	Verdict string
 }
 
@@ -61,20 +68,31 @@ type Result struct {
 	// transient race, so it should not damage a score.
 	RejectedClass FailureClass
 	Finality      string // finality of the rejected block ("finalized"/"unfinalized"/"unknown"); "" if no reject
-	Recorded      []Recorded
-	Outcomes      []CheckOutcome
+	// FallbackEligible marks a rejection that AutoCorrect escalated from a
+	// recordOnly verdict: hunt a replacement, but if every alternative is
+	// exhausted the caller must serve the flagged original instead of an
+	// error. Never set for a hardReject verdict.
+	FallbackEligible bool
+	// RejectedReason is the violation text (meaningful only when Err != nil),
+	// so a fallback serve can be recorded with the original reason.
+	RejectedReason string
+	Recorded       []Recorded
+	Outcomes       []CheckOutcome
 }
 
 // CheckOutcome records what one check evaluation did. Outcome is one of:
 // "pass" (an actual verification ran and found no violation), "skip" (the
 // check could not evaluate this response — missing wiring, cold cache, data
 // not fully modeled; see Skipped), "reject" (failed, response rejected),
-// "soft_flag" (reorg-sensitive mismatch recorded but served), "reconfirmed"
-// (a pin-anchored mismatch cleared once the stale pin was re-confirmed
-// against a fresh canonical fetch — a reorg, not corruption; served),
-// "would_reject" (observe-only mode suppressed a rejection and served the
-// response anyway — the count is the client-facing cost enforcement would
-// incur), "off" (disabled for this finality or check).
+// "reject_recoverable" (a recordOnly verdict escalated by AutoCorrect: the
+// response is rejected so the failsafe hunts a replacement, but exhaustion
+// serves the flagged original instead of an error), "record_only" (mismatch
+// recorded but served, no correction sought), "reconfirmed" (a pin-anchored
+// mismatch cleared once the stale pin was re-confirmed against a fresh
+// canonical fetch — a reorg, not corruption; served), "would_reject"
+// (observe-only mode suppressed a rejection and served the response anyway —
+// the count is the client-facing cost enforcement would incur), "off"
+// (disabled for this finality or check).
 type CheckOutcome struct {
 	CheckID string
 	Outcome string
@@ -212,12 +230,29 @@ func Validate(ctx context.Context, in Input) Result {
 			res.Err = contentValidation(c, v, in.Upstream)
 			res.RejectedCheckID = c.ID
 			res.RejectedClass = c.Class
+			res.RejectedReason = v.Reason
 			res.Finality = fin.label(ctx, in, d)
 			return res
 		}
-		// soft-flag: surface the violation but still serve the response.
-		res.Outcomes = append(res.Outcomes, CheckOutcome{c.ID, "soft_flag"})
-		res.Recorded = append(res.Recorded, Recorded{CheckID: c.ID, Reason: v.Reason, Class: c.Class, Finality: fin.label(ctx, in, d), Verdict: "soft_flag"})
+		// recordOnly verdict. With AutoCorrect the violation still rejects —
+		// the failsafe machinery hunts a validated replacement — but the
+		// rejection is FALLBACK-ELIGIBLE: exhausting every alternative serves
+		// the flagged original instead of an error, so the client never pays
+		// for a mismatch that might be a benign reorg. ObserveOnly was handled
+		// above (a recordOnly verdict under observe is just a record).
+		if in.AutoCorrect && !in.ObserveOnly {
+			res.Outcomes = append(res.Outcomes, CheckOutcome{c.ID, "reject_recoverable"})
+			res.Err = contentValidation(c, v, in.Upstream)
+			res.RejectedCheckID = c.ID
+			res.RejectedClass = c.Class
+			res.RejectedReason = v.Reason
+			res.Finality = fin.label(ctx, in, d)
+			res.FallbackEligible = true
+			return res
+		}
+		// No correction wanted: surface the violation but serve the response.
+		res.Outcomes = append(res.Outcomes, CheckOutcome{c.ID, "record_only"})
+		res.Recorded = append(res.Recorded, Recorded{CheckID: c.ID, Reason: v.Reason, Class: c.Class, Finality: fin.label(ctx, in, d), Verdict: "record_only"})
 	}
 	return res
 }

--- a/architecture/evm/integrity/observe_only_test.go
+++ b/architecture/evm/integrity/observe_only_test.go
@@ -109,9 +109,9 @@ func TestObserveOnly(t *testing.T) {
 		res := validateBlockPolicy(t, blockResult("0x10", "0xnew", "0xparent"),
 			only("hashStability", nil), mockHistory{0x10: "0xold"}, DefaultReorgPolicy())
 		require.NoError(t, res.Err)
-		assert.Equal(t, "soft_flag", outcomeOf(res, "hashStability"))
+		assert.Equal(t, "record_only", outcomeOf(res, "hashStability"))
 		require.Len(t, res.Recorded, 1)
-		assert.Equal(t, "soft_flag", res.Recorded[0].Verdict)
+		assert.Equal(t, "record_only", res.Recorded[0].Verdict)
 	})
 
 	// Off must stay off: observe mode reports what enforcement WOULD do, so it
@@ -150,10 +150,10 @@ func TestObserveOnly_IsMarginalOverInvalidBehavior(t *testing.T) {
 		})
 	}
 	enforce, observe := run(false), run(true)
-	assert.Equal(t, "soft_flag", outcomeOf(enforce, "hashStability"))
-	assert.Equal(t, "soft_flag", outcomeOf(observe, "hashStability"),
+	assert.Equal(t, "record_only", outcomeOf(enforce, "hashStability"))
+	assert.Equal(t, "record_only", outcomeOf(observe, "hashStability"),
 		"a soft-flag must NOT be relabelled would_reject — otherwise would_reject overstates the enforcement cost")
 	require.Len(t, observe.Recorded, 1)
-	assert.Equal(t, "soft_flag", observe.Recorded[0].Verdict)
+	assert.Equal(t, "record_only", observe.Recorded[0].Verdict)
 	assert.NoError(t, enforce.Err, "already served under the policy, nothing for observe mode to suppress")
 }

--- a/architecture/evm/integrity/reconfirm_test.go
+++ b/architecture/evm/integrity/reconfirm_test.go
@@ -138,7 +138,7 @@ func TestReconfirm_RateLimitedPinNeverRejects(t *testing.T) {
 		res := validateBlockPolicy(t, blockResult("0x10", "0xhonest", "0xparent"), cs, hist, rejectAll)
 
 		assert.NoError(t, res.Err, "an unverified pin must not reject an honest response")
-		assert.Equal(t, "soft_flag", outcomeOf(res, "hashStability"))
+		assert.Equal(t, "record_only", outcomeOf(res, "hashStability"))
 		require.Len(t, res.Recorded, 1, "the mismatch must still be recorded, not swallowed")
 		assert.Equal(t, "hashStability", res.Recorded[0].CheckID)
 		assert.Equal(t, 1, hist.calls)
@@ -152,7 +152,7 @@ func TestReconfirm_RateLimitedPinNeverRejects(t *testing.T) {
 		for i := 0; i < 24; i++ {
 			res := validateBlockPolicy(t, blockResult("0x10", "0xhonest", "0xparent"), cs, hist, rejectAll)
 			require.NoErrorf(t, res.Err, "request %d was rejected on an unverified pin", i)
-			require.Equal(t, "soft_flag", outcomeOf(res, "hashStability"))
+			require.Equal(t, "record_only", outcomeOf(res, "hashStability"))
 		}
 		assert.Equal(t, 24, hist.calls)
 	})
@@ -162,7 +162,7 @@ func TestReconfirm_RateLimitedPinNeverRejects(t *testing.T) {
 		policy := ReorgPolicy{Finalized: BehaviorRecord, Unfinalized: BehaviorRecord}
 		res := validateBlockPolicy(t, blockResult("0x10", "0xhonest", "0xparent"), cs, hist, policy)
 		assert.NoError(t, res.Err)
-		assert.Equal(t, "soft_flag", outcomeOf(res, "hashStability"))
+		assert.Equal(t, "record_only", outcomeOf(res, "hashStability"))
 	})
 
 	t.Run("a fresh reconfirm still rejects a genuine mismatch", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestReconfirm_RateLimitedPinNeverRejects(t *testing.T) {
 		}
 		res := validateBlockPolicy(t, blockResult("0x11", "0xchild", "0xrealparent"), only("parentHashLinkage", nil), hist, rejectAll)
 		assert.NoError(t, res.Err)
-		assert.Equal(t, "soft_flag", outcomeOf(res, "parentHashLinkage"))
+		assert.Equal(t, "record_only", outcomeOf(res, "parentHashLinkage"))
 	})
 }
 

--- a/architecture/evm/integrity_config.go
+++ b/architecture/evm/integrity_config.go
@@ -72,10 +72,10 @@ func applyCheckOverride(cs integrity.CheckSet, id string, oc *common.IntegrityCh
 // resolveIntegrity computes the effective CheckSet and ReorgPolicy for a request.
 // The network's integrity config is the single source: its level/profiles plus
 // the per-request header selector. With no config, nothing runs (opt-in).
-func resolveIntegrity(n common.Network, dirs *common.RequestDirectives) (integrity.CheckSet, integrity.ReorgPolicy, bool) {
+func resolveIntegrity(n common.Network, dirs *common.RequestDirectives) (integrity.CheckSet, integrity.ReorgPolicy, bool, bool) {
 	// Opt-in: with no integrity config, nothing runs.
 	if n == nil || n.Config() == nil || n.Config().Integrity == nil {
-		return nil, integrity.ReorgPolicy{}, false
+		return nil, integrity.ReorgPolicy{}, false, false
 	}
 	selector := ""
 	if dirs != nil {
@@ -88,7 +88,10 @@ func resolveIntegrity(n common.Network, dirs *common.RequestDirectives) (integri
 	settings := resolveRequestSettings(n.Config().Integrity, selector)
 	cs, policy := compileIntegritySettings(settings, chainId)
 	observeOnly := settings != nil && settings.ObserveOnly != nil && *settings.ObserveOnly
-	return cs, policy, observeOnly
+	// Default TRUE: a violation hunts for a validated replacement unless the
+	// operator explicitly opts out.
+	autoCorrect := settings == nil || settings.AutoCorrectWhenPossible == nil || *settings.AutoCorrectWhenPossible
+	return cs, policy, observeOnly, autoCorrect
 }
 
 // resolveRequestSettings computes the effective settings for one request: the
@@ -135,6 +138,9 @@ func overlaySettings(base, over *common.IntegritySettings) {
 	if over.InvalidBehavior != nil {
 		base.InvalidBehavior = over.InvalidBehavior.Copy()
 	}
+	if over.AutoCorrectWhenPossible != nil {
+		base.AutoCorrectWhenPossible = over.AutoCorrectWhenPossible
+	}
 	for id, c := range over.Checks {
 		if base.Checks == nil {
 			base.Checks = make(map[string]*common.IntegrityCheckConfig, len(over.Checks))
@@ -151,16 +157,16 @@ func isIntegrityLevel(s string) bool {
 	return false
 }
 
-// parseBehavior maps the config/header vocabulary (reject | soft-flag | off) to
-// an engine Behavior. ok=false when the string is empty/unrecognized so callers
-// keep their default.
+// parseBehavior maps the config/header vocabulary (recordOnly | hardReject |
+// off — exactly these, validated loudly at load) to an engine Behavior.
+// ok=false when the string is empty/unrecognized so callers keep their default.
 func parseBehavior(s string) (integrity.Behavior, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "reject", "error", "hard-fail":
+	case "hardreject":
 		return integrity.BehaviorError, true
-	case "soft-flag", "softflag", "record", "warn":
+	case "recordonly":
 		return integrity.BehaviorRecord, true
-	case "off", "ignore", "none":
+	case "off":
 		return integrity.BehaviorIgnore, true
 	default:
 		return integrity.BehaviorError, false

--- a/architecture/evm/integrity_config_test.go
+++ b/architecture/evm/integrity_config_test.go
@@ -53,7 +53,7 @@ func TestCompileIntegritySettings(t *testing.T) {
 	t.Run("invalidBehavior maps to the reorg policy", func(t *testing.T) {
 		_, p := compileIntegritySettings(&common.IntegritySettings{
 			Level:           "authoritative",
-			InvalidBehavior: &common.IntegrityInvalidBehaviorConfig{Finalized: "reject", Unfinalized: "off"},
+			InvalidBehavior: &common.IntegrityInvalidBehaviorConfig{Finalized: "hardReject", Unfinalized: "off"},
 		}, 0)
 		assert.Equal(t, integrity.BehaviorError, p.Finalized)
 		assert.Equal(t, integrity.BehaviorIgnore, p.Unfinalized)
@@ -62,7 +62,7 @@ func TestCompileIntegritySettings(t *testing.T) {
 	t.Run("per-check onFailure becomes a fail override", func(t *testing.T) {
 		cs, _ := compileIntegritySettings(&common.IntegritySettings{
 			Level:  "intrinsic",
-			Checks: map[string]*common.IntegrityCheckConfig{"bloomMatch": {OnFailure: "soft-flag"}},
+			Checks: map[string]*common.IntegrityCheckConfig{"bloomMatch": {OnFailure: "recordOnly"}},
 		}, 0)
 		require.NotNil(t, cs.For("bloomMatch").FailOverride)
 		assert.Equal(t, integrity.BehaviorRecord, *cs.For("bloomMatch").FailOverride)
@@ -108,8 +108,8 @@ func TestParseBehavior(t *testing.T) {
 		want integrity.Behavior
 		ok   bool
 	}{
-		"reject":    {integrity.BehaviorError, true},
-		"soft-flag": {integrity.BehaviorRecord, true},
+		"hardReject":    {integrity.BehaviorError, true},
+		"recordOnly": {integrity.BehaviorRecord, true},
 		"off":       {integrity.BehaviorIgnore, true},
 		"":          {integrity.BehaviorError, false},
 		"nonsense":  {integrity.BehaviorError, false},

--- a/architecture/evm/integrity_config_vocab_test.go
+++ b/architecture/evm/integrity_config_vocab_test.go
@@ -12,7 +12,7 @@ import (
 // vocabulary the runtime (parseBehavior) understands — otherwise validation
 // either rejects working configs or lets a silently-ignored value through.
 func TestIntegrityBehaviorVocabMatchesValidation(t *testing.T) {
-	accepted := []string{"reject", "error", "hard-fail", "soft-flag", "softflag", "record", "warn", "off", "ignore", "none", " Reject "}
+	accepted := []string{"recordOnly", "hardReject", "off", " RecordOnly ", "HARDREJECT"}
 	for _, v := range accepted {
 		_, ok := parseBehavior(v)
 		require.True(t, ok, "runtime must parse %q", v)
@@ -21,7 +21,9 @@ func TestIntegrityBehaviorVocabMatchesValidation(t *testing.T) {
 		}}
 		assert.NoError(t, cfg.Validate(), "validation must accept %q (runtime parses it)", v)
 	}
-	for _, v := range []string{"rejct", "soft flag", "flag", "true"} {
+	// The pre-release vocabulary is deliberately DEAD — it must fail loudly,
+	// never alias silently.
+	for _, v := range []string{"reject", "error", "hard-fail", "soft-flag", "softflag", "record", "warn", "ignore", "none", "rejct", "soft flag", "flag", "true"} {
 		_, ok := parseBehavior(v)
 		require.False(t, ok, "runtime must NOT parse %q", v)
 		cfg := &common.IntegrityConfig{IntegritySettings: common.IntegritySettings{

--- a/architecture/evm/integrity_export.go
+++ b/architecture/evm/integrity_export.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Integrity catches (rejects and soft-flags) are rare and each one is
+// Integrity catches (rejects, record-only flags, fallback serves) are rare and each one is
 // forensic gold: metrics carry the counts, this archive carries the WHAT —
 // upstream, check, verbatim reason, and the offending response body — as
 // durable JSONL via integrity.misbehaviorsDestination (same file/S3 shape as
@@ -52,7 +52,7 @@ type integrityCatchRecord struct {
 	Method    string `json:"method"`
 	Check     string `json:"check"`
 	Class     string `json:"class"`
-	Verdict   string `json:"verdict"` // reject | soft_flag
+	Verdict   string `json:"verdict"` // reject | record_only | would_reject | served_fallback
 	Finality  string `json:"finality"`
 	Reason    string `json:"reason"`
 	Response  string `json:"response,omitempty"`

--- a/architecture/evm/integrity_export_test.go
+++ b/architecture/evm/integrity_export_test.go
@@ -51,7 +51,7 @@ func TestExportIntegrityCatch_WritesJSONL(t *testing.T) {
 
 // An empty-response record marshals cleanly (response omitted, not "").
 func TestIntegrityCatchRecord_MarshalOmitsEmptyResponse(t *testing.T) {
-	line, err := common.SonicCfg.Marshal(integrityCatchRecord{Check: "x", Verdict: "soft_flag"})
+	line, err := common.SonicCfg.Marshal(integrityCatchRecord{Check: "x", Verdict: "record_only"})
 	require.NoError(t, err)
 	assert.NotContains(t, string(line), `"response"`)
 }

--- a/common/config_integrity.go
+++ b/common/config_integrity.go
@@ -22,9 +22,24 @@ type IntegritySettings struct {
 	Checks map[string]*IntegrityCheckConfig `yaml:"checks,omitempty" json:"checks,omitempty"`
 	// Budget caps the canonical force-fetches the authoritative tier issues.
 	Budget *IntegrityBudgetConfig `yaml:"budget,omitempty" json:"budget,omitempty"`
+	// AutoCorrectWhenPossible controls whether a violation triggers a hunt for a
+	// validated replacement (retry/hedge against other upstreams) BEFORE the
+	// InvalidBehavior verdict applies. Default TRUE (nil = true). The two knobs
+	// are orthogonal on purpose:
+	//
+	//   autoCorrectWhenPossible | invalidBehavior | on violation
+	//   ------------------------+-----------------+---------------------------------
+	//   true                    | recordOnly      | seek replacement; serve it if one
+	//                           |                 | validates; exhausted -> serve the
+	//                           |                 | flagged ORIGINAL (never an error)
+	//   true                    | hardReject      | seek replacement; exhausted -> error
+	//   false                   | recordOnly      | serve original immediately + record
+	//   false                   | hardReject      | fail immediately, no alternates
+	AutoCorrectWhenPossible *bool `yaml:"autoCorrectWhenPossible,omitempty" json:"autoCorrectWhenPossible,omitempty"`
 	// InvalidBehavior is the per-finality verdict for reorg-sensitive checks,
-	// where invalid data is ambiguously a node bug or a reorg. Deterministic
-	// checks ignore it and always reject.
+	// where invalid data is ambiguously a node bug or a reorg: recordOnly |
+	// hardReject | off. Deterministic checks ignore it and always hardReject
+	// (override per check via checks.<id>.onFailure).
 	InvalidBehavior *IntegrityInvalidBehaviorConfig `yaml:"invalidBehavior,omitempty" json:"invalidBehavior,omitempty"`
 	// ReorgWindow is how many blocks back from the tip the integrity ChainView
 	// keeps a number→hash pin + header and tracks reorgs (default 32). Raise for
@@ -144,7 +159,7 @@ type IntegrityCheckConfig struct {
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Params are check-specific knobs (e.g. bloom equality-vs-superset).
 	Params map[string]string `yaml:"params,omitempty" json:"params,omitempty"`
-	// OnFailure overrides this check's failure mode: reject | soft-flag.
+	// OnFailure overrides this check's failure mode: recordOnly | hardReject.
 	OnFailure string `yaml:"onFailure,omitempty" json:"onFailure,omitempty"`
 }
 
@@ -155,8 +170,9 @@ type IntegrityBudgetConfig struct {
 }
 
 // IntegrityInvalidBehaviorConfig is the per-finality verdict for reorg-sensitive
-// checks: reject | soft-flag | off, split by whether the response's block is
-// finalized.
+// checks: recordOnly | hardReject | off, split by whether the response's block
+// is finalized. The verdict describes what happens when no valid answer is
+// obtainable; whether a replacement is sought first is AutoCorrectWhenPossible.
 type IntegrityInvalidBehaviorConfig struct {
 	Finalized   string `yaml:"finalized,omitempty" json:"finalized,omitempty"`
 	Unfinalized string `yaml:"unfinalized,omitempty" json:"unfinalized,omitempty"`
@@ -196,6 +212,9 @@ func MergeIntegrityConfig(base, over *IntegrityConfig) *IntegrityConfig {
 	if over.ObserveOnly != nil {
 		out.ObserveOnly = over.ObserveOnly
 	}
+	if over.AutoCorrectWhenPossible != nil {
+		out.AutoCorrectWhenPossible = over.AutoCorrectWhenPossible
+	}
 	if over.MisbehaviorsDestination != nil {
 		out.MisbehaviorsDestination = over.MisbehaviorsDestination
 	}
@@ -225,13 +244,14 @@ func (c *IntegritySettings) Copy() *IntegritySettings {
 		return nil
 	}
 	copied := &IntegritySettings{
-		Level:           c.Level,
-		Budget:          c.Budget.Copy(),
-		InvalidBehavior: c.InvalidBehavior.Copy(),
-		ReorgWindow:     c.ReorgWindow,
-		ObserveOnly:     c.ObserveOnly,
-		Follow:          c.Follow.Copy(),
-		StateProbe:      c.StateProbe.Copy(),
+		Level:                   c.Level,
+		Budget:                  c.Budget.Copy(),
+		InvalidBehavior:         c.InvalidBehavior.Copy(),
+		ReorgWindow:             c.ReorgWindow,
+		ObserveOnly:             c.ObserveOnly,
+		AutoCorrectWhenPossible: c.AutoCorrectWhenPossible,
+		Follow:                  c.Follow.Copy(),
+		StateProbe:              c.StateProbe.Copy(),
 		// Shared, not deep-copied: destination configs are read-only after load.
 		MisbehaviorsDestination: c.MisbehaviorsDestination,
 	}

--- a/common/config_integrity_test.go
+++ b/common/config_integrity_test.go
@@ -16,12 +16,12 @@ budget:
   maxPerSecond: 50
   maxConcurrent: 8
 invalidBehavior:
-  finalized: reject
-  unfinalized: soft-flag
+  finalized: hardReject
+  unfinalized: recordOnly
 checks:
   receiptVsBlock:
     enabled: true
-    onFailure: reject
+    onFailure: hardReject
   bloomMatch:
     params:
       mode: superset
@@ -29,8 +29,8 @@ profiles:
   strict:
     level: authoritative
     invalidBehavior:
-      finalized: reject
-      unfinalized: reject
+      finalized: hardReject
+      unfinalized: hardReject
 `
 	var cfg IntegrityConfig
 	require.NoError(t, yaml.Unmarshal([]byte(src), &cfg))
@@ -44,19 +44,19 @@ profiles:
 	assert.Equal(t, 8, cfg.Budget.MaxConcurrent)
 
 	require.NotNil(t, cfg.InvalidBehavior)
-	assert.Equal(t, "reject", cfg.InvalidBehavior.Finalized)
-	assert.Equal(t, "soft-flag", cfg.InvalidBehavior.Unfinalized)
+	assert.Equal(t, "hardReject", cfg.InvalidBehavior.Finalized)
+	assert.Equal(t, "recordOnly", cfg.InvalidBehavior.Unfinalized)
 
 	require.Contains(t, cfg.Checks, "receiptVsBlock")
 	require.NotNil(t, cfg.Checks["receiptVsBlock"].Enabled)
 	assert.True(t, *cfg.Checks["receiptVsBlock"].Enabled)
-	assert.Equal(t, "reject", cfg.Checks["receiptVsBlock"].OnFailure)
+	assert.Equal(t, "hardReject", cfg.Checks["receiptVsBlock"].OnFailure)
 	assert.Equal(t, "superset", cfg.Checks["bloomMatch"].Params["mode"])
 
 	require.Contains(t, cfg.Profiles, "strict")
 	assert.Equal(t, "authoritative", cfg.Profiles["strict"].Level)
 	require.NotNil(t, cfg.Profiles["strict"].InvalidBehavior)
-	assert.Equal(t, "reject", cfg.Profiles["strict"].InvalidBehavior.Unfinalized)
+	assert.Equal(t, "hardReject", cfg.Profiles["strict"].InvalidBehavior.Unfinalized)
 }
 
 func TestMergeIntegrityConfig(t *testing.T) {
@@ -99,7 +99,7 @@ func TestIntegrityConfig_CopyIsDeep(t *testing.T) {
 			Level:           "authoritative",
 			Checks:          map[string]*IntegrityCheckConfig{"x": {Enabled: &tru, Params: map[string]string{"a": "b"}}},
 			Budget:          &IntegrityBudgetConfig{MaxPerSecond: 10},
-			InvalidBehavior: &IntegrityInvalidBehaviorConfig{Finalized: "reject", Unfinalized: "soft-flag"},
+			InvalidBehavior: &IntegrityInvalidBehaviorConfig{Finalized: "hardReject", Unfinalized: "recordOnly"},
 		},
 		HeaderMode: "full",
 		Profiles:   map[string]*IntegritySettings{"p": {Level: "intrinsic"}},
@@ -119,7 +119,7 @@ func TestIntegrityConfig_CopyIsDeep(t *testing.T) {
 	assert.True(t, *cp.Checks["x"].Enabled)
 	assert.Equal(t, "b", cp.Checks["x"].Params["a"])
 	assert.Equal(t, 10, cp.Budget.MaxPerSecond)
-	assert.Equal(t, "reject", cp.InvalidBehavior.Finalized)
+	assert.Equal(t, "hardReject", cp.InvalidBehavior.Finalized)
 	assert.Equal(t, "intrinsic", cp.Profiles["p"].Level)
 }
 

--- a/common/request.go
+++ b/common/request.go
@@ -241,6 +241,11 @@ type NormalizedRequest struct {
 	integrityCaught        atomic.Bool  // an integrity check rejected a response during this request
 	integrityRejectedCheck    atomic.Value // id of the last check that rejected (the "why")
 	integrityRejectedFinality atomic.Value // finality of the last rejected block (for saved/failed metric)
+	// integrityFallback holds the newest FALLBACK-ELIGIBLE original: a response
+	// a recordOnly verdict flagged, escalated to a rejection only so the
+	// failsafe could hunt a validated replacement. If the hunt exhausts,
+	// project.Forward serves this instead of an error.
+	integrityFallback atomic.Pointer[IntegrityFallback]
 	integrityOverheadNs       atomic.Int64 // ns the request waited on integrity checks + aux force-fetches
 	lastUpstream           atomic.Value
 	evmBlockRef            atomic.Value
@@ -456,6 +461,37 @@ func (r *NormalizedRequest) MarkIntegrityCaught(checkID, finality string) {
 // response during this request.
 func (r *NormalizedRequest) IntegrityCaught() bool {
 	return r != nil && r.integrityCaught.Load()
+}
+
+// IntegrityFallback is a flagged-but-serveable original response stashed by a
+// fallback-eligible integrity rejection (recordOnly verdict escalated by
+// autoCorrectWhenPossible), plus the violation metadata a fallback serve is
+// recorded with.
+type IntegrityFallback struct {
+	Response *NormalizedResponse
+	CheckID  string
+	Finality string
+	Reason   string
+}
+
+// SetIntegrityFallbackResponse stashes resp as the fallback to serve if no
+// upstream produces a validated replacement. The newest stash wins: every
+// eligible original satisfies the recordOnly policy equally, and the newest
+// is the most likely to be post-reorg.
+func (r *NormalizedRequest) SetIntegrityFallbackResponse(resp *NormalizedResponse, checkID, finality, reason string) {
+	if r == nil || resp == nil {
+		return
+	}
+	r.integrityFallback.Store(&IntegrityFallback{Response: resp, CheckID: checkID, Finality: finality, Reason: reason})
+}
+
+// TakeIntegrityFallbackResponse returns the stashed fallback (nil if none) and
+// clears the slot so a fallback is served at most once.
+func (r *NormalizedRequest) TakeIntegrityFallbackResponse() *IntegrityFallback {
+	if r == nil {
+		return nil
+	}
+	return r.integrityFallback.Swap(nil)
 }
 
 // IntegrityRejectedCheck returns the id of the last integrity check that

--- a/common/request_integrity_fallback_test.go
+++ b/common/request_integrity_fallback_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrityFallbackStash(t *testing.T) {
+	rq := NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[]}`))
+
+	assert.Nil(t, rq.TakeIntegrityFallbackResponse(), "empty stash yields nil")
+
+	r1 := NewNormalizedResponse().WithRequest(rq)
+	r2 := NewNormalizedResponse().WithRequest(rq)
+	rq.SetIntegrityFallbackResponse(r1, "checkA", "unfinalized", "first")
+	rq.SetIntegrityFallbackResponse(r2, "checkB", "unfinalized", "second")
+
+	fb := rq.TakeIntegrityFallbackResponse()
+	require.NotNil(t, fb)
+	assert.Same(t, r2, fb.Response, "the NEWEST eligible original wins")
+	assert.Equal(t, "checkB", fb.CheckID)
+	assert.Equal(t, "second", fb.Reason)
+
+	assert.Nil(t, rq.TakeIntegrityFallbackResponse(), "take clears the slot: a fallback serves at most once")
+
+	rq.SetIntegrityFallbackResponse(nil, "checkC", "finalized", "nil response ignored")
+	assert.Nil(t, rq.TakeIntegrityFallbackResponse(), "a nil response never stashes")
+}

--- a/common/validation.go
+++ b/common/validation.go
@@ -1698,10 +1698,12 @@ func RegisterIntegrityCheckID(id string) { integrityCheckIDs[id] = struct{}{} }
 
 // isIntegrityBehavior mirrors the runtime behavior vocabulary (evm
 // parseBehavior): unrecognized values are silently ignored at runtime, so the
-// only place a typo can be caught is here.
+// only place a typo can be caught is here. The vocabulary is EXACTLY
+// recordOnly | hardReject | off — the pre-release reject/soft-flag words are
+// deliberately NOT accepted (fail loudly, no silent aliasing).
 func isIntegrityBehavior(s string) bool {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "reject", "error", "hard-fail", "soft-flag", "softflag", "record", "warn", "off", "ignore", "none":
+	case "recordonly", "hardreject", "off":
 		return true
 	}
 	return false
@@ -1755,15 +1757,15 @@ func (s *IntegritySettings) validate() error {
 			}
 		}
 		if oc != nil && oc.OnFailure != "" && !isIntegrityBehavior(oc.OnFailure) {
-			return fmt.Errorf("integrity.checks.%s.onFailure '%s' is invalid (an unknown value silently keeps the default), must be one of: reject | soft-flag | off", id, oc.OnFailure)
+			return fmt.Errorf("integrity.checks.%s.onFailure '%s' is invalid (an unknown value silently keeps the default), must be one of: recordOnly | hardReject | off", id, oc.OnFailure)
 		}
 	}
 	if ib := s.InvalidBehavior; ib != nil {
 		if ib.Finalized != "" && !isIntegrityBehavior(ib.Finalized) {
-			return fmt.Errorf("integrity.invalidBehavior.finalized '%s' is invalid (an unknown value silently keeps the default), must be one of: reject | soft-flag | off", ib.Finalized)
+			return fmt.Errorf("integrity.invalidBehavior.finalized '%s' is invalid (an unknown value silently keeps the default), must be one of: recordOnly | hardReject | off", ib.Finalized)
 		}
 		if ib.Unfinalized != "" && !isIntegrityBehavior(ib.Unfinalized) {
-			return fmt.Errorf("integrity.invalidBehavior.unfinalized '%s' is invalid (an unknown value silently keeps the default), must be one of: reject | soft-flag | off", ib.Unfinalized)
+			return fmt.Errorf("integrity.invalidBehavior.unfinalized '%s' is invalid (an unknown value silently keeps the default), must be one of: recordOnly | hardReject | off", ib.Unfinalized)
 		}
 	}
 	if b := s.Budget; b != nil && (b.MaxPerSecond < 0 || b.MaxConcurrent < 0) {

--- a/common/validation_integrity_test.go
+++ b/common/validation_integrity_test.go
@@ -27,9 +27,9 @@ func TestIntegrityConfigValidate(t *testing.T) {
 			IntegritySettings: IntegritySettings{
 				Level: "authoritative",
 				Checks: map[string]*IntegrityCheckConfig{
-					"receiptVsBlock": {Enabled: boolPtr(true), OnFailure: "soft-flag"},
+					"receiptVsBlock": {Enabled: boolPtr(true), OnFailure: "recordOnly"},
 				},
-				InvalidBehavior: &IntegrityInvalidBehaviorConfig{Finalized: "reject", Unfinalized: "soft-flag"},
+				InvalidBehavior: &IntegrityInvalidBehaviorConfig{Finalized: "hardReject", Unfinalized: "recordOnly"},
 				Budget:          &IntegrityBudgetConfig{MaxPerSecond: 50, MaxConcurrent: 8},
 				ReorgWindow:     256,
 			},
@@ -63,7 +63,7 @@ func TestIntegrityConfigValidate(t *testing.T) {
 
 	t.Run("unknown onFailure rejected", func(t *testing.T) {
 		c := &IntegrityConfig{IntegritySettings: IntegritySettings{
-			Checks: map[string]*IntegrityCheckConfig{"hashStability": {OnFailure: "soft_flagg"}},
+			Checks: map[string]*IntegrityCheckConfig{"hashStability": {OnFailure: "recordOnlyy"}},
 		}}
 		require.Error(t, c.Validate())
 	})

--- a/docs/pages/config/failsafe/integrity.mdx
+++ b/docs/pages/config/failsafe/integrity.mdx
@@ -90,7 +90,7 @@ non-standard encoding). Reference: https://docs.erpc.cloud/config/failsafe/integ
 	prompt={`I want the strongest data-integrity guarantees on my mainnet network, including
 force-fetching the canonical block to corroborate single receipts. Set integrity level
 to authoritative with a sensible budget, and explain the per-finality invalidBehavior
-(reject on finalized, soft-flag on unfinalized). Reference:
+(hardReject on finalized, recordOnly on unfinalized) and autoCorrectWhenPossible. Reference:
 https://docs.erpc.cloud/config/failsafe/integrity.llms.txt`}
 />
 
@@ -200,16 +200,21 @@ One knob picks a preset over the check catalog. Each level is a superset of the 
 	yaml={`integrity:
   level: authoritative              # off | intrinsic | corroborated | authoritative
 
-  # Per-finality verdict for the reorg-sensitive checks only. At the tip you can't
-  # tell a node bug from a reorg, so unfinalized mismatches are recorded, not rejected.
+  # Whether a violation hunts for a validated replacement (retry other
+  # upstreams) BEFORE the invalidBehavior verdict applies. Default true.
+  autoCorrectWhenPossible: true
+
+  # Per-finality verdict for the reorg-sensitive checks only — what happens
+  # when no valid answer is obtainable. At the tip you can't tell a node bug
+  # from a reorg, so unfinalized mismatches are recorded, not rejected.
   invalidBehavior:
-    finalized: reject               # reject | soft-flag | off
-    unfinalized: soft-flag
+    finalized: hardReject           # recordOnly | hardReject | off
+    unfinalized: recordOnly
 
   # Override individual checks by id (enable / disable / params / onFailure).
   checks:
     receiptVsBlock: { enabled: false }          # drop one authoritative check
-    bloomMatch:     { onFailure: soft-flag }     # record instead of reject
+    bloomMatch:     { onFailure: recordOnly }    # record instead of reject
     txHashUniqueness: { params: { strict: "true" } }  # the one check with a param
 
   # Cost cap on the canonical force-fetches the authoritative tier issues.
@@ -218,10 +223,11 @@ One knob picks a preset over the check catalog. Each level is a superset of the 
     maxConcurrent: 8`}
 	ts={`integrity: {
   level: "authoritative",
-  invalidBehavior: { finalized: "reject", unfinalized: "soft-flag" },
+  autoCorrectWhenPossible: true,
+  invalidBehavior: { finalized: "hardReject", unfinalized: "recordOnly" },
   checks: {
     receiptVsBlock: { enabled: false },
-    bloomMatch: { onFailure: "soft-flag" },
+    bloomMatch: { onFailure: "recordOnly" },
     txHashUniqueness: { params: { strict: "true" } },
   },
   budget: { maxPerSecond: 50, maxConcurrent: 8 },
@@ -280,8 +286,24 @@ they always reject. A handful are **reorg-sensitive** (`parentHashLinkage`,
 tip a disagreement may be a benign reorg rather than a bug. `invalidBehavior` decides
 what to do for those, by the block's finality (read from the upstream state poller):
 
-- `finalized` → default `reject` (a finalized block can't reorg; a mismatch is corruption).
-- `unfinalized` → default `soft-flag` (record a metric/log, still serve — it may be a reorg). `off` skips the check (and any force-fetch) on the hot tip entirely.
+- `finalized` → default `hardReject` (a finalized block can't reorg; a mismatch is corruption).
+- `unfinalized` → default `recordOnly` (record a metric/log, still serve — it may be a reorg). `off` skips the check (and any force-fetch) on the hot tip entirely.
+
+The verdict is only half the policy. **`autoCorrectWhenPossible`** (default `true`)
+decides whether a violation first hunts for a **validated replacement** — the
+rejection routes the request to another upstream, whose response runs the same
+checks. The two knobs compose:
+
+| `autoCorrectWhenPossible` | verdict | on violation |
+|---|---|---|
+| `true` | `recordOnly` | seek a replacement; serve it if one validates; **exhausted → serve the flagged original** (never a client error; counted in `erpc_integrity_fallback_served_total`) |
+| `true` | `hardReject` | seek a replacement; exhausted → error (correct-or-die) |
+| `false` | `recordOnly` | serve the original immediately + record; no correction attempted |
+| `false` | `hardReject` | fail immediately; no alternates tried |
+
+The vocabulary is exactly `recordOnly | hardReject | off` — anything else
+(including the pre-release `reject`/`soft-flag` words) fails config validation
+loudly rather than aliasing silently.
 
 ### Rolling out safely: `observeOnly`
 

--- a/erpc/projects.go
+++ b/erpc/projects.go
@@ -277,6 +277,26 @@ func (p *PreparedProject) Forward(ctx context.Context, networkId string, nq *com
 		).Observe(dur.Seconds())
 		return resp, err
 	} else {
+		// FALLBACK SERVE: a fallback-eligible rejection (recordOnly verdict
+		// escalated by autoCorrectWhenPossible) hunted a validated replacement
+		// and found none. The policy's promise is that the client never pays
+		// an error for such a mismatch — serve the flagged original, recorded
+		// loudly. Deliberately checked before any error classification: ANY
+		// terminal failure while a stash exists is strictly worse for the
+		// client than the stashed answer the policy already deemed serveable.
+		if fb := nq.TakeIntegrityFallbackResponse(); fb != nil && fb.Response != nil {
+			telemetry.MetricIntegrityFallbackServed.WithLabelValues(
+				p.Config.Id, network.Label(), method, fb.CheckID, fb.Finality,
+			).Inc()
+			lg.Warn().
+				Str("check", fb.CheckID).
+				Str("finality", fb.Finality).
+				Str("reason", fb.Reason).
+				Err(err).
+				Msg("integrity: no validated replacement found — serving the flagged original (recordOnly policy)")
+			fb.Response.SetDuration(time.Since(start))
+			return fb.Response, nil
+		}
 		// Failed due to integrity: a check rejected a response and no good one was
 		// found (every candidate failed), so the request errored rather than serving
 		// bad data. The rejecting check is the "why".

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -484,6 +484,19 @@ var (
 		Help:      "Total requests that failed toward the user due to integrity (a check rejected and no good response was found), by the rejecting check and target-block finality (finalized/unfinalized/unknown).",
 	}, []string{"project", "network", "category", "check", "finality"})
 
+	// MetricIntegrityFallbackServed counts requests where a fallback-eligible
+	// rejection (recordOnly verdict escalated by autoCorrectWhenPossible)
+	// hunted a validated replacement, found none, and served the flagged
+	// original instead of an error. The count is the residual "suspect data
+	// served" volume — zero is the goal; a persistent rate on one check is
+	// the same protocol-invalid signature MetricIntegrityProtocolSuspect
+	// tracks for hard failures.
+	MetricIntegrityFallbackServed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "integrity_fallback_served_total",
+		Help:      "Total requests where no validated replacement was found and the flagged original was served (recordOnly policy with autoCorrectWhenPossible), by the rejecting check and target-block finality.",
+	}, []string{"project", "network", "category", "check", "finality"})
+
 	// MetricIntegrityProtocolSuspect counts times a (network, check) pair showed
 	// the ALL-UPSTREAM signature: repeated request failures where that check
 	// rejected and no upstream produced an acceptable response. A check that

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -1988,9 +1988,25 @@ export interface IntegritySettings {
    */
   budget?: IntegrityBudgetConfig;
   /**
+   * AutoCorrectWhenPossible controls whether a violation triggers a hunt for a
+   * validated replacement (retry/hedge against other upstreams) BEFORE the
+   * InvalidBehavior verdict applies. Default TRUE (nil = true). The two knobs
+   * are orthogonal on purpose:
+   *   autoCorrectWhenPossible | invalidBehavior | on violation
+   *   ------------------------+-----------------+---------------------------------
+   *   true                    | recordOnly      | seek replacement; serve it if one
+   *                           |                 | validates; exhausted -> serve the
+   *                           |                 | flagged ORIGINAL (never an error)
+   *   true                    | hardReject      | seek replacement; exhausted -> error
+   *   false                   | recordOnly      | serve original immediately + record
+   *   false                   | hardReject      | fail immediately, no alternates
+   */
+  autoCorrectWhenPossible?: boolean;
+  /**
    * InvalidBehavior is the per-finality verdict for reorg-sensitive checks,
-   * where invalid data is ambiguously a node bug or a reorg. Deterministic
-   * checks ignore it and always reject.
+   * where invalid data is ambiguously a node bug or a reorg: recordOnly |
+   * hardReject | off. Deterministic checks ignore it and always hardReject
+   * (override per check via checks.<id>.onFailure).
    */
   invalidBehavior?: IntegrityInvalidBehaviorConfig;
   /**
@@ -2109,7 +2125,7 @@ export interface IntegrityCheckConfig {
    */
   params?: { [key: string]: string};
   /**
-   * OnFailure overrides this check's failure mode: reject | soft-flag.
+   * OnFailure overrides this check's failure mode: recordOnly | hardReject.
    */
   onFailure?: string;
 }
@@ -2122,8 +2138,9 @@ export interface IntegrityBudgetConfig {
 }
 /**
  * IntegrityInvalidBehaviorConfig is the per-finality verdict for reorg-sensitive
- * checks: reject | soft-flag | off, split by whether the response's block is
- * finalized.
+ * checks: recordOnly | hardReject | off, split by whether the response's block
+ * is finalized. The verdict describes what happens when no valid answer is
+ * obtainable; whether a replacement is sought first is AutoCorrectWhenPossible.
  */
 export interface IntegrityInvalidBehaviorConfig {
   finalized?: string;


### PR DESCRIPTION
## Why

`invalidBehavior` conflated two independent decisions: what to do WITH an invalid response, and whether to SEEK a valid one. One enum could not express the most useful combination — *try to correct, but never turn a suspect tip answer into a client error*. `soft-flag` observed without correcting; `reject` corrected but exhausted into client errors during every reorg window.

## The two orthogonal knobs

```yaml
integrity:
  autoCorrectWhenPossible: true   # default true
  invalidBehavior:                # recordOnly | hardReject | off, per finality
    finalized: hardReject
    unfinalized: recordOnly
```

| `autoCorrectWhenPossible` | verdict | on violation |
|---|---|---|
| `true` | `recordOnly` | hunt a validated replacement via the failsafe; serve it if one validates; **exhausted → serve the flagged original** (never a client error; counted in `erpc_integrity_fallback_served_total`) |
| `true` | `hardReject` | hunt; exhausted → error (correct-or-die; unchanged semantics) |
| `false` | `recordOnly` | serve + record immediately (old soft-flag) |
| `false` | `hardReject` | fail immediately, no alternates |

## Mechanics

- Engine: a `recordOnly` verdict under AutoCorrect escalates to a **fallback-eligible rejection** (`Result.FallbackEligible`, outcome `reject_recoverable`) so the existing retry machinery hunts a replacement; the replacement is validated by the same hook on its own attempt.
- Hook: stashes the flagged original on the request (`SetIntegrityFallbackResponse`, newest-wins).
- `project.Forward`: on terminal failure with a stash present, serves the stash instead of the error — new counter `erpc_integrity_fallback_served_total`, loud log.
- The `PinRateLimited` degradation rides the same path: all-upstream mismatches against a stale pin end in a served fallback, so the self-block hazard is gone even with correction on.
- `ObserveOnly` still outranks everything.

## Deliberate breakage (module is unreleased)

- Vocabulary is exactly `recordOnly | hardReject | off`; the old `reject`/`soft-flag`/aliases now **fail config validation loudly** — no silent aliasing.
- Metric/trace labels renamed `soft_flag` → `record_only`; new outcome `reject_recoverable`; export verdicts extended.

## Testing

- New: `TestAutoCorrect_*` (escalation, off-mode, hardReject never fallback-eligible, observe-only outranks), `TestIntegrityFallbackStash` (newest-wins, take-clears-once).
- Updated vocab/round-trip/label tests. `./architecture/evm/... ./common/...` green locally; full suite in CI.
- Docs (`integrity.mdx`) rewritten for the new schema; tygo TS regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)