### PR TITLE
feat(cache): per-executor attempt and breaker-transition metrics

### DIFF
--- a/data/cache_executor.go
+++ b/data/cache_executor.go
@@ -3,11 +3,14 @@ package data
 import (
 	"context"
 	"errors"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/erpc/erpc/common"
 	"github.com/erpc/erpc/failsafe"
 	"github.com/erpc/erpc/health"
+	"github.com/erpc/erpc/telemetry"
 	"github.com/rs/zerolog"
 )
 
@@ -43,6 +46,68 @@ type cacheExecutor struct {
 
 	method     string
 	finalities []common.DataFinalityState
+
+	// Telemetry identity, set once by identify(). connectorId and direction
+	// come from the owning FailsafeConnector; finalityLabel is the sorted
+	// `a|b` join of finalities, or "*" when the executor has no finality
+	// filter. Empty connectorId means telemetry is off (executor built
+	// outside a connector, e.g. tests).
+	connectorId   string
+	direction     string
+	finalityLabel string
+}
+
+// identify binds the executor to the connector and direction it serves and
+// wires breaker state transitions to the cache_executor_breaker_state_change
+// metric and a warn log. Called by buildCacheExecutors; without it the
+// executor runs but emits nothing.
+func (e *cacheExecutor) identify(connectorId, direction string) {
+	e.connectorId = connectorId
+	e.direction = direction
+	e.finalityLabel = finalityLabel(e.finalities)
+	if e.breaker == nil {
+		return
+	}
+	e.breaker.OnTransition = func(from, to failsafe.State, reason string) {
+		telemetry.MetricCacheExecutorBreakerStateChange.WithLabelValues(
+			connectorId, direction, e.method, e.finalityLabel, from.String()+"_to_"+to.String(),
+		).Inc()
+		e.logger.Warn().
+			Str("connector", connectorId).
+			Str("direction", direction).
+			Str("matchMethod", e.method).
+			Str("matchFinality", e.finalityLabel).
+			Str("from", from.String()).
+			Str("to", to.String()).
+			Str("reason", reason).
+			Msg("cache connector circuit breaker state changed")
+	}
+}
+
+// finalityLabel renders a matchFinality filter as a stable metric label:
+// "*" for no filter, otherwise the sorted names joined by "|" so the same
+// set always yields the same series regardless of config order.
+func finalityLabel(fs []common.DataFinalityState) string {
+	if len(fs) == 0 {
+		return "*"
+	}
+	names := make([]string, len(fs))
+	for i, f := range fs {
+		names[i] = f.String()
+	}
+	sort.Strings(names)
+	return strings.Join(names, "|")
+}
+
+// observe records one governed attempt's outcome under this executor's
+// identity. No-op until identify() has run.
+func (e *cacheExecutor) observe(outcome string) {
+	if e.connectorId == "" {
+		return
+	}
+	telemetry.MetricCacheExecutorAttempt.WithLabelValues(
+		e.connectorId, e.direction, e.method, e.finalityLabel, outcome,
+	).Inc()
 }
 
 // NewCacheExecutor builds a per-(method, finality) cache executor. ctx
@@ -228,6 +293,7 @@ func (e *cacheExecutor) callBreaker(
 ) ([]byte, error) {
 	if e.breaker != nil {
 		if !e.breaker.TryAcquirePermit() {
+			e.observe("breaker_open")
 			startTime := time.Now()
 			return nil, common.NewErrFailsafeCircuitBreakerOpen(scopeConnector, failsafe.ErrCircuitOpen, &startTime)
 		}
@@ -278,7 +344,29 @@ func (e *cacheExecutor) callBreaker(
 	if e.breaker != nil {
 		e.breaker.Record(breakerOutcome(err, ourTimeout, interrupted))
 	}
+	e.observe(attemptOutcome(err, ourTimeout, interrupted))
 	return data, err
+}
+
+// attemptOutcome names a completed attempt for cache_executor_attempt_total.
+// Same partition breakerOutcome uses, kept apart so the metric can tell a
+// miss from a hit and a timeout from a transport failure — the breaker
+// collapses those pairs, the operator reading the ratio must not.
+func attemptOutcome(err error, ourTimeout, interrupted bool) string {
+	switch {
+	case interrupted:
+		return "interrupted"
+	case ourTimeout:
+		return "timeout"
+	case err == nil:
+		return "hit"
+	case common.HasErrorCode(err, common.ErrCodeRecordNotFound):
+		return "miss"
+	case isTransportError(err):
+		return "transport_error"
+	default:
+		return "error"
+	}
 }
 
 // breakerOutcome classifies a completed cache attempt for the breaker.

--- a/data/cache_executor_finality_test.go
+++ b/data/cache_executor_finality_test.go
@@ -1,0 +1,114 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/telemetry"
+	promUtil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// finalityNetwork is the smallest common.Network that lets a request resolve
+// a fixed finality: NormalizedRequest.Finality delegates to network.GetFinality
+// and caches the answer, and everything else on the interface is unused here.
+type finalityNetwork struct {
+	common.Network
+	finality common.DataFinalityState
+}
+
+func (n *finalityNetwork) GetFinality(context.Context, *common.NormalizedRequest, *common.NormalizedResponse) common.DataFinalityState {
+	return n.finality
+}
+
+func requestWithFinality(method string, f common.DataFinalityState) context.Context {
+	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"` + method + `","params":[],"id":1}`))
+	req.SetNetwork(&finalityNetwork{finality: f})
+	return context.WithValue(context.Background(), common.RequestContextKey, req)
+}
+
+func executorAttempts(connector, direction, method, finality, outcome string) float64 {
+	return promUtil.ToFloat64(telemetry.MetricCacheExecutorAttempt.WithLabelValues(connector, direction, method, finality, outcome))
+}
+
+func executorTransitions(connector, direction, method, finality, transition string) float64 {
+	return promUtil.ToFloat64(telemetry.MetricCacheExecutorBreakerStateChange.WithLabelValues(connector, direction, method, finality, transition))
+}
+
+// A finalized read must land on the finalized|unknown executor and open ONLY
+// that executor's breaker; the unfinalized|realtime executor must keep
+// serving, and the metrics must attribute every attempt and the transition
+// to the executor that actually handled it. This is the contract the
+// per-finality cache failsafe split depends on, and the reason
+// cache_executor_* metrics exist: cache_get_* carries the policy's finality,
+// which cannot tell these two apart.
+func TestCacheFailsafe_FinalitySplit_BreakerIsolatedPerExecutor(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	mc := NewMockConnector("prism-test")
+
+	connErr := errors.New("connection refused")
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, connErr)
+
+	fc, err := NewFailsafeConnector(context.Background(), &logger, mc, []*common.FailsafeConfig{
+		{
+			MatchMethod:   "*",
+			MatchFinality: []common.DataFinalityState{common.DataFinalityStateFinalized, common.DataFinalityStateUnknown},
+			CircuitBreaker: &common.CircuitBreakerPolicyConfig{
+				FailureThresholdCount: 2,
+				HalfOpenAfter:         common.Duration(1 * time.Minute),
+			},
+		},
+		{
+			MatchMethod:   "*",
+			MatchFinality: []common.DataFinalityState{common.DataFinalityStateUnfinalized, common.DataFinalityStateRealtime},
+			CircuitBreaker: &common.CircuitBreakerPolicyConfig{
+				FailureThresholdCount: 2,
+				HalfOpenAfter:         common.Duration(1 * time.Minute),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	const cold, hot = "finalized|unknown", "realtime|unfinalized"
+	coldBefore := executorAttempts("prism-test", "get", "*", cold, "breaker_open")
+	hotBefore := executorAttempts("prism-test", "get", "*", hot, "breaker_open")
+	coldErrBefore := executorAttempts("prism-test", "get", "*", cold, "transport_error")
+	openBefore := executorTransitions("prism-test", "get", "*", cold, "closed_to_open")
+
+	finalized := requestWithFinality("eth_getBlockByNumber", common.DataFinalityStateFinalized)
+	for range 2 {
+		_, _ = fc.Get(finalized, "", "pk", "rk", nil)
+	}
+	_, err = fc.Get(finalized, "", "pk", "rk", nil)
+	require.Error(t, err)
+	assert.True(t, common.HasErrorCode(err, common.ErrCodeFailsafeCircuitBreakerOpen), "third finalized read must be rejected by the cold breaker")
+
+	// The hot executor's breaker never saw a failure: an unfinalized read of
+	// the same method still reaches the connector.
+	unfinalized := requestWithFinality("eth_getBlockByNumber", common.DataFinalityStateUnfinalized)
+	_, err = fc.Get(unfinalized, "", "pk", "rk", nil)
+	require.Error(t, err)
+	assert.False(t, common.HasErrorCode(err, common.ErrCodeFailsafeCircuitBreakerOpen), "unfinalized read must not be rejected by the cold executor's open breaker")
+	mc.AssertNumberOfCalls(t, "Get", 3)
+
+	assert.Equal(t, 2.0, executorAttempts("prism-test", "get", "*", cold, "transport_error")-coldErrBefore)
+	assert.Equal(t, 1.0, executorAttempts("prism-test", "get", "*", cold, "breaker_open")-coldBefore)
+	assert.Equal(t, 0.0, executorAttempts("prism-test", "get", "*", hot, "breaker_open")-hotBefore)
+	assert.Equal(t, 1.0, executorTransitions("prism-test", "get", "*", cold, "closed_to_open")-openBefore)
+}
+
+func TestFinalityLabel_StableAcrossOrder(t *testing.T) {
+	a := finalityLabel([]common.DataFinalityState{common.DataFinalityStateUnfinalized, common.DataFinalityStateRealtime})
+	b := finalityLabel([]common.DataFinalityState{common.DataFinalityStateRealtime, common.DataFinalityStateUnfinalized})
+	assert.Equal(t, a, b)
+	assert.Equal(t, "realtime|unfinalized", a)
+	assert.Equal(t, "*", finalityLabel(nil))
+}

--- a/data/failsafe.go
+++ b/data/failsafe.go
@@ -117,11 +117,11 @@ func NewFailsafeConnector(
 ) (*FailsafeConnector, error) {
 	lg := logger.With().Str("component", "failsafeConnector").Str("connectorId", wrapped.Id()).Logger()
 
-	getExecutors, err := buildCacheExecutors(ctx, &lg, wrapped.Id(), getCfgs)
+	getExecutors, err := buildCacheExecutors(ctx, &lg, wrapped.Id(), "get", getCfgs)
 	if err != nil {
 		return nil, err
 	}
-	setExecutors, err := buildCacheExecutors(ctx, &lg, wrapped.Id(), setCfgs)
+	setExecutors, err := buildCacheExecutors(ctx, &lg, wrapped.Id(), "set", setCfgs)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func NewFailsafeConnector(
 	}, nil
 }
 
-func buildCacheExecutors(ctx context.Context, logger *zerolog.Logger, connectorId string, cfgs []*common.FailsafeConfig) ([]*cacheExecutor, error) {
+func buildCacheExecutors(ctx context.Context, logger *zerolog.Logger, connectorId, direction string, cfgs []*common.FailsafeConfig) ([]*cacheExecutor, error) {
 	var executors []*cacheExecutor
 
 	for _, fsCfg := range cfgs {
@@ -148,11 +148,13 @@ func buildCacheExecutors(ctx context.Context, logger *zerolog.Logger, connectorI
 				map[string]interface{}{"connectorId": connectorId},
 			)
 		}
+		ex.identify(connectorId, direction)
 		executors = append(executors, ex)
 	}
 
 	// Append a no-op fallback executor so unmatched operations always have one.
 	noop, _ := NewCacheExecutor(ctx, nil, logger)
+	noop.identify(connectorId, direction)
 	executors = append(executors, noop)
 
 	return executors, nil

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -14701,6 +14701,322 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 956,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Total",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\"}[$__interval])) by (region, connector, match_method, match_finality, outcome) > 0",
+              "legendFormat": "{{region}} {{connector}} [{{match_method}} / {{match_finality}}] {{outcome}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache executor attempts (by executor & outcome)",
+          "type": "timeseries",
+          "description": "Per failsafe executor on each cache connector: which (matchMethod, matchFinality) entry a GET landed on and how it ended. Unlike the Cache GET panels above, whose policy label carries the POLICY's finality (a finalized read matches the unfinalized policy first), this is keyed by the executor that actually ran the read."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "id": 957,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\", outcome=~\"timeout|transport_error\"}[$rate_window])) by (region, connector, match_method, match_finality) / sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\", outcome!~\"breaker_open|interrupted\"}[$rate_window])) by (region, connector, match_method, match_finality)",
+              "legendFormat": "{{region}} {{connector}} [{{match_method}} / {{match_finality}}]",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache executor failure ratio (what the breaker sees)",
+          "type": "timeseries",
+          "description": "(timeout + transport_error) / (all attempts the breaker records). breaker_open and interrupted are excluded because the breaker ignores them. Compare against the executor's failureThresholdCount / failureThresholdCapacity to see how close it is to tripping - and remember the window is count-based, so this time-based ratio is only an approximation of the ring's."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 72
+          },
+          "id": 958,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Total",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(erpc_cache_executor_breaker_state_change_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\"}[$__interval])) by (region, connector, match_method, match_finality, direction, transition) > 0",
+              "legendFormat": "{{region}} {{connector}} {{direction}} [{{match_method}} / {{match_finality}}] {{transition}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache executor breaker transitions",
+          "type": "timeseries",
+          "description": "Circuit-breaker state transitions per cache failsafe executor, both directions."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "description": "Block range each read-through cache connector (e.g. gRPC indexer) currently serves, per network (PR #909): earliest / latest / finalized.",
           "fieldConfig": {
             "defaults": {
@@ -14763,7 +15079,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 80
           },
           "id": 221,
           "options": {
@@ -14915,7 +15231,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 80
           },
           "id": 222,
           "interval": "1m",
@@ -15042,7 +15358,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 90
           },
           "id": 223,
           "interval": "1m",
@@ -15155,7 +15471,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 98
           },
           "id": 953,
           "interval": "1m",
@@ -15263,7 +15579,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 98
           },
           "id": 954,
           "interval": "1m",
@@ -15371,7 +15687,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 88
+            "y": 106
           },
           "id": 955,
           "interval": "1m",

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -739,6 +739,28 @@ var (
 		Help:      "Total circuit-breaker state transitions per upstream and direction (closed_to_open/half_open_to_open/half_open_to_closed/open_to_half_open).",
 	}, []string{"project", "upstream", "transition"})
 
+	// MetricCacheExecutorAttempt counts every attempt a cache-connector
+	// failsafe executor governs, keyed by the executor's identity (the
+	// matchMethod / matchFinality it was configured with) and the outcome
+	// the breaker saw. This is the breaker's own denominator: the
+	// cache_get_* counters carry the POLICY's finality, which for a GET is
+	// the first policy that matched (a finalized request also matches an
+	// unfinalized policy), not the request's — so they cannot say which
+	// executor a read landed on, and cannot explain why a breaker tripped.
+	MetricCacheExecutorAttempt = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "cache_executor_attempt_total",
+		Help:      "Per cache-connector failsafe executor attempt count by outcome. Outcomes: hit/miss/timeout/transport_error/error/breaker_open/interrupted.",
+	}, []string{"connector", "direction", "match_method", "match_finality", "outcome"})
+
+	// MetricCacheExecutorBreakerStateChange is the cache-connector twin of
+	// MetricUpstreamBreakerStateChange, keyed by executor identity.
+	MetricCacheExecutorBreakerStateChange = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "erpc",
+		Name:      "cache_executor_breaker_state_change_total",
+		Help:      "Total circuit-breaker state transitions per cache-connector failsafe executor (closed_to_open/half_open_to_open/half_open_to_closed/open_to_half_open).",
+	}, []string{"connector", "direction", "match_method", "match_finality", "transition"})
+
 	MetricNetworkFailedRequests = newLabeledCounterUnregistered(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "network_failed_request_total",


### PR DESCRIPTION
Two new metrics on cache-connector failsafe executors, plus a warn log on every breaker transition. No existing metric changes shape.

```
erpc_cache_executor_attempt_total{connector, direction, match_method, match_finality, outcome}
  outcome: hit | miss | timeout | transport_error | error | breaker_open | interrupted
erpc_cache_executor_breaker_state_change_total{connector, direction, match_method, match_finality, transition}
  transition: closed_to_open | open_to_half_open | half_open_to_closed | half_open_to_open
```

`match_finality` is the executor's configured `matchFinality`, sorted and `|`-joined (`finalized|unknown`), or `*` when unset. `direction` is `get`/`set`. The no-op fallback executor reports as `match_method="*"`, `match_finality="*"`.

## Why

`cache_get_{hit,miss,error}_total` carry the **policy's** finality, and for a GET that is the first policy that matched. A finalized request also matches an `unfinalized` policy (`data/cache_policy.go` `MatchesForGet`), and `findGetPolicies` dedups by connector — so on any deployment that lists the unfinalized policy first, every finalized read is labelled `finality=unfinalized`. Measured today on a prism connector: a 1k rps archive scan (100% `request.finality: finalized` in traces) showed as 100% unfinalized in the metric.

The failsafe executor is *not* fooled — `pickCacheExecutor` keys on `req.Finality(ctx)` — which means a per-finality `failsafeForGets` split works, but nothing observable says which executor a read landed on or which executor's breaker opened. With the split live and the breaker still opening at a failure ratio well below the cold tier's threshold, we could not tell whether reads were landing on the wrong executor or the breaker was counting differently. This metric is the executor's own outcome ring, so the ratio it shows is the ratio the breaker sees.

## Design

- Identity is bound once in `buildCacheExecutors` via `identify(connectorId, direction)`; an executor built outside a connector (tests) emits nothing. `NewCacheExecutor`'s signature is unchanged.
- `attemptOutcome` uses the same partition as `breakerOutcome` but keeps hit/miss and timeout/transport_error apart — the breaker collapses those pairs, an operator reading the ratio must not.
- Breaker transitions reuse `failsafe.Breaker.OnTransition`, the same hook `upstream/upstream.go` uses for `upstream_breaker_state_change_total`.
- Cardinality: connectors × 2 × executors-per-connector × 7 outcomes. Bounded by config, not by traffic.

## Dashboard

`monitoring/grafana/dashboards/erpc.json`, Cache row, right after the Cache GET error panels (the mirror in erpc-deployments picks this up via `just dashboards-sync-upstream`):

- **Cache executor attempts (by executor & outcome)** — stacked bars, `[match_method / match_finality] outcome`.
- **Cache executor failure ratio (what the breaker sees)** — `(timeout+transport_error) / (all recorded)` per executor, `percentunit`; `breaker_open`/`interrupted` excluded because the breaker ignores them.
- **Cache executor breaker transitions** — bars per executor and transition.

Only `cluster`/`namespace`/`region` filters apply: these metrics carry no project/network/category by design (the executor is a connector-level object). Diff is the three panels plus six `gridPos.y` shifts; nothing else in the file is touched.

## Test

`TestCacheFailsafe_FinalitySplit_BreakerIsolatedPerExecutor`: two `*` executors split by finality, each with a 2-failure breaker. Two failing finalized reads open the cold breaker; the third finalized read is rejected `ErrFailsafeCircuitBreakerOpen`; an unfinalized read of the same method still reaches the connector. Asserts 2 `transport_error` + 1 `breaker_open` on the cold series, 0 `breaker_open` on the hot series, exactly 1 `closed_to_open` on the cold series. Also `TestFinalityLabel_StableAcrossOrder`.

`go test ./data/ ./telemetry/ ./erpc/ -run 'Cache|Failsafe|Executor'` green; `gofmt`/`go vet` clean.
