### PR TITLE
fix(ci): pin xray diff to validated PR head SHA

### DIFF
--- a/.github/workflows/xray.yml
+++ b/.github/workflows/xray.yml
@@ -70,13 +70,21 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
         run: |
           set -euo pipefail
           case "$PR_NUMBER" in
             ''|*[!0-9]*) echo "invalid PR number" >&2; exit 1 ;;
           esac
           [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          CURRENT_HEAD=$(printf '%s' "$PR_JSON" | jq -r .head.sha)
+          if [ "$CURRENT_HEAD" != "$HEAD_SHA" ]; then
+            echo "head SHA changed since validation" >&2
+            exit 1
+          fi
+          gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
             -H "Accept: application/vnd.github.diff" \
             > "${RUNNER_TEMP}/pr.diff"
           git config user.email "xray@erpc.invalid"


### PR DESCRIPTION
## Summary

The xray workflow validates `head.sha` in one step, then fetches the PR diff in a later step via `GET /pulls/{n}` without confirming the head is unchanged. If the PR is updated between steps, `OPENROUTER_API_KEY` can analyze a diff that was never validated against the event SHA.

## Fix

In the apply step:
1. Re-fetch the PR and fail if `head.sha` no longer matches the validated `HEAD_SHA`.
2. Fetch the patch via `compare/{base}...{head}` so the diff is bound to the validated SHAs rather than whatever the PR tip is at fetch time.

## Test plan

- [ ] Trigger xray on a same-repo PR and confirm the workflow completes
- [ ] Push a new commit mid-run (optional) and confirm the apply step fails with "head SHA changed since validation"

Made with [Cursor](https://cursor.com)