### PR TITLE
test(integrity): drop a deployment-specific throughput figure from a comment

### DIFF
--- a/architecture/evm/integrity/checks_recompute_test.go
+++ b/architecture/evm/integrity/checks_recompute_test.go
@@ -189,8 +189,7 @@ func TestCheck_ReceiptsRootRecompute(t *testing.T) {
 // It is not hypothetical. Every Arbitrum One block carries `l1BlockNumber`, and
 // post-Nitro blocks add `sendCount`/`sendRoot` — none of them geth header
 // fields — so blockHashRecompute can never verify a single block on that chain,
-// on either side of the Nitro fork, while the outcome metric read 100% pass at
-// ~1.7k block responses per second.
+// on either side of the Nitro fork, while the outcome metric read 100% pass.
 func TestRecompute_UnverifiableDataReportsSkipNotPass(t *testing.T) {
 	h := sampleHeader()
 	realHash := h.Hash().Hex()


### PR DESCRIPTION
A comment added in #1107 quantified its point with a request rate observed on one operator's fleet.

The technical claim it supports is unaffected: `blockHashRecompute` cannot verify an Arbitrum block on either side of the Nitro fork, because every block carries `l1BlockNumber` (plus `sendCount`/`sendRoot` post-Nitro) — none of them geth header fields. That rests on protocol facts, and it is what the test actually asserts.

Operational figures from a private deployment do not belong in this repo.

Comment-only; no behaviour or assertion changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)