### PR TITLE
fix(integrity): state prober publishes evidence, not routing — misbehavior witness + execution-height callState probe

### DIFF
--- a/architecture/evm/evm_state_poller.go
+++ b/architecture/evm/evm_state_poller.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/erpc/erpc/architecture/evm/integrity"
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/data"
 	"github.com/erpc/erpc/health"
@@ -1586,12 +1587,65 @@ func (e *EvmStatePoller) checkEventLogsProbe(ctx context.Context, block int64) (
 	return false, false, nil
 }
 
-// checkCallStateProbe verifies whether historical state (e.g., balance) is available at the given block.
-// Any non-null result (including "0x0") is considered available.
+// checkCallStateProbe verifies whether historical STATE is available at the
+// given block.
+//
+// Strong form first: the per-architecture execution canary (the same
+// integrity.ChainStateContextProbe the state prober uses — Multicall3
+// getBlockNumber() on standard EVMs, ArbSys arbBlockNumber() on Nitro, where
+// block.number is the L1 height) is eth_call'ed pinned at the block, and
+// availability means the node EXECUTED at exactly that height. A node serving
+// stale state answers eth_getBalance with a well-formed 0x0, but it cannot
+// answer the canary with the pinned height — the returned number comes from
+// the execution context the node actually used. A wrong canary for a chain
+// (the Multicall3-on-Nitro precedent) mismatches on every upstream alike, so
+// it degrades bounds symmetrically and leaves relative ranking unchanged.
+//
+// Where the canary yields no evidence — not deployed at that height ("0x"),
+// erroring/reverting, or answering something unparseable — this DISCOVERS the
+// gap and falls back to the balance heuristic, so chains and heights without
+// the canary keep exactly the previous behavior.
 func (e *EvmStatePoller) checkCallStateProbe(ctx context.Context, block int64) (bool, bool, error) {
 	if block < 0 {
 		return false, false, nil
 	}
+	hex := fmt.Sprintf("0x%x", uint64(block))
+	var chainId int64
+	if upCfg := e.upstream.Config(); upCfg != nil && upCfg.Evm != nil {
+		chainId = upCfg.Evm.ChainId
+	}
+	canary := integrity.ChainStateContextProbe(chainId)
+	pr := common.NewNormalizedRequest([]byte(
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_call","params":[{"to":"%s","data":"%s"},"%s"]}`,
+			util.RandomID(), canary.To, canary.Data, hex,
+		),
+	))
+	resp, err := e.upstream.Forward(ctx, pr, true, false)
+	if resp != nil {
+		defer resp.Release()
+	}
+	if err != nil {
+		if common.HasErrorCode(err,
+			common.ErrCodeUpstreamRequestSkipped,
+			common.ErrCodeUpstreamMethodIgnored,
+			common.ErrCodeEndpointUnsupported,
+		) {
+			return false, true, nil
+		}
+	} else if jrr, jerr := resp.JsonRpcResponse(); jerr == nil && jrr != nil && jrr.Error == nil {
+		if got, ok := parseHexQuantity(string(jrr.GetResultBytes())); ok {
+			return got == block, false, nil
+		}
+	}
+	return e.checkBalanceStateProbe(ctx, block)
+}
+
+// checkBalanceStateProbe is the weak fallback behind checkCallStateProbe:
+// eth_getBalance(0x0, block) accepting any non-null result. It cannot tell
+// state AT the block from state anywhere (a stale node happily answers 0x0),
+// which is why it is only consulted where the execution canary yields no
+// evidence.
+func (e *EvmStatePoller) checkBalanceStateProbe(ctx context.Context, block int64) (bool, bool, error) {
 	hex := fmt.Sprintf("0x%x", uint64(block))
 	pr := common.NewNormalizedRequest([]byte(
 		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_getBalance","params":["0x0000000000000000000000000000000000000000","%s"]}`,

--- a/architecture/evm/evm_state_poller_callstate_probe_test.go
+++ b/architecture/evm/evm_state_poller_callstate_probe_test.go
@@ -1,0 +1,169 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/erpc/erpc/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// canaryUpstream is a scriptable common.Upstream for the callState probe: the
+// handler decides each response, and every request is recorded so tests can
+// assert WHICH canary was asked and whether the fallback was consulted.
+type canaryUpstream struct {
+	cfg     *common.UpstreamConfig
+	logger  zerolog.Logger
+	handler func(method, params string) (*common.NormalizedResponse, error)
+	calls   []string // methods, in order
+}
+
+func (f *canaryUpstream) Id() string                     { return f.cfg.Id }
+func (f *canaryUpstream) VendorName() string             { return "test" }
+func (f *canaryUpstream) NetworkId() string              { return "evm:123" }
+func (f *canaryUpstream) NetworkLabel() string           { return "evm:123" }
+func (f *canaryUpstream) Config() *common.UpstreamConfig { return f.cfg }
+func (f *canaryUpstream) Logger() *zerolog.Logger        { return &f.logger }
+func (f *canaryUpstream) Vendor() common.Vendor          { return nil }
+func (f *canaryUpstream) Tracker() common.HealthTracker  { return nil }
+func (f *canaryUpstream) Forward(ctx context.Context, nq *common.NormalizedRequest, byPassMethodExclusion, isHedgeAttempt bool) (*common.NormalizedResponse, error) {
+	jrq, err := nq.JsonRpcRequest()
+	if err != nil {
+		return nil, err
+	}
+	params, _ := common.SonicCfg.Marshal(jrq.Params)
+	f.calls = append(f.calls, jrq.Method)
+	return f.handler(jrq.Method, string(params))
+}
+func (f *canaryUpstream) Cordon(method string, reason string)   {}
+func (f *canaryUpstream) Uncordon(method string, reason string) {}
+func (f *canaryUpstream) IgnoreMethod(method string)            {}
+func (f *canaryUpstream) ShouldHandleMethod(method string) (bool, error) {
+	return true, nil
+}
+
+var _ common.Upstream = (*canaryUpstream)(nil)
+
+func newCanaryPoller(chainId int64, handler func(method, params string) (*common.NormalizedResponse, error)) (*EvmStatePoller, *canaryUpstream) {
+	lg := zerolog.Nop()
+	up := &canaryUpstream{
+		logger:  lg,
+		handler: handler,
+		cfg: &common.UpstreamConfig{
+			Id:   "test-upstream",
+			Type: common.UpstreamTypeEvm,
+			Evm:  &common.EvmUpstreamConfig{ChainId: chainId},
+		},
+	}
+	return &EvmStatePoller{upstream: up, logger: &lg}, up
+}
+
+func hexWordResponse(v int64) *common.NormalizedResponse {
+	return common.NewNormalizedResponse().WithJsonRpcResponse(
+		common.MustNewJsonRpcResponseFromBytes([]byte(`"1"`), []byte(fmt.Sprintf(`"0x%064x"`, v)), nil))
+}
+
+func rawResultResponse(result string) *common.NormalizedResponse {
+	return common.NewNormalizedResponse().WithJsonRpcResponse(
+		common.MustNewJsonRpcResponseFromBytes([]byte(`"1"`), []byte(result), nil))
+}
+
+// The callState availability probe must measure EXECUTION at the pinned
+// height, not the mere presence of a well-formed answer: eth_getBalance(0x0, N)
+// is answerable from any state (a stale node returns 0x0), while the
+// per-architecture execution canary returns the height of the context the node
+// actually executed in. The balance heuristic survives only as the fallback
+// where the canary yields no evidence — discovered per height, never assumed.
+func TestCheckCallStateProbe_ExecutionCanary(t *testing.T) {
+	const block = int64(0x1234)
+
+	t.Run("canary executing at the pinned height is available, without consulting the fallback", func(t *testing.T) {
+		e, up := newCanaryPoller(123456, func(method, params string) (*common.NormalizedResponse, error) {
+			require.Equal(t, "eth_call", method)
+			return hexWordResponse(block), nil
+		})
+		ok, unsupported, err := e.checkCallStateProbe(context.Background(), block)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.False(t, unsupported)
+		assert.Equal(t, []string{"eth_call"}, up.calls)
+	})
+
+	t.Run("canary executing at a DIFFERENT height is unavailable, even though a balance would answer", func(t *testing.T) {
+		e, up := newCanaryPoller(123456, func(method, params string) (*common.NormalizedResponse, error) {
+			if method == "eth_getBalance" {
+				return rawResultResponse(`"0x0"`), nil // the stale-node alibi the canary exists to pierce
+			}
+			return hexWordResponse(block - 500), nil // executes 500 back from the pin
+		})
+		ok, unsupported, err := e.checkCallStateProbe(context.Background(), block)
+		require.NoError(t, err)
+		assert.False(t, ok, "a wrong execution height is evidence AGAINST availability, not a gap")
+		assert.False(t, unsupported)
+		assert.Equal(t, []string{"eth_call"}, up.calls,
+			"a definite canary answer must not be second-guessed by the weak fallback")
+	})
+
+	t.Run("canary absent (0x returndata) falls back to the balance heuristic", func(t *testing.T) {
+		e, up := newCanaryPoller(123456, func(method, params string) (*common.NormalizedResponse, error) {
+			if method == "eth_getBalance" {
+				return rawResultResponse(`"0x0"`), nil
+			}
+			return rawResultResponse(`"0x"`), nil // no code at the canary address
+		})
+		ok, _, err := e.checkCallStateProbe(context.Background(), block)
+		require.NoError(t, err)
+		assert.True(t, ok, "no canary deployed -> exactly the previous (balance) behavior")
+		assert.Equal(t, []string{"eth_call", "eth_getBalance"}, up.calls)
+	})
+
+	t.Run("canary erroring falls back too, and the fallback's verdict stands", func(t *testing.T) {
+		for _, balance := range []struct {
+			result string
+			want   bool
+		}{
+			{`"0x0"`, true},
+			{`null`, false},
+		} {
+			e, _ := newCanaryPoller(123456, func(method, params string) (*common.NormalizedResponse, error) {
+				if method == "eth_getBalance" {
+					return rawResultResponse(balance.result), nil
+				}
+				return nil, fmt.Errorf("execution reverted")
+			})
+			ok, _, err := e.checkCallStateProbe(context.Background(), block)
+			require.NoError(t, err)
+			assert.Equal(t, balance.want, ok, "balance=%s", balance.result)
+		}
+	})
+
+	t.Run("the canary is per-architecture: Nitro asks ArbSys, everyone else Multicall3", func(t *testing.T) {
+		// On Nitro chains block.number is the L1 height, so the standard
+		// Multicall3 getBlockNumber() canary would mismatch on every honest
+		// node; ArbSys arbBlockNumber() answers the chain's own height. An
+		// unknown chainId takes the Multicall3 default (200+ chains).
+		cases := []struct {
+			chainId  int64
+			wantTo   string
+			wantData string
+		}{
+			{42161, "0x0000000000000000000000000000000000000064", "0xa3b1b31d"},  // arbitrum-nitro -> ArbSys
+			{123456, "0xcA11bde05977b3631167028862bE2a173976CA11", "0x42cbb15c"}, // unknown chain -> Multicall3 default
+		}
+		for _, tc := range cases {
+			var gotParams string
+			e, _ := newCanaryPoller(tc.chainId, func(method, params string) (*common.NormalizedResponse, error) {
+				gotParams = params
+				return hexWordResponse(block), nil
+			})
+			ok, _, err := e.checkCallStateProbe(context.Background(), block)
+			require.NoError(t, err)
+			assert.True(t, ok)
+			assert.Contains(t, gotParams, tc.wantTo, "chain %d", tc.chainId)
+			assert.Contains(t, gotParams, tc.wantData, "chain %d", tc.chainId)
+		}
+	})
+}

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -126,11 +126,23 @@ func HandleUpstreamPreForward(ctx context.Context, n common.Network, u common.Up
 	}
 }
 
-// upstreamPreForward_stateBoundary refuses to send a state query to an
-// upstream whose STATE-PROVEN head does not cover the requested block. Nodes
-// sometimes answer state methods from older state while reporting a current
-// head; the proven head (advanced only by verified probes — see the state
-// prober) is the boundary that cannot silently outrun reality.
+// upstreamPreForward_stateBoundary diverts state queries away from an upstream
+// the state prober has DISPROVED: one that ANSWERS pinned probes and executes
+// them at the wrong height (see stateProber.disproved). That node has not
+// failed to prove itself — it has proven the opposite, at every depth, and
+// letting it serve is the silent-wrong-data case the prober was built for.
+//
+// Absence of proof, by contrast, never blocks routing. The boundary used to
+// also refuse any request pinned above the upstream's state-PROVEN head, and
+// that comparison misfired structurally: the proven head is advanced by probes
+// of the FOLLOWED head at a bounded cadence (follow interval + probe interval),
+// so on any chain whose block time is shorter than that cadence every honest
+// upstream's proven head sits several blocks behind its claimed head at all
+// times. Meanwhile "latest" interpolation pins requests at the majority CLAIMED
+// head — a height no proven head has reached yet — so every upstream refused
+// every tip request and state call can fail network-wide on a fast chain.
+// "Not yet proven at height H" is the same epistemic state as "never probed"
+// (which has always failed open); only DISPROOF is evidence against a node.
 //
 // Inert unless the state prober is running for this network, so the default
 // behavior is byte-identical with the feature off.
@@ -139,72 +151,62 @@ func upstreamPreForward_stateBoundary(ctx context.Context, n common.Network, u c
 	if prober == nil {
 		return false, nil, nil
 	}
-	// The probes themselves are internal state calls aimed at upstreams whose
-	// boundary has NOT advanced yet — gating them would deadlock the proving.
+	// The probes themselves are internal state calls aimed at upstreams that
+	// may currently be failing them — gating them would deadlock the proving.
 	if dirs := r.Directives(); dirs != nil && dirs.IsInternal {
+		return false, nil, nil
+	}
+	if !prober.disproved(u.Id()) {
 		return false, nil, nil
 	}
 	_, blockNumber, err := ExtractBlockReferenceFromRequest(ctx, r)
 	if err != nil || blockNumber <= 0 {
 		// Tags (latest/pending), unparseable refs, and requests whose height the
-		// method config cannot locate are not gated here: the proven boundary is
-		// a statement about a CONCRETE height, so with no height there is nothing
-		// to compare and the request goes out as it does today.
+		// method config cannot locate are not diverted: the sibling check below
+		// needs a CONCRETE height to answer, so with no height the request goes
+		// out as it does today. ("latest" on state methods is interpolated to a
+		// concrete height upstream of this hook whenever the tip is known.)
 		return false, nil, nil
 	}
-	eu, ok := u.(common.EvmUpstream)
-	if !ok {
+	// Divert only when someone else can actually answer. A disproved upstream
+	// that is the only one able to serve the height still serves; excluding the
+	// last resort trades wrong data for an outage.
+	if !prober.aSiblingCanServe(ctx, u.Id(), blockNumber) {
 		return false, nil, nil
 	}
-	available, err := eu.EvmAssertBlockAvailability(ctx, method, common.AvailbilityConfidenceStateProven, false, blockNumber)
-	if err != nil {
+	if integrityObserveOnly(n) {
+		// observeOnly is documented as ABSOLUTE over every integrity effect, and
+		// diversion is a routing effect: record that it would have happened,
+		// change nothing.
+		prober.count(u, "boundary", "would_divert")
 		return false, nil, nil
 	}
-	var proven int64
-	if r, ok := u.(common.EvmStateProvenReader); ok {
-		proven = r.EvmStateProvenBlock()
-	}
-	if available {
-		// The claimed-head fallback (proven == 0) exists so that upstreams which
-		// cannot be probed keep serving. It must not shelter an upstream that
-		// ANSWERS the probe and executes at the wrong height — that node has not
-		// failed to prove itself, it has proven the opposite, and letting it
-		// serve is the silent-wrong-data case this boundary was built for.
-		if proven > 0 || !prober.disproved(u.Id()) {
-			return false, nil, nil
-		}
-		// Divert only when someone else can actually answer. A disproved
-		// upstream that is the only one able to serve the height still serves;
-		// excluding the last resort trades wrong data for an outage.
-		if !prober.aSiblingCanServe(ctx, u.Id(), blockNumber) {
-			return false, nil, nil
-		}
-		prober.count(u, "boundary", "diverted")
-		return true, nil, &common.ErrUpstreamBlockUnavailable{
-			BaseError: common.BaseError{
-				Code: common.ErrCodeUpstreamBlockUnavailable,
-				Message: fmt.Sprintf(
-					"state for block %d is DISPROVEN on this node (it answers pinned calls at the wrong height) for %s",
-					blockNumber, method),
-				Details: map[string]interface{}{
-					"upstreamId":  u.Id(),
-					"blockNumber": blockNumber,
-					"disproven":   true,
-				},
-			},
-		}
-	}
+	prober.count(u, "boundary", "diverted")
 	return true, nil, &common.ErrUpstreamBlockUnavailable{
 		BaseError: common.BaseError{
-			Code:    common.ErrCodeUpstreamBlockUnavailable,
-			Message: fmt.Sprintf("state for block %d is not yet PROVEN on this node (stateProvenBlock: %d) for %s", blockNumber, proven, method),
+			Code: common.ErrCodeUpstreamBlockUnavailable,
+			Message: fmt.Sprintf(
+				"state for block %d is DISPROVEN on this node (it answers pinned calls at the wrong height) for %s",
+				blockNumber, method),
 			Details: map[string]interface{}{
-				"upstreamId":       u.Id(),
-				"blockNumber":      blockNumber,
-				"stateProvenBlock": proven,
+				"upstreamId":  u.Id(),
+				"blockNumber": blockNumber,
+				"disproven":   true,
 			},
 		},
 	}
+}
+
+// integrityObserveOnly reports the network's base integrity observeOnly
+// setting — the operator's blanket "measure, never intervene". Read directly
+// (not via resolveIntegrity) because the boundary is network-scoped like the
+// prober itself: per-request selector profiles adjust CHECKS, not routing.
+func integrityObserveOnly(n common.Network) bool {
+	cfg := n.Config()
+	if cfg == nil || cfg.Integrity == nil || cfg.Integrity.ObserveOnly == nil {
+		return false
+	}
+	return *cfg.Integrity.ObserveOnly
 }
 
 func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.Upstream, rq *common.NormalizedRequest, rs *common.NormalizedResponse, re error, skipCacheRead bool) (*common.NormalizedResponse, error) {

--- a/architecture/evm/hooks.go
+++ b/architecture/evm/hooks.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -115,98 +114,18 @@ func HandleUpstreamPreForward(ctx context.Context, n common.Network, u common.Up
 	case "eth_queryblocks", "eth_querytransactions", "eth_querylogs", "eth_querytraces", "eth_querytransfers":
 		return upstreamPreForward_eth_query(ctx, n, u, r)
 	default:
-		// The state-proven boundary protects a CLASS (methods answered from the
-		// state trie at a block), not a list copied to this call site. The class
-		// is defined once, in common.IsEvmStateQueryMethod, so a method joining
-		// it cannot be gated in one place and forgotten in another.
-		if common.IsEvmStateQueryMethod(methodLower) {
-			return upstreamPreForward_stateBoundary(ctx, n, u, r, method)
-		}
+		// Deliberately NO per-request gate on the integrity state prober's
+		// findings here. The prober publishes evidence — proven-head telemetry
+		// and, for a sustained streak of wrong-height answers, upstream
+		// misbehavior on the health tracker (see noteDisproved) — and exclusion
+		// decisions belong to the operator's selection policy, which already
+		// reads that ledger (misbehaviorRateAbove). A hook-level refusal keyed
+		// to the proven head was tried and misfired structurally: the proven
+		// head advances at probe cadence, so on a chain whose block time is
+		// shorter than that cadence it trails every honest upstream's claimed
+		// head and the network's own advertised tip becomes unroutable.
 		return false, nil, nil
 	}
-}
-
-// upstreamPreForward_stateBoundary diverts state queries away from an upstream
-// the state prober has DISPROVED: one that ANSWERS pinned probes and executes
-// them at the wrong height (see stateProber.disproved). That node has not
-// failed to prove itself — it has proven the opposite, at every depth, and
-// letting it serve is the silent-wrong-data case the prober was built for.
-//
-// Absence of proof, by contrast, never blocks routing. The boundary used to
-// also refuse any request pinned above the upstream's state-PROVEN head, and
-// that comparison misfired structurally: the proven head is advanced by probes
-// of the FOLLOWED head at a bounded cadence (follow interval + probe interval),
-// so on any chain whose block time is shorter than that cadence every honest
-// upstream's proven head sits several blocks behind its claimed head at all
-// times. Meanwhile "latest" interpolation pins requests at the majority CLAIMED
-// head — a height no proven head has reached yet — so every upstream refused
-// every tip request and state call can fail network-wide on a fast chain.
-// "Not yet proven at height H" is the same epistemic state as "never probed"
-// (which has always failed open); only DISPROOF is evidence against a node.
-//
-// Inert unless the state prober is running for this network, so the default
-// behavior is byte-identical with the feature off.
-func upstreamPreForward_stateBoundary(ctx context.Context, n common.Network, u common.Upstream, r *common.NormalizedRequest, method string) (bool, *common.NormalizedResponse, error) {
-	prober := stateProberFor(n.Id())
-	if prober == nil {
-		return false, nil, nil
-	}
-	// The probes themselves are internal state calls aimed at upstreams that
-	// may currently be failing them — gating them would deadlock the proving.
-	if dirs := r.Directives(); dirs != nil && dirs.IsInternal {
-		return false, nil, nil
-	}
-	if !prober.disproved(u.Id()) {
-		return false, nil, nil
-	}
-	_, blockNumber, err := ExtractBlockReferenceFromRequest(ctx, r)
-	if err != nil || blockNumber <= 0 {
-		// Tags (latest/pending), unparseable refs, and requests whose height the
-		// method config cannot locate are not diverted: the sibling check below
-		// needs a CONCRETE height to answer, so with no height the request goes
-		// out as it does today. ("latest" on state methods is interpolated to a
-		// concrete height upstream of this hook whenever the tip is known.)
-		return false, nil, nil
-	}
-	// Divert only when someone else can actually answer. A disproved upstream
-	// that is the only one able to serve the height still serves; excluding the
-	// last resort trades wrong data for an outage.
-	if !prober.aSiblingCanServe(ctx, u.Id(), blockNumber) {
-		return false, nil, nil
-	}
-	if integrityObserveOnly(n) {
-		// observeOnly is documented as ABSOLUTE over every integrity effect, and
-		// diversion is a routing effect: record that it would have happened,
-		// change nothing.
-		prober.count(u, "boundary", "would_divert")
-		return false, nil, nil
-	}
-	prober.count(u, "boundary", "diverted")
-	return true, nil, &common.ErrUpstreamBlockUnavailable{
-		BaseError: common.BaseError{
-			Code: common.ErrCodeUpstreamBlockUnavailable,
-			Message: fmt.Sprintf(
-				"state for block %d is DISPROVEN on this node (it answers pinned calls at the wrong height) for %s",
-				blockNumber, method),
-			Details: map[string]interface{}{
-				"upstreamId":  u.Id(),
-				"blockNumber": blockNumber,
-				"disproven":   true,
-			},
-		},
-	}
-}
-
-// integrityObserveOnly reports the network's base integrity observeOnly
-// setting — the operator's blanket "measure, never intervene". Read directly
-// (not via resolveIntegrity) because the boundary is network-scoped like the
-// prober itself: per-request selector profiles adjust CHECKS, not routing.
-func integrityObserveOnly(n common.Network) bool {
-	cfg := n.Config()
-	if cfg == nil || cfg.Integrity == nil || cfg.Integrity.ObserveOnly == nil {
-		return false
-	}
-	return *cfg.Integrity.ObserveOnly
 }
 
 func HandleUpstreamPostForward(ctx context.Context, n common.Network, u common.Upstream, rq *common.NormalizedRequest, rs *common.NormalizedResponse, re error, skipCacheRead bool) (*common.NormalizedResponse, error) {

--- a/architecture/evm/integrity_stateprobe.go
+++ b/architecture/evm/integrity_stateprobe.go
@@ -40,10 +40,14 @@ import (
 //     Not all providers expose eth_getProof — support is DISCOVERED per
 //     upstream, never assumed.
 //
-// A success advances the upstream's state-proven head (monotonic); routing for
-// state methods asserts AvailbilityConfidenceStateProven against it. Failure
-// just fails to advance — a mismatch at the tip can be a fork-transient, so it
-// is counted and logged, never scored as misbehavior.
+// A success advances the upstream's state-proven head (monotonic) — telemetry,
+// and the strongest tier of the diversion's sibling check. Failure just fails
+// to advance — a mismatch at the tip can be a fork-transient, so it is counted
+// and logged, never scored as misbehavior. Routing reacts ONLY to a sustained
+// streak of mismatches (disproved → diverted, see the state boundary in
+// hooks.go): the proven head itself is never a routing bound, because it lags
+// the claimed head by the probe cadence on any fast chain, where a proven-head
+// bound would refuse the network's own advertised tip.
 // The context-probe target is per-ARCHITECTURE (integrity.ChainStateContextProbe):
 // standard EVMs use Multicall3 getBlockNumber, but e.g. Nitro's block.number is
 // the L1 height and needs ArbSys arbBlockNumber instead — assuming one probe

--- a/architecture/evm/integrity_stateprobe.go
+++ b/architecture/evm/integrity_stateprobe.go
@@ -40,14 +40,19 @@ import (
 //     Not all providers expose eth_getProof — support is DISCOVERED per
 //     upstream, never assumed.
 //
-// A success advances the upstream's state-proven head (monotonic) — telemetry,
-// and the strongest tier of the diversion's sibling check. Failure just fails
-// to advance — a mismatch at the tip can be a fork-transient, so it is counted
-// and logged, never scored as misbehavior. Routing reacts ONLY to a sustained
-// streak of mismatches (disproved → diverted, see the state boundary in
-// hooks.go): the proven head itself is never a routing bound, because it lags
-// the claimed head by the probe cadence on any fast chain, where a proven-head
-// bound would refuse the network's own advertised tip.
+// The prober PUBLISHES evidence; it holds no routing authority of its own.
+// A success advances the upstream's state-proven head (monotonic) — pure
+// telemetry, never a routing bound: the proven head advances at probe cadence,
+// so on any chain whose block time is shorter than that cadence it trails
+// every honest upstream's claimed head, and a bound built on it would refuse
+// the network's own advertised tip. A single failure just fails to advance —
+// a mismatch at the tip can be a fork-transient. Only a SUSTAINED streak of
+// wrong-height answers is evidence against a node, and that evidence goes
+// where every other proven-bad-data signal already goes: upstream misbehavior
+// on the health tracker (the ledger consensus disputes, integrity
+// deterministic rejects and wrong-empty responses feed — see noteDisproved).
+// Whether and when to exclude is the operator's selection policy's call, via
+// the existing misbehaviorRateAbove predicate.
 // The context-probe target is per-ARCHITECTURE (integrity.ChainStateContextProbe):
 // standard EVMs use Multicall3 getBlockNumber, but e.g. Nitro's block.number is
 // the L1 height and needs ArbSys arbBlockNumber instead — assuming one probe
@@ -69,15 +74,14 @@ type stateProber struct {
 	// eth_getProof, so the probe is not re-attempted on every block.
 	proofUnsupported sync.Map // upstream id -> true
 
-	// disprovedStreak counts CONSECUTIVE probe mismatches per upstream.
-	//
-	// The distinction it exists to draw: an upstream that cannot be probed has
-	// merely FAILED TO PROVE itself, and must keep serving (the boundary falls
-	// back to its claimed head). An upstream that answers the probe and executes
-	// at the wrong height has proven the OPPOSITE — measured on shadow hyperevm,
-	// where one upstream returned pin_ignored on 202 of 202 probes while all six
-	// of its siblings matched on all 202. Treating those two as the same thing
-	// is what let a demonstrably wrong node keep serving state calls.
+	// disprovedStreak counts CONSECUTIVE probe mismatches per upstream — the
+	// INTERNAL debounce between one unlucky probe and real evidence. Never
+	// config, never API: it only separates a probe landing across a reorg from
+	// an upstream that answers pinned calls at the wrong height sustainedly
+	// (measured on a live shadow: one upstream returned pin_ignored on 202 of
+	// 202 probes while all six of its siblings matched on all 202). An upstream
+	// that merely CANNOT be probed accrues no streak — absence of proof is not
+	// evidence and has no effect anywhere.
 	disprovedStreak sync.Map // upstream id -> *atomic.Int64
 
 	// work carries the newest followed head; size 1, newest wins — probing is
@@ -113,8 +117,8 @@ func startStateProber(n common.Network, v *chainView, cfg *common.IntegrityState
 	go p.run()
 }
 
-// stateProberFor is the routing gate's cheap activity test: nil means probing
-// is off for this network and the gate must be a no-op.
+// stateProberFor returns the network's running prober (nil = probing off for
+// this network); the chain follower uses it to hand over freshly verified heads.
 func stateProberFor(networkId string) *stateProber {
 	v, ok := stateProbers.Load(networkId)
 	if !ok {
@@ -181,12 +185,11 @@ func (p *stateProber) probeUpstream(ctx context.Context, u common.Upstream, n in
 	ctxMatch := p.probeContext(ctx, u, n)
 	proofMatch := p.probeProof(ctx, u, n, h)
 
-	// Advance on any positive proof, refuse on any negative one. "unknown"
-	// (unsupported/error) neither advances nor blocks — but if BOTH probes are
-	// unknown there is no evidence at all, and the boundary stays put (the
-	// assert falls back to the claimed head for such upstreams, visibly).
+	// Advance on any positive proof, count any negative one. "unknown"
+	// (unsupported/error) neither advances nor counts — if BOTH probes are
+	// unknown there is no evidence at all, and nothing changes anywhere.
 	if ctxMatch == probeMismatch || proofMatch == probeMismatch {
-		p.noteDisproved(u.Id())
+		p.noteDisproved(u)
 		return
 	}
 	if ctxMatch != probeMatch && proofMatch != probeMatch {
@@ -311,8 +314,8 @@ func (p *stateProber) probeProof(ctx context.Context, u common.Upstream, n int64
 
 // forwardTo sends one probe to EXACTLY the given upstream: cache bypassed (the
 // cache would answer instead of the node — the circular-evidence trap), and
-// marked internal so the state-boundary gate itself ignores it (the probe must
-// be able to reach an upstream whose boundary has not advanced yet).
+// marked internal so the integrity engine does not recurse into validating the
+// probe's own response.
 func (p *stateProber) forwardTo(ctx context.Context, u common.Upstream, body string) (string, error) {
 	req := common.NewNormalizedRequest([]byte(body))
 	req.SetDirectives(&common.RequestDirectives{
@@ -336,15 +339,40 @@ func (p *stateProber) forwardTo(ctx context.Context, u common.Upstream, body str
 }
 
 // stateProbeDisprovedStreak is how many CONSECUTIVE mismatches make an upstream
-// disproved rather than merely unproven. At the shadow's 2s interval that is
+// disproved rather than merely unproven. At the default 2s interval that is
 // ~20s of unbroken evidence; the observed real case ran 202/202, so the
 // threshold exists only to rule out a transient (a probe landing across a
-// reorg, a momentary lag spike), not to be a tuning knob.
+// reorg, a momentary lag spike), not to be a tuning knob — which is why it is
+// a constant here and not config.
 const stateProbeDisprovedStreak = 10
 
-func (p *stateProber) noteDisproved(id string) {
-	v, _ := p.disprovedStreak.LoadOrStore(id, new(atomic.Int64))
-	v.(*atomic.Int64).Add(1)
+// noteDisproved counts a probe mismatch and, once the streak crosses the
+// debounce, records each further mismatch as upstream misbehavior — the same
+// ledger consensus disputes, integrity deterministic rejects and wrong-empty
+// responses already feed. Disproof is a fourth witness to that ledger, not a
+// new concept: the prober publishes the evidence, and the operator's selection
+// policy decides what to do with it (misbehaviorRateAbove in the policy stdlib
+// reads exactly this counter). Recording per mismatch — not once per crossing —
+// keeps the rolling rate elevated for exactly as long as the node keeps
+// failing probes; one good probe resets the streak and the evidence stops.
+func (p *stateProber) noteDisproved(u common.Upstream) {
+	v, _ := p.disprovedStreak.LoadOrStore(u.Id(), new(atomic.Int64))
+	if v.(*atomic.Int64).Add(1) < stateProbeDisprovedStreak {
+		return
+	}
+	// Under integrity observeOnly no check may influence routing: rejections
+	// are suppressed before they reach misbehavior scoring, so probe disproof
+	// stays consistent and records nothing either.
+	if integrityObserveOnly(p.network) {
+		return
+	}
+	if ht := u.Tracker(); ht != nil {
+		// Recorded under the context probe's own method: the probe IS a pinned
+		// eth_call, and eth_call traffic is what a wrong-height execution
+		// context silently corrupts. The probe pins the followed (not yet
+		// finalized) head, hence the unfinalized stratum.
+		ht.RecordUpstreamMisbehavior(u, "eth_call", common.DataFinalityStateUnfinalized)
+	}
 }
 
 func (p *stateProber) clearDisproved(id string) {
@@ -353,60 +381,16 @@ func (p *stateProber) clearDisproved(id string) {
 	}
 }
 
-// disproved reports whether an upstream has answered probes wrongly for long
-// enough that its silence about the state trie is evidence, not a gap.
-func (p *stateProber) disproved(id string) bool {
-	v, ok := p.disprovedStreak.Load(id)
-	if !ok {
+// integrityObserveOnly reports the network's base integrity observeOnly
+// setting — the operator's blanket "measure, never intervene". Read directly
+// (not via resolveIntegrity) because the prober is network-scoped: per-request
+// selector profiles adjust CHECKS, not evidence recording.
+func integrityObserveOnly(n common.Network) bool {
+	cfg := n.Config()
+	if cfg == nil || cfg.Integrity == nil || cfg.Integrity.ObserveOnly == nil {
 		return false
 	}
-	return v.(*atomic.Int64).Load() >= stateProbeDisprovedStreak
-}
-
-// aSiblingCanServe reports whether some OTHER upstream is a credible
-// alternative for `block`.
-//
-// Diverting away from a disproved upstream is conditioned on this because the
-// alternative is the failure mode that took Base down: a selection rule that
-// EXCLUDES rather than deprioritizes turns "every candidate looks bad" into an
-// outage. If nothing else can serve the height, the disproved upstream still
-// serves — wrong data beats no data, and the operator sees it in the probe
-// metrics either way.
-//
-// Two tiers, because requiring PROOF at the exact height leaves the newest
-// blocks unprotected: the proven head necessarily lags the followed tip (~15
-// blocks on the shadow), while the defect is present at every depth — the
-// upstream this was built for ignored the pin identically at the tip and 5,000
-// blocks back. A sibling carrying no such evidence, whose claimed head covers
-// the height, is still strictly better than one proven to answer at the wrong
-// height.
-func (p *stateProber) aSiblingCanServe(ctx context.Context, exceptId string, block int64) bool {
-	enum, ok := p.network.(interface {
-		EvmAllUpstreams(context.Context) []common.Upstream
-	})
-	if !ok {
-		return false
-	}
-	fallback := false
-	for _, u := range enum.EvmAllUpstreams(ctx) {
-		if u.Id() == exceptId || p.disproved(u.Id()) {
-			continue
-		}
-		// Strongest: a sibling that has PROVEN state at or beyond the height.
-		if r, ok := u.(common.EvmStateProvenReader); ok && r.EvmStateProvenBlock() >= block {
-			return true
-		}
-		if fallback {
-			continue
-		}
-		if eu, ok := u.(common.EvmUpstream); ok {
-			avail, err := eu.EvmAssertBlockAvailability(ctx, "eth_call", common.AvailbilityConfidenceBlockHead, false, block)
-			if err == nil && avail {
-				fallback = true
-			}
-		}
-	}
-	return fallback
+	return *cfg.Integrity.ObserveOnly
 }
 
 func (p *stateProber) count(u common.Upstream, probe, outcome string) {

--- a/architecture/evm/integrity_stateprobe_disproved_test.go
+++ b/architecture/evm/integrity_stateprobe_disproved_test.go
@@ -71,6 +71,10 @@ type siblingNetwork struct {
 
 func (s *siblingNetwork) EvmAllUpstreams(ctx context.Context) []common.Upstream { return s.ups }
 
+// Metric-label lookups the boundary's diverted/would_divert counter performs.
+func (s *siblingNetwork) ProjectId() string { return "test" }
+func (s *siblingNetwork) Label() string     { return "testnet" }
+
 func provenUp(id string, proven int64) common.Upstream {
 	u := common.NewFakeUpstream(id)
 	if w, ok := u.(common.EvmStateProvenWriter); ok && proven > 0 {

--- a/architecture/evm/integrity_stateprobe_disproved_test.go
+++ b/architecture/evm/integrity_stateprobe_disproved_test.go
@@ -2,126 +2,177 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/erpc/erpc/architecture/evm/integrity"
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// The whole point of the disproved streak is to separate two things that both
-// look like "this upstream has proven nothing":
-//
-//	cannot be probed  -> unproven -> keeps serving on its claimed head
-//	answers wrongly   -> DISPROVEN -> diverted, if someone else can serve
-//
-// Collapsing them is what let a node that returned pin_ignored on 202 of 202
-// shadow probes keep answering state calls.
-func TestDisprovedStreak(t *testing.T) {
-	p := &stateProber{}
+// fleetNetwork is the minimal network shape the prober needs in tests: it can
+// enumerate its upstreams, answer the metric-label lookups, expose a config
+// (for the observeOnly gate), and forward probe requests to a scripted handler.
+type fleetNetwork struct {
+	common.Network
+	ups     []common.Upstream
+	cfg     *common.NetworkConfig
+	forward func(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error)
+}
 
-	t.Run("an upstream nobody has probed is not disproved", func(t *testing.T) {
-		assert.False(t, p.disproved("never-probed"))
-	})
+func (s *fleetNetwork) EvmAllUpstreams(ctx context.Context) []common.Upstream { return s.ups }
+func (s *fleetNetwork) ProjectId() string                                     { return "test" }
+func (s *fleetNetwork) Label() string                                         { return "testnet" }
+func (s *fleetNetwork) Config() *common.NetworkConfig                         { return s.cfg }
+func (s *fleetNetwork) Forward(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+	return s.forward(ctx, req)
+}
 
-	t.Run("a short run of mismatches is not yet evidence", func(t *testing.T) {
+func fakeTrackerOf(t *testing.T, u common.Upstream) *common.FakeHealthTracker {
+	t.Helper()
+	ht, ok := u.Tracker().(*common.FakeHealthTracker)
+	require.True(t, ok)
+	return ht
+}
+
+// Probe disproof is the FOURTH witness to the existing misbehavior ledger
+// (consensus disputes, integrity deterministic rejects, wrong-empty responses
+// are the other three). The streak is the INTERNAL debounce between one
+// unlucky probe and real evidence:
+//
+//	cannot be probed  -> unproven  -> no evidence, records nothing, ever
+//	answers wrongly,  -> DISPROVED -> each further mismatch is one recorded
+//	  sustainedly                     misbehavior, for selection policies
+//	                                  (misbehaviorRateAbove) to act on
+//
+// Collapsing those two is what let a node that returned pin_ignored on 202 of
+// 202 shadow probes keep a clean score while answering state calls wrongly.
+func TestDisprovedStreak_RecordsMisbehavior(t *testing.T) {
+	p := &stateProber{network: &fleetNetwork{}}
+
+	t.Run("below the threshold nothing is recorded", func(t *testing.T) {
+		u := common.NewFakeUpstream("flaky")
 		for i := 0; i < stateProbeDisprovedStreak-1; i++ {
-			p.noteDisproved("flaky")
+			p.noteDisproved(u)
 		}
-		assert.False(t, p.disproved("flaky"),
-			"a probe landing across a reorg must not be enough to divert traffic")
+		assert.Equal(t, 0, fakeTrackerOf(t, u).MisbehaviorCount,
+			"a probe landing across a reorg must not incriminate an upstream")
 	})
 
-	t.Run("a sustained run is", func(t *testing.T) {
-		p.noteDisproved("flaky")
-		assert.True(t, p.disproved("flaky"))
+	t.Run("crossing the threshold records, and keeps recording per mismatch", func(t *testing.T) {
+		u := common.NewFakeUpstream("wrong-height")
+		for i := 0; i < stateProbeDisprovedStreak; i++ {
+			p.noteDisproved(u)
+		}
+		ht := fakeTrackerOf(t, u)
+		assert.Equal(t, 1, ht.MisbehaviorCount)
+		p.noteDisproved(u)
+		p.noteDisproved(u)
+		assert.Equal(t, 3, ht.MisbehaviorCount,
+			"evidence must keep accruing while the node keeps failing probes, or the rolling rate decays while the defect persists")
+		assert.Equal(t, "eth_call", ht.LastMisbehaviorMethod,
+			"the context probe IS a pinned eth_call; that is the traffic a wrong-height execution context corrupts")
+		assert.Equal(t, common.DataFinalityStateUnfinalized, ht.LastMisbehaviorFinality,
+			"probes pin the followed (not yet finalized) head")
 	})
 
-	t.Run("one good probe clears it", func(t *testing.T) {
-		p.clearDisproved("flaky")
-		assert.False(t, p.disproved("flaky"),
-			"an upstream that starts answering correctly must recover immediately")
+	t.Run("one good probe resets the debounce", func(t *testing.T) {
+		u := common.NewFakeUpstream("recovers")
+		for i := 0; i < stateProbeDisprovedStreak+2; i++ {
+			p.noteDisproved(u)
+		}
+		ht := fakeTrackerOf(t, u)
+		require.Equal(t, 3, ht.MisbehaviorCount)
+		p.clearDisproved(u.Id())
+		for i := 0; i < stateProbeDisprovedStreak-1; i++ {
+			p.noteDisproved(u)
+		}
+		assert.Equal(t, 3, ht.MisbehaviorCount,
+			"after recovery the full debounce applies again before anything is recorded")
 	})
 
 	t.Run("the streak must be consecutive, not cumulative", func(t *testing.T) {
+		u := common.NewFakeUpstream("intermittent")
 		for i := 0; i < stateProbeDisprovedStreak*3; i++ {
-			p.noteDisproved("intermittent")
-			p.clearDisproved("intermittent")
+			p.noteDisproved(u)
+			p.clearDisproved(u.Id())
 		}
-		assert.False(t, p.disproved("intermittent"),
+		assert.Equal(t, 0, fakeTrackerOf(t, u).MisbehaviorCount,
 			"an upstream that mismatches occasionally but recovers is unreliable, not disproven")
 	})
 }
 
-// aSiblingCanServe is the guard that keeps this from repeating the Base
-// failover outage: it must answer false when there is no one else, so the
-// diversion never removes the last upstream able to serve a height.
-func TestASiblingCanServeRefusesWithoutAnEnumerableNetwork(t *testing.T) {
-	p := &stateProber{}
-	assert.False(t, p.aSiblingCanServe(context.Background(), "u1", 100),
-		"with no way to enumerate siblings the answer must be 'no alternative', which keeps the upstream serving")
-}
-
-// siblingNetwork is the minimal shape aSiblingCanServe needs: a network that
-// can enumerate its upstreams.
-type siblingNetwork struct {
-	common.Network
-	ups []common.Upstream
-}
-
-func (s *siblingNetwork) EvmAllUpstreams(ctx context.Context) []common.Upstream { return s.ups }
-
-// Metric-label lookups the boundary's diverted/would_divert counter performs.
-func (s *siblingNetwork) ProjectId() string { return "test" }
-func (s *siblingNetwork) Label() string     { return "testnet" }
-
-func provenUp(id string, proven int64) common.Upstream {
-	u := common.NewFakeUpstream(id)
-	if w, ok := u.(common.EvmStateProvenWriter); ok && proven > 0 {
-		w.EvmSetStateProvenBlock(proven)
+// Under integrity observeOnly, rejections never reach misbehavior scoring (they
+// are suppressed before they happen), so probe disproof must stay consistent
+// and record nothing either — observeOnly is documented ABSOLUTE over every
+// integrity effect.
+func TestDisprovedStreak_ObserveOnlyRecordsNothing(t *testing.T) {
+	p := &stateProber{network: &fleetNetwork{cfg: &common.NetworkConfig{
+		Integrity: &common.IntegrityConfig{IntegritySettings: common.IntegritySettings{ObserveOnly: util.BoolPtr(true)}},
+	}}}
+	u := common.NewFakeUpstream("observed")
+	for i := 0; i < stateProbeDisprovedStreak*2; i++ {
+		p.noteDisproved(u)
 	}
-	return u
+	assert.Equal(t, 0, fakeTrackerOf(t, u).MisbehaviorCount,
+		"an observeOnly network must never see an integrity-driven scoring effect")
 }
 
-// The guard has two tiers because insisting on PROOF at the exact height would
-// leave the newest blocks permanently unprotected: the proven head lags the
-// followed tip, while the defect this exists for is present at every depth
-// (the real upstream ignored the pin identically at the tip and 5,000 blocks
-// back). A sibling with no adverse evidence is still strictly better than one
-// proven to answer at the wrong height.
-func TestASiblingCanServeTiers(t *testing.T) {
-	ctx := context.Background()
-	const block = int64(1000)
-
-	t.Run("a sibling proven at the height qualifies", func(t *testing.T) {
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-			provenUp("bad", 0), provenUp("good", 1200),
-		}}}
-		assert.True(t, p.aSiblingCanServe(ctx, "bad", block))
-	})
-
-	t.Run("an unproven but unincriminated sibling still qualifies", func(t *testing.T) {
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-			provenUp("bad", 0), provenUp("warming", 0),
-		}}}
-		assert.True(t, p.aSiblingCanServe(ctx, "bad", block),
-			"otherwise the last ~15 blocks are never protected, which is where most state traffic lives")
-	})
-
-	t.Run("a DISPROVED sibling does not qualify", func(t *testing.T) {
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-			provenUp("bad", 0), provenUp("alsoBad", 0),
-		}}}
-		for i := 0; i < stateProbeDisprovedStreak; i++ {
-			p.noteDisproved("alsoBad")
+// A WRONG canary for a chain must degrade symmetrically. The measured
+// precedent: on a Nitro chain block.number is the L1 height, so before the
+// per-architecture override existed the standard Multicall3 probe mismatched
+// on every honest upstream at once — the all-upstream signature that means the
+// probe is wrong, not the nodes. This test pins the safety property that makes
+// that mistake survivable: when every node answers the canary with the same
+// wrong height, every upstream accrues IDENTICAL evidence (and no proven
+// head), so the fleet's RELATIVE ranking is unchanged and a rate-based policy
+// has nothing to reorder.
+func TestStateProber_WrongCanaryFailsSymmetrically(t *testing.T) {
+	const head = int64(1000)
+	ups := []common.Upstream{
+		common.NewFakeUpstream("upstream-a"),
+		common.NewFakeUpstream("upstream-b"),
+		common.NewFakeUpstream("upstream-c"),
+	}
+	net := &fleetNetwork{ups: ups, cfg: &common.NetworkConfig{}}
+	net.forward = func(ctx context.Context, req *common.NormalizedRequest) (*common.NormalizedResponse, error) {
+		jrq, _ := req.JsonRpcRequest()
+		switch jrq.Method {
+		case "eth_call":
+			// Every node answers the same height that is NOT the pin — the
+			// signature of a canary that is wrong for the chain, not of any
+			// one node being wrong.
+			ret := fmt.Sprintf(`"0x%064x"`, head+12345)
+			return common.NewNormalizedResponse().WithJsonRpcResponse(
+				common.MustNewJsonRpcResponseFromBytes([]byte(`"1"`), []byte(ret), nil)), nil
 		}
-		assert.False(t, p.aSiblingCanServe(ctx, "bad", block),
-			"diverting onto another liar is not a correction")
-	})
+		return nil, fmt.Errorf("method not found")
+	}
 
-	t.Run("the upstream itself never counts as its own alternative", func(t *testing.T) {
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{provenUp("bad", 5000)}}}
-		assert.False(t, p.aSiblingCanServe(ctx, "bad", block),
-			"a lone upstream must keep serving — excluding the last resort trades wrong data for an outage")
+	v := newChainView(net, 32, "", "", nil)
+	v.adoptFollowed(head, &integrity.Header{
+		Number: fmt.Sprintf("0x%x", head), Hash: "0xhead", ParentHash: "0xpar",
 	})
+	p := &stateProber{
+		network: net, view: v, interval: 0,
+		ctxProbe:  integrity.ChainStateContextProbe(0),
+		lastProbe: map[string]time.Time{}, work: make(chan int64, 1),
+	}
+
+	rounds := stateProbeDisprovedStreak + 2
+	for i := 0; i < rounds; i++ {
+		p.probeAll(head)
+	}
+
+	want := rounds - stateProbeDisprovedStreak + 1 // one record per round past the debounce
+	for _, u := range ups {
+		assert.Equal(t, want, fakeTrackerOf(t, u).MisbehaviorCount,
+			"%s: symmetric failure must produce identical evidence on every upstream", u.Id())
+		assert.EqualValues(t, 0, u.(*common.FakeUpstream).EvmStateProvenBlock(),
+			"%s: nothing proves under a wrong canary", u.Id())
+	}
 }

--- a/architecture/evm/integrity_stateprobe_test.go
+++ b/architecture/evm/integrity_stateprobe_test.go
@@ -3,13 +3,11 @@ package evm
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/erpc/erpc/architecture/evm/integrity"
 	"github.com/erpc/erpc/common"
-	"github.com/erpc/erpc/util"
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -81,13 +79,13 @@ func proberFor(pn *probeNetwork, headN int64, stateRoot string) (*stateProber, *
 
 // The whole feature in one scenario: a node whose EVM truly executes at the
 // pinned height and whose proof roots at the VERIFIED stateRoot earns the
-// boundary; every deviation refuses it.
+// proven head; every deviation withholds it.
 func TestStateProber(t *testing.T) {
 	const head = int64(1000)
 	trieNode := []byte("state-trie-root-node-payload")
 	stateRoot := fmt.Sprintf("0x%x", gethcrypto.Keccak256(trieNode))
 
-	t.Run("both probes match: the boundary advances", func(t *testing.T) {
+	t.Run("both probes match: the proven head advances", func(t *testing.T) {
 		pn := newProbeNetwork(t)
 		pn.execContext, pn.proofNode = head, trieNode
 		p, _ := proberFor(pn, head, stateRoot)
@@ -95,7 +93,7 @@ func TestStateProber(t *testing.T) {
 		assert.EqualValues(t, head, pn.upstream.EvmStateProvenBlock())
 	})
 
-	t.Run("a PIN-IGNORING node (executes at latest, not the pin) also refuses the boundary", func(t *testing.T) {
+	t.Run("a PIN-IGNORING node (executes at latest, not the pin) is also never proven", func(t *testing.T) {
 		// Measured live on a vendor endpoint: claimed head exactly current,
 		// but every call pinned at N executed at N+3..N+4 — the node ignores
 		// the block parameter and answers historical questions with present
@@ -108,7 +106,7 @@ func TestStateProber(t *testing.T) {
 			"executing AHEAD of the pin means the pin was ignored — never proven")
 	})
 
-	t.Run("STALE EXECUTION CONTEXT refuses the boundary — the exact silent-bad-data case", func(t *testing.T) {
+	t.Run("STALE EXECUTION CONTEXT is never proven — the exact silent-bad-data case", func(t *testing.T) {
 		pn := newProbeNetwork(t)
 		pn.execContext, pn.proofNode = head-7, trieNode // claims head, executes 7 back
 		p, _ := proberFor(pn, head, stateRoot)
@@ -117,7 +115,7 @@ func TestStateProber(t *testing.T) {
 			"a node executing pinned calls in an older context must never be proven at the pin")
 	})
 
-	t.Run("a proof not rooted at the verified stateRoot refuses, even with a matching context", func(t *testing.T) {
+	t.Run("a proof not rooted at the verified stateRoot does not prove, even with a matching context", func(t *testing.T) {
 		pn := newProbeNetwork(t)
 		pn.execContext, pn.proofNode = head, []byte("some-other-trie")
 		p, _ := proberFor(pn, head, stateRoot)
@@ -145,235 +143,6 @@ func TestStateProber(t *testing.T) {
 	})
 }
 
-// The routing gate: inert with the prober off; never gates internal (probe)
-// traffic; diverts ONLY an upstream the probes have DISPROVED. Absence of
-// proof never blocks routing — see
-// TestStateBoundary_TipChosenFromClaimedHeadsMustRoute for why that
-// distinction is load-bearing on a fast chain.
-func TestStateBoundaryGate(t *testing.T) {
-	mkReq := func(method, block string, internal bool) *common.NormalizedRequest {
-		r := common.NewNormalizedRequest([]byte(fmt.Sprintf(
-			`{"jsonrpc":"2.0","id":1,"method":"%s","params":[{"to":"0x1234"},"%s"]}`, method, block)))
-		if internal {
-			r.SetDirectives(&common.RequestDirectives{IsInternal: true})
-		}
-		return r
-	}
-	netFor := func(id string) *mockNetwork {
-		n := &mockNetwork{}
-		n.On("Id").Return(id).Maybe()
-		return n
-	}
-	disprove := func(p *stateProber, id string) {
-		for i := 0; i < stateProbeDisprovedStreak; i++ {
-			p.noteDisproved(id)
-		}
-	}
-	// A prober whose sibling scan finds a healthy alternative for "u2".
-	proberWithSibling := func() *stateProber {
-		return &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-			common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
-		}}}
-	}
-
-	t.Run("no prober registered: byte-identical passthrough", func(t *testing.T) {
-		n := netFor("evm:404")
-		handled, resp, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u"), mkReq("eth_call", "0x100", false), "eth_call")
-		assert.False(t, handled)
-		assert.Nil(t, resp)
-		assert.NoError(t, err)
-	})
-
-	t.Run("a height far beyond the proven head passes: absence of proof is not disproof", func(t *testing.T) {
-		n := netFor("evm:7777")
-		stateProbers.Store("evm:7777", proberWithSibling())
-		defer stateProbers.Delete("evm:7777")
-		u := common.NewFakeUpstream("u2")
-		if w, ok := u.(common.EvmStateProvenWriter); ok {
-			w.EvmSetStateProvenBlock(0x0f0) // proven long ago; request far above it
-		}
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "0x100000", false), "eth_call")
-		assert.False(t, handled,
-			"the proven head lags the claimed head structurally (probe cadence); it must never refuse routing")
-		assert.NoError(t, err)
-	})
-
-	t.Run("a DISPROVED upstream is diverted when a sibling can serve", func(t *testing.T) {
-		n := netFor("evm:7777")
-		n.On("Config").Return(&common.NetworkConfig{}).Maybe()
-		p := proberWithSibling()
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
-		assert.True(t, handled)
-		require.Error(t, err)
-		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable))
-		assert.True(t, strings.Contains(err.Error(), "DISPROVEN"), err.Error())
-	})
-
-	t.Run("a DISPROVED last resort keeps serving — wrong data beats no data", func(t *testing.T) {
-		n := netFor("evm:7777")
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{common.NewFakeUpstream("u2")}}}
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
-		assert.False(t, handled)
-		assert.NoError(t, err)
-	})
-
-	t.Run("observeOnly suppresses the diversion — it is documented ABSOLUTE over integrity effects", func(t *testing.T) {
-		n := netFor("evm:7777")
-		n.On("Config").Return(&common.NetworkConfig{
-			Integrity: &common.IntegrityConfig{IntegritySettings: common.IntegritySettings{ObserveOnly: util.BoolPtr(true)}},
-		}).Maybe()
-		p := proberWithSibling()
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
-		assert.False(t, handled, "observeOnly network must never see a routing intervention")
-		assert.NoError(t, err)
-	})
-
-	t.Run("internal probe traffic is never gated — gating it would deadlock the proving", func(t *testing.T) {
-		n := netFor("evm:7777")
-		p := proberWithSibling()
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", true), "eth_call")
-		assert.False(t, handled)
-		assert.NoError(t, err)
-	})
-
-	t.Run("tag requests are not diverted (the sibling check needs a concrete height)", func(t *testing.T) {
-		n := netFor("evm:7777")
-		p := proberWithSibling()
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "latest", false), "eth_call")
-		assert.False(t, handled)
-		assert.NoError(t, err)
-	})
-
-	t.Run("non-canonical method casing is diverted identically to canonical", func(t *testing.T) {
-		// Through the real dispatch: HandleUpstreamPreForward lowercases the
-		// method to route into the boundary, so the per-method config lookup
-		// (block-ref extraction, which the sibling check depends on) must
-		// resolve case-insensitively too — otherwise ETH_CALL resolves no block
-		// number and silently skips the diversion eth_call would have taken.
-		n := netFor("evm:7777")
-		n.On("Config").Return(&common.NetworkConfig{}).Maybe()
-		p := proberWithSibling()
-		disprove(p, "u2")
-		stateProbers.Store("evm:7777", p)
-		defer stateProbers.Delete("evm:7777")
-
-		handled, _, err := HandleUpstreamPreForward(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("ETH_CALL", "0x100", false), false)
-		assert.True(t, handled, "a disproved upstream must be diverted regardless of method casing")
-		require.Error(t, err)
-		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable))
-		assert.Contains(t, err.Error(), "ETH_CALL",
-			"canonicalization is lookup-only: the wire method string stays verbatim")
-	})
-}
-
-// The boundary protects a CLASS of methods — everything answered from the state
-// trie at a block — and the routing switch is where a member gets forgotten: an
-// ungated state method keeps flowing to a DISPROVED upstream, which is the
-// silent-wrong-data case the diversion exists to prevent. Every case here goes
-// through the public hook entry point, so dropping a method from the dispatch
-// fails this test rather than silently disabling the protection for it.
-//
-// The params are written the way a client sends them (block parameter in its
-// real position, later arguments present), so a wrong ReqRefs position shows up
-// as an undiverted request instead of passing by accident.
-func TestStateBoundaryGate_StateMethodCoverage(t *testing.T) {
-	cases := []struct {
-		method string
-		params string // %s is where the block parameter goes
-	}{
-		{"eth_call", `[{"to":"0x1234"},"%s"]`},
-		{"eth_getBalance", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
-		{"eth_getCode", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
-		{"eth_getStorageAt", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","0x0","%s"]`},
-		{"eth_getTransactionCount", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
-		{"eth_estimateGas", `[{"to":"0x1234"},"%s"]`},
-		// The state trie itself: block is the THIRD param, after the storage keys.
-		{"eth_getProof", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x00"],"%s"]`},
-		// EVM execution at a block, exactly like eth_call: block is the SECOND param.
-		{"eth_simulateV1", `[{"blockStateCalls":[{"calls":[{"to":"0x1234"}]}]},"%s"]`},
-		// Same, with a trailing tracer config the extraction must not mistake
-		// for the block parameter.
-		{"debug_traceCall", `[{"to":"0x1234"},"%s",{"tracer":"callTracer"}]`},
-	}
-
-	mkReq := func(method, params, block string) *common.NormalizedRequest {
-		return common.NewNormalizedRequest([]byte(fmt.Sprintf(
-			`{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}`,
-			method, fmt.Sprintf(params, block))))
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.method, func(t *testing.T) {
-			n := &mockNetwork{}
-			n.On("Id").Return("evm:7777").Maybe()
-			n.On("Config").Return(&common.NetworkConfig{}).Maybe()
-			p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-				common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
-			}}}
-			for i := 0; i < stateProbeDisprovedStreak; i++ {
-				p.noteDisproved("u2")
-			}
-			stateProbers.Store("evm:7777", p)
-			defer stateProbers.Delete("evm:7777")
-			u := common.NewFakeUpstream("u2")
-
-			// Disproved + sibling available: diverted, whatever the depth.
-			handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0x100"), false)
-			assert.True(t, handled, "a state method must divert away from a disproved upstream")
-			require.Error(t, err)
-			assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable), err.Error())
-			assert.Contains(t, err.Error(), tc.method, "the diversion must name the method it diverted")
-
-			// A tag names no concrete height, so the sibling check cannot run —
-			// unchanged from before this method joined the class.
-			handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "latest"), false)
-			assert.False(t, handled, "tag requests are not diverted (no concrete height)")
-			assert.NoError(t, err)
-		})
-	}
-}
-
-// Widening the class must not pull in chain-data methods: those read blocks,
-// receipts and logs, which a node with a wrong-height STATE answer mode still
-// answers correctly, and they have their own availability enforcement.
-func TestStateBoundaryGate_ChainDataMethodsStayUngated(t *testing.T) {
-	for _, body := range []string{
-		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x100",false]}`,
-		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts","params":["0x100"]}`,
-		`{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":["0x100"]}`,
-		`{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["0xdead"]}`,
-	} {
-		n := &mockNetwork{}
-		n.On("Id").Return("evm:7777").Maybe()
-		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
-			common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
-		}}}
-		for i := 0; i < stateProbeDisprovedStreak; i++ {
-			p.noteDisproved("u2")
-		}
-		stateProbers.Store("evm:7777", p)
-		handled, _, err := HandleUpstreamPreForward(context.Background(), n, common.NewFakeUpstream("u2"), common.NewNormalizedRequest([]byte(body)), false)
-		stateProbers.Delete("evm:7777")
-		assert.False(t, handled, body)
-		assert.NoError(t, err, body)
-	}
-}
-
 // A fast-chain fleet where structural probe lag exceeds nothing but the clock.
 //
 // eRPC advertises "latest" as the majority CLAIMED head (PickServedTip), and
@@ -386,14 +155,15 @@ func TestStateBoundaryGate_ChainDataMethodsStayUngated(t *testing.T) {
 // function of cadence, not of node quality. An upstream reads 0 only for the
 // instant after its own probe, and is back to ~8 by the next one.
 //
-// A boundary that refused any state request above the proven head therefore
-// refused the very tip eRPC itself advertised, on nearly every upstream at
-// nearly every moment — while the nodes were all behaving correctly.
+// A pre-forward boundary that refused any state request above the proven head
+// therefore refused the very tip eRPC itself advertised, on nearly every
+// upstream at nearly every moment — while the nodes were all behaving
+// correctly.
 //
 // The invariant this test pins: a height the network advertises as "latest"
-// must pass the state boundary on every upstream the probes have NOT disproved
-// — structural probe lag is absence of proof, and absence of proof never
-// blocks routing.
+// must pass the upstream pre-forward hook on every honest upstream, prober
+// active or not — structural probe lag is absence of proof, and absence of
+// proof never blocks routing.
 func TestStateBoundary_TipChosenFromClaimedHeadsMustRoute(t *testing.T) {
 	const head = int64(374_000_000) // an L2-scale height; only the lags matter
 	// Lags spanning one probe cycle on a ~250ms-block chain: every entry is an
@@ -434,16 +204,18 @@ func TestStateBoundary_TipChosenFromClaimedHeadsMustRoute(t *testing.T) {
 	// network's own "latest" is unroutable.
 	beyondProof := 0
 	for _, u := range ups {
-		if r, ok := u.(common.EvmStateProvenReader); ok && r.EvmStateProvenBlock() < tip {
+		if u.(*cadenceLaggedUpstream).EvmStateProvenBlock() < tip {
 			beyondProof++
 		}
 	}
 	require.GreaterOrEqual(t, beyondProof, len(fleet)/2+1,
 		"fixture must keep its bite: the advertised tip is above most proven heads")
 
+	// A running prober must make no difference: it publishes evidence (proven
+	// heads, misbehavior), never routing refusals.
 	n := &mockNetwork{}
 	n.On("Id").Return("evm:42161").Maybe()
-	stateProbers.Store("evm:42161", &stateProber{network: &siblingNetwork{ups: ups}})
+	stateProbers.Store("evm:42161", &stateProber{network: &fleetNetwork{ups: ups}})
 	defer stateProbers.Delete("evm:42161")
 
 	req := func() *common.NormalizedRequest {

--- a/architecture/evm/integrity_stateprobe_test.go
+++ b/architecture/evm/integrity_stateprobe_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/erpc/erpc/architecture/evm/integrity"
 	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -145,7 +146,10 @@ func TestStateProber(t *testing.T) {
 }
 
 // The routing gate: inert with the prober off; never gates internal (probe)
-// traffic; refuses an upstream whose proven head does not cover the block.
+// traffic; diverts ONLY an upstream the probes have DISPROVED. Absence of
+// proof never blocks routing — see
+// TestStateBoundary_TipChosenFromClaimedHeadsMustRoute for why that
+// distinction is load-bearing on a fast chain.
 func TestStateBoundaryGate(t *testing.T) {
 	mkReq := func(method, block string, internal bool) *common.NormalizedRequest {
 		r := common.NewNormalizedRequest([]byte(fmt.Sprintf(
@@ -160,6 +164,17 @@ func TestStateBoundaryGate(t *testing.T) {
 		n.On("Id").Return(id).Maybe()
 		return n
 	}
+	disprove := func(p *stateProber, id string) {
+		for i := 0; i < stateProbeDisprovedStreak; i++ {
+			p.noteDisproved(id)
+		}
+	}
+	// A prober whose sibling scan finds a healthy alternative for "u2".
+	proberWithSibling := func() *stateProber {
+		return &stateProber{network: &siblingNetwork{ups: []common.Upstream{
+			common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
+		}}}
+	}
 
 	t.Run("no prober registered: byte-identical passthrough", func(t *testing.T) {
 		n := netFor("evm:404")
@@ -169,89 +184,118 @@ func TestStateBoundaryGate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("with a prober active, a proven-covered block passes and an unproven one is refused", func(t *testing.T) {
+	t.Run("a height far beyond the proven head passes: absence of proof is not disproof", func(t *testing.T) {
 		n := netFor("evm:7777")
-		stateProbers.Store("evm:7777", &stateProber{})
+		stateProbers.Store("evm:7777", proberWithSibling())
 		defer stateProbers.Delete("evm:7777")
-
-		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 0x0f0}
-		// covered: 0x0e0 <= proven
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "0xe0", false), "eth_call")
-		assert.False(t, handled)
+		u := common.NewFakeUpstream("u2")
+		if w, ok := u.(common.EvmStateProvenWriter); ok {
+			w.EvmSetStateProvenBlock(0x0f0) // proven long ago; request far above it
+		}
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "0x100000", false), "eth_call")
+		assert.False(t, handled,
+			"the proven head lags the claimed head structurally (probe cadence); it must never refuse routing")
 		assert.NoError(t, err)
-		// beyond proof: refuse with a retryable block-unavailable error
-		handled, _, err = upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "0x100", false), "eth_call")
+	})
+
+	t.Run("a DISPROVED upstream is diverted when a sibling can serve", func(t *testing.T) {
+		n := netFor("evm:7777")
+		n.On("Config").Return(&common.NetworkConfig{}).Maybe()
+		p := proberWithSibling()
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
+		defer stateProbers.Delete("evm:7777")
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
 		assert.True(t, handled)
 		require.Error(t, err)
 		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable))
-		assert.True(t, strings.Contains(err.Error(), "PROVEN"), err.Error())
+		assert.True(t, strings.Contains(err.Error(), "DISPROVEN"), err.Error())
+	})
+
+	t.Run("a DISPROVED last resort keeps serving — wrong data beats no data", func(t *testing.T) {
+		n := netFor("evm:7777")
+		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{common.NewFakeUpstream("u2")}}}
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
+		defer stateProbers.Delete("evm:7777")
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
+		assert.False(t, handled)
+		assert.NoError(t, err)
+	})
+
+	t.Run("observeOnly suppresses the diversion — it is documented ABSOLUTE over integrity effects", func(t *testing.T) {
+		n := netFor("evm:7777")
+		n.On("Config").Return(&common.NetworkConfig{
+			Integrity: &common.IntegrityConfig{IntegritySettings: common.IntegritySettings{ObserveOnly: util.BoolPtr(true)}},
+		}).Maybe()
+		p := proberWithSibling()
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
+		defer stateProbers.Delete("evm:7777")
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", false), "eth_call")
+		assert.False(t, handled, "observeOnly network must never see a routing intervention")
+		assert.NoError(t, err)
 	})
 
 	t.Run("internal probe traffic is never gated — gating it would deadlock the proving", func(t *testing.T) {
 		n := netFor("evm:7777")
-		stateProbers.Store("evm:7777", &stateProber{})
+		p := proberWithSibling()
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
 		defer stateProbers.Delete("evm:7777")
-		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 1}
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "0x100", true), "eth_call")
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "0x100", true), "eth_call")
 		assert.False(t, handled)
 		assert.NoError(t, err)
 	})
 
-	t.Run("tag requests are not gated (the boundary is about concrete heights)", func(t *testing.T) {
+	t.Run("tag requests are not diverted (the sibling check needs a concrete height)", func(t *testing.T) {
 		n := netFor("evm:7777")
-		stateProbers.Store("evm:7777", &stateProber{})
+		p := proberWithSibling()
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
 		defer stateProbers.Delete("evm:7777")
-		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 1}
-		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, u, mkReq("eth_call", "latest", false), "eth_call")
+		handled, _, err := upstreamPreForward_stateBoundary(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("eth_call", "latest", false), "eth_call")
 		assert.False(t, handled)
 		assert.NoError(t, err)
 	})
 
-	t.Run("non-canonical method casing is gated identically to canonical", func(t *testing.T) {
+	t.Run("non-canonical method casing is diverted identically to canonical", func(t *testing.T) {
 		// Through the real dispatch: HandleUpstreamPreForward lowercases the
 		// method to route into the boundary, so the per-method config lookup
-		// (block-ref extraction) must resolve case-insensitively too —
-		// otherwise ETH_CALL resolves no block number and silently passes the
-		// gate that eth_call would have refused.
+		// (block-ref extraction, which the sibling check depends on) must
+		// resolve case-insensitively too — otherwise ETH_CALL resolves no block
+		// number and silently skips the diversion eth_call would have taken.
 		n := netFor("evm:7777")
-		stateProbers.Store("evm:7777", &stateProber{})
+		n.On("Config").Return(&common.NetworkConfig{}).Maybe()
+		p := proberWithSibling()
+		disprove(p, "u2")
+		stateProbers.Store("evm:7777", p)
 		defer stateProbers.Delete("evm:7777")
-		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 0x0f0}
 
-		// beyond proof: refused exactly like the lowercase request above
-		handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, mkReq("ETH_CALL", "0x100", false), false)
-		assert.True(t, handled, "an unproven block must be refused regardless of method casing")
+		handled, _, err := HandleUpstreamPreForward(context.Background(), n, common.NewFakeUpstream("u2"), mkReq("ETH_CALL", "0x100", false), false)
+		assert.True(t, handled, "a disproved upstream must be diverted regardless of method casing")
 		require.Error(t, err)
 		assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable))
 		assert.Contains(t, err.Error(), "ETH_CALL",
 			"canonicalization is lookup-only: the wire method string stays verbatim")
-
-		// covered by proof: passes with the same non-canonical casing
-		handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq("eth_Call", "0xe0", false), false)
-		assert.False(t, handled)
-		assert.NoError(t, err)
 	})
 }
 
 // The boundary protects a CLASS of methods — everything answered from the state
 // trie at a block — and the routing switch is where a member gets forgotten: an
-// ungated state method reaches the upstream with no proof at all, which is the
-// silent-wrong-data case the gate exists to prevent. Every case here goes
+// ungated state method keeps flowing to a DISPROVED upstream, which is the
+// silent-wrong-data case the diversion exists to prevent. Every case here goes
 // through the public hook entry point, so dropping a method from the dispatch
 // fails this test rather than silently disabling the protection for it.
 //
 // The params are written the way a client sends them (block parameter in its
 // real position, later arguments present), so a wrong ReqRefs position shows up
-// as an ungated request instead of passing by accident.
+// as an undiverted request instead of passing by accident.
 func TestStateBoundaryGate_StateMethodCoverage(t *testing.T) {
-	const proven = int64(0x0f0)
-
 	cases := []struct {
 		method string
 		params string // %s is where the block parameter goes
 	}{
-		// Already covered before this test existed — pinned so the six cannot
-		// regress while the class is being widened.
 		{"eth_call", `[{"to":"0x1234"},"%s"]`},
 		{"eth_getBalance", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
 		{"eth_getCode", `["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842","%s"]`},
@@ -277,35 +321,36 @@ func TestStateBoundaryGate_StateMethodCoverage(t *testing.T) {
 		t.Run(tc.method, func(t *testing.T) {
 			n := &mockNetwork{}
 			n.On("Id").Return("evm:7777").Maybe()
-			stateProbers.Store("evm:7777", &stateProber{})
+			n.On("Config").Return(&common.NetworkConfig{}).Maybe()
+			p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
+				common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
+			}}}
+			for i := 0; i < stateProbeDisprovedStreak; i++ {
+				p.noteDisproved("u2")
+			}
+			stateProbers.Store("evm:7777", p)
 			defer stateProbers.Delete("evm:7777")
-			u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: proven}
+			u := common.NewFakeUpstream("u2")
 
-			// Below the proven head: the upstream demonstrably holds this state.
-			handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0xe0"), false)
-			assert.False(t, handled, "a block the upstream has PROVEN must pass through")
-			assert.NoError(t, err)
-
-			// Above the proven head: no proof covers it, so refuse and let
-			// retry/consensus route to an upstream that can prove it.
-			handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0x100"), false)
-			assert.True(t, handled, "an unproven block must not be forwarded ungated")
+			// Disproved + sibling available: diverted, whatever the depth.
+			handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "0x100"), false)
+			assert.True(t, handled, "a state method must divert away from a disproved upstream")
 			require.Error(t, err)
 			assert.True(t, common.HasErrorCode(err, common.ErrCodeUpstreamBlockUnavailable), err.Error())
-			assert.Contains(t, err.Error(), tc.method, "the refusal must name the method it refused")
+			assert.Contains(t, err.Error(), tc.method, "the diversion must name the method it diverted")
 
-			// A tag names no concrete height, so there is nothing to compare it
-			// against — unchanged from before this method joined the class.
+			// A tag names no concrete height, so the sibling check cannot run —
+			// unchanged from before this method joined the class.
 			handled, _, err = HandleUpstreamPreForward(context.Background(), n, u, mkReq(tc.method, tc.params, "latest"), false)
-			assert.False(t, handled, "tag requests are not gated (the boundary is about concrete heights)")
+			assert.False(t, handled, "tag requests are not diverted (no concrete height)")
 			assert.NoError(t, err)
 		})
 	}
 }
 
 // Widening the class must not pull in chain-data methods: those read blocks,
-// receipts and logs, which a node with stale STATE still answers correctly, and
-// they have their own availability enforcement.
+// receipts and logs, which a node with a wrong-height STATE answer mode still
+// answers correctly, and they have their own availability enforcement.
 func TestStateBoundaryGate_ChainDataMethodsStayUngated(t *testing.T) {
 	for _, body := range []string{
 		`{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x100",false]}`,
@@ -315,26 +360,119 @@ func TestStateBoundaryGate_ChainDataMethodsStayUngated(t *testing.T) {
 	} {
 		n := &mockNetwork{}
 		n.On("Id").Return("evm:7777").Maybe()
-		stateProbers.Store("evm:7777", &stateProber{})
-		u := &gateUpstream{FakeUpstream: common.NewFakeUpstream("u2").(*common.FakeUpstream), proven: 0x0f0}
-		handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, common.NewNormalizedRequest([]byte(body)), false)
+		p := &stateProber{network: &siblingNetwork{ups: []common.Upstream{
+			common.NewFakeUpstream("u2"), provenUp("healthy-sibling", 1<<40),
+		}}}
+		for i := 0; i < stateProbeDisprovedStreak; i++ {
+			p.noteDisproved("u2")
+		}
+		stateProbers.Store("evm:7777", p)
+		handled, _, err := HandleUpstreamPreForward(context.Background(), n, common.NewFakeUpstream("u2"), common.NewNormalizedRequest([]byte(body)), false)
 		stateProbers.Delete("evm:7777")
 		assert.False(t, handled, body)
 		assert.NoError(t, err, body)
 	}
 }
 
-// gateUpstream lets a test dictate the proven head and route the assert through
-// the real StateProven semantics (refuse above proven, allow at/below).
-type gateUpstream struct {
-	*common.FakeUpstream
-	proven int64
+// A fast-chain fleet where structural probe lag exceeds nothing but the clock.
+//
+// eRPC advertises "latest" as the majority CLAIMED head (PickServedTip), and
+// clients additionally pin state calls at concrete heights they derive
+// themselves (an indexer calls eth_getBlockByNumber, then eth_call at that
+// number). The state prober advances each upstream's PROVEN head only at probe
+// cadence (follow interval + probe interval), so on a chain producing a block
+// every ~250ms with a 2s probe floor, every HONEST upstream's proven head
+// trails its claimed head by roughly 8-18 blocks at all times — purely as a
+// function of cadence, not of node quality. An upstream reads 0 only for the
+// instant after its own probe, and is back to ~8 by the next one.
+//
+// A boundary that refused any state request above the proven head therefore
+// refused the very tip eRPC itself advertised, on nearly every upstream at
+// nearly every moment — while the nodes were all behaving correctly.
+//
+// The invariant this test pins: a height the network advertises as "latest"
+// must pass the state boundary on every upstream the probes have NOT disproved
+// — structural probe lag is absence of proof, and absence of proof never
+// blocks routing.
+func TestStateBoundary_TipChosenFromClaimedHeadsMustRoute(t *testing.T) {
+	const head = int64(374_000_000) // an L2-scale height; only the lags matter
+	// Lags spanning one probe cycle on a ~250ms-block chain: every entry is an
+	// honest node, differing only in how long ago its probe landed.
+	fleet := []struct {
+		id        string
+		provenLag int64 // claimed head minus state-proven head
+	}{
+		{"upstream-a", 18},
+		{"upstream-b", 13},
+		{"upstream-c", 11},
+		{"upstream-d", 11},
+		{"upstream-e", 8},
+		{"upstream-f", 0},
+	}
+
+	// The tip eRPC advertises: the majority order statistic over CLAIMED heads
+	// (all live and within a block of each other).
+	tips := make([]ServedTipInput, 0, len(fleet))
+	ups := make([]common.Upstream, 0, len(fleet))
+	for _, f := range fleet {
+		tips = append(tips, ServedTipInput{UpstreamID: f.id, BlockNumber: head})
+		u := &cadenceLaggedUpstream{
+			FakeUpstream: common.NewFakeUpstream(f.id).(*common.FakeUpstream),
+			claimed:      head,
+		}
+		if head-f.provenLag > 0 {
+			u.EvmSetStateProvenBlock(head - f.provenLag)
+		}
+		ups = append(ups, u)
+	}
+	tip := PickServedTip(tips).Tip
+	require.Equal(t, head, tip, "sanity: a healthy fleet's majority tip is the head")
+
+	// The precondition, asserted so the fixture cannot rot into triviality: the
+	// advertised tip exceeds the proven head of a strict majority of the fleet
+	// (all but the just-probed one) — under a proven-head routing bound the
+	// network's own "latest" is unroutable.
+	beyondProof := 0
+	for _, u := range ups {
+		if r, ok := u.(common.EvmStateProvenReader); ok && r.EvmStateProvenBlock() < tip {
+			beyondProof++
+		}
+	}
+	require.GreaterOrEqual(t, beyondProof, len(fleet)/2+1,
+		"fixture must keep its bite: the advertised tip is above most proven heads")
+
+	n := &mockNetwork{}
+	n.On("Id").Return("evm:42161").Maybe()
+	stateProbers.Store("evm:42161", &stateProber{network: &siblingNetwork{ups: ups}})
+	defer stateProbers.Delete("evm:42161")
+
+	req := func() *common.NormalizedRequest {
+		return common.NewNormalizedRequest([]byte(fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x1234"},"0x%x"]}`, tip)))
+	}
+	for _, u := range ups {
+		handled, _, err := HandleUpstreamPreForward(context.Background(), n, u, req(), false)
+		assert.False(t, handled,
+			"%s: a tip the network advertises must be routable on an upstream nothing has disproved", u.Id())
+		assert.NoError(t, err, u.Id())
+	}
 }
 
-func (g *gateUpstream) EvmStateProvenBlock() int64 { return g.proven }
-func (g *gateUpstream) EvmAssertBlockAvailability(ctx context.Context, forMethod string, confidence common.AvailbilityConfidence, forceFreshIfStale bool, blockNumber int64) (bool, error) {
-	if confidence == common.AvailbilityConfidenceStateProven && g.proven > 0 {
-		return blockNumber <= g.proven, nil
+// cadenceLaggedUpstream answers availability asserts the way a real honest upstream
+// does: bounded by the CLAIMED head for the known confidences — and bounded by
+// the PROVEN head for any confidence it does not recognize. The second branch
+// is the tripwire: if a routing bound on the proven head is ever reintroduced
+// under a new AvailbilityConfidence, the fixture above goes red
+// instead of silently passing through a permissive fake.
+type cadenceLaggedUpstream struct {
+	*common.FakeUpstream
+	claimed int64
+}
+
+func (g *cadenceLaggedUpstream) EvmAssertBlockAvailability(ctx context.Context, forMethod string, confidence common.AvailbilityConfidence, forceFreshIfStale bool, blockNumber int64) (bool, error) {
+	switch confidence {
+	case common.AvailbilityConfidenceBlockHead, common.AvailbilityConfidenceFinalized:
+		return blockNumber <= g.claimed, nil
 	}
-	return true, nil
+	return blockNumber <= g.EvmStateProvenBlock(), nil
 }

--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -30,20 +30,14 @@ type EvmUpstream interface {
 	EvmBlockAvailabilityBounds() (int64, int64)
 }
 
-// EvmStateProvenReader is the OPTIONAL, separately-asserted surface for the
-// state-proven boundary (see the integrity state prober). Deliberately NOT part
-// of EvmUpstream: that interface is implemented outside this repo, and widening
-// it broke every existing implementor — the chainId suggest-gate silently
-// degraded when its upstream stopped satisfying the assertion. Optional
-// capabilities are asserted narrowly, never added to the core interface.
-type EvmStateProvenReader interface {
-	// EvmStateProvenBlock is the highest block for which this upstream has
-	// PROVEN it holds the state trie. 0 = never proven (probe disabled,
-	// warming up, or unsupported) — callers fall back to the claimed head.
-	EvmStateProvenBlock() int64
-}
-
-// EvmStateProvenWriter is the prober-facing half.
+// EvmStateProvenWriter is the OPTIONAL, separately-asserted surface the
+// integrity state prober records proofs through. The proven head is telemetry
+// (the state-proven block / proven-lag gauges), never a routing input.
+// Deliberately NOT part of EvmUpstream: that interface is implemented outside
+// this repo, and widening it broke every existing implementor — the chainId
+// suggest-gate silently degraded when its upstream stopped satisfying the
+// assertion. Optional capabilities are asserted narrowly, never added to the
+// core interface.
 type EvmStateProvenWriter interface {
 	// EvmSetStateProvenBlock records a successful state proof at a height.
 	// Monotonic: a lower value than the current one is ignored.
@@ -59,10 +53,10 @@ const (
 	// (see the integrity state prober) advances at probe cadence, so on any
 	// chain whose block time is shorter than that cadence it sits structurally
 	// behind every honest upstream's claimed head — a routing bound built on it
-	// would refuse the entire network's tip traffic. Absence
-	// of proof is not evidence; only DISPROOF is, and that is handled by the
-	// state boundary's diversion (architecture/evm/hooks.go), not by an
-	// availability confidence.
+	// would refuse the entire network's tip traffic. Absence of proof is not
+	// evidence; only DISPROOF is, and the prober publishes that as upstream
+	// misbehavior on the health tracker for selection policies to act on
+	// (misbehaviorRateAbove), not as an availability confidence.
 )
 
 func (c AvailbilityConfidence) String() string {
@@ -185,45 +179,3 @@ type EvmProbeEarliestInfo struct {
 	SchedulerRunning bool                     `json:"schedulerRunning,omitempty"`
 }
 
-// IsEvmStateQueryMethod reports whether a method reads the STATE TRIE at a
-// block (as opposed to chain data like blocks/receipts/logs). These are the
-// methods a node can silently answer from older state, so they are the ones
-// the state-proven boundary applies to (architecture/evm/hooks.go).
-//
-// Membership is a two-part test, and BOTH parts must hold:
-//
-//  1. the method's answer is a function of the state trie at the requested
-//     block (a balance, a slot, code, an account proof, or an EVM execution in
-//     that block's context) — a node with stale state answers it wrongly while
-//     reporting a current head; and
-//  2. the requested block is resolvable from the request through the method's
-//     ReqRefs (common/defaults.go), because a boundary that cannot name a
-//     height cannot enforce one.
-//
-// This list is an enumeration over an open set, so its unmatched path is the
-// one that matters: an unlisted state method is simply NOT gated (fail-open,
-// exactly today's behavior for it). Adding a method here can only ever divert
-// traffic away from an upstream the probes have DISPROVED (and only when a
-// sibling can serve), so extend it whenever parts 1 and 2 both hold. Known
-// state-reading methods still absent:
-//
-//   - eth_createAccessList, debug_traceCallMany — no method config at all, so
-//     part 2 fails and gating them would be inert until they get one.
-//   - trace_call — its block parameter is the second OR third argument
-//     depending on the client, and on the variant where trace types occupy the
-//     second argument the extraction errors out, so the gate would be inert for
-//     exactly those requests. Pin the position first.
-//   - the arbtrace_call family — parts 1 and 2 both hold; left out only to keep
-//     this change to the methods the gap review named.
-func IsEvmStateQueryMethod(methodLower string) bool {
-	switch methodLower {
-	case "eth_call", "eth_getbalance", "eth_getcode", "eth_getstorageat",
-		"eth_gettransactioncount", "eth_estimategas",
-		// eth_getProof IS the state trie (params[2] is the block); eth_simulateV1
-		// (params[1]) and debug_traceCall (params[1]) execute the EVM against the
-		// state at the requested block exactly like eth_call does.
-		"eth_getproof", "eth_simulatev1", "debug_tracecall":
-		return true
-	}
-	return false
-}

--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -178,4 +178,3 @@ type EvmProbeEarliestInfo struct {
 	EarliestBlock    int64                    `json:"earliestBlock"`
 	SchedulerRunning bool                     `json:"schedulerRunning,omitempty"`
 }
-

--- a/common/architecture_evm.go
+++ b/common/architecture_evm.go
@@ -55,20 +55,18 @@ type AvailbilityConfidence int
 const (
 	AvailbilityConfidenceBlockHead AvailbilityConfidence = 1
 	AvailbilityConfidenceFinalized AvailbilityConfidence = 2
-	// AvailbilityConfidenceStateProven gates on the state-PROVEN head rather
-	// than the claimed head: the highest block for which the integrity state
-	// probe verified the upstream truly executes in that block's context /
-	// holds its state trie. Nodes sometimes answer state queries (eth_call,
-	// eth_getBalance, ...) from OLDER state while their reported head is
-	// current; this confidence exists so routing for state methods can refuse
-	// to outrun proof. Falls back to blockHead while nothing is proven yet.
-	AvailbilityConfidenceStateProven AvailbilityConfidence = 3
+	// NOTE: there is deliberately no "state-proven" confidence. The proven head
+	// (see the integrity state prober) advances at probe cadence, so on any
+	// chain whose block time is shorter than that cadence it sits structurally
+	// behind every honest upstream's claimed head — a routing bound built on it
+	// would refuse the entire network's tip traffic. Absence
+	// of proof is not evidence; only DISPROOF is, and that is handled by the
+	// state boundary's diversion (architecture/evm/hooks.go), not by an
+	// availability confidence.
 )
 
 func (c AvailbilityConfidence) String() string {
 	switch c {
-	case AvailbilityConfidenceStateProven:
-		return "stateProven"
 	case AvailbilityConfidenceBlockHead:
 		return "blockHead"
 	case AvailbilityConfidenceFinalized:
@@ -204,9 +202,10 @@ type EvmProbeEarliestInfo struct {
 //
 // This list is an enumeration over an open set, so its unmatched path is the
 // one that matters: an unlisted state method is simply NOT gated (fail-open,
-// exactly today's behavior for it). Adding a method here can only ever refuse
-// or divert traffic the proven head does not cover, so extend it whenever parts
-// 1 and 2 both hold. Known state-reading methods still absent:
+// exactly today's behavior for it). Adding a method here can only ever divert
+// traffic away from an upstream the probes have DISPROVED (and only when a
+// sibling can serve), so extend it whenever parts 1 and 2 both hold. Known
+// state-reading methods still absent:
 //
 //   - eth_createAccessList, debug_traceCallMany — no method config at all, so
 //     part 2 fails and gating them would be inert until they get one.

--- a/common/config_integrity.go
+++ b/common/config_integrity.go
@@ -64,8 +64,12 @@ type IntegritySettings struct {
 	// execution-context call (and eth_getProof where supported) verified
 	// against the follower's verified header, and advance that upstream's
 	// state-proven head only on success. Routing for state methods (eth_call,
-	// eth_getBalance, ...) then refuses to outrun proof. Requires follow to be
-	// enabled (the verified header is the trust anchor). Off by default.
+	// eth_getBalance, ...) then DIVERTS an upstream a sustained streak of
+	// probes has DISPROVED (it answers pinned calls at the wrong height),
+	// whenever a sibling can serve the height; absence of proof alone never
+	// blocks routing, and ObserveOnly suppresses the diversion too. Requires
+	// follow to be enabled (the verified header is the trust anchor). Off by
+	// default.
 	StateProbe *IntegrityStateProbeConfig `yaml:"stateProbe,omitempty" json:"stateProbe,omitempty"`
 	// Follow turns the ChainView into an actual chain follower: it walks the
 	// chain forward block by block, requires each block to name its

--- a/common/config_integrity.go
+++ b/common/config_integrity.go
@@ -63,13 +63,15 @@ type IntegritySettings struct {
 	// trie it claims: on each new followed block, probe every upstream with an
 	// execution-context call (and eth_getProof where supported) verified
 	// against the follower's verified header, and advance that upstream's
-	// state-proven head only on success. Routing for state methods (eth_call,
-	// eth_getBalance, ...) then DIVERTS an upstream a sustained streak of
-	// probes has DISPROVED (it answers pinned calls at the wrong height),
-	// whenever a sibling can serve the height; absence of proof alone never
-	// blocks routing, and ObserveOnly suppresses the diversion too. Requires
-	// follow to be enabled (the verified header is the trust anchor). Off by
-	// default.
+	// state-proven head only on success. The probes PUBLISH evidence, they
+	// never route: proofs feed the state-proven telemetry, and a sustained
+	// streak of wrong-height answers is recorded as upstream misbehavior on
+	// the health tracker — the same ledger consensus disputes and integrity
+	// rejects feed — for the selection policy to act on (e.g. the
+	// misbehaviorRateAbove predicate); absence of proof has no effect at all,
+	// and ObserveOnly suppresses the misbehavior recording like every other
+	// integrity effect. Requires follow to be enabled (the verified header is
+	// the trust anchor). Off by default.
 	StateProbe *IntegrityStateProbeConfig `yaml:"stateProbe,omitempty" json:"stateProbe,omitempty"`
 	// Follow turns the ChainView into an actual chain follower: it walks the
 	// chain forward block by block, requires each block to name its

--- a/common/upstream_fake.go
+++ b/common/upstream_fake.go
@@ -316,9 +316,11 @@ func (p *FakeEvmStatePoller) GetDiagnostics() *EvmStatePollerDiagnostics {
 
 // FakeHealthTracker is a no-op implementation of HealthTracker for testing
 type FakeHealthTracker struct {
-	MisbehaviorRecorded bool
-	MisbehaviorCount    int
-	mu                  sync.Mutex
+	MisbehaviorRecorded     bool
+	MisbehaviorCount        int
+	LastMisbehaviorMethod   string
+	LastMisbehaviorFinality DataFinalityState
+	mu                      sync.Mutex
 }
 
 func (t *FakeHealthTracker) RecordUpstreamMisbehavior(up Upstream, method string, finality DataFinalityState) {
@@ -326,6 +328,8 @@ func (t *FakeHealthTracker) RecordUpstreamMisbehavior(up Upstream, method string
 	defer t.mu.Unlock()
 	t.MisbehaviorRecorded = true
 	t.MisbehaviorCount++
+	t.LastMisbehaviorMethod = method
+	t.LastMisbehaviorFinality = finality
 }
 
 func (t *FakeHealthTracker) RecordUpstreamRequest(up Upstream, method string, finality DataFinalityState) {

--- a/typescript/config/src/generated.ts
+++ b/typescript/config/src/generated.ts
@@ -65,31 +65,19 @@ export const UpstreamTypeEvm: UpstreamType = "evm";
 export type EvmUpstream = 
     Upstream;
 /**
- * EvmStateProvenReader is the OPTIONAL, separately-asserted surface for the
- * state-proven boundary (see the integrity state prober). Deliberately NOT part
- * of EvmUpstream: that interface is implemented outside this repo, and widening
- * it broke every existing implementor — the chainId suggest-gate silently
- * degraded when its upstream stopped satisfying the assertion. Optional
- * capabilities are asserted narrowly, never added to the core interface.
- */
-export type EvmStateProvenReader = any;
-/**
- * EvmStateProvenWriter is the prober-facing half.
+ * EvmStateProvenWriter is the OPTIONAL, separately-asserted surface the
+ * integrity state prober records proofs through. The proven head is telemetry
+ * (the state-proven block / proven-lag gauges), never a routing input.
+ * Deliberately NOT part of EvmUpstream: that interface is implemented outside
+ * this repo, and widening it broke every existing implementor — the chainId
+ * suggest-gate silently degraded when its upstream stopped satisfying the
+ * assertion. Optional capabilities are asserted narrowly, never added to the
+ * core interface.
  */
 export type EvmStateProvenWriter = any;
 export type AvailbilityConfidence = number /* int */;
 export const AvailbilityConfidenceBlockHead: AvailbilityConfidence = 1;
 export const AvailbilityConfidenceFinalized: AvailbilityConfidence = 2;
-/**
- * AvailbilityConfidenceStateProven gates on the state-PROVEN head rather
- * than the claimed head: the highest block for which the integrity state
- * probe verified the upstream truly executes in that block's context /
- * holds its state trie. Nodes sometimes answer state queries (eth_call,
- * eth_getBalance, ...) from OLDER state while their reported head is
- * current; this confidence exists so routing for state methods can refuse
- * to outrun proof. Falls back to blockHead while nothing is proven yet.
- */
-export const AvailbilityConfidenceStateProven: AvailbilityConfidence = 3;
 export type EvmNodeType = string;
 export const EvmNodeTypeUnknown: EvmNodeType = "unknown";
 export const EvmNodeTypeFull: EvmNodeType = "full";
@@ -2035,9 +2023,15 @@ export interface IntegritySettings {
    * trie it claims: on each new followed block, probe every upstream with an
    * execution-context call (and eth_getProof where supported) verified
    * against the follower's verified header, and advance that upstream's
-   * state-proven head only on success. Routing for state methods (eth_call,
-   * eth_getBalance, ...) then refuses to outrun proof. Requires follow to be
-   * enabled (the verified header is the trust anchor). Off by default.
+   * state-proven head only on success. The probes PUBLISH evidence, they
+   * never route: proofs feed the state-proven telemetry, and a sustained
+   * streak of wrong-height answers is recorded as upstream misbehavior on
+   * the health tracker — the same ledger consensus disputes and integrity
+   * rejects feed — for the selection policy to act on (e.g. the
+   * misbehaviorRateAbove predicate); absence of proof has no effect at all,
+   * and ObserveOnly suppresses the misbehavior recording like every other
+   * integrity effect. Requires follow to be enabled (the verified header is
+   * the trust anchor). Off by default.
    */
   stateProbe?: IntegrityStateProbeConfig;
   /**

--- a/upstream/evm_upstream_ops.go
+++ b/upstream/evm_upstream_ops.go
@@ -209,45 +209,6 @@ func (u *Upstream) EvmAssertBlockAvailability(ctx context.Context, forMethod str
 
 		// Block is finalized and within range (or archive node)
 		return true, nil
-	case common.AvailbilityConfidenceStateProven:
-		//
-		// UPPER BOUND: the state-PROVEN head, not the claimed one. A node can
-		// report head N yet still answer state queries from older state; the
-		// probe (execution-context call / getProof vs the follower's verified
-		// header) is what earns the boundary. While nothing is proven yet —
-		// probing off, warming up, or unsupported on this upstream/chain —
-		// fall back to the claimed head so the gate cannot brown out traffic
-		// on capability gaps; the proven-lag metric keeps that visible.
-		//
-		proven := u.stateProvenBlock.Load()
-		if proven > 0 && blockNumber > proven+cfg.Evm.HeadLagToleranceBlocks {
-			telemetry.MetricUpstreamStaleUpperBound.WithLabelValues(
-				u.ProjectId,
-				u.VendorName(),
-				u.NetworkLabel(),
-				u.Id(),
-				forMethod,
-				confidence.String(),
-			).Inc()
-			return false, nil
-		}
-		//
-		// LOWER BOUND: state on full nodes only reaches back
-		// maxAvailableRecentBlocks — reuse the same bound as blockHead.
-		//
-		if proven > 0 {
-			if cfg.Evm.MaxAvailableRecentBlocks > 0 {
-				available, err := u.assertUpstreamLowerBound(ctx, statePoller, blockNumber, cfg.Evm.MaxAvailableRecentBlocks, forMethod, confidence)
-				if err != nil {
-					return false, err
-				}
-				if !available {
-					return false, nil
-				}
-			}
-			return true, nil
-		}
-		fallthrough
 	case common.AvailbilityConfidenceBlockHead:
 		//
 		// UPPER BOUND: Check if block is before the latest block

--- a/upstream/upstream_block_availability_test.go
+++ b/upstream/upstream_block_availability_test.go
@@ -1242,15 +1242,4 @@ func TestEvmAssertBlockAvailability_HeadLagTolerance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, canHandle)
 	})
-
-	t.Run("ToleranceAppliesToStateProvenHead", func(t *testing.T) {
-		upstream := newUpstream(1)
-		upstream.stateProvenBlock.Store(1000)
-		canHandle, err := upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceStateProven, false, 1001)
-		assert.NoError(t, err)
-		assert.True(t, canHandle)
-		canHandle, err = upstream.EvmAssertBlockAvailability(context.Background(), "test_method", common.AvailbilityConfidenceStateProven, false, 1002)
-		assert.NoError(t, err)
-		assert.False(t, canHandle)
-	})
 }

--- a/upstream/upstream_stateproven_test.go
+++ b/upstream/upstream_stateproven_test.go
@@ -1,13 +1,11 @@
 package upstream
 
 import (
-	"context"
 	"testing"
 
 	"github.com/erpc/erpc/common"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func stateProvenUpstream(latest int64) *Upstream {
@@ -22,51 +20,17 @@ func stateProvenUpstream(latest int64) *Upstream {
 	}
 }
 
-// The state-proven confidence exists because a node's CLAIMED head says nothing
-// about its state trie: nodes answer eth_call from older state while reporting
-// a current head. The boundary must therefore be the proven head — and fall
-// back to the claimed head only while nothing is proven at all (probing off,
-// warming up, or unsupported), so capability gaps degrade to today's behavior
-// instead of browning out traffic.
-func TestEvmAssertBlockAvailability_StateProven(t *testing.T) {
-	t.Run("falls back to the claimed head while nothing is proven", func(t *testing.T) {
-		u := stateProvenUpstream(1000)
-		ok, err := u.EvmAssertBlockAvailability(context.Background(), "eth_call", common.AvailbilityConfidenceStateProven, false, 900)
-		require.NoError(t, err)
-		assert.True(t, ok, "proven=0 must behave exactly like blockHead — the gate cannot punish unsupported upstreams")
-	})
-
-	t.Run("blocks beyond the proven head are refused once proof exists", func(t *testing.T) {
-		u := stateProvenUpstream(1000)
-		u.EvmSetStateProvenBlock(950)
-		ok, err := u.EvmAssertBlockAvailability(context.Background(), "eth_call", common.AvailbilityConfidenceStateProven, false, 980)
-		require.NoError(t, err)
-		assert.False(t, ok, "the node CLAIMS 1000 but has only PROVEN 950 — 980 must not route here")
-	})
-
-	t.Run("blocks at or below the proven head are served", func(t *testing.T) {
-		u := stateProvenUpstream(1000)
-		u.EvmSetStateProvenBlock(950)
-		for _, n := range []int64{950, 949, 900} {
-			ok, err := u.EvmAssertBlockAvailability(context.Background(), "eth_call", common.AvailbilityConfidenceStateProven, false, n)
-			require.NoError(t, err)
-			assert.True(t, ok, "block %d is within proof", n)
-		}
-	})
-
-	t.Run("the proven head is monotonic — a stale probe cannot move it back", func(t *testing.T) {
-		u := stateProvenUpstream(1000)
-		u.EvmSetStateProvenBlock(950)
-		u.EvmSetStateProvenBlock(940) // late/racing probe result
-		assert.EqualValues(t, 950, u.EvmStateProvenBlock())
-	})
-
-	t.Run("the recent-state lower bound still applies under proof", func(t *testing.T) {
-		u := stateProvenUpstream(1000)
-		u.config.Evm.MaxAvailableRecentBlocks = 128
-		u.EvmSetStateProvenBlock(1000)
-		ok, err := u.EvmAssertBlockAvailability(context.Background(), "eth_call", common.AvailbilityConfidenceStateProven, false, 500)
-		require.NoError(t, err)
-		assert.False(t, ok, "a full node's state only reaches back maxAvailableRecentBlocks; proof of the tip does not extend history")
-	})
+// The proven head is telemetry plus the strongest tier of the disproved
+// diversion's sibling check — it is deliberately NOT a routing bound (see
+// AvailbilityConfidence in common/architecture_evm.go for why: it lags the
+// claimed head by the probe cadence on any fast chain, so bounding routing on
+// it would refuse all tip traffic). What must still hold is
+// its monotonicity: racing probe results cannot move it backwards.
+func TestEvmStateProvenBlock_Monotonic(t *testing.T) {
+	u := stateProvenUpstream(1000)
+	u.EvmSetStateProvenBlock(950)
+	u.EvmSetStateProvenBlock(940) // late/racing probe result
+	assert.EqualValues(t, 950, u.EvmStateProvenBlock())
+	u.EvmSetStateProvenBlock(951)
+	assert.EqualValues(t, 951, u.EvmStateProvenBlock())
 }

--- a/upstream/upstream_stateproven_test.go
+++ b/upstream/upstream_stateproven_test.go
@@ -20,12 +20,11 @@ func stateProvenUpstream(latest int64) *Upstream {
 	}
 }
 
-// The proven head is telemetry plus the strongest tier of the disproved
-// diversion's sibling check — it is deliberately NOT a routing bound (see
+// The proven head is telemetry — deliberately NOT a routing bound (see
 // AvailbilityConfidence in common/architecture_evm.go for why: it lags the
 // claimed head by the probe cadence on any fast chain, so bounding routing on
-// it would refuse all tip traffic). What must still hold is
-// its monotonicity: racing probe results cannot move it backwards.
+// it would refuse all tip traffic). What must still hold is its monotonicity:
+// racing probe results cannot move it backwards.
 func TestEvmStateProvenBlock_Monotonic(t *testing.T) {
 	u := stateProvenUpstream(1000)
 	u.EvmSetStateProvenBlock(950)


### PR DESCRIPTION
## The bug

The state boundary refused any state request above an upstream's state-**proven** head. That inverted its own evidence rule:

| upstream state | evidence | outcome |
|---|---|---|
| `proven == 0` — never probed | **none** | failed **open** |
| `proven = head − 8` — probed, correct | **strong, recent** | failed **closed** |

A perfect probe record made an upstream *less* routable than one that had never answered a probe at all.

## Why it is unworkable on fast chains

The proven head only advances at probe cadence (follow interval + probe interval). On a chain producing a block every ~250ms with a 2s probe floor, **every honest upstream's proven head trails its claimed head by roughly 8–18 blocks at all times** — a function of cadence, not of node quality.

Meanwhile eRPC advertises `latest` as the majority **claimed** head (`PickServedTip`), and indexers pin state calls at concrete heights they derive themselves (`eth_getBlockByNumber`, then `eth_call` at that number).

So the bound refused the very tip the network advertised, on nearly every upstream, at nearly every moment — while every node was behaving correctly.

The repo deleted this same bound-class once before: the implicit claimed-head check, removed for false rejections on fast chains (#934).

## The change — the prober publishes evidence; it holds no routing authority

An earlier draft of this PR replaced the proven-head bound with a narrower hook-level diversion of "disproved" upstreams. That still hard-coded a routing decision into the prober's hook, still duplicated selection machinery (a bespoke sibling check), and still bypassed the operator's policy. This version deletes the per-request state boundary entirely and routes every consequence through machinery that already exists:

1. **`AvailbilityConfidenceStateProven` and its assert case are removed** (kept from the draft). It was internal-only — `UnmarshalYAML` accepts only `blockhead` and `finalizedblock`, so no operator config can reference it. Absence of proof no longer blocks routing at any height; the proven head stays as pure telemetry (`erpc_upstream_state_proven_block` / `..._lag`).

2. **Disproof is the fourth witness to the existing misbehavior ledger — no new concept.** `RecordUpstreamMisbehavior` already receives consensus disputes, integrity deterministic rejects, and wrong-empty responses. When an upstream answers pinned probes at the wrong height for a sustained streak (10 consecutive mismatches — an internal debounce against reorg transients, deliberately a constant, not config), each further mismatch records one misbehavior under `eth_call` (the context probe *is* a pinned `eth_call`). One good probe resets the streak and the evidence stops. Under integrity `observeOnly`, nothing is recorded — consistent with integrity rejects, which never reach misbehavior scoring in observe mode.

   Operators act on it with the predicate that **already exists** in the policy stdlib — no new surface:

   ```js
   .excludeIf(all(misbehaviorRateAbove(0.05), samplesAbove(50)))
   // or audition it first, without dropping anyone:
   .shadowExcludeIf(all(misbehaviorRateAbove(0.05), samplesAbove(50)))
   ```

   Exclusion thresholds, guards, deprioritize-vs-exclude — all stay where they belong, in the operator's `evalFunction`.

3. **The `callState` availability probe now measures execution height, chain-generically.** `blockAvailability.*.probe: callState` used `eth_getBalance(0x0, N)` and accepted any non-null answer — a stale node passes by answering a well-formed `0x0`. It now asks the per-architecture execution canary (`integrity.ChainStateContextProbe`: Multicall3 `getBlockNumber()` by default — one address on 200+ chains — ArbSys `arbBlockNumber()` on Nitro, where `block.number` is the L1 height) pinned at the block, and availability means the node **executed at exactly that height**. Where the canary yields no evidence (not deployed at that height, erroring/reverting, unparseable) the probe discovers that and falls back to the balance heuristic — chains without the canary behave exactly as before. The verdict feeds the existing availability-bounds machinery; bound-capped upstreams already enter the served-tip ballot as capped inputs, so tip and routing agree through existing paths.

**Safe degradation is symmetric.** No canary → fallback → previous behavior. A canary that is *wrong* for a chain (the Multicall3-on-Nitro precedent) mismatches on every upstream alike: identical misbehavior evidence, no proven heads, symmetric bounds — relative ranking unchanged, pinned by test.

## The tests

- `TestStateBoundary_TipChosenFromClaimedHeadsMustRoute` (kept from the draft, verified red on the pre-draft code): one fleet whose proven lags span a full probe cycle (18/13/11/11/8/0 — all honest nodes, differing only in how long ago their probe landed); the advertised tip must stay routable on every upstream, prober active or not. A reintroduced proven bound under a new confidence value turns it red, because the fake upstream answers unknown confidences from the proven head.
- `TestDisprovedStreak_RecordsMisbehavior` — threshold, per-mismatch accrual, reset on recovery, consecutive-not-cumulative.
- `TestDisprovedStreak_ObserveOnlyRecordsNothing` — observe-only consistency with the other integrity effects.
- `TestStateProber_WrongCanaryFailsSymmetrically` — the symmetric-degradation property above, through the full probe path.
- `TestCheckCallStateProbe_ExecutionCanary` — pinned-height execution accepted, wrong-height rejected (even when a balance would answer), absent/erroring canary falls back, per-architecture canary resolution (ArbSys on Nitro, Multicall3 default for unknown chains).

`go build ./...` and the `architecture/evm`, `architecture/evm/integrity`, `upstream`, `common`, `health` suites pass.
