### PR TITLE
fix(cli): reject unsupported --format values in erpc validate

### DIFF
--- a/cmd/erpc/main.go
+++ b/cmd/erpc/main.go
@@ -108,11 +108,18 @@ func main() {
 			// Suppress all logs
 			zerolog.SetGlobalLevel(zerolog.Disabled)
 
+			// Reject unsupported formats before loading the configuration.
+			format := cmd.String("format")
+			if err := validateReportFormat(format); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				util.OsExit(1)
+				return nil
+			}
+
 			cfg, err := getConfig(logger, cmd)
 			if err != nil {
 				// Config load errors should be included as Errors in output, not printed
 				report := &erpc.ValidationReport{Errors: []string{fmt.Sprintf("config load error: %v", err)}}
-				format := cmd.String("format")
 				if format == "md" {
 					out := erpc.RenderValidationReportMarkdown(report)
 					fmt.Println(out)
@@ -125,7 +132,6 @@ func main() {
 			}
 
 			report := erpc.GenerateValidationReport(ctx, cfg)
-			format := cmd.String("format")
 			if format == "md" {
 				out := erpc.RenderValidationReportMarkdown(report)
 				fmt.Println(out)
@@ -245,6 +251,16 @@ func main() {
 	if err := cmd.Run(ctx, os.Args); err != nil {
 		logger.Error().Msgf("failed to start erpc: %v", err)
 		util.OsExit(util.ExitCodeERPCStartFailed)
+	}
+}
+
+// Supported output formats of the validation report
+func validateReportFormat(format string) error {
+	switch format {
+	case "json", "md":
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %q (use json or md)", format)
 	}
 }
 

--- a/cmd/erpc/main_test.go
+++ b/cmd/erpc/main_test.go
@@ -229,6 +229,32 @@ func TestMain_Validate_RealConfigFile(t *testing.T) {
 	}
 }
 
+func TestMain_Validate_ReportFormat(t *testing.T) {
+	tests := []struct {
+		format  string
+		wantErr bool
+	}{
+		{format: "json", wantErr: false},
+		{format: "md", wantErr: false},
+		{format: "mdx", wantErr: true},
+		{format: "yaml", wantErr: true},
+		{format: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		err := validateReportFormat(tt.format)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("expected format %q to be rejected", tt.format)
+			} else if !strings.Contains(err.Error(), "unsupported format") {
+				t.Errorf("expected 'unsupported format' error for %q, got %v", tt.format, err)
+			}
+		} else if err != nil {
+			t.Errorf("expected format %q to be accepted, got %v", tt.format, err)
+		}
+	}
+}
+
 // Test that the very first requests issued against the local erpc instance
 // successfully wait for upstream lazy‑loading to complete, ensuring they are
 // not rejected due to missing upstreams.


### PR DESCRIPTION
## Summary

`erpc validate` documents only `json` and `md` as supported output formats, but unsupported values were silently treated as JSON.

This PR makes `erpc validate` reject unsupported `--format` values before loading the config.

## Problem

The CLI currently documents:

```text
--format string  Output format: json|md
```

But a typo like:

```bash
go run ./cmd/erpc validate \
  --config does-not-exist.yaml \
  --format mdx
```

previously returned a JSON validation report instead of reporting that `mdx` is unsupported.

## Fix

The validate command now checks the format before config loading.

Supported values are:

```text
json
md
```

Anything else returns an error like:

```text
error: unsupported format "mdx" (use json or md)
```

This also makes the behavior consistent with `erpc dump`, which already rejects unsupported output formats.

## Changes

- validate `--format` before loading the config
- accept only `json` and `md`
- keep existing JSON and Markdown rendering unchanged
- add tests for supported and unsupported format values

Manual verification:

```bash
go run ./cmd/erpc validate \
  --config does-not-exist.yaml \
  --format json
```

Returns the JSON validation report.

```bash
go run ./cmd/erpc validate \
  --config does-not-exist.yaml \
  --format md
```

Returns the Markdown validation report.

```bash
go run ./cmd/erpc validate \
  --config does-not-exist.yaml \
  --format mdx
```

Returns:

```text
error: unsupported format "mdx" (use json or md)
```

The default behavior without `--format` is unchanged and still uses JSON.

Related #1142 