### PR TITLE
fix(redis): honor context deadlines on in-flight commands

### DIFF
--- a/data/redis.go
+++ b/data/redis.go
@@ -150,6 +150,15 @@ func (r *RedisConnector) connectTask(ctx context.Context) error {
 		r.setTimeout = options.WriteTimeout
 	}
 
+	// Honor context deadlines on in-flight commands. go-redis v9 defaults
+	// ContextTimeoutEnabled to false, where a ctx deadline only gates pool
+	// acquisition and an in-flight read waits for the socket ReadTimeout —
+	// so every WithTimeout wrapper in this file (getTimeout/setTimeout) and
+	// the connector-failsafe timeout silently failed to bound a slow
+	// command. ReadTimeout/WriteTimeout remain the safety net for
+	// deadline-less contexts.
+	options.ContextTimeoutEnabled = true
+
 	/**
 	* if tls.enabled: true in config → build a tls.Config and
 	* apply or merge it.


### PR DESCRIPTION
Context deadlines on redis operations never bounded an in-flight command: go-redis v9 defaults `ContextTimeoutEnabled` to false, where a ctx deadline only gates pool acquisition and an in-flight read waits for the socket `ReadTimeout`. Every `WithTimeout` wrapper around redis calls — the connector's `getTimeout`/`setTimeout` and any connector-failsafe timeout — was therefore silently ineffective mid-command: a call configured to abandon a slow read at 25ms would still block for the full server-side latency (observed: a 200ms-degraded GET served at ~204ms straight through a 25ms deadline; after this fix the same scenario cuts at ~25ms and falls through to upstreams).

One line enables the documented go-redis knob; `ReadTimeout`/`WriteTimeout` remain the safety net for deadline-less contexts. Affects all redis usage (cache connector, shared state, locks) — in every case the caller already expresses its intended bound via a ctx deadline, which now actually holds.

Test plan: full `data` package suite green (miniredis-backed redis tests included); verified live against a real redis behind a latency-injecting proxy — pre-fix a 25ms deadline could not cut a 200ms-slow GET, post-fix it does.

Surfaced by (and a prerequisite for the redis-backed scenarios of) erpc/erpc#1112.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OH MY PI](https://img.shields.io/badge/Claude_Fable_5-D97757?logo=claude&logoColor=white)
