### PR TITLE
feat(cache): label executor attempts by project and network; success not hit

### DIFF
--- a/data/cache_executor.go
+++ b/data/cache_executor.go
@@ -100,13 +100,24 @@ func finalityLabel(fs []common.DataFinalityState) string {
 }
 
 // observe records one governed attempt's outcome under this executor's
-// identity. No-op until identify() has run.
-func (e *cacheExecutor) observe(outcome string) {
+// identity plus the request's project and network, read from ctx the same
+// way pickCacheExecutor reads finality. No-op until identify() has run.
+// A connector is shared across projects and (for pooled connectors) across
+// networks; the executor is the unit the breaker lives on, the request is
+// the unit operators filter on, so both are labelled.
+func (e *cacheExecutor) observe(ctx context.Context, outcome string) {
 	if e.connectorId == "" {
 		return
 	}
+	project, network := "n/a", "n/a"
+	if r, ok := ctx.Value(common.RequestContextKey).(*common.NormalizedRequest); ok && r != nil {
+		network = r.NetworkLabel()
+		if n := r.Network(); n != nil {
+			project = n.ProjectId()
+		}
+	}
 	telemetry.MetricCacheExecutorAttempt.WithLabelValues(
-		e.connectorId, e.direction, e.method, e.finalityLabel, outcome,
+		project, network, e.connectorId, e.direction, e.method, e.finalityLabel, outcome,
 	).Inc()
 }
 
@@ -293,7 +304,7 @@ func (e *cacheExecutor) callBreaker(
 ) ([]byte, error) {
 	if e.breaker != nil {
 		if !e.breaker.TryAcquirePermit() {
-			e.observe("breaker_open")
+			e.observe(ctx, "breaker_open")
 			startTime := time.Now()
 			return nil, common.NewErrFailsafeCircuitBreakerOpen(scopeConnector, failsafe.ErrCircuitOpen, &startTime)
 		}
@@ -344,14 +355,20 @@ func (e *cacheExecutor) callBreaker(
 	if e.breaker != nil {
 		e.breaker.Record(breakerOutcome(err, ourTimeout, interrupted))
 	}
-	e.observe(attemptOutcome(err, ourTimeout, interrupted))
+	e.observe(ctx, attemptOutcome(err, ourTimeout, interrupted))
 	return data, err
 }
 
 // attemptOutcome names a completed attempt for cache_executor_attempt_total.
 // Same partition breakerOutcome uses, kept apart so the metric can tell a
-// miss from a hit and a timeout from a transport failure — the breaker
-// collapses those pairs, the operator reading the ratio must not.
+// not-found from a success and a timeout from a transport failure — the
+// breaker collapses those pairs, the operator reading the ratio must not.
+//
+// "success" is NOT "cache hit". It means the connector answered inside the
+// budget; whether the answer carried data is decided above this layer. The
+// gRPC connector returns a prism miss as a successful call with a null result
+// (clients/grpc_bds_client.go), so at this level it is a success — which is
+// also exactly what the breaker counts it as. Hit/miss live in cache_get_*.
 func attemptOutcome(err error, ourTimeout, interrupted bool) string {
 	switch {
 	case interrupted:
@@ -359,9 +376,9 @@ func attemptOutcome(err error, ourTimeout, interrupted bool) string {
 	case ourTimeout:
 		return "timeout"
 	case err == nil:
-		return "hit"
+		return "success"
 	case common.HasErrorCode(err, common.ErrCodeRecordNotFound):
-		return "miss"
+		return "not_found"
 	case isTransportError(err):
 		return "transport_error"
 	default:

--- a/data/cache_executor_finality_test.go
+++ b/data/cache_executor_finality_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 // finalityNetwork is the smallest common.Network that lets a request resolve
-// a fixed finality: NormalizedRequest.Finality delegates to network.GetFinality
-// and caches the answer, and everything else on the interface is unused here.
+// a fixed finality and carry a project/network identity: Finality delegates to
+// network.GetFinality, the executor metric reads ProjectId/Label, and nothing
+// else on the interface is touched.
 type finalityNetwork struct {
 	common.Network
 	finality common.DataFinalityState
@@ -27,6 +28,9 @@ type finalityNetwork struct {
 func (n *finalityNetwork) GetFinality(context.Context, *common.NormalizedRequest, *common.NormalizedResponse) common.DataFinalityState {
 	return n.finality
 }
+func (n *finalityNetwork) ProjectId() string { return "test-project" }
+func (n *finalityNetwork) Label() string     { return "evm:4663" }
+func (n *finalityNetwork) Id() string        { return "evm:4663" }
 
 func requestWithFinality(method string, f common.DataFinalityState) context.Context {
 	req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"` + method + `","params":[],"id":1}`))
@@ -35,7 +39,7 @@ func requestWithFinality(method string, f common.DataFinalityState) context.Cont
 }
 
 func executorAttempts(connector, direction, method, finality, outcome string) float64 {
-	return promUtil.ToFloat64(telemetry.MetricCacheExecutorAttempt.WithLabelValues(connector, direction, method, finality, outcome))
+	return promUtil.ToFloat64(telemetry.MetricCacheExecutorAttempt.WithLabelValues("test-project", "evm:4663", connector, direction, method, finality, outcome))
 }
 
 func executorTransitions(connector, direction, method, finality, transition string) float64 {

--- a/monitoring/grafana/dashboards/erpc.json
+++ b/monitoring/grafana/dashboards/erpc.json
@@ -14791,8 +14791,8 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\"}[$__interval])) by (region, connector, match_method, match_finality, outcome) > 0",
-              "legendFormat": "{{region}} {{connector}} [{{match_method}} / {{match_finality}}] {{outcome}}",
+              "expr": "sum(increase(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", project=~\"${project:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", direction=\"get\"}[$__interval])) by (region, project, network, connector, match_method, match_finality, outcome) > 0",
+              "legendFormat": "{{region}} {{project}} {{network}} {{connector}} [{{match_method}} / {{match_finality}}] {{outcome}}",
               "range": true,
               "refId": "A"
             }
@@ -14897,8 +14897,8 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\", outcome=~\"timeout|transport_error\"}[$rate_window])) by (region, connector, match_method, match_finality) / sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", direction=\"get\", outcome!~\"breaker_open|interrupted\"}[$rate_window])) by (region, connector, match_method, match_finality)",
-              "legendFormat": "{{region}} {{connector}} [{{match_method}} / {{match_finality}}]",
+              "expr": "sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", project=~\"${project:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", direction=\"get\", outcome=~\"timeout|transport_error\"}[$rate_window])) by (region, project, network, connector, match_method, match_finality) / sum(rate(erpc_cache_executor_attempt_total{cluster=~\"${cluster:regex}\", namespace=~\"${namespace:regex}\", region=~\"${region:regex}\", project=~\"${project:regex}\", network=~\"${network:regex}\", network!~\"${ignore_network:regex}\", direction=\"get\", outcome!~\"breaker_open|interrupted\"}[$rate_window])) by (region, project, network, connector, match_method, match_finality)",
+              "legendFormat": "{{region}} {{project}} {{network}} {{connector}} [{{match_method}} / {{match_finality}}]",
               "range": true,
               "refId": "A"
             }

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -747,11 +747,14 @@ var (
 	// the first policy that matched (a finalized request also matches an
 	// unfinalized policy), not the request's — so they cannot say which
 	// executor a read landed on, and cannot explain why a breaker tripped.
+	// project/network come from the request; the executor itself is shared
+	// across both. "success" means answered in budget, not cache hit — the
+	// gRPC connector returns a miss as a null-result success.
 	MetricCacheExecutorAttempt = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "erpc",
 		Name:      "cache_executor_attempt_total",
-		Help:      "Per cache-connector failsafe executor attempt count by outcome. Outcomes: hit/miss/timeout/transport_error/error/breaker_open/interrupted.",
-	}, []string{"connector", "direction", "match_method", "match_finality", "outcome"})
+		Help:      "Per cache-connector failsafe executor attempt count by outcome. Outcomes: success/not_found/timeout/transport_error/error/breaker_open/interrupted. success = answered within budget (a null-result miss is a success here; hit/miss live in cache_get_*).",
+	}, []string{"project", "network", "connector", "direction", "match_method", "match_finality", "outcome"})
 
 	// MetricCacheExecutorBreakerStateChange is the cache-connector twin of
 	// MetricUpstreamBreakerStateChange, keyed by executor identity.


### PR DESCRIPTION
Follow-up to #1132, before anything depends on its label set.

**`erpc_cache_executor_attempt_total` gains `project` and `network`.** Read from the request in ctx — the same place `pickCacheExecutor` reads finality — so it costs nothing. The executor is a connector-level object shared across projects and, for pooled connectors like `goldsky-edge`, across networks; without these two labels the metric can't be filtered like every other cache panel. Cardinality stays config-bounded: connectors × executors × networks-the-connector-serves × 7 outcomes. `n/a` when no request is in ctx.

**Outcome rename: `hit` → `success`, `miss` → `not_found`.** The gRPC connector returns a prism miss as a successful call with `result: null` (`clients/grpc_bds_client.go`), so at this level a miss *is* a success — which is exactly what the breaker counts it as. `hit` implied data was found; it didn't. Hit/miss remain in `cache_get_*`.

**Dashboard:** the two attempt-based Cache panels gain `project`/`network`/`ignore_network` filters and `{{project}} {{network}}` in the legend. The breaker-transition panel is unchanged: the breaker lives on the executor, not on a network.

`erpc_cache_executor_breaker_state_change_total` is untouched.

## Test

`TestCacheFailsafe_FinalitySplit_BreakerIsolatedPerExecutor` updated: the stub network now carries `ProjectId`/`Label`/`Id`, and every series lookup includes them. `go test ./data/ ./telemetry/ ./erpc/ -run 'Cache|Failsafe|Executor'` green; `-count=15` on the failsafe suite green; `gofmt`/`go vet` clean.
