### PR TITLE
fix(evm): state prober latches getProof as unsupported when the upstream ignores it

### DIFF
--- a/architecture/evm/integrity_stateprobe.go
+++ b/architecture/evm/integrity_stateprobe.go
@@ -275,6 +275,16 @@ func (p *stateProber) probeProof(ctx context.Context, u common.Upstream, n int64
 	if _, off := p.proofUnsupported.Load(u.Id()); off {
 		return probeUnknown
 	}
+	// An upstream whose own configuration excludes the method (ignoreMethods /
+	// allowMethods) never receives the probe: the router refuses the forward
+	// first, and that refusal does not read as "unsupported" to the check
+	// below — so the probe erred on every block instead of latching once.
+	// Ask the upstream before forwarding and remember the answer.
+	if ok, _ := u.ShouldHandleMethod("eth_getProof"); !ok {
+		p.proofUnsupported.Store(u.Id(), true)
+		p.count(u, "proof", "unsupported")
+		return probeUnknown
+	}
 	body := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"eth_getProof","params":["%s",[],"0x%x"]}`,
 		p.ctxProbe.To, n)

--- a/architecture/evm/integrity_stateprobe_test.go
+++ b/architecture/evm/integrity_stateprobe_test.go
@@ -134,6 +134,17 @@ func TestStateProber(t *testing.T) {
 		assert.True(t, remembered, "unsupported must be remembered, not rediscovered every block")
 	})
 
+	t.Run("getProof ignored by the upstream's own config: latched without a forward, context still proves", func(t *testing.T) {
+		pn := newProbeNetwork(t)
+		pn.upstream.Config().IgnoreMethods = []string{"eth_getProof"}
+		pn.execContext, pn.proofErr = head, "must not be forwarded"
+		p, _ := proberFor(pn, head, stateRoot)
+		p.probeAll(head)
+		assert.EqualValues(t, head, pn.upstream.EvmStateProvenBlock())
+		_, remembered := p.proofUnsupported.Load("u1")
+		assert.True(t, remembered, "an ignored method is remembered as unsupported, not re-asked every block")
+	})
+
 	t.Run("no verified header at the height: nothing advances (no anchor, no proof)", func(t *testing.T) {
 		pn := newProbeNetwork(t)
 		pn.execContext, pn.proofNode = head, trieNode

--- a/data/cache_executor_finality_test.go
+++ b/data/cache_executor_finality_test.go
@@ -102,7 +102,12 @@ func TestCacheFailsafe_FinalitySplit_BreakerIsolatedPerExecutor(t *testing.T) {
 	assert.Equal(t, 2.0, executorAttempts("prism-test", "get", "*", cold, "transport_error")-coldErrBefore)
 	assert.Equal(t, 1.0, executorAttempts("prism-test", "get", "*", cold, "breaker_open")-coldBefore)
 	assert.Equal(t, 0.0, executorAttempts("prism-test", "get", "*", hot, "breaker_open")-hotBefore)
-	assert.Equal(t, 1.0, executorTransitions("prism-test", "get", "*", cold, "closed_to_open")-openBefore)
+	// The breaker fires OnTransition on its own goroutine (failsafe/breaker.go:
+	// "without holding the breaker mutex"), so the counter lands after the
+	// rejecting call returns; read it as an eventual fact, not an immediate one.
+	assert.Eventually(t, func() bool {
+		return executorTransitions("prism-test", "get", "*", cold, "closed_to_open")-openBefore == 1.0
+	}, 2*time.Second, 10*time.Millisecond, "exactly one closed_to_open transition on the cold executor")
 }
 
 func TestFinalityLabel_StableAcrossOrder(t *testing.T) {


### PR DESCRIPTION
- `probeProof` asks `ShouldHandleMethod("eth_getProof")` before forwarding
- ignored by the upstream's own config → `proofUnsupported` latched, counted `unsupported`, no forward
- before: the router refused the forward, the error did not read as unsupported, `proof error` counted every block
- context probe unaffected; test added
- also fixes `TestCacheFailsafe_FinalitySplit_BreakerIsolatedPerExecutor` (red on main since #1132): the breaker fires `OnTransition` on a goroutine (`failsafe/breaker.go`), so the transition counter is read as an eventual fact

🤖 Generated with [Claude Code](https://claude.com/claude-code)