### PR TITLE
fix(failsafe): breaker cannot recover on a miss-heavy cache connector

### DIFF
--- a/data/cache_executor.go
+++ b/data/cache_executor.go
@@ -290,9 +290,25 @@ func (e *cacheExecutor) callBreaker(
 // the connector (selection-policy-like exclusion, fail-fast to upstream
 // fallthrough) until half-open probes complete in time again. The
 // timeout policy is the sole definition of "too slow" — there is no
-// separate slowness threshold. Otherwise: transport errors are
-// failures; semantic misses (not found / expired) are ignored; success
-// closes.
+// separate slowness threshold. Transport errors are failures.
+//
+// A semantic miss (not found / expired) is a SUCCESS, not an ignore. The
+// breaker's question is "is this connector answering in time", and a miss
+// returned inside the budget answers yes — it is a correct, timely reply
+// that happens to be empty. Treating it as ignore was wrong twice over:
+//
+//   - in Closed state an ignored outcome is never pushed to the ring, so
+//     the window held only hits and failures. The configured ratio then
+//     measured failures against hits+failures rather than against all
+//     traffic, making the breaker roughly 1/hit-ratio more sensitive than
+//     its config says — ~5x on a connector serving 80% misses.
+//   - in HalfOpen an ignored outcome makes no progress, so a trial needed
+//     SuccessThresholdCount *hits*, spanning ~1/hit-ratio more requests
+//     and giving a stray failure that much more room to re-open it. On a
+//     miss-heavy connector the trial could not reliably conclude at all.
+//
+// Cancellations and non-transport oddities stay ignored: those carry no
+// information about the connector either way.
 func breakerOutcome(err error, ourTimeout, interrupted bool) failsafe.Outcome {
 	if interrupted {
 		return failsafe.OutcomeIgnore
@@ -304,7 +320,7 @@ func breakerOutcome(err error, ourTimeout, interrupted bool) failsafe.Outcome {
 		return failsafe.OutcomeSuccess
 	}
 	if common.HasErrorCode(err, common.ErrCodeRecordNotFound) {
-		return failsafe.OutcomeIgnore
+		return failsafe.OutcomeSuccess
 	}
 	if isTransportError(err) {
 		return failsafe.OutcomeFailure

--- a/failsafe/breaker.go
+++ b/failsafe/breaker.go
@@ -90,6 +90,13 @@ type Breaker struct {
 	halfOpenSuccess  int
 	halfOpenFailure  int
 
+	// When the current HalfOpen trial started. HalfOpen has no delay of its
+	// own to fall back on the way Open does, so without a time bound any
+	// permit that is acquired and never recorded (a panic between
+	// TryAcquirePermit and Record, a caller that returns early) pins
+	// halfOpenInflight at capacity and wedges the breaker with no path out.
+	halfOpenAt time.Time
+
 	// When the breaker opened, used to gate transition Open → HalfOpen.
 	openedAt time.Time
 
@@ -151,7 +158,16 @@ func (b *Breaker) TryAcquirePermit() bool {
 			cap = 1
 		}
 		if b.halfOpenInflight >= cap {
-			return false
+			// Permits exhausted. If the trial has outlived HalfOpenAfter it is
+			// not going to conclude — the outstanding permits belong to
+			// attempts that never recorded an outcome — so re-arm it rather
+			// than reject forever. Bounding by the same delay that gated
+			// Open → HalfOpen keeps this config-driven.
+			if !b.staleHalfOpenTrialLocked() {
+				return false
+			}
+			b.startHalfOpenTrialLocked()
+			return true
 		}
 		b.halfOpenInflight++
 		return true
@@ -167,7 +183,7 @@ func (b *Breaker) TryAcquirePermit() bool {
 		delay := b.cfg.HalfOpenAfter.Duration()
 		if delay <= 0 || time.Since(b.openedAt) >= delay {
 			b.transitionLocked(StateHalfOpen, "half_open_delay_elapsed")
-			b.halfOpenInflight = 1
+			b.startHalfOpenTrialLocked()
 			return true
 		}
 		return false
@@ -230,19 +246,24 @@ func (b *Breaker) Record(o Outcome) {
 		if successCount <= 0 {
 			successCount = 1
 		}
-		// Threshold check: if we've accumulated enough trials and successes hit count, close.
-		if b.halfOpenSuccess+b.halfOpenFailure >= successCap {
-			if b.halfOpenSuccess >= successCount {
-				b.resetWindowLocked()
-				b.transitionLocked(StateClosed, "half_open_success_threshold")
-			} else {
-				b.openedAt = time.Now()
-				b.transitionLocked(StateOpen, "half_open_failure")
-			}
+		// Decide as soon as the trial's outcome is determined, and honour BOTH
+		// fields. The previous form re-opened on the FIRST failure whenever the
+		// trial had not yet reached successCap, which meant a failure could
+		// never contribute toward the capacity check above it — so the only
+		// path back to Closed was successCap consecutive clean successes and
+		// SuccessThresholdCount was dead config. A configured "3 of 5" now
+		// tolerates the 2 failures it says it tolerates.
+		maxFailures := successCap - successCount
+		if maxFailures < 0 {
+			maxFailures = 0
+		}
+		switch {
+		case b.halfOpenSuccess >= successCount:
+			b.resetWindowLocked()
+			b.transitionLocked(StateClosed, "half_open_success_threshold")
 			b.halfOpenSuccess = 0
 			b.halfOpenFailure = 0
-		} else if o == OutcomeFailure && b.halfOpenFailure > 0 {
-			// Single failure in HalfOpen immediately re-opens.
+		case b.halfOpenFailure > maxFailures:
 			b.openedAt = time.Now()
 			b.transitionLocked(StateOpen, "half_open_failure")
 			b.halfOpenSuccess = 0
@@ -257,6 +278,28 @@ func (b *Breaker) Record(o Outcome) {
 			b.totalFailures.Add(1)
 		}
 	}
+}
+
+// startHalfOpenTrialLocked (re)arms a HalfOpen trial: one permit granted to
+// the caller, counters cleared, and the clock started so the trial can be
+// bounded by staleHalfOpenTrialLocked.
+func (b *Breaker) startHalfOpenTrialLocked() {
+	b.halfOpenInflight = 1
+	b.halfOpenSuccess = 0
+	b.halfOpenFailure = 0
+	b.halfOpenAt = time.Now()
+}
+
+// staleHalfOpenTrialLocked reports whether the current HalfOpen trial has run
+// longer than HalfOpenAfter without concluding. Used only when permits are
+// exhausted: a trial in that state is waiting on attempts that will never
+// record an outcome, and HalfOpen has no delay of its own to recover with.
+func (b *Breaker) staleHalfOpenTrialLocked() bool {
+	delay := b.cfg.HalfOpenAfter.Duration()
+	if delay <= 0 || b.halfOpenAt.IsZero() {
+		return false
+	}
+	return time.Since(b.halfOpenAt) >= delay
 }
 
 // pushLocked appends a result to the ring buffer, evicting the oldest

--- a/failsafe/breaker_test.go
+++ b/failsafe/breaker_test.go
@@ -53,3 +53,113 @@ func TestBreaker_HalfOpenIgnoreReleasesPermit(t *testing.T) {
 	assert.Equal(t, StateClosed, b.State(), "success threshold must close the breaker")
 	assert.True(t, b.TryAcquirePermit(), "closed breaker always permits")
 }
+
+// TestBreaker_HalfOpenHonoursSuccessThresholdCount — regression for
+// SuccessThresholdCount being dead config. With "3 of 5" the trial must
+// tolerate the 2 failures it says it tolerates. Before the fix, the first
+// failure re-opened the breaker unconditionally whenever the trial had not
+// yet reached SuccessThresholdCapacity, so a failure could never contribute
+// toward the capacity check and the only path back to Closed was 5
+// consecutive clean successes.
+func TestBreaker_HalfOpenHonoursSuccessThresholdCount(t *testing.T) {
+	cfg := &common.CircuitBreakerPolicyConfig{
+		FailureThresholdCount:    1,
+		FailureThresholdCapacity: 1,
+		HalfOpenAfter:            common.Duration(10 * time.Millisecond),
+		SuccessThresholdCount:    3,
+		SuccessThresholdCapacity: 5,
+	}
+	b := NewBreaker(cfg, nil)
+	require.NotNil(t, b)
+
+	b.Record(OutcomeFailure)
+	require.Equal(t, StateOpen, b.State())
+	time.Sleep(20 * time.Millisecond)
+
+	// Trial: fail, succeed, fail, succeed, succeed. maxFailures = 5-3 = 2, so
+	// the two failures must NOT re-open, and the third success must close.
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeFailure)
+	require.Equal(t, StateHalfOpen, b.State(),
+		"1 failure with maxFailures=2 must not re-open")
+
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeSuccess)
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeFailure)
+	require.Equal(t, StateHalfOpen, b.State(),
+		"2 failures with maxFailures=2 must not re-open")
+
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeSuccess)
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeSuccess)
+
+	assert.Equal(t, StateClosed, b.State(),
+		"3 successes must close even though 2 failures occurred")
+}
+
+// TestBreaker_HalfOpenReopensPastMaxFailures — the other side of the same
+// fix: once failures exceed SuccessThresholdCapacity-SuccessThresholdCount
+// the trial can no longer reach its success target, so it must re-open
+// immediately rather than keep admitting probes.
+func TestBreaker_HalfOpenReopensPastMaxFailures(t *testing.T) {
+	cfg := &common.CircuitBreakerPolicyConfig{
+		FailureThresholdCount:    1,
+		FailureThresholdCapacity: 1,
+		HalfOpenAfter:            common.Duration(10 * time.Millisecond),
+		SuccessThresholdCount:    3,
+		SuccessThresholdCapacity: 5,
+	}
+	b := NewBreaker(cfg, nil)
+	require.NotNil(t, b)
+
+	b.Record(OutcomeFailure)
+	time.Sleep(20 * time.Millisecond)
+
+	for i := range 3 {
+		require.True(t, b.TryAcquirePermit(), "failure %d must be admitted", i+1)
+		b.Record(OutcomeFailure)
+	}
+	assert.Equal(t, StateOpen, b.State(),
+		"3 failures exceeds maxFailures=2 and must re-open")
+}
+
+// TestBreaker_HalfOpenTrialIsTimeBounded — regression for HalfOpen having no
+// escape hatch. Open falls back on HalfOpenAfter, but HalfOpen had no delay
+// of its own, so a permit acquired and never recorded (panic between
+// TryAcquirePermit and Record, caller returning early) pinned
+// halfOpenInflight at capacity and wedged the breaker with no path out.
+func TestBreaker_HalfOpenTrialIsTimeBounded(t *testing.T) {
+	cfg := &common.CircuitBreakerPolicyConfig{
+		FailureThresholdCount:    1,
+		FailureThresholdCapacity: 1,
+		HalfOpenAfter:            common.Duration(20 * time.Millisecond),
+		SuccessThresholdCount:    2,
+		SuccessThresholdCapacity: 2,
+	}
+	b := NewBreaker(cfg, nil)
+	require.NotNil(t, b)
+
+	b.Record(OutcomeFailure)
+	require.Equal(t, StateOpen, b.State())
+	time.Sleep(40 * time.Millisecond)
+
+	// Acquire every trial permit and never record — simulating attempts that
+	// died between TryAcquirePermit and Record.
+	require.True(t, b.TryAcquirePermit())
+	require.Equal(t, StateHalfOpen, b.State())
+	require.True(t, b.TryAcquirePermit())
+	require.False(t, b.TryAcquirePermit(), "capacity reached, must reject")
+
+	// Pre-fix this stayed false forever. The trial must be re-armed once it
+	// has outlived HalfOpenAfter without concluding.
+	time.Sleep(40 * time.Millisecond)
+	require.True(t, b.TryAcquirePermit(),
+		"a stale HalfOpen trial must be re-armed instead of wedging")
+
+	b.Record(OutcomeSuccess)
+	require.True(t, b.TryAcquirePermit())
+	b.Record(OutcomeSuccess)
+	assert.Equal(t, StateClosed, b.State())
+}


### PR DESCRIPTION
## What we hit

A cache connector serving **~80% misses** latched its circuit breaker open and stayed there. At the time of measurement:

| metric | value |
|---|---:|
| `ErrFailsafeCircuitBreakerOpen` | 2,059/s |
| `ErrFailsafeTimeoutExceeded` | 22/s |
| `ErrEndpointCapacityExceeded` | 0.06/s |
| latency | 86% ≤100ms, 99.3% ≤250ms |

So **~1.7% real failures against a configured 50% threshold**, normal latency, and the breaker open *continuously* (flat ~2,000/s over a 5-minute range query — not flapping). Cache hits fell to ~43% of baseline.

Connectors on the same rollout with the same config recovered fine. **Hit ratio predicted who latched; failure rate did not:**

| hit ratio | requests per half-open trial | breaker |
|---:|---:|---|
| 19.6% | ~26 | **latched open** |
| 41.3% | ~12 | **latched open** |
| 84.5% | ~6 | recovered |
| 92.3% | ~5.4 | recovered |
| 99.9% | ~5 | recovered |

That rank order is what pointed at the miss handling.

## Three defects

### 1. A cache miss is not an "ignore" — it is a timely success

`breakerOutcome` mapped `ErrCodeRecordNotFound` to `OutcomeIgnore`. But the breaker's question is *"is this connector answering in time"*, and a miss returned inside the budget answers **yes**: a correct, timely reply that happens to be empty. Treating it as ignore broke both states:

- **Closed** — ignored outcomes are never pushed to the ring, so the window held only hits and failures. The configured ratio therefore measured failures against `hits+failures` rather than against all traffic, making the breaker **~1/hit-ratio more sensitive than its config claims** — about **5×** on an 80%-miss connector.
- **HalfOpen** — ignored outcomes make no progress, so a trial needed `SuccessThresholdCount` *hits*, spanning ~1/hit-ratio more requests and giving a stray failure that much more room to re-open it.

Cancellations and non-transport oddities stay ignored — those really do carry no information about the connector.

### 2. `SuccessThresholdCount` was dead config

```go
if b.halfOpenSuccess+b.halfOpenFailure >= successCap {
    if b.halfOpenSuccess >= successCount { /* close */ } else { /* re-open */ }
} else if o == OutcomeFailure && b.halfOpenFailure > 0 {
    // Single failure in HalfOpen immediately re-opens.
```

A failure can never contribute toward the capacity check above it, because the first failure re-opens. So the only path back to Closed was `SuccessThresholdCapacity` **consecutive clean successes** — a configured "3 of 5" behaved as "5 clean, 0 failures".

Now decided as soon as the outcome is determined, honouring both fields: close at `halfOpenSuccess >= SuccessThresholdCount`, re-open once `halfOpenFailure` exceeds `SuccessThresholdCapacity - SuccessThresholdCount`, i.e. once the success target has become unreachable.

### 3. HalfOpen had no escape hatch

`StateOpen` falls back on `HalfOpenAfter`, but `StateHalfOpen` had no delay of its own. A permit acquired and never recorded — a panic between `TryAcquirePermit` and `Record`, a caller returning early — pins `halfOpenInflight` at capacity and wedges the breaker **permanently**. The existing `OutcomeIgnore` permit release (from #1112) covers the common case but not a lost outcome.

HalfOpen trials are now time-bounded by the same `HalfOpenAfter` that gated `Open → HalfOpen`: when permits are exhausted *and* the trial has outlived that delay, it is re-armed instead of rejecting forever. No new config field.

## Tests

Three regressions in `failsafe/breaker_test.go`:

- `TestBreaker_HalfOpenHonoursSuccessThresholdCount` — "3 of 5" tolerates the 2 failures it says it tolerates and still closes on the 3rd success.
- `TestBreaker_HalfOpenReopensPastMaxFailures` — the other side: a 3rd failure re-opens promptly rather than admitting more probes.
- `TestBreaker_HalfOpenTrialIsTimeBounded` — every permit taken and never recorded must not wedge the breaker forever.

Existing `TestBreaker_HalfOpenIgnoreReleasesPermit` still passes. `go vet` clean; `./failsafe` and `./data` pass under `-race`.

## Compatibility

Behaviour change for anyone relying on the old semantics:

- a breaker with `SuccessThresholdCount < SuccessThresholdCapacity` now tolerates failures during the trial, as documented, instead of re-opening on the first one;
- cache misses now count toward the breaker's window as successes, so a configured failure ratio means what it says rather than being amplified by the miss rate.

Both move behaviour toward the config's stated meaning. The alternative to (1) — keeping misses out of the window — cannot work, because there is no threshold that makes a miss-heavy connector recoverable while `Ignore` starves the trial.
