### PR TITLE
fix(cordon): clear operator reason after local admin call

### DIFF
--- a/upstream/operator_cordon_test.go
+++ b/upstream/operator_cordon_test.go
@@ -104,9 +104,14 @@ func TestCordonAdmin_PropagatesAcrossReplicasAndRestarts(t *testing.T) {
 	require.Eventually(t, notCordoned(a), 5*time.Second, 20*time.Millisecond)
 	require.Eventually(t, notCordoned(c), 5*time.Second, 20*time.Millisecond)
 
-	// A later cordon after an uncordon is accepted again.
+	// A later cordon after an uncordon is accepted again. The originating
+	// replica's reason must not leak into a peer that never issued this call.
 	c.CordonAdmin(ctx, "incident #2")
 	require.Eventually(t, cordoned(a), 5*time.Second, 20*time.Millisecond)
+	reason, _ = a.CordonedReason("eth_call")
+	require.Equal(t, "operator cordon (set on another replica)", reason)
+	reason, _ = c.CordonedReason("eth_call")
+	require.Equal(t, "incident #2", reason)
 }
 
 func TestCordonAdmin_DetectorsCannotLiftAnOperatorCordon(t *testing.T) {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -222,8 +222,10 @@ type Upstream struct {
 	// it in-process. Created once, lazily (see operatorCordonVar).
 	operatorCordon     atomic.Value // data.CounterInt64SharedVariable
 	operatorCordonOnce sync.Once
-	// operatorCordonReason is the reason given on this replica; peers and
-	// restarted pods only see that an operator cordon exists.
+	// operatorCordonReason is the reason given on this replica for the
+	// in-flight CordonAdmin/UncordonAdmin call; it is cleared when that
+	// call returns. Peers and restarted pods only see that an operator
+	// cordon exists.
 	operatorCordonReason atomic.Value
 }
 
@@ -1528,6 +1530,7 @@ func (u *Upstream) CordonedReason(method string) (string, bool) {
 // and pushed in the background, like every other shared counter.
 func (u *Upstream) CordonAdmin(ctx context.Context, reason string) {
 	u.operatorCordonReason.Store(reason)
+	defer u.operatorCordonReason.Store("")
 	if v := u.operatorCordonVar(); v.GetValue() == 0 {
 		v.TryUpdate(ctx, time.Now().UnixMilli())
 	} else {
@@ -1540,6 +1543,7 @@ func (u *Upstream) CordonAdmin(ctx context.Context, reason string) {
 // override for a detector verdict.
 func (u *Upstream) UncordonAdmin(ctx context.Context, reason string) {
 	u.operatorCordonReason.Store(reason)
+	defer u.operatorCordonReason.Store("")
 	u.operatorCordonVar().TryUpdate(ctx, 0)
 	u.metricsTracker.Uncordon(u, "*", reason)
 }


### PR DESCRIPTION
## Summary

`operatorCordonReason` is only meant for the in-flight `CordonAdmin` / `UncordonAdmin` call on this replica. It was never cleared, so a later peer `OnValue` (remote uncordon, then a new cordon) reused a stale incident string instead of `operator cordon (set on another replica)`.

`TryUpdate` fires `OnValue` synchronously, so a `defer` reset after the local admin call is enough. The replica-propagation test now asserts the peer reason after a second cordon.

## Test plan

- [x] `go test -run TestCordonAdmin_ ./upstream/`

Made with [Cursor](https://cursor.com)