### PR TITLE
fix(evm): wire getLogs response-size budget into JSON-RPC translation

### DIFF
--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -1852,7 +1852,7 @@ func TranslateToJsonRpcException(err error) error {
 			nil,
 		)
 	}
-	if HasErrorCode(err, ErrCodeGetLogsExceededMaxAllowedRange, ErrCodeGetLogsExceededMaxAllowedAddresses, ErrCodeGetLogsExceededMaxAllowedTopics) {
+	if HasErrorCode(err, ErrCodeGetLogsExceededMaxAllowedRange, ErrCodeGetLogsExceededMaxAllowedAddresses, ErrCodeGetLogsExceededMaxAllowedTopics, ErrCodeGetLogsExceededMaxAllowedResponseSize) {
 		return NewErrJsonRpcExceptionInternal(
 			0,
 			JsonRpcErrorEvmLargeRange,

--- a/common/json_rpc_test.go
+++ b/common/json_rpc_test.go
@@ -951,6 +951,15 @@ func TestTranslateToJsonRpcException_ExhaustedInsideFanOut_DoesNotHijack(t *test
 	}
 }
 
+// The getLogs response-size budget is deliberately its own error code so it
+// cannot re-enter the splitting path. It must still translate to the same
+// client-visible JSON-RPC code as the other getLogs hard limits — otherwise it
+// falls through to -32603 and looks like an internal failure.
+func TestTranslateToJsonRpcException_GetLogsExceededMaxAllowedResponseSize(t *testing.T) {
+	err := NewErrGetLogsExceededMaxAllowedResponseSize(4096, 2048)
+	require.EqualValues(t, JsonRpcErrorEvmLargeRange, clientWireCode(t, TranslateToJsonRpcException(err)))
+}
+
 // TestJsonRpcRequest_UnmarshalID_NumericPrecision pins the contract that a
 // numeric request id is either preserved exactly as an int64 or rejected — it
 // must never be silently truncated/clamped into a different internal id (see


### PR DESCRIPTION
## Summary
`ErrGetLogsExceededMaxAllowedResponseSize` is intentionally a distinct code so it cannot re-enter the eth_getLogs splitting path. `TranslateToJsonRpcException` already maps the three sibling getLogs hard limits to `JsonRpcErrorEvmLargeRange` (`-32012`), but omitted this new code, so budget refusals fell through to `-32603` (internal server error).

## Test plan
- [x] `go test ./common/ -run TestTranslateToJsonRpcException_GetLogsExceededMaxAllowedResponseSize`
- [x] `go build ./common/...`

Made with [Cursor](https://cursor.com)