### PR TITLE
fix(monitoring): replace EOL ubuntu:22.10 base image in monitoring Dockerfile

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,9 +1,11 @@
 FROM prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69 as prometheus
 FROM grafana/grafana:12.4.7@sha256:0b059afc13dc5bd60ac35b8655976faa1b6f61ef83fc87491a03a7cdb8bf9d18 as grafana
 
-FROM ubuntu:22.10@sha256:e322f4808315c387868a9135beeb11435b5b83130a8599fd7d0014452c34f489
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
 
 # Copy Prometheus files
 COPY --from=prometheus /bin/prometheus /bin/prometheus


### PR DESCRIPTION
## Issue
`monitoring/Dockerfile` pins its final stage to `ubuntu:22.10` (kinetic), which is end-of-life. Its apt repositories have been pulled from `ports.ubuntu.com`/`archive.ubuntu.com`, so `apt-get update` returns 404s on every suite (release, updates, backports, security). This breaks `docker-compose up` (and any fresh build) for the `monitoring` service with:

```
E: The repository 'http://ports.ubuntu.com/ubuntu-ports kinetic Release' does not have a Release file.
```

## Fix
- Pin the base image to `ubuntu:24.04` LTS (digest-pinned) instead of the EOL `22.10` release.
- Keep installing `curl`, and add `ca-certificates` explicitly, since the 24.04 base image ships without a CA bundle and Grafana's outbound HTTPS calls (e.g. update checks) fail with `x509: certificate signed by unknown authority` otherwise.
- Clean up apt lists in the same layer to avoid bloating the image.

## Testing
- `docker build ./monitoring` succeeds.
- Ran the resulting image standalone: Prometheus `/-/ready` returns 200 and Grafana `/api/health` reports `database: ok`, with no TLS/CA errors in the logs.
- `docker-compose up -d` from the repo root brings up the `monitoring` service successfully.