### PR TITLE
test(metrics): add Forward/tracker/telemetry hot-path benches

### DIFF
--- a/erpc/forward_hotpath_bench_test.go
+++ b/erpc/forward_hotpath_bench_test.go
@@ -1,0 +1,146 @@
+package erpc
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/erpc/erpc/common"
+	"github.com/erpc/erpc/util"
+)
+
+func init() {
+	util.ConfigureTestLogger()
+}
+
+// These benches isolate Network.Forward's success and failure code paths
+// (selection + tracker state + prometheus recording). They share the
+// httptest fixture in failsafe_perf_bench_test.go so HTTP is in-process
+// and parallel-safe. Failsafe is kept to a single attempt so retry/hedge
+// do not dominate the measurement.
+//
+// Run:
+//
+//	go test -run=^$ -bench='BenchmarkForward_' -benchmem -count=5 ./erpc
+
+func newBareSuccessNetwork(b *testing.B) *benchNetwork {
+	b.Helper()
+	mock := newBenchUpstream(benchMethod, nil)
+	return setupBenchNetwork(b, nil, []*benchMockUpstream{mock})
+}
+
+func newBareFailureNetwork(b *testing.B) *benchNetwork {
+	b.Helper()
+	mock := newBenchUpstream(benchMethod, func(_ int64) (int, string, time.Duration) {
+		return 503, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"unavailable"}}`, 0
+	})
+	return setupBenchNetwork(b, []*common.FailsafeConfig{{
+		Retry: &common.RetryPolicyConfig{MaxAttempts: 1},
+	}}, []*benchMockUpstream{mock})
+}
+
+func warmupForward(bn *benchNetwork, n int) {
+	body := benchRequestBody()
+	for i := 0; i < n; i++ {
+		req := common.NewNormalizedRequest(body)
+		resp, _ := bn.ntw.Forward(context.Background(), req)
+		if resp != nil {
+			resp.Release()
+		}
+	}
+}
+
+func runForwardSerial(b *testing.B, bn *benchNetwork) {
+	body := benchRequestBody()
+	warmupForward(bn, 50)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := common.NewNormalizedRequest(body)
+		resp, _ := bn.ntw.Forward(context.Background(), req)
+		if resp != nil {
+			resp.Release()
+		}
+	}
+}
+
+func runForwardParallel(b *testing.B, bn *benchNetwork) {
+	body := benchRequestBody()
+	warmupForward(bn, 50)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := common.NewNormalizedRequest(body)
+			resp, _ := bn.ntw.Forward(context.Background(), req)
+			if resp != nil {
+				resp.Release()
+			}
+		}
+	})
+}
+
+func runForwardHeap(b *testing.B, bn *benchNetwork) {
+	const reqs = 200
+	body := benchRequestBody()
+	warmupForward(bn, 50)
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < reqs; j++ {
+			req := common.NewNormalizedRequest(body)
+			resp, _ := bn.ntw.Forward(context.Background(), req)
+			if resp != nil {
+				resp.Release()
+			}
+		}
+	}
+	b.StopTimer()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	total := int64(b.N) * reqs
+	b.ReportMetric(float64(after.Mallocs-before.Mallocs)/float64(total), "mallocs/req")
+	b.ReportMetric(float64(int64(after.HeapAlloc)-int64(before.HeapAlloc))/float64(total), "heap-delta-B/req")
+}
+
+func BenchmarkForward_Success_Serial(b *testing.B) {
+	bn := newBareSuccessNetwork(b)
+	defer bn.Close()
+	runForwardSerial(b, bn)
+}
+
+func BenchmarkForward_Success_Parallel(b *testing.B) {
+	bn := newBareSuccessNetwork(b)
+	defer bn.Close()
+	runForwardParallel(b, bn)
+}
+
+func BenchmarkForward_Failure_Serial(b *testing.B) {
+	bn := newBareFailureNetwork(b)
+	defer bn.Close()
+	runForwardSerial(b, bn)
+}
+
+func BenchmarkForward_Failure_Parallel(b *testing.B) {
+	bn := newBareFailureNetwork(b)
+	defer bn.Close()
+	runForwardParallel(b, bn)
+}
+
+func BenchmarkForward_Success_Heap(b *testing.B) {
+	bn := newBareSuccessNetwork(b)
+	defer bn.Close()
+	runForwardHeap(b, bn)
+}
+
+func BenchmarkForward_Failure_Heap(b *testing.B) {
+	bn := newBareFailureNetwork(b)
+	defer bn.Close()
+	runForwardHeap(b, bn)
+}

--- a/health/tracker_bench_test.go
+++ b/health/tracker_bench_test.go
@@ -63,6 +63,7 @@ func BenchmarkTrackerRecordUpstreamRequest(b *testing.B) {
 
 	methods := []string{"eth_call", "eth_getBalance", "eth_getBlockByNumber", "eth_sendRawTransaction"}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
@@ -73,6 +74,38 @@ func BenchmarkTrackerRecordUpstreamRequest(b *testing.B) {
 			i++
 		}
 	})
+}
+
+// Serial counterpart so lock contention on upsMetrics/ntwMetrics is visible
+// against the parallel bench above.
+func BenchmarkTrackerRecordUpstreamRequest_Serial(b *testing.B) {
+	tracker := NewTracker(&log.Logger, "test-project", 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+
+	up := &MockUpstream{id: "upstream-0", network: "network-0", vendor: "test-vendor"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tracker.RecordUpstreamRequest(up, "eth_getBalance", common.DataFinalityStateUnknown)
+	}
+}
+
+// Unique methods force a new upsMetrics map entry per op — the growth /
+// LoadOrStore path, not the steady-state hit path.
+func BenchmarkTrackerRecordUpstreamRequest_UniqueMethods(b *testing.B) {
+	tracker := NewTracker(&log.Logger, "test-project", 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+	up := &MockUpstream{id: "upstream-0", network: "network-0", vendor: "test-vendor"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tracker.RecordUpstreamRequest(up, fmt.Sprintf("eth_method_%d", i), common.DataFinalityStateUnknown)
+	}
 }
 
 // BenchmarkTrackerRecordUpstreamDuration benchmarks duration recording
@@ -93,6 +126,7 @@ func BenchmarkTrackerRecordUpstreamDuration(b *testing.B) {
 
 	methods := []string{"eth_call", "eth_getBalance", "eth_getBlockByNumber", "eth_sendRawTransaction"}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
@@ -132,6 +166,7 @@ func BenchmarkTrackerRecordUpstreamFailure(b *testing.B) {
 	methods := []string{"eth_call", "eth_getBalance", "eth_getBlockByNumber", "eth_sendRawTransaction"}
 	testErr := fmt.Errorf("test error")
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
@@ -142,6 +177,21 @@ func BenchmarkTrackerRecordUpstreamFailure(b *testing.B) {
 			i++
 		}
 	})
+}
+
+func BenchmarkTrackerRecordUpstreamFailure_Serial(b *testing.B) {
+	tracker := NewTracker(&log.Logger, "test-project", 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tracker.Bootstrap(ctx)
+	up := &MockUpstream{id: "upstream-0", network: "network-0", vendor: "test-vendor"}
+	testErr := fmt.Errorf("test error")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tracker.RecordUpstreamFailure(up, "eth_getBalance", common.DataFinalityStateUnknown, testErr)
+	}
 }
 
 // BenchmarkTrackerSetLatestBlockNumber benchmarks block number updates
@@ -163,6 +213,7 @@ func BenchmarkTrackerSetLatestBlockNumber(b *testing.B) {
 		tracker.RecordUpstreamRequest(upstreams[i], "eth_call", common.DataFinalityStateUnknown)
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
@@ -196,6 +247,7 @@ func BenchmarkTrackerMixedOperations(b *testing.B) {
 	methods := []string{"eth_call", "eth_getBalance", "eth_getBlockByNumber", "eth_sendRawTransaction"}
 	testErr := fmt.Errorf("test error")
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
@@ -243,6 +295,7 @@ func BenchmarkTrackerRecordUpstreamDurationWithTimer(b *testing.B) {
 
 	methods := []string{"eth_call", "eth_getBalance", "eth_getBlockByNumber", "eth_sendRawTransaction"}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0

--- a/telemetry/hotpath_bench_test.go
+++ b/telemetry/hotpath_bench_test.go
@@ -1,0 +1,154 @@
+package telemetry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/erpc/erpc/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	util.ConfigureTestLogger()
+}
+
+// Isolates the prometheus recording layer used on every Forward:
+// LabeledCounter.WithLabelValues, CounterHandle (sync.Map + idle atomic),
+// and histogram Observe. Steady labels measure the hit path; rotating
+// labels force cache/vec misses (mutex + series create).
+//
+// Run:
+//
+//	go test -run=^$ -bench='Benchmark(CounterHandle|WithLabelValues|HistogramObserve)_' -benchmem -count=5 ./telemetry
+
+func initHotpathMetrics(b *testing.B) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	if err := SetHistogramBuckets(""); err != nil {
+		b.Fatalf("SetHistogramBuckets: %v", err)
+	}
+}
+
+var (
+	reqLabels = []string{
+		"bench", "vendor", "evm:123", "up-1", "eth_getBalance",
+		"1", "none", "unknown", "n/a", "unknown",
+	}
+	errLabels = []string{
+		"bench", "vendor", "evm:123", "up-1", "eth_getBalance",
+		"ErrEndpointServerSideException", "major", "none", "unknown", "n/a", "unknown",
+	}
+	durLabels = []string{
+		"bench", "vendor", "evm:123", "up-1", "eth_getBalance", "none", "unknown", "n/a",
+	}
+)
+
+func prewarmCounterHandles() {
+	CounterHandle(MetricUpstreamRequestTotal, reqLabels...).Inc()
+	CounterHandle(MetricUpstreamErrorTotal, errLabels...).Inc()
+	MetricUpstreamRequestTotal.WithLabelValues(reqLabels...).Inc()
+	MetricUpstreamErrorTotal.WithLabelValues(errLabels...).Inc()
+	ObserverHandle(MetricUpstreamRequestDuration, durLabels...).Observe(0.001)
+	MetricUpstreamRequestDuration.WithLabelValues(durLabels...).Observe(0.001)
+}
+
+func rotatingReqLabels(i int) []string {
+	return []string{
+		"bench", "vendor", "evm:123", "up-1",
+		fmt.Sprintf("eth_method_%d", i%1024),
+		"1", "none", "unknown", "n/a", "unknown",
+	}
+}
+
+func BenchmarkCounterHandle_SteadyLabels_Serial(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CounterHandle(MetricUpstreamRequestTotal, reqLabels...).Inc()
+	}
+}
+
+func BenchmarkCounterHandle_SteadyLabels_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			CounterHandle(MetricUpstreamRequestTotal, reqLabels...).Inc()
+		}
+	})
+}
+
+func BenchmarkWithLabelValues_SteadyLabels_Serial(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MetricUpstreamRequestTotal.WithLabelValues(reqLabels...).Inc()
+	}
+}
+
+func BenchmarkWithLabelValues_SteadyLabels_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			MetricUpstreamRequestTotal.WithLabelValues(reqLabels...).Inc()
+		}
+	})
+}
+
+func BenchmarkCounterHandle_ErrorTotal_Steady_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			CounterHandle(MetricUpstreamErrorTotal, errLabels...).Inc()
+		}
+	})
+}
+
+func BenchmarkCounterHandle_RotatingLabels_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			CounterHandle(MetricUpstreamRequestTotal, rotatingReqLabels(i)...).Inc()
+			i++
+		}
+	})
+}
+
+func BenchmarkHistogramObserve_CachedHandle_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ObserverHandle(MetricUpstreamRequestDuration, durLabels...).Observe(0.003)
+		}
+	})
+}
+
+func BenchmarkHistogramObserve_WithLabelValues_Parallel(b *testing.B) {
+	initHotpathMetrics(b)
+	prewarmCounterHandles()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			MetricUpstreamRequestDuration.WithLabelValues(durLabels...).Observe(0.003)
+		}
+	})
+}


### PR DESCRIPTION
<!-- What changes and why. Keep it short — the diff already shows the how. -->

Shared unit benches so `main` vs `feat/unified-metrics-manager` can be compared on ops/s and allocs/s without production traffic. Isolates `Network.Forward` success/failure, tracker `RecordUpstream*` state, and `CounterHandle`/`WithLabelValues`/histogram Observe (the recording layer the metrics manager changes).

## Verification

```bash
go test -run=^$ -bench='BenchmarkForward_' -benchmem -count=5 ./erpc
go test -run=^$ -bench='BenchmarkTrackerRecordUpstream' -benchmem -count=5 ./health
go test -run=^$ -bench='Benchmark(CounterHandle|WithLabelValues|HistogramObserve)_' -benchmem -count=5 ./telemetry
```

On `bench/forward-metrics-hotpath` (main + these benches), a local `-count=5` run completed: Forward success serial ~54µs / 330 allocs/op; failure serial ~66µs / 499 allocs/op; CounterHandle steady ~100ns / 1 alloc; WithLabelValues steady ~110ns / 0 allocs.

## Test plan

- [x] New benches compile and run on main
- [ ] Same benches on `feat/unified-metrics-manager` after rebase; compare with `benchstat`

## AI assistance

- **Model:** Cursor Grok 4.6
- **Harness / skills:** Cursor
- **Human-reviewed:** no


Made with [Cursor](https://cursor.com)